### PR TITLE
Add code fixes for Analyze diagnostic portion

### DIFF
--- a/MetaCompilation/MetaCompilation/MetaCompilation/DiagnosticAnalyzer.cs
+++ b/MetaCompilation/MetaCompilation/MetaCompilation/DiagnosticAnalyzer.cs
@@ -196,7 +196,8 @@ namespace MetaCompilation
                                              WhitespaceCheckMissingRule,
                                              WhitespaceCheckIncorrectRule,
                                              ReturnStatementMissingRule,
-                                             ReturnStatementIncorrectRule);
+                                             ReturnStatementIncorrectRule,
+                                             TooManyStatementsRule);
             }
         }
 


### PR DESCRIPTION
Added code fixes for following rules:
-IncorrectIfStatement
-IfKeywordIncorrectRule
-TrailingTriviaIncorrectRule
-TrailingTriviaVarMissingRule
-TrailingTriviaVarIncorrectRule
-TrailingTriviaKindCheckIncorrectRule
-WhitespaceCheckIncorrectRule
-ReturnStatementIncorrectRule
-TooManyStatementsRule
