### PR TITLE
Use compiler package

### DIFF
--- a/build/Targets/Analyzers.Settings.targets
+++ b/build/Targets/Analyzers.Settings.targets
@@ -27,10 +27,27 @@
     <ProjectLanguage Condition="'$(MSBuildProjectExtension)' == '.vcxproj' OR '$(Language)' == 'C++'">C++</ProjectLanguage>
   </PropertyGroup>
   
+  <!-- Import the global NuGet packages -->
+  <PropertyGroup>
+    <ToolsetCompilerPackageName>Microsoft.Net.Compilers</ToolsetCompilerPackageName>
+    <ToolsetCompilerPropsFilePath>$(NuGetPackagesPath)\Microsoft.Net.Compilers.1.0.0-rc2\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
+  </PropertyGroup>
+  
   <!-- Use the compiler server -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <UseSharedCompilation>true</UseSharedCompilation>
   </PropertyGroup>
+  
+  <!-- Import the props file from the toolset NuGet package -->
+  <ImportGroup Label="GlobalNuGets">
+    <Import Project="$(ToolsetCompilerPropsFilePath)"
+            Condition="Exists('$(ToolsetCompilerPropsFilePath)')" />
+  </ImportGroup>
+
+  <Target Name="EnsureGlobalNuGets" Condition="'$(BootstrapBuildPath)' == ''">
+    <Error Condition="!Exists('$(ToolsetCompilerPropsFilePath)')"
+           Text="This project requires the $(ToolsetCompilerPackageName) NuGet package to build. Use NuGet Package Restore to download the required files (&quot;powershell .nuget\NuGetRestore.ps1&quot;). The missing file is &quot;$(ToolsetCompilerPropsFilePath)&quot;." />
+  </Target>
   
   <!-- Common project settings -->
   <PropertyGroup>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <packages>
+  <package id="Microsoft.Net.Compilers" version="1.0.0-rc2" targetFramework="net45" />
   <package id="FakeSign" version="0.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Update the build to use the compilers in the Microsoft.Net.Compilers
NuGet package, rather than the ones installed with MSBuild. This way
the build runs the same regardless of which version of VS you have
installed.
