### PR TITLE
Capture unit test errors

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -10,7 +10,7 @@
 
     <!-- Emit XML in a CIBuild in order to get structured test results -->
     <RunTestArgs>$(RunTestArgs) /noisolation</RunTestArgs>
-    <RunTestArgs Condition="'$(CIBuild)' == 'true'">$(RunTestArgs) /resultsfile:TestResults.trx</RunTestArgs>
+    <RunTestArgs Condition="'$(CIBuild)' == 'true'">$(RunTestArgs) /resultsfile:TestResults.trx /detail:errormessage /detail:errorstacktrace</RunTestArgs>
   </PropertyGroup>
 
   <Target Name="RestorePackages">


### PR DESCRIPTION
In CI builds, log the unit test failures to standard output, not just
the results files. This way they can be viewed even in Jenkins fails to
read the results files.
