### PR TITLE
Preserve trailing trivia

### DIFF
--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/CodeFixProvider.cs
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/CodeFixProvider.cs
@@ -931,7 +931,7 @@ namespace MetaCompilation
             var internalKeyword = SyntaxFactory.ParseToken("internal").WithTrailingTrivia(whiteSpace);
             var staticKeyword = SyntaxFactory.ParseToken("static").WithTrailingTrivia(whiteSpace);
             var modifierList = SyntaxFactory.TokenList(internalKeyword, staticKeyword);
-            var newFieldDeclaration = declaration.WithModifiers(modifierList).WithLeadingTrivia(declaration.GetLeadingTrivia()).WithTrailingTrivia(whiteSpace);
+            var newFieldDeclaration = declaration.WithModifiers(modifierList).WithLeadingTrivia(declaration.GetLeadingTrivia()).WithTrailingTrivia(declaration.GetTrailingTrivia());
 
             return await ReplaceNode(declaration, newFieldDeclaration, document);
         }


### PR DESCRIPTION
The `InternalStaticAsync` method updates an existing field declaration
to have specific accessibility and modifiers. In doing so, it replaces
the trailing trivia with a single space. Under the code formatter in
Roslyn 1.0.0-rc2 this happens to produce the desired output, but it does
not do so using 1.0.0-rc3.

The correct thing to do is to simply preserve the existing trailing
trivia. That should produce the desired output regardless of changes in
the formatter.
