### PR TITLE
Don't force ids to be const

### DIFF
--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/DiagnosticAnalyzer.cs
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/DiagnosticAnalyzer.cs
@@ -2159,7 +2159,7 @@ namespace MetaCompilation
                 List<string> idNames = new List<string>();
                 foreach (IFieldSymbol field in _analyzerFieldSymbols)
                 {
-                    if (field.IsConst && field.IsStatic && field.DeclaredAccessibility == Accessibility.Public && field.Type.SpecialType == SpecialType.System_String)
+                    if (field.IsStatic && field.DeclaredAccessibility == Accessibility.Public && field.Type.SpecialType == SpecialType.System_String)
                     {
                         if (field.Name == null)
                         {


### PR DESCRIPTION
No longer forces ids to be const, just public strings

@tmeschter @jepetty @zoepetard 
