### PR TITLE
Remove options for .Hidden and .Info

### DIFF
--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/UnitTests.cs
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/UnitTests.cs
@@ -9410,7 +9410,7 @@ namespace SyntaxNodeAnalyzer
 
         #region DefaultSeverityError
 
-        public const string DefaultSeverityErrorMessage = MessagePrefix + "The 'defaultSeverity' should be of the form: DiagnosticSeverity.[severity]";
+        public const string DefaultSeverityErrorMessage = MessagePrefix + "The 'defaultSeverity' should be either DiagnosticSeverity.Error or DiagnosticSeverity.Warning";
 
         [Fact]
         public void DefaultSeverity1() // defaultSeverity set to undeclared variable.
@@ -9568,106 +9568,8 @@ namespace SyntaxNodeAnalyzer
     }
 }";
 
-            var fixtestHidden = @"using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-
-namespace SyntaxNodeAnalyzer
-{
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
-    {
-        public const string spacingRuleId = ""IfSpacing"";
-
-        // If the analyzer finds an issue, it will report the DiagnosticDescriptor rule
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-            id: spacingRuleId, // make the id specific
-            title: ""If statement must have a space between 'if' and the boolean expression"", // allow any title
-            messageFormat: ""If statements must contain a space between the 'if' keyword and the boolean expression"", // allow any message
-            category: ""Syntax"", // make the category specific
-            defaultSeverity: DiagnosticSeverity.Hidden, // possible options
-            isEnabledByDefault: true);
-        // defaultSeverity: Is set to DiagnosticSeverity.[severity] where severity can be Error, Warning, Hidden or Info, but can only be Error or Warning for the purposes of this tutorial
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(Rule);
-            }
-        }
-
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
-        }
-
-        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext obj)
-        {
-            throw new NotImplementedException();
-        }
-    }
-}";
-
-            var fixtestInfo = @"using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-
-namespace SyntaxNodeAnalyzer
-{
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
-    {
-        public const string spacingRuleId = ""IfSpacing"";
-
-        // If the analyzer finds an issue, it will report the DiagnosticDescriptor rule
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-            id: spacingRuleId, // make the id specific
-            title: ""If statement must have a space between 'if' and the boolean expression"", // allow any title
-            messageFormat: ""If statements must contain a space between the 'if' keyword and the boolean expression"", // allow any message
-            category: ""Syntax"", // make the category specific
-            defaultSeverity: DiagnosticSeverity.Info, // possible options
-            isEnabledByDefault: true);
-        // defaultSeverity: Is set to DiagnosticSeverity.[severity] where severity can be Error, Warning, Hidden or Info, but can only be Error or Warning for the purposes of this tutorial
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(Rule);
-            }
-        }
-
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
-        }
-
-        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext obj)
-        {
-            throw new NotImplementedException();
-        }
-    }
-}";
-
             VerifyCSharpFix(test, fixtestError, 0);
             VerifyCSharpFix(test, fixtestWarning, 1);
-            VerifyCSharpFix(test, fixtestHidden, 2);
-            VerifyCSharpFix(test, fixtestInfo, 3);
         }
 
         [Fact]
@@ -9823,104 +9725,8 @@ namespace SyntaxNodeAnalyzer
     }
 }";
 
-            var fixtestHidden = @"using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-
-namespace SyntaxNodeAnalyzer
-{
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
-    {
-        public const string spacingRuleId = ""IfSpacing"";
-
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-            id: spacingRuleId, // make the id specific
-            title: ""If statement must have a space between 'if' and the boolean expression"", // allow any title
-            messageFormat: ""If statements must contain a space between the 'if' keyword and the boolean expression"", // allow any message
-            category: ""Syntax"", // make the category specific
-            defaultSeverity: DiagnosticSeverity.Hidden, // possible options
-            isEnabledByDefault: true);
-        // defaultSeverity: Is set to DiagnosticSeverity.[severity] where severity can be Error, Warning, Hidden or Info, but can only be Error or Warning for the purposes of this tutorial
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(Rule);
-            }
-        }
-
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
-        }
-
-        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext obj)
-        {
-            throw new NotImplementedException();
-        }
-    }
-}";
-
-            var fixtestInfo = @"using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-
-namespace SyntaxNodeAnalyzer
-{
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
-    {
-        public const string spacingRuleId = ""IfSpacing"";
-
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-            id: spacingRuleId, // make the id specific
-            title: ""If statement must have a space between 'if' and the boolean expression"", // allow any title
-            messageFormat: ""If statements must contain a space between the 'if' keyword and the boolean expression"", // allow any message
-            category: ""Syntax"", // make the category specific
-            defaultSeverity: DiagnosticSeverity.Info, // possible options
-            isEnabledByDefault: true);
-        // defaultSeverity: Is set to DiagnosticSeverity.[severity] where severity can be Error, Warning, Hidden or Info, but can only be Error or Warning for the purposes of this tutorial
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(Rule);
-            }
-        }
-
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
-        }
-
-        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext obj)
-        {
-            throw new NotImplementedException();
-        }
-    }
-}";
-
             VerifyCSharpFix(test, fixtestError, 0);
             VerifyCSharpFix(test, fixtestWarning, 1);
-            VerifyCSharpFix(test, fixtestHidden, 2);
-            VerifyCSharpFix(test, fixtestInfo, 3);
         }
 
         [Fact]
@@ -10064,96 +9870,8 @@ namespace SyntaxNodeAnalyzer
     }
 }";
 
-            var fixtestHidden = @"using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-namespace SyntaxNodeAnalyzer
-{
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
-    {
-        public const string spacingRuleId = ""IfSpacing"";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-            id: spacingRuleId, // make the id specific
-            title: ""If statement must have a space between 'if' and the boolean expression"", // allow any title
-            messageFormat: ""If statements must contain a space between the 'if' keyword and the boolean expression"", // allow any message
-            category: ""Syntax"", // make the category specific
-            defaultSeverity: DiagnosticSeverity.Hidden, // possible options
-            isEnabledByDefault: true);
-        // defaultSeverity: Is set to DiagnosticSeverity.[severity] where severity can be Error, Warning, Hidden or Info, but can only be Error or Warning for the purposes of this tutorial
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(Rule);
-            }
-        }
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
-        }
-
-        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext obj)
-        {
-            throw new NotImplementedException();
-        }
-    }
-}";
-
-            var fixtestInfo = @"using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-namespace SyntaxNodeAnalyzer
-{
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
-    {
-        public const string spacingRuleId = ""IfSpacing"";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-            id: spacingRuleId, // make the id specific
-            title: ""If statement must have a space between 'if' and the boolean expression"", // allow any title
-            messageFormat: ""If statements must contain a space between the 'if' keyword and the boolean expression"", // allow any message
-            category: ""Syntax"", // make the category specific
-            defaultSeverity: DiagnosticSeverity.Info, // possible options
-            isEnabledByDefault: true);
-        // defaultSeverity: Is set to DiagnosticSeverity.[severity] where severity can be Error, Warning, Hidden or Info, but can only be Error or Warning for the purposes of this tutorial
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(Rule);
-            }
-        }
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
-        }
-
-        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext obj)
-        {
-            throw new NotImplementedException();
-        }
-    }
-}";
-
             VerifyCSharpFix(test, fixtestError, 0);
             VerifyCSharpFix(test, fixtestWarning, 1);
-            VerifyCSharpFix(test, fixtestHidden, 2);
-            VerifyCSharpFix(test, fixtestInfo, 3);
         }
         #endregion
 

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/CodeFixProvider.cs
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/CodeFixProvider.cs
@@ -195,8 +195,6 @@ namespace MetaCompilation
                             ArgumentSyntax declaration = severityDeclarations.First();
                             context.RegisterCodeFix(CodeAction.Create(MessagePrefix + "Set the severity to 'Error' if something is not allowed", c => DiagnosticSeverityError(context.Document, declaration, c), "Set the severity to 'Error' if something is not allowed"), diagnostic);
                             context.RegisterCodeFix(CodeAction.Create(MessagePrefix + "Set the severity to 'Warning' if something is suspicious but allowed", c => DiagnosticSeverityWarning(context.Document, declaration, c), "Set the severity to 'Warning' if something is suspicious but allowed"), diagnostic);
-                            context.RegisterCodeFix(CodeAction.Create(MessagePrefix + "Set the severity to 'Hidden' if something is an issue, but is not surfaced", c => DiagnosticSeverityHidden(context.Document, declaration, c), "Set the severity to 'Hidden' if something is an issue, but is not surfaced"), diagnostic);
-                            context.RegisterCodeFix(CodeAction.Create(MessagePrefix + "Set the severity to 'Info' for information not indicating a problem", c => DiagnosticSeverityInfo(context.Document, declaration, c), "Set the severity to 'Info' for information not indicating a problem"), diagnostic);
                         }
                         break;
                     case MetaCompilationAnalyzer.MissingIdDeclaration:

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/DiagnosticAnalyzer.cs
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/DiagnosticAnalyzer.cs
@@ -101,7 +101,7 @@ namespace MetaCompilation
         internal static DiagnosticDescriptor MissingIdDeclarationRule = CreateRule(MissingIdDeclaration, "Missing Diagnostic id declaration", MessagePrefix + "This diagnostic id should be the constant string declared above", "The id parameter of a DiagnosticDescriptor should be a string constant previously declared. This ensures that the diagnostic id is accessible from the CodeFixProvider.cs file.");
 
         public const string DefaultSeverityError = "MetaAnalyzer016";
-        internal static DiagnosticDescriptor DefaultSeverityErrorRule = CreateRule(DefaultSeverityError, "Incorrect defaultSeverity", MessagePrefix + "The 'defaultSeverity' should be of the form: DiagnosticSeverity.[severity]", "There are four option for the severity of the diagnostic: error, warning, hidden, and info. An error is completely not allowed and causes build errors. A warning is something that might be a problem, but is not a build error. An info diagnostic is simply information and is not actually a problem. A hidden diagnostic is raised as an issue, but it is not accessible through normal means. In simple analyzers, the most common severities are error and warning.");
+        internal static DiagnosticDescriptor DefaultSeverityErrorRule = CreateRule(DefaultSeverityError, "Incorrect defaultSeverity", MessagePrefix + "The 'defaultSeverity' should be either DiagnosticSeverity.Error or DiagnosticSeverity.Warning", "There are four option for the severity of the diagnostic: error, warning, hidden, and info. An error is completely not allowed and causes build errors. A warning is something that might be a problem, but is not a build error. An info diagnostic is simply information and is not actually a problem. A hidden diagnostic is raised as an issue, but it is not accessible through normal means. In simple analyzers, the most common severities are error and warning.");
 
         public const string EnabledByDefaultError = "MetaAnalyzer017";
         internal static DiagnosticDescriptor EnabledByDefaultErrorRule = CreateRule(EnabledByDefaultError, "Incorrect isEnabledByDefault", MessagePrefix + "The 'isEnabledByDefault' field should be set to true", "The 'isEnabledByDefault' field determines whether the diagnostic is enabled by default or the user of the analyzer has to manually enable the diagnostic. Generally, it will be set to true.");
@@ -2256,7 +2256,7 @@ namespace MetaCompilation
                                     {
                                         string identifierExpr = memberAccessExpr.Expression.ToString();
                                         string identifierName = memberAccessExpr.Name.Identifier.Text;
-                                        List<string> severities = new List<string> { "Warning", "Error", "Hidden", "Info" };
+                                        List<string> severities = new List<string> { "Warning", "Error" };
 
                                         if (identifierExpr != "DiagnosticSeverity")
                                         {


### PR DESCRIPTION
Limit the user to using DiagnosticSeverity.Error and
DiagnosticSeverity.Warning

@tmeschter @jepetty @zoepetard 
