### PR TITLE
Update reference to NuGet package

### DIFF
--- a/src/Test/Utilities/DiagnosticsTestUtilities.csproj
+++ b/src/Test/Utilities/DiagnosticsTestUtilities.csproj
@@ -44,7 +44,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-05\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/Test/Utilities/packages.config
+++ b/src/Test/Utilities/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-05" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net452" />


### PR DESCRIPTION
Fix test failure caused by improperly signed Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll
on machine not skipping SN verification.

@tmeschter @srivatsn 