### PR TITLE
Don't deploy extensions during BuildAndTest

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -26,7 +26,7 @@
   <Target Name="Build" DependsOnTargets="RestorePackages">
     <MSBuild BuildInParallel="true"
              Projects="$(SolutionFile)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
+             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=false"
              Targets="Build"/>
   </Target>
 
@@ -42,7 +42,7 @@
   <Target Name="Rebuild">
     <MSBuild BuildInParallel="true"
              Projects="$(SolutionFile)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
+             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=false"
              Targets="Rebuild"/>
   </Target>
 


### PR DESCRIPTION
Don't deploy VS extensions when running BuildAndTest.proj. Since we only run
unit tests, there's no need to do this step.

This also avoids issues when the extension can't be updated for whatever reason.