### PR TITLE
Code fix that creates immutable array also inserts rule arguments

### DIFF
--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/UnitTests.cs
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/UnitTests.cs
@@ -11988,10 +11988,9 @@ namespace SyntaxNodeAnalyzer
         }
         #endregion
 
-        #region AccessorReturnValue (fix for IncorrectAccessorReturn & SuppDiagReturn)
+        #region IncorrectAccessorReturn
         
         private const string s_incorrectAccessorReturnMessage = s_messagePrefix + "The get-accessor should return an ImmutableArray containing all of the DiagnosticDescriptor rules";
-        private const string s_suppDiagReturnValueMessage = s_messagePrefix + "The 'SupportedDiagnostics' property's get-accessor should return an ImmutableArray containing all DiagnosticDescriptor rules";
 
         [Fact]
         public void IncorrectAccessorReturn1() // empty get accessor
@@ -12081,7 +12080,7 @@ namespace SyntaxNodeAnalyzer
             get
             {
                 // This array contains all the diagnostics that can be shown to the user
-                return ImmutableArray.Create();
+                return ImmutableArray.Create(Rule);
             }
         }
 
@@ -12188,7 +12187,7 @@ namespace SyntaxNodeAnalyzer
             get
             {
                 // This array contains all the diagnostics that can be shown to the user
-                return ImmutableArray.Create();
+                return ImmutableArray.Create(Rule);
             }
         }
 
@@ -12295,7 +12294,7 @@ namespace SyntaxNodeAnalyzer
             get
             {
                 // This array contains all the diagnostics that can be shown to the user
-                return ImmutableArray.Create();
+                return ImmutableArray.Create(Rule);
             }
         }
 
@@ -12402,7 +12401,7 @@ namespace SyntaxNodeAnalyzer
             get
             {
                 // This array contains all the diagnostics that can be shown to the user
-                return ImmutableArray.Create();
+                return ImmutableArray.Create(Rule);
             }
         }
 
@@ -12509,7 +12508,7 @@ namespace SyntaxNodeAnalyzer
             get
             {
                 // This array contains all the diagnostics that can be shown to the user
-                return ImmutableArray.Create();
+                return ImmutableArray.Create(Rule);
             }
         }
 
@@ -12617,7 +12616,7 @@ namespace SyntaxNodeAnalyzer
             get
             {
                 // This array contains all the diagnostics that can be shown to the user
-                var array = ImmutableArray.Create();
+                var array = ImmutableArray.Create(Rule);
                 return array;
             }
         }
@@ -12636,115 +12635,11 @@ namespace SyntaxNodeAnalyzer
 
             VerifyCSharpFix(test, fixtest, allowNewCompilerDiagnostics: true);
         }
+        #endregion
 
-        [Fact]
-        public void IncorrectAccessorReturn7() // variable declaration form, incorrect invocation expression
-        {
-            var test = @"using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
+        #region SuppDiagReturn
 
-namespace SyntaxNodeAnalyzer
-{
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
-    {
-        public const string spacingRuleId = ""IfSpacing"";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-            id: spacingRuleId,
-            title: ""title"",
-            messageFormat: ""message"",
-            category: ""Syntax"",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                var array = ImmutableArray.Equals();
-                return array;
-            }
-        }
-
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
-        }
-
-        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext context)
-        {
-            throw new NotImplementedException();
-        }
-    }
-}";
-
-            var expected = new DiagnosticResult
-            {
-                Id = MetaCompilationAnalyzer.IncorrectAccessorReturn,
-                Message = s_incorrectAccessorReturnMessage,
-                Severity = DiagnosticSeverity.Error,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 30, 44) }
-            };
-
-            VerifyCSharpDiagnostic(test, expected);
-
-            var fixtest = @"using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-
-namespace SyntaxNodeAnalyzer
-{
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
-    {
-        public const string spacingRuleId = ""IfSpacing"";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-            id: spacingRuleId,
-            title: ""title"",
-            messageFormat: ""message"",
-            category: ""Syntax"",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                // This array contains all the diagnostics that can be shown to the user
-                var array = ImmutableArray.Create();
-                return array;
-            }
-        }
-
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
-        }
-
-        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext context)
-        {
-            throw new NotImplementedException();
-        }
-    }
-}";
-
-            VerifyCSharpFix(test, fixtest, allowNewCompilerDiagnostics: true);
-        }
+        private const string s_suppDiagReturnValueMessage = s_messagePrefix + "The 'SupportedDiagnostics' property's get-accessor should return an ImmutableArray containing all DiagnosticDescriptor rules";
 
         [Fact]
         public void SuppDiagReturn1() // invocation expression form, incorrect invocation expression
@@ -12799,7 +12694,7 @@ namespace SyntaxNodeAnalyzer
                 Id = MetaCompilationAnalyzer.SuppDiagReturnValue,
                 Message = s_suppDiagReturnValueMessage,
                 Severity = DiagnosticSeverity.Error,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 30, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 30, 24) }
             };
 
             VerifyCSharpDiagnostic(test, expected);
@@ -12835,6 +12730,115 @@ namespace SyntaxNodeAnalyzer
             {
                 // This array contains all the diagnostics that can be shown to the user
                 return ImmutableArray.Create();
+            }
+        }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
+        }
+
+        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}";
+
+            VerifyCSharpFix(test, fixtest, allowNewCompilerDiagnostics: true);
+        }
+
+        [Fact]
+        public void SuppDiagReturn2() // variable declaration form, incorrect invocation expression
+        {
+            var test = @"using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace SyntaxNodeAnalyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
+    {
+        public const string spacingRuleId = ""IfSpacing"";
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            id: spacingRuleId,
+            title: ""title"",
+            messageFormat: ""message"",
+            category: ""Syntax"",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                var array = ImmutableArray.Equals();
+                return array;
+            }
+        }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
+        }
+
+        private void AnalyzeIfStatement(SyntaxNodeAnalysisContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}";
+
+            var expected = new DiagnosticResult
+            {
+                Id = MetaCompilationAnalyzer.SuppDiagReturnValue,
+                Message = s_suppDiagReturnValueMessage,
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 30, 44) }
+            };
+
+            VerifyCSharpDiagnostic(test, expected);
+
+            var fixtest = @"using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace SyntaxNodeAnalyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SyntaxNodeAnalyzerAnalyzer : DiagnosticAnalyzer
+    {
+        public const string spacingRuleId = ""IfSpacing"";
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            id: spacingRuleId,
+            title: ""title"",
+            messageFormat: ""message"",
+            category: ""Syntax"",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                // This array contains all the diagnostics that can be shown to the user
+                var array = ImmutableArray.Create();
+                return array;
             }
         }
 

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/CodeFixProvider.cs
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/CodeFixProvider.cs
@@ -472,7 +472,6 @@ namespace MetaCompilation
                         }
                         break;
                     case MetaCompilationAnalyzer.SuppDiagReturnValue:
-                    case MetaCompilationAnalyzer.IncorrectAccessorReturn:
                         IEnumerable<PropertyDeclarationSyntax> incorrectAccessorDeclarations = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<PropertyDeclarationSyntax>();
                         if (incorrectAccessorDeclarations.Count() != 0)
                         {
@@ -480,12 +479,20 @@ namespace MetaCompilation
                             context.RegisterCodeFix(CodeAction.Create(MessagePrefix + "Return an ImmutableArray of DiagnosticDescriptors from SupportedDiagnostics", c => AccessorReturnValueAsync(context.Document, declaration, c), "Return an ImmutableArray of DiagnosticDescriptors from SupportedDiagnostics"), diagnostic);
                         }
                         break;
+                    case MetaCompilationAnalyzer.IncorrectAccessorReturn:
+                        IEnumerable<ClassDeclarationSyntax> accessorReturnDeclarations = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<ClassDeclarationSyntax>();
+                        if (accessorReturnDeclarations.Count() != 0)
+                        {
+                            ClassDeclarationSyntax declaration = accessorReturnDeclarations.First();
+                            context.RegisterCodeFix(CodeAction.Create(MessagePrefix + "Return an ImmutableArray of all DiagnosticDescriptors that can be reported", c => AccessorWithRulesAsync(context.Document, declaration, c), "Return an ImmutableArray of all DiagnosticDescriptors that can be reported"), diagnostic);
+                        }
+                        break;
                     case MetaCompilationAnalyzer.SupportedRules:
                         IEnumerable<ClassDeclarationSyntax> rulesDeclarations = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<ClassDeclarationSyntax>();
                         if (rulesDeclarations.Count() != 0)
                         {
                             ClassDeclarationSyntax declaration = rulesDeclarations.First();
-                            context.RegisterCodeFix(CodeAction.Create(MessagePrefix + "Return a list of all diagnostics that can be reported by this analyzer", c => SupportedRulesAsync(context.Document, declaration, c), "Return a list of all diagnostics that can be reported by this analyzer"), diagnostic);
+                            context.RegisterCodeFix(CodeAction.Create(MessagePrefix + "Return a list of all diagnostics that can be reported by this analyzer", c => AccessorWithRulesAsync(context.Document, declaration, c), "Return a list of all diagnostics that can be reported by this analyzer"), diagnostic);
                         }
                         break;
                     case MetaCompilationAnalyzer.MissingSuppDiag:
@@ -1574,7 +1581,7 @@ namespace MetaCompilation
             return await ReplaceNode(declaration, newPropertyDeclaration, document);
         }
 
-        // return an ImmutableArray from the get accessor
+        // inserts ImmutableArray.Create()
         private async Task<Document> AccessorReturnValueAsync(Document document, PropertyDeclarationSyntax declaration, CancellationToken c)
         {
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
@@ -1631,20 +1638,10 @@ namespace MetaCompilation
             return newDocument;
         }
 
-        // adds all rules to the SupportedDiagnostics ImmutableArray
-        private async Task<Document> SupportedRulesAsync(Document document, ClassDeclarationSyntax declaration, CancellationToken c)
+        // inserts ImmutableArray.Create(all rules)
+        private async Task<Document> AccessorWithRulesAsync(Document document, ClassDeclarationSyntax declaration, CancellationToken c)
         {
-            List<string> ruleNames = new List<string>();
-            var fieldMembers = declaration.Members.OfType<FieldDeclarationSyntax>();
-            foreach (FieldDeclarationSyntax fieldSyntax in fieldMembers)
-            {
-                var fieldType = fieldSyntax.Declaration.Type as IdentifierNameSyntax;
-                if (fieldType != null && fieldType.Identifier.Text == "DiagnosticDescriptor")
-                {
-                    string ruleName = fieldSyntax.Declaration.Variables[0].Identifier.Text;
-                    ruleNames.Add(ruleName);
-                }
-            }
+            List<string> ruleNames = CodeFixHelper.GetAllRuleNames(declaration);
 
             var propertyMembers = declaration.Members.OfType<PropertyDeclarationSyntax>();
             foreach (PropertyDeclarationSyntax propertySyntax in propertyMembers)
@@ -1654,56 +1651,33 @@ namespace MetaCompilation
                     continue;
                 }
 
-                AccessorDeclarationSyntax getAccessor = propertySyntax.AccessorList.Accessors.First();
-                var returnStatement = getAccessor.Body.Statements.First() as ReturnStatementSyntax;
-                InvocationExpressionSyntax invocationExpression = null;
-                if (returnStatement == null)
-                {
-                    var declarationStatement = getAccessor.Body.Statements.First() as LocalDeclarationStatementSyntax;
-                    if (declarationStatement == null)
-                    {
-                        return document;
-                    }
-
-                    invocationExpression = declarationStatement.Declaration.Variables[0].Initializer.Value as InvocationExpressionSyntax;
-                }
-                else
-                {
-                    invocationExpression = returnStatement.Expression as InvocationExpressionSyntax;
-                }
-
-                var oldArgumentList = invocationExpression.ArgumentList as ArgumentListSyntax;
-
-                string argumentListString = "";
-                foreach (string ruleName in ruleNames)
-                {
-                    if (ruleName == ruleNames.First())
-                    {
-                        argumentListString += ruleName;
-                    }
-                    else
-                    {
-                        argumentListString += ", " + ruleName;
-                    }
-                }
-
-                ArgumentListSyntax argumentListSyntax = SyntaxFactory.ParseArgumentList("(" + argumentListString + ")");
+                SyntaxList<SyntaxNode> nodeArgs = CodeFixHelper.CreateRuleList(document, ruleNames);
                 SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
+                var newInvocationExpression = (generator.InvocationExpression(generator.MemberAccessExpression(generator.IdentifierName("ImmutableArray"), "Create"), nodeArgs));
+                var leadingTrivia = SyntaxFactory.TriviaList(SyntaxFactory.ParseLeadingTrivia("// This array contains all the diagnostics that can be shown to the user").ElementAt(0), SyntaxFactory.EndOfLine("\r\n"));
+                var newReturnStatement = generator.ReturnStatement(newInvocationExpression).WithLeadingTrivia(leadingTrivia);
+                AccessorDeclarationSyntax getAccessor = propertySyntax.AccessorList.Accessors.First();
 
-                SeparatedSyntaxList<ArgumentSyntax> args = argumentListSyntax.Arguments;
-                var nodeArgs = new SyntaxList<SyntaxNode>();
-                foreach (ArgumentSyntax arg in args)
+                if (getAccessor.Body.Statements.Count == 0)
                 {
-                    nodeArgs = nodeArgs.Add(arg as SyntaxNode);
+                    return await ReplaceNode(getAccessor, getAccessor.AddBodyStatements(newReturnStatement as ReturnStatementSyntax), document);
                 }
 
-                if (invocationExpression.FirstAncestorOrSelf<ReturnStatementSyntax>() == null)
+                var localDeclaration = getAccessor.Body.Statements.First() as LocalDeclarationStatementSyntax;
+                var returnStatement = getAccessor.Body.Statements.First() as ReturnStatementSyntax;
+                var otherStatement = getAccessor.Body.Statements.First();
+
+                if (localDeclaration != null)
                 {
-                    return await ReplaceNode(invocationExpression.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>(), generator.LocalDeclarationStatement(invocationExpression.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>().Declaration.Variables[0].Identifier.Text, generator.InvocationExpression(generator.MemberAccessExpression(generator.IdentifierName("ImmutableArray"), "Create"), nodeArgs)).WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ParseLeadingTrivia("// This array contains all the diagnostics that can be shown to the user").ElementAt(0), SyntaxFactory.EndOfLine("\r\n"))), document);
+                    return await ReplaceNode(localDeclaration, generator.LocalDeclarationStatement(localDeclaration.Declaration.Variables[0].Identifier.Text, newInvocationExpression).WithLeadingTrivia(leadingTrivia), document);
                 }
-                else
+                else if (returnStatement != null)
                 {
-                    return await ReplaceNode(invocationExpression.Parent, generator.ReturnStatement(generator.InvocationExpression(generator.MemberAccessExpression(generator.IdentifierName("ImmutableArray"), "Create"), nodeArgs)).WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ParseLeadingTrivia("// This array contains all the diagnostics that can be shown to the user").ElementAt(0), SyntaxFactory.EndOfLine("\r\n"))), document);
+                    return await ReplaceNode(returnStatement, newReturnStatement, document);
+                }
+                else if (otherStatement != null)
+                {
+                    return await ReplaceNode(otherStatement, newReturnStatement, document);
                 }
             }
 
@@ -2433,6 +2407,51 @@ namespace MetaCompilation
 
                 SyntaxNode newDeclaration = generator.MethodDeclaration(methodName, parameters, returnType: returnType, accessibility: Accessibility.Private, statements: statements);
                 return newDeclaration;
+            }
+
+            protected internal static List<string> GetAllRuleNames(ClassDeclarationSyntax declaration)
+            {
+                List<string> ruleNames = new List<string>();
+                var fieldMembers = declaration.Members.OfType<FieldDeclarationSyntax>();
+                foreach (FieldDeclarationSyntax fieldSyntax in fieldMembers)
+                {
+                    var fieldType = fieldSyntax.Declaration.Type as IdentifierNameSyntax;
+                    if (fieldType != null && fieldType.Identifier.Text == "DiagnosticDescriptor")
+                    {
+                        string ruleName = fieldSyntax.Declaration.Variables[0].Identifier.Text;
+                        ruleNames.Add(ruleName);
+                    }
+                }
+                return ruleNames;
+            }
+
+            protected internal static SyntaxList<SyntaxNode> CreateRuleList(Document document, List<string> ruleNames)
+            {
+              
+                string argumentListString = "";
+                foreach (string ruleName in ruleNames)
+                {
+                    if (ruleName == ruleNames.First())
+                    {
+                        argumentListString += ruleName;
+                    }
+                    else
+                    {
+                        argumentListString += ", " + ruleName;
+                    }
+                }
+
+                ArgumentListSyntax argumentListSyntax = SyntaxFactory.ParseArgumentList("(" + argumentListString + ")");
+                SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
+
+                SeparatedSyntaxList<ArgumentSyntax> args = argumentListSyntax.Arguments;
+                var nodeArgs = new SyntaxList<SyntaxNode>();
+                foreach (ArgumentSyntax arg in args)
+                {
+                    nodeArgs = nodeArgs.Add(arg as SyntaxNode);
+                }
+
+                return nodeArgs;
             }
         }
     }


### PR DESCRIPTION
Fix issue #233 
Any code fix that creates immutable array also inserts rule arguments
EXCEPT if the invocation expression itself is wrong eg
"ImmutableArary.Equals()"

@daking2014  @jepetty 