### PR TITLE
Fix issues of NuGet arthoring projects in FxCop analyzers

### DIFF
--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzers.csproj
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzers.csproj
@@ -82,11 +82,15 @@
     <InternalsVisibleToTest Include="Desktop.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="DesktopAnalyzers.nuspec" />
+    <None Include="install.ps1" />
+    <None Include="uninstall.ps1" />
+    <None Include="ThirdPartyNotices.rtf" />
     <Content Include="..\Desktop.Analyzers.Common.props">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Security\SecurityTypes.cs" />

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzers.nuspec
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzers.nuspec
@@ -4,7 +4,7 @@
     <id>Desktop.Analyzers</id>
     <summary>Desktop Analyzers</summary>
     <description>
-      Analyzers for the APIs only exist in .NET Framework.
+      Analyzers for APIs specific to the desktop .NET Framework.
     </description>
     <dependencies>
     </dependencies>

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzers.nuspec
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzers.nuspec
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>System.Runtime.InteropServices.Analyzers</id>
-    <summary>System.Runtime.InteropServices Analyzers</summary>
+    <id>Desktop.Analyzers</id>
+    <summary>Desktop Analyzers</summary>
     <description>
-      Analyzers for the APIs in System.Runtime.InteropServices
+      Analyzers for the APIs only exist in .NET Framework.
     </description>
     <dependencies>
     </dependencies>
@@ -22,14 +22,13 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="$binaries$System.Runtime.InteropServices.Analyzers.dll" target="analyzers\dotnet\cs" />
-    <file src="$binaries$System.Runtime.InteropServices.CSharp.Analyzers.dll" target="analyzers\dotnet\cs" />
-    <file src="$binaries$System.Runtime.InteropServices.Analyzers.dll" target="analyzers\dotnet\vb" />
-    <file src="$binaries$System.Runtime.InteropServices.VisualBasic.Analyzers.dll" target="analyzers\dotnet\vb" />
-    <file src="$binaries$System.Runtime.InteropServices.Analyzers.Common.props" target="build" />
+    <file src="$binaries$Desktop.Analyzers.dll" target="analyzers\dotnet\cs" />
+    <file src="$binaries$Desktop.CSharp.Analyzers.dll" target="analyzers\dotnet\cs" />
+    <file src="$binaries$Desktop.Analyzers.dll" target="analyzers\dotnet\vb" />
+    <file src="$binaries$Desktop.VisualBasic.Analyzers.dll" target="analyzers\dotnet\vb" />
+    <file src="$binaries$Desktop.Analyzers.Common.props" target="build" />
     <file src="install.ps1" target="tools" />
     <file src="uninstall.ps1" target="tools" />
     <file src="ThirdPartyNotices.rtf" target="" />
   </files>
 </package>
-

--- a/src/FxCop/Desktop.Analyzers/Core/ThirdPartyNotices.rtf
+++ b/src/FxCop/Desktop.Analyzers/Core/ThirdPartyNotices.rtf
@@ -1,0 +1,54 @@
+{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033\deflangfe1033{\fonttbl{\f0\fswiss\fprq2\fcharset0 Tahoma;}}
+{\colortbl ;\red0\green0\blue255;}
+{\*\generator Riched20 10.0.10037}{\*\mmathPr\mnaryLim0\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
+\pard\nowidctlpar\sb120\sa120\f0\fs19 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION\par
+Do Not Translate or Localize\par
+\par
+This file provides information regarding components that are being relicensed to you by Microsoft Corporation under Microsoft's software licensing terms. Microsoft Corporation reserves all rights not expressly granted herein.\par
+\par
+%% \caps .NET Compiler Platform\caps0  NOTICES AND INFORMATION BEGIN HERE\par
+=========================================\par
+Copyright (C) .NET Foundation. All rights reserved.\par
+\par
+Apache License, Version 2.0\par
+Apache License\par
+Version 2.0, January 2004\par
+{{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/ }}{\fldrslt{http://www.apache.org/licenses/\ul0\cf0}}}}\f0\fs19\par
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\par
+1. Definitions.\par
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.\par
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.\par
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.\par
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.\par
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.\par
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.\par
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).\par
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.\par
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."\par
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.\par
+2. Grant of Copyright License.\par
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.\par
+3. Grant of Patent License.\par
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.\par
+4. Redistribution.\par
+You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:\par
+1. You must give any other recipients of the Work or Derivative Works a copy of this License; and\par
+2. You must cause any modified files to carry prominent notices stating that You changed the files; and\par
+3. You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and\par
+4. If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.\par
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.\par
+5. Submission of Contributions.\par
+Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.\par
+6. Trademarks.\par
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.\par
+7. Disclaimer of Warranty.\par
+Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.\par
+8. Limitation of Liability.\par
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.\par
+9. Accepting Warranty or Additional Liability.\par
+While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.\par
+END OF TERMS AND CONDITIONS\par
+=========================================\par
+END OF \caps .NET Compiler Platform\caps0  NOTICES AND INFORMATION\par
+}
+ 

--- a/src/FxCop/Desktop.Analyzers/Core/install.ps1
+++ b/src/FxCop/Desktop.Analyzers/Core/install.ps1
@@ -1,0 +1,49 @@
+﻿param($installPath, $toolsPath, $package, $project)
+
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+
+foreach($analyzersPath in $analyzersPaths)
+{
+    # Install the language agnostic analyzers.
+    if (Test-Path $analyzersPath)
+    {
+        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        {
+            if($project.Object.AnalyzerReferences)
+            {
+                $project.Object.AnalyzerReferences.Add($analyzerFilePath.FullName)
+            }
+        }
+    }
+}
+
+# $project.Type gives the language name like (C# or VB.NET)
+$languageFolder = ""
+if($project.Type -eq "C#")
+{
+    $languageFolder = "cs"
+}
+if($project.Type -eq "VB.NET")
+{
+    $languageFolder = "vb"
+}
+if($languageFolder -eq "")
+{
+    return
+}
+
+foreach($analyzersPath in $analyzersPaths)
+{
+    # Install language specific analyzers.
+    $languageAnalyzersPath = join-path $analyzersPath $languageFolder
+    if (Test-Path $languageAnalyzersPath)
+    {
+        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        {
+            if($project.Object.AnalyzerReferences)
+            {
+                $project.Object.AnalyzerReferences.Add($analyzerFilePath.FullName)
+            }
+        }
+    }
+}

--- a/src/FxCop/Desktop.Analyzers/Core/uninstall.ps1
+++ b/src/FxCop/Desktop.Analyzers/Core/uninstall.ps1
@@ -1,0 +1,56 @@
+﻿param($installPath, $toolsPath, $package, $project)
+
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+
+foreach($analyzersPath in $analyzersPaths)
+{
+    # Uninstall the language agnostic analyzers.
+    if (Test-Path $analyzersPath)
+    {
+        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        {
+            if($project.Object.AnalyzerReferences)
+            {
+                $project.Object.AnalyzerReferences.Remove($analyzerFilePath.FullName)
+            }
+        }
+    }
+}
+
+# $project.Type gives the language name like (C# or VB.NET)
+$languageFolder = ""
+if($project.Type -eq "C#")
+{
+    $languageFolder = "cs"
+}
+if($project.Type -eq "VB.NET")
+{
+    $languageFolder = "vb"
+}
+if($languageFolder -eq "")
+{
+    return
+}
+
+foreach($analyzersPath in $analyzersPaths)
+{
+    # Uninstall language specific analyzers.
+    $languageAnalyzersPath = join-path $analyzersPath $languageFolder
+    if (Test-Path $languageAnalyzersPath)
+    {
+        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        {
+            if($project.Object.AnalyzerReferences)
+            {
+                try
+                {
+                    $project.Object.AnalyzerReferences.Remove($analyzerFilePath.FullName)
+                }
+                catch
+                {
+
+                }
+            }
+        }
+    }
+}

--- a/src/FxCop/Desktop.Analyzers/NuGet/DesktopAnalyzers.NuGet.proj
+++ b/src/FxCop/Desktop.Analyzers/NuGet/DesktopAnalyzers.NuGet.proj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="Settings">
+    <Import Project="..\..\..\..\build\Targets\Analyzers.Settings.targets" />
+    <Import Project="..\..\..\..\build\Targets\Analyzers.NuGet.Settings.targets" />
+  </ImportGroup>
+  <PropertyGroup>
+    <SemanticVersion>$(DesktopAnalyzersSemanticVersion)</SemanticVersion>
+    <PreReleaseVersion>$(DesktopAnalyzersPreReleaseVersion)</PreReleaseVersion>
+    <NuGetLicenseURL>$(NuGetLicenseURLRedist)</NuGetLicenseURL>
+  </PropertyGroup>
+  <ItemGroup>
+    <NuSpec Include="..\Core\DesktopAnalyzers.nuspec" />
+  </ItemGroup>
+  <ImportGroup Label="Targets">
+    <Import Project="..\..\..\..\build\Targets\Analyzers.Imports.targets" />
+    <Import Project="..\..\..\..\build\Targets\Analyzers.NuGet.Imports.targets" />
+  </ImportGroup>
+</Project>

--- a/src/FxCop/System.Runtime.Analyzers/Core/SystemRuntimeAnalyzers.nuspec
+++ b/src/FxCop/System.Runtime.Analyzers/Core/SystemRuntimeAnalyzers.nuspec
@@ -2,10 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>System.Runtime.Analyzers</id>
-    <summary>Analyzers for .NET System.Runtime APIs</summary>
+    <summary>System.Runtime Analyzers</summary>
     <description>
-      Guidelines for using .NET System.Runtime APIs.
+      Analyzers for the APIs in System.Runtime.
     </description>
+    <dependencies>
+    </dependencies>
 
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -15,7 +17,6 @@
     <projectUrl>$projectUrl$</projectUrl>
     <releaseNotes>$releaseNotes$</releaseNotes>
     <tags>$tags$ analyzers</tags>
-
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
@@ -25,8 +26,11 @@
     <file src="$binaries$System.Runtime.CSharp.Analyzers.dll" target="analyzers\dotnet\cs" />
     <file src="$binaries$System.Runtime.Analyzers.dll" target="analyzers\dotnet\vb" />
     <file src="$binaries$System.Runtime.VisualBasic.Analyzers.dll" target="analyzers\dotnet\vb" />
-    <file src="Install.ps1" target="tools" />
-    <file src="Uninstall.ps1" target="tools" />
+    <file src="$binaries$System.Runtime.Analyzers.Common.props" target="build" />
+    <file src="$binaries$System.Runtime.CSharp.Analyzers.props" target="build" />
+    <file src="$binaries$System.Runtime.VisualBasic.Analyzers.props" target="build" />
+    <file src="install.ps1" target="tools" />
+    <file src="uninstall.ps1" target="tools" />
     <file src="ThirdPartyNotices.rtf" target="" />
   </files>
 </package>

--- a/src/Packaging/Packaging.proj
+++ b/src/Packaging/Packaging.proj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <Project Include="..\MetaCompilation\MetaCompilation\MetaCompilation.Nuget\MetaCompilation.Nuget.proj" />
     <Project Include="..\CodeAnalysis\NuGet\CodeAnalysisDiagnosticAnalyzers.NuGet.proj" />
-    <Project Include="..\FxCop\Desktop.Analyzers\NuGet\DEsktopAnalyzers.NuGet.proj" />
+    <Project Include="..\FxCop\Desktop.Analyzers\NuGet\DesktopAnalyzers.NuGet.proj" />
     <Project Include="..\FxCop\System.Runtime.Analyzers\NuGet\SystemRuntimeAnalyzers.NuGet.proj" />
     <Project Include="..\FxCop\System.Runtime.InteropServices.Analyzers\NuGet\SystemRuntimeInteropServicesAnalyzers.NuGet.proj" />
     <Project Include="..\AnalyzerPowerPack\NuGet\AnalyzerPowerPack.NuGet.proj" />

--- a/src/Packaging/Packaging.proj
+++ b/src/Packaging/Packaging.proj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <Project Include="..\MetaCompilation\MetaCompilation\MetaCompilation.Nuget\MetaCompilation.Nuget.proj" />
     <Project Include="..\CodeAnalysis\NuGet\CodeAnalysisDiagnosticAnalyzers.NuGet.proj" />
+    <Project Include="..\FxCop\Desktop.Analyzers\NuGet\DEsktopAnalyzers.NuGet.proj" />
     <Project Include="..\FxCop\System.Runtime.Analyzers\NuGet\SystemRuntimeAnalyzers.NuGet.proj" />
     <Project Include="..\FxCop\System.Runtime.InteropServices.Analyzers\NuGet\SystemRuntimeInteropServicesAnalyzers.NuGet.proj" />
     <Project Include="..\AnalyzerPowerPack\NuGet\AnalyzerPowerPack.NuGet.proj" />


### PR DESCRIPTION
- Make content of existing nuspec files identical to their counterpart in dotnet/roslyn repo.
- Add Nuget authoring to Desktop.Analyzers.

@tmeschter @srivatsn @mavasani @lgolding 