### PR TITLE
Add support for signing files

### DIFF
--- a/build/Targets/Analyzers.Imports.targets
+++ b/build/Targets/Analyzers.Imports.targets
@@ -152,6 +152,24 @@
   </Target>
 
   <!-- ====================================================================================
+  
+         Support for real-signing assemblies
+
+       ==================================================================================== -->
+
+  <PropertyGroup>
+    <OutputExtension Condition="'$(OutputType)' == 'Library'">dll</OutputExtension>
+    <OutputExtension Condition="'$(OutputType)' == 'Exe'">exe</OutputExtension>
+  </PropertyGroup>
+  
+  <ItemGroup Condition="'$(DelaySign)' == 'true' AND '$(ShouldSignBuild)' == 'true' AND ('$(Language)' == 'C#' OR '$(Language)' == 'VB')">
+    <FilesToSign Include="$(OutDir)\$(OutputName).$(OutputExtension)">
+      <AuthenticodeCertificateName>MicrosoftSHA1</AuthenticodeCertificateName>
+      <StrongName>MsSharedLib72</StrongName>
+    </FilesToSign>
+  </ItemGroup>
+
+  <!-- ====================================================================================
        
          Generation of AssemblyVersion attributes from the BuildVersion property
        


### PR DESCRIPTION
Add support for signing files.

If a file has been delay-signed and we're real-signing the build, we
create a <FilesToSign> item pointing at the output binary. The Microsoft
build systems will use this to sign the appropriate binaries at the end
of a project build.

Note that this currently only supports signing .dll and .exe binaries;
it does not yet support signing .vsix files.