### PR TITLE
Fix signed file name

### DIFF
--- a/build/Targets/Analyzers.Imports.targets
+++ b/build/Targets/Analyzers.Imports.targets
@@ -156,14 +156,9 @@
          Support for real-signing assemblies
 
        ==================================================================================== -->
-
-  <PropertyGroup>
-    <OutputExtension Condition="'$(OutputType)' == 'Library'">dll</OutputExtension>
-    <OutputExtension Condition="'$(OutputType)' == 'Exe'">exe</OutputExtension>
-  </PropertyGroup>
   
   <ItemGroup Condition="'$(DelaySign)' == 'true' AND '$(ShouldSignBuild)' == 'true' AND ('$(Language)' == 'C#' OR '$(Language)' == 'VB')">
-    <FilesToSign Include="$(OutDir)\$(OutputName).$(OutputExtension)">
+    <FilesToSign Include="$(OutDir)$(TargetFileName)">
       <AuthenticodeCertificateName>MicrosoftSHA1</AuthenticodeCertificateName>
       <StrongName>MsSharedLib72</StrongName>
     </FilesToSign>


### PR DESCRIPTION
Fix how we compute the signed file name.

Right now we're computing a property, OutputExtension, based on
OutputType. We're also using another property, OutputName, which doesn't
actually exist as it turns out.

Instead, use TargetFileName.