### PR TITLE
Fix Authenticode signing

### DIFF
--- a/build/Targets/Analyzers.Imports.targets
+++ b/build/Targets/Analyzers.Imports.targets
@@ -159,7 +159,7 @@
   
   <ItemGroup Condition="'$(DelaySign)' == 'true' AND '$(ShouldSignBuild)' == 'true' AND ('$(Language)' == 'C#' OR '$(Language)' == 'VB')">
     <FilesToSign Include="$(OutDir)$(TargetFileName)">
-      <AuthenticodeCertificateName>MicrosoftSHA1</AuthenticodeCertificateName>
+      <Authenticode>MicrosoftSHA1</Authenticode>
       <StrongName>MsSharedLib72</StrongName>
     </FilesToSign>
   </ItemGroup>


### PR DESCRIPTION
Fix Authenticode signing. The wrong item metadata was being set to
indicate the certificate to use. We need to set the `<Authenticode>`
metadata, not `<AuthenticodeCertficateName>`.