### PR TITLE
Correct removed api logic

### DIFF
--- a/src/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.Impl.cs
@@ -30,12 +30,24 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             }
         }
 
+        private struct RemovedApiLine
+        {
+            public readonly string Text;
+            public readonly ApiLine ApiLine;
+
+            internal RemovedApiLine(string text, ApiLine apiLine)
+            {
+                Text = text;
+                ApiLine = apiLine;
+            }
+        }
+
         private struct ApiData
         {
             public readonly ImmutableArray<ApiLine> ApiList;
-            public readonly ImmutableArray<ApiLine> RemovedApiList;
+            public readonly ImmutableArray<RemovedApiLine> RemovedApiList;
 
-            internal ApiData(ImmutableArray<ApiLine> apiList, ImmutableArray<ApiLine> removedApiList)
+            internal ApiData(ImmutableArray<ApiLine> apiList, ImmutableArray<RemovedApiLine> removedApiList)
             {
                 ApiList = apiList;
                 RemovedApiList = removedApiList;

--- a/src/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
+++ b/src/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
@@ -190,7 +190,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
         private static ApiData ReadApiData(string path, SourceText sourceText)
         {
             var apiBuilder = ImmutableArray.CreateBuilder<ApiLine>();
-            var removedBuilder = ImmutableArray.CreateBuilder<ApiLine>();
+            var removedBuilder = ImmutableArray.CreateBuilder<RemovedApiLine>();
 
             foreach (var line in sourceText.Lines)
             {
@@ -203,7 +203,8 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
                 var apiLine = new ApiLine(text, line.Span, sourceText, path);
                 if (text.StartsWith(RemovedApiPrefix, StringComparison.Ordinal))
                 {
-                    removedBuilder.Add(apiLine);
+                    var removedtext = text.Substring(RemovedApiPrefix.Length);
+                    removedBuilder.Add(new RemovedApiLine(removedtext, apiLine));
                 }
                 else
                 {

--- a/src/Roslyn/Test/ApiDesign/DeclarePublicAPIAnalyzerTests.cs
+++ b/src/Roslyn/Test/ApiDesign/DeclarePublicAPIAnalyzerTests.cs
@@ -196,6 +196,7 @@ C
 C.Field -> int
 C.Property.get -> int
 C.Property.set -> void
+C.Method() -> void
 ";
 
             var unshippedText = $@"

--- a/src/Test/Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test/Utilities/DiagnosticAnalyzerTestBase.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis.CSharp;
@@ -364,25 +365,32 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 compilation = EnableAnalyzer(analyzer, compilation);
 
                 var diags = compilation.GetAnalyzerDiagnostics(new[] { analyzer });
-
-                foreach (var diag in diags)
+                if (spans == null)
                 {
-                    if (diag.Location == Location.None || diag.Location.IsInMetadata)
+                    diagnostics.AddRange(diags);
+                }
+                else
+                {
+                    Debug.Assert(spans.Length == documents.Length);
+                    foreach (var diag in diags)
                     {
-                        diagnostics.Add(diag);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < documents.Length; i++)
+                        if (diag.Location == Location.None || diag.Location.IsInMetadata)
                         {
-                            var document = documents[i];
-                            var tree = document.GetSyntaxTreeAsync().Result;
-                            if (tree == diag.Location.SourceTree)
+                            diagnostics.Add(diag);
+                        }
+                        else
+                        {
+                            for (int i = 0; i < documents.Length; i++)
                             {
-                                var span = spans != null ? spans[i] : null;
-                                if (span == null || span.Value.Contains(diag.Location.SourceSpan))
+                                var document = documents[i];
+                                var tree = document.GetSyntaxTreeAsync().Result;
+                                if (tree == diag.Location.SourceTree)
                                 {
-                                    diagnostics.Add(diag);
+                                    var span = spans[i];
+                                    if (span == null || span.Value.Contains(diag.Location.SourceSpan))
+                                    {
+                                        diagnostics.Add(diag);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
The logic for detecting a removed API in the unshipped API text was
comparing against the full entry.  This meant it compared the calculated
name to the stored name + the removed prefix.  Updated to compare
against the correct name.

There was a unit test to catch this case but the unit tests themselves
weren't functioning correctly.  They didn't include the error because it
was in an additional document.  Updated the unit test to report this
type of error.