### PR TITLE
CA1052: class with a base class shouldn't be considered static holder.

### DIFF
--- a/src/AnalyzerPowerPack/Core/Design/CA1052DiagnosticAnalyzer.cs
+++ b/src/AnalyzerPowerPack/Core/Design/CA1052DiagnosticAnalyzer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AnalyzerPowerPack.Design
     /// Like FxCop, this analyzer does emit a diagnostic when the type has a private default
     /// constructor, even though the documentation of CA1053 says it should only trigger for public
     /// or protected default constructor. Like FxCop, this analyzer does not emit a diagnostic when 
-    /// class has a base class, however the diagnostic is emited if class supports empty interface".
+    /// class has a base class, however the diagnostic is emitted if class supports empty interface.
     /// </para>
     /// <para>
     /// The rationale for all of this is to facilitate a smooth transition from FxCop rules to the
@@ -91,9 +91,6 @@ namespace Microsoft.AnalyzerPowerPack.Design
         /// </summary>
         /// <param name="symbol">
         /// The symbol being examined.
-        /// </param>
-        /// <param name="compilation">
-        /// The compilation containing the examined symbol.
         /// </param>
         /// <returns>
         /// <c>true</c> if <paramref name="symbol"/> is a static holder type;

--- a/src/AnalyzerPowerPack/Core/Design/CA1052DiagnosticAnalyzer.cs
+++ b/src/AnalyzerPowerPack/Core/Design/CA1052DiagnosticAnalyzer.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AnalyzerPowerPack.Design
         {
             if (!symbol.IsStatic
                 && (symbol.IsPublic() || symbol.IsProtected())
-                && symbol.IsStaticHolderType(compilation))
+                && symbol.IsStaticHolderType())
             {
                 addDiagnostic(symbol.CreateDiagnostic(Rule, symbol.Name));
             }
@@ -104,14 +104,14 @@ namespace Microsoft.AnalyzerPowerPack.Design
         /// "qualifying member" (<see cref="IsQualifyingMember(ISymbol)"/>) and no
         /// "disqualifying members" (<see cref="IsDisqualifyingMember(ISymbol)"/>).
         /// </remarks>
-        internal static bool IsStaticHolderType(this INamedTypeSymbol symbol, Compilation compilation)
+        internal static bool IsStaticHolderType(this INamedTypeSymbol symbol)
         {
             if (symbol.TypeKind != TypeKind.Class)
             {
                 return false;
             }
 
-            if (symbol.BaseType != compilation.GetTypeByMetadataName("System.Object"))
+            if (symbol.BaseType.SpecialType != SpecialType.System_Object)
             {
                 return false;
             }

--- a/src/AnalyzerPowerPack/Core/Design/CA1052DiagnosticAnalyzer.cs
+++ b/src/AnalyzerPowerPack/Core/Design/CA1052DiagnosticAnalyzer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AnalyzerPowerPack.Design
         {
             if (!symbol.IsStatic
                 && (symbol.IsPublic() || symbol.IsProtected())
-                && symbol.IsStaticHolderType())
+                && symbol.IsStaticHolderType(compilation))
             {
                 addDiagnostic(symbol.CreateDiagnostic(Rule, symbol.Name));
             }
@@ -100,9 +100,14 @@ namespace Microsoft.AnalyzerPowerPack.Design
         /// "qualifying member" (<see cref="IsQualifyingMember(ISymbol)"/>) and no
         /// "disqualifying members" (<see cref="IsDisqualifyingMember(ISymbol)"/>).
         /// </remarks>
-        internal static bool IsStaticHolderType(this INamedTypeSymbol symbol)
+        internal static bool IsStaticHolderType(this INamedTypeSymbol symbol, Compilation compilation)
         {
             if (symbol.TypeKind != TypeKind.Class)
+            {
+                return false;
+            }
+
+            if (symbol.BaseType != compilation.GetTypeByMetadataName("System.Object"))
             {
                 return false;
             }

--- a/src/AnalyzerPowerPack/Core/Design/CA1052DiagnosticAnalyzer.cs
+++ b/src/AnalyzerPowerPack/Core/Design/CA1052DiagnosticAnalyzer.cs
@@ -32,7 +32,8 @@ namespace Microsoft.AnalyzerPowerPack.Design
     /// even though the title of CA1053 is "Static holder types should not have constructors".
     /// Like FxCop, this analyzer does emit a diagnostic when the type has a private default
     /// constructor, even though the documentation of CA1053 says it should only trigger for public
-    /// or protected default constructor.
+    /// or protected default constructor. Like FxCop, this analyzer does not emit a diagnostic when 
+    /// class has a base class, however the diagnostic is emited if class supports empty interface".
     /// </para>
     /// <para>
     /// The rationale for all of this is to facilitate a smooth transition from FxCop rules to the
@@ -90,6 +91,9 @@ namespace Microsoft.AnalyzerPowerPack.Design
         /// </summary>
         /// <param name="symbol">
         /// The symbol being examined.
+        /// </param>
+        /// <param name="compilation">
+        /// The compilation containing the examined symbol.
         /// </param>
         /// <returns>
         /// <c>true</c> if <paramref name="symbol"/> is a static holder type;

--- a/src/AnalyzerPowerPack/Test/Design/CA1052Tests.cs
+++ b/src/AnalyzerPowerPack/Test/Design/CA1052Tests.cs
@@ -665,5 +665,47 @@ End Class
 ");
         }
 
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndIncompleteBaseClassDefinitionCSharp()
+        {
+            VerifyCSharp(@"
+public class C26 :
+{
+    public static void Foo() { }
+}
+");
+        }
+
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndIncompleteBaseClassDefinitionBasic()
+        {
+            VerifyBasic(@"
+Public Class B26
+	Inherits
+	Public Shared Sub Foo()
+	End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1052NoDiagnosticForEmptyNonStaticClassWithIncompleteBaseClassDefinitionCSharp()
+        {
+            VerifyCSharp(@"
+public class C27 :
+{
+}
+");
+        }
+
+        [Fact]
+        public void CA1052NoDiagnosticForEmptyNonStaticClassWithIncompleteBaseClassDefinitionBasic()
+        {
+            VerifyBasic(@"
+Public Class B27
+	Inherits
+End Class
+");
+        }
     }
 }

--- a/src/AnalyzerPowerPack/Test/Design/CA1052Tests.cs
+++ b/src/AnalyzerPowerPack/Test/Design/CA1052Tests.cs
@@ -581,24 +581,55 @@ End Class
 public class C23Base
 {
 }
-public class C23 : C22Base
+public class C23 : C23Base
 {
     public static void Foo() { }
 }
 ");
         }
+
         [Fact]
         public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndBaseClassBasic()
         {
             VerifyBasic(@"
-Public Class C23Base
+Public Class B23Base
 End Class
-Public Class C23
-	Inherits C22Base
+Public Class B23
+	Inherits B23Base
 	Public Shared Sub Foo()
 	End Sub
 End Class
 ");
+        }
+
+        [Fact]
+        public void CA1052DiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceCSharp()
+        {
+            VerifyCSharp(@"
+public interface IC24Base
+{
+}
+public class C24 : IC24Base
+{
+    public static void Foo() { }
+}
+",
+                CSharpResult(5, 14, "C24"));
+        }
+
+        [Fact]
+        public void CA1052DiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceBasic()
+        {
+            VerifyBasic(@"
+Public Interface IB24Base
+End Interface
+Public Class B24
+	Implements IB24Base
+	Public Shared Sub Foo()
+	End Sub
+End Class
+",
+                BasicResult(4, 14, "B24"));
         }
     }
 }

--- a/src/AnalyzerPowerPack/Test/Design/CA1052Tests.cs
+++ b/src/AnalyzerPowerPack/Test/Design/CA1052Tests.cs
@@ -631,5 +631,39 @@ End Class
 ",
                 BasicResult(4, 14, "B24"));
         }
+
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndNotEmptyBaseInterfaceCSharp()
+        {
+            VerifyCSharp(@"
+public interface IC25Base
+{
+    void Moo();
+}
+public class C25 : IC24Base
+{
+    public static void Foo() { }
+    void C25Base.Moo() { }
+}
+");
+        }
+
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndNotEmptyBaseInterfaceBasic()
+        {
+            VerifyBasic(@"
+Public Interface IB25Base
+    Sub Moo()
+End Interface
+Public Class B25
+	Implements IB25Base
+	Public Shared Sub Foo()
+	End Sub
+	Private Sub B25Base_Moo() Implements B25Base.Moo
+	End Sub
+End Class
+");
+        }
+
     }
 }

--- a/src/AnalyzerPowerPack/Test/Design/CA1052Tests.cs
+++ b/src/AnalyzerPowerPack/Test/Design/CA1052Tests.cs
@@ -574,5 +574,31 @@ Public Class B22
 End Class
 ");
         }
+
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndBaseClassCSharp() {
+            VerifyCSharp(@"
+public class C23Base
+{
+}
+public class C23 : C22Base
+{
+    public static void Foo() { }
+}
+");
+        }
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndBaseClassBasic()
+        {
+            VerifyBasic(@"
+Public Class C23Base
+End Class
+Public Class C23
+	Inherits C22Base
+	Public Shared Sub Foo()
+	End Sub
+End Class
+");
+        }
     }
 }


### PR DESCRIPTION
CA1053 behavior differs from original FxCop version: if a class has a base class it is still qualified as a static holder, while the original FxCop's version leaves this class be:

    public class C23Base
    { }
    public class C23 : C23Base
    {
        public static void Foo()
        { }
    }