### PR TITLE
Fix false positive on CA1001 analyzer

### DIFF
--- a/src/FxCop/System.Runtime.Analyzers/CSharp/CSharpSystemRuntimeAnalyzers.csproj
+++ b/src/FxCop/System.Runtime.Analyzers/CSharp/CSharpSystemRuntimeAnalyzers.csproj
@@ -18,8 +18,8 @@
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
     <RestorePackages>true</RestorePackages>
-    <SemanticVersion>$(SystemRuntimeAnalyzersSemanticVersion)</SemanticVersion>  
-    <PreReleaseVersion>$(SystemRuntimeAnalyzersPreReleaseVersion)</PreReleaseVersion>  
+    <SemanticVersion>$(SystemRuntimeAnalyzersSemanticVersion)</SemanticVersion>
+    <PreReleaseVersion>$(SystemRuntimeAnalyzersPreReleaseVersion)</PreReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
@@ -100,6 +100,7 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <Compile Include="Design\TypesThatOwnDisposableFieldsShouldBeDisposable.cs" />
     <Compile Include="Design\UseGenericEventHandler.cs" />
     <Compile Include="Globalization\UseOrdinalStringComparison.Fixer.cs" />
     <Compile Include="Globalization\UseOrdinalStringComparison.cs" />

--- a/src/FxCop/System.Runtime.Analyzers/CSharp/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/FxCop/System.Runtime.Analyzers/CSharp/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -12,14 +12,14 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace System.Runtime.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer : TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer<TypeDeclarationSyntax>
+    public sealed class CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer : TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer<TypeDeclarationSyntax>
     {
         protected override DisposableFieldAnalyzer GetAnalyzer(INamedTypeSymbol disposableTypeSymbol)
         {
             return new CSharpDisposableFieldAnalyzer(disposableTypeSymbol);
         }
 
-        protected sealed class CSharpDisposableFieldAnalyzer : DisposableFieldAnalyzer
+        private class CSharpDisposableFieldAnalyzer : DisposableFieldAnalyzer
         {
             public CSharpDisposableFieldAnalyzer(INamedTypeSymbol disposableTypeSymbol)
                 : base(disposableTypeSymbol)
@@ -41,7 +41,7 @@ namespace System.Runtime.Analyzers
                     var fieldDecl = ((FieldDeclarationSyntax)node).Declaration;
                     foreach (var fieldInit in fieldDecl.Variables)
                     {                                               
-                        if (fieldInit?.Initializer?.Value is ObjectCreationExpressionSyntax &&
+                        if (fieldInit.Initializer?.Value is ObjectCreationExpressionSyntax &&
                             disposableFields.Contains(model.GetDeclaredSymbol(fieldInit, cancellationToken)))
                         {
                             return true;

--- a/src/FxCop/System.Runtime.Analyzers/CSharp/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/FxCop/System.Runtime.Analyzers/CSharp/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace System.Runtime.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer : TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer<TypeDeclarationSyntax>
+    {
+        protected override DisposableFieldAnalyzer GetAnalyzer(INamedTypeSymbol disposableTypeSymbol)
+        {
+            return new CSharpDisposableFieldAnalyzer(disposableTypeSymbol);
+        }
+
+        protected sealed class CSharpDisposableFieldAnalyzer : DisposableFieldAnalyzer
+        {
+            public CSharpDisposableFieldAnalyzer(INamedTypeSymbol disposableTypeSymbol)
+                : base(disposableTypeSymbol)
+            { }
+
+            protected override bool IsDisposableFieldCreation(SyntaxNode node, SemanticModel model, HashSet<ISymbol> disposableFields, CancellationToken cancellationToken)
+            { 
+                if (node is AssignmentExpressionSyntax)
+                {
+                    var assignment = (AssignmentExpressionSyntax)node;
+                    if (assignment.Right is ObjectCreationExpressionSyntax &&
+                        disposableFields.Contains(model.GetSymbolInfo(assignment.Left, cancellationToken).Symbol))
+                    {
+                        return true;
+                    }    
+                }
+                else if (node is FieldDeclarationSyntax)
+                {
+                    var fieldDecl = ((FieldDeclarationSyntax)node).Declaration;
+                    Debug.Assert(fieldDecl.Variables.Count == 1);
+                    var fieldInit = fieldDecl.Variables.First();
+                    if (fieldInit?.Initializer?.Value is ObjectCreationExpressionSyntax &&
+                        disposableFields.Contains(model.GetDeclaredSymbol(fieldInit, cancellationToken)))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/src/FxCop/System.Runtime.Analyzers/CSharp/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/FxCop/System.Runtime.Analyzers/CSharp/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -39,12 +39,13 @@ namespace System.Runtime.Analyzers
                 else if (node is FieldDeclarationSyntax)
                 {
                     var fieldDecl = ((FieldDeclarationSyntax)node).Declaration;
-                    Debug.Assert(fieldDecl.Variables.Count == 1);
-                    var fieldInit = fieldDecl.Variables.First();
-                    if (fieldInit?.Initializer?.Value is ObjectCreationExpressionSyntax &&
-                        disposableFields.Contains(model.GetDeclaredSymbol(fieldInit, cancellationToken)))
-                    {
-                        return true;
+                    foreach (var fieldInit in fieldDecl.Variables)
+                    {                                               
+                        if (fieldInit?.Initializer?.Value is ObjectCreationExpressionSyntax &&
+                            disposableFields.Contains(model.GetDeclaredSymbol(fieldInit, cancellationToken)))
+                        {
+                            return true;
+                        }
                     }
                 }
                 return false;

--- a/src/FxCop/System.Runtime.Analyzers/Core/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.Fixer.cs
+++ b/src/FxCop/System.Runtime.Analyzers/Core/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.Fixer.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.Analyzers
         protected const string NotImplementedExceptionName = "System.NotImplementedException";
         protected const string IDisposableName = "System.IDisposable";
 
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.RuleId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer<SyntaxNode>.RuleId);
 
         public async override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -66,7 +66,7 @@ namespace System.Runtime.Analyzers
             else
             {
                 var throwStatement = generator.ThrowStatement(generator.ObjectCreationExpression(WellKnownTypes.NotImplementedException(model.Compilation)));
-                var member = generator.MethodDeclaration(TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Dispose, statements: new[] { throwStatement });
+                var member = generator.MethodDeclaration(TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer<SyntaxNode>.Dispose, statements: new[] { throwStatement });
                 member = generator.AsPublicInterfaceImplementation(member, interfaceType);
                 editor.AddMember(declaration, member);
             }

--- a/src/FxCop/System.Runtime.Analyzers/Test/Design/TypesThatOwnDisposableFieldsShouldBeDisposableTests.Fixer.cs
+++ b/src/FxCop/System.Runtime.Analyzers/Test/Design/TypesThatOwnDisposableFieldsShouldBeDisposableTests.Fixer.cs
@@ -12,7 +12,7 @@ namespace System.Runtime.Analyzers.UnitTests
     {
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
-            return new TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
+            return new BasicTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
         }
 
         protected override CodeFixProvider GetBasicCodeFixProvider()
@@ -22,7 +22,7 @@ namespace System.Runtime.Analyzers.UnitTests
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return new TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
+            return new CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()
@@ -119,7 +119,7 @@ using System.IO;
 // This class violates the rule.
 public class NoDisposeClass
 {
-    FileStream newFile;
+    FileStream newFile = new FileStream("""", FileMode.Append);
 
     void Dispose() {
 // Some content
@@ -133,7 +133,7 @@ using System.IO;
 // This class violates the rule.
 public class NoDisposeClass : IDisposable
 {
-    FileStream newFile;
+    FileStream newFile = new FileStream("""", FileMode.Append);
 
     public void Dispose() {
 // Some content
@@ -152,7 +152,7 @@ using System.IO;
 // This class violates the rule.
 public partial class NoDisposeClass
 {
-    FileStream newFile;
+    FileStream newFile = new FileStream("""", FileMode.Append);
 
     void Dispose(int x) {
 // Some content
@@ -166,7 +166,7 @@ using System.IO;
 // This class violates the rule.
 public partial class NoDisposeClass : IDisposable
 {
-    FileStream newFile;
+    FileStream newFile = new FileStream("""", FileMode.Append);
 
     void Dispose(int x) {
 // Some content
@@ -190,7 +190,7 @@ Imports System.IO
 ' This class violates the rule. 
 Public Class NoDisposeMethod
 
-    Dim newFile As FileStream
+    Dim newFile As FileStream = New FileStream("""", FileMode.Append)
 
     Sub Dispose()
 
@@ -205,7 +205,7 @@ Imports System.IO
 Public Class NoDisposeMethod
     Implements IDisposable
 
-    Dim newFile As FileStream
+    Dim newFile As FileStream = New FileStream("""", FileMode.Append)
 
     Public Sub Dispose() Implements IDisposable.Dispose
     End Sub
@@ -223,7 +223,7 @@ Imports System.IO
 ' This class violates the rule. 
 Public Class NoDisposeMethod
 
-    Dim newFile As FileStream
+    Dim newFile As FileStream = New FileStream("""", FileMode.Append)
 
     Sub Dispose(x As Integer)
     End Sub
@@ -237,7 +237,7 @@ Imports System.IO
 Public Class NoDisposeMethod
     Implements IDisposable
 
-    Dim newFile As FileStream
+    Dim newFile As FileStream = New FileStream("""", FileMode.Append)
 
     Sub Dispose(x As Integer)
     End Sub

--- a/src/FxCop/System.Runtime.Analyzers/Test/Design/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/FxCop/System.Runtime.Analyzers/Test/Design/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -53,7 +53,7 @@ using System.IO;
 
     public class NoDisposeClass
     {
-        FileStream newFile = new FileStream(""data.txt"", FileMode.Append);
+        FileStream newFile1, newFile2 = new FileStream(""data.txt"", FileMode.Append);
     }
 ",
             GetCA1001CSharpResultAt(4, 18, "NoDisposeClass"));
@@ -239,7 +239,7 @@ Imports System.IO
       
    ' This class violates the rule. 
     Public Class NoDisposeClass
-        Dim num As Integer, newFile As FileStream = New FileStream(""data.txt"", FileMode.Append)
+        Dim newFile1 As FileStream, newFile2 As FileStream = New FileStream(""data.txt"", FileMode.Append)
     End Class
 ",
             GetCA1001BasicResultAt(5, 18, "NoDisposeClass"));
@@ -249,8 +249,8 @@ Imports System.IO
     
    ' This class violates the rule. 
     Public Class NoDisposeClass
-        Dim num As Integer
-        Dim newFile As FileStream = New FileStream(""data.txt"", FileMode.Append)
+        Dim newFile1 As FileStream
+        Dim newFile2 As FileStream = New FileStream(""data.txt"", FileMode.Append)
     End Class
 ",
             GetCA1001BasicResultAt(5, 18, "NoDisposeClass"));

--- a/src/FxCop/System.Runtime.Analyzers/Test/Design/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/FxCop/System.Runtime.Analyzers/Test/Design/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -11,12 +11,12 @@ namespace System.Runtime.Analyzers.UnitTests
     {
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
-            return new TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
+            return new BasicTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return new TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
+            return new CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
         }
 
         [Fact]
@@ -33,7 +33,34 @@ namespace System.Runtime.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CA1001CSharpTestWithNoDisposeMethod()
+        public void CA1001CSharpTestWithNoCreationOfDisposableObject()
+        {
+            VerifyCSharp(@"
+using System.IO;
+
+    public class NoDisposeClass
+    {
+        FileStream newFile;
+    }
+");
+        }
+
+        [Fact]
+        public void CA1001CSharpTestWithFieldInitAndNoDisposeMethod()
+        {
+            VerifyCSharp(@"
+using System.IO;
+
+    public class NoDisposeClass
+    {
+        FileStream newFile = new FileStream(""data.txt"", FileMode.Append);
+    }
+",
+            GetCA1001CSharpResultAt(4, 18, "NoDisposeClass"));
+        }
+
+        [Fact]
+        public void CA1001CSharpTestWithCtorInitAndNoDisposeMethod()
         {
             VerifyCSharp(@"
 using System.IO;
@@ -50,6 +77,41 @@ using System.IO;
     }
 ",
             GetCA1001CSharpResultAt(5, 18, "NoDisposeClass"));
+        }
+
+        [Fact]
+        public void CA1001CSharpTestWithCreationOfDisposableObjectInOtherClass()
+        {
+            VerifyCSharp(@"
+using System.IO;                 
+
+    public class NoDisposeClass
+    {
+        public FileStream newFile;
+    }                 
+
+    public class CreationClass
+    {
+        public void Create()
+        {
+            var obj = new NoDisposeClass() { newFile = new FileStream(""data.txt"", FileMode.Append) }; 
+        }
+    }
+");
+
+            VerifyCSharp(@"
+using System.IO;                 
+
+    public class NoDisposeClass
+    {
+        public FileStream newFile;
+
+        public NoDisposeClass(FileStream fs)
+        {
+            newFile = fs;
+        }
+    }
+");
         }
 
         [Fact]
@@ -148,7 +210,54 @@ End Module
         }
 
         [Fact]
-        public void CA1001BasicTestWithNoDisposeMethod()
+        public void CA1001BasicTestWithNoCreationOfDisposableObject()
+        {
+            VerifyBasic(@"
+Imports System.IO
+
+    Public Class NoDisposeClass
+	    Dim newFile As FileStream
+    End Class
+");
+        }
+
+        [Fact]
+        public void CA1001BasicTestWithFieldInitAndNoDisposeMethod()
+        {
+            VerifyBasic(@"
+Imports System.IO
+           
+   ' This class violates the rule. 
+    Public Class NoDisposeClass
+        Dim newFile As FileStream = New FileStream(""data.txt"", FileMode.Append)
+    End Class
+",
+            GetCA1001BasicResultAt(5, 18, "NoDisposeClass"));
+
+            VerifyBasic(@"
+Imports System.IO
+      
+   ' This class violates the rule. 
+    Public Class NoDisposeClass
+        Dim num As Integer, newFile As FileStream = New FileStream(""data.txt"", FileMode.Append)
+    End Class
+",
+            GetCA1001BasicResultAt(5, 18, "NoDisposeClass"));
+
+            VerifyBasic(@"
+Imports System.IO
+    
+   ' This class violates the rule. 
+    Public Class NoDisposeClass
+        Dim num As Integer
+        Dim newFile As FileStream = New FileStream(""data.txt"", FileMode.Append)
+    End Class
+",
+            GetCA1001BasicResultAt(5, 18, "NoDisposeClass"));
+        }
+
+        [Fact]
+        public void CA1001BasicTestWithCtorInitAndNoDisposeMethod()
         {
             VerifyBasic(@"
    Imports System
@@ -166,6 +275,36 @@ End Module
    End Class
 ",
             GetCA1001BasicResultAt(6, 17, "NoDisposeMethod"));
+        }
+
+        [Fact]
+        public void CA1001BasicTestWithCreationOfDisposableObjectInOtherClass()
+        {
+            VerifyBasic(@"
+Imports System.IO
+
+    Public Class NoDisposeClass
+        Public newFile As FileStream
+    End Class
+
+    Public Class CreationClass
+        Public Sub Create()
+            Dim obj As NoDisposeClass = New NoDisposeClass()
+            obj.newFile = New FileStream(""data.txt"", FileMode.Append)
+        End Sub
+    End Class
+");
+
+            VerifyBasic(@"
+Imports System.IO
+
+    Public Class NoDisposeClass
+        Public newFile As FileStream
+        Public Sub New(fs As FileStream)
+            newFile = fs
+        End Sub
+    End Class
+");
         }
 
         [Fact]

--- a/src/FxCop/System.Runtime.Analyzers/VisualBasic/BasicSystemRuntimeAnalyzers.vbproj
+++ b/src/FxCop/System.Runtime.Analyzers/VisualBasic/BasicSystemRuntimeAnalyzers.vbproj
@@ -17,8 +17,8 @@
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
     <RestorePackages>true</RestorePackages>
-    <SemanticVersion>$(SystemRuntimeAnalyzersSemanticVersion)</SemanticVersion>  
-    <PreReleaseVersion>$(SystemRuntimeAnalyzersPreReleaseVersion)</PreReleaseVersion>  
+    <SemanticVersion>$(SystemRuntimeAnalyzersSemanticVersion)</SemanticVersion>
+    <PreReleaseVersion>$(SystemRuntimeAnalyzersPreReleaseVersion)</PreReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
@@ -98,6 +98,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Design\TypesThatOwnDisposableFieldsShouldBeDisposable.vb" />
     <Compile Include="Design\UseGenericEventHandler.vb" />
     <Compile Include="Design\DefineAccessorsForAttributeArguments.vb" />
     <Compile Include="Design\OverrideMethodsOnComparableTypes.Fixer.vb" />

--- a/src/FxCop/System.Runtime.Analyzers/VisualBasic/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.vb
+++ b/src/FxCop/System.Runtime.Analyzers/VisualBasic/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.vb
@@ -1,0 +1,51 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace System.Runtime.Analyzers
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+    Public Class BasicTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer
+        Inherits TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer(Of TypeBlockSyntax)
+        Protected Overrides Function GetAnalyzer(disposableTypeSymbol As INamedTypeSymbol) As DisposableFieldAnalyzer
+            Return New BasicDisposableFieldAnalyzer(disposableTypeSymbol)
+        End Function
+
+        Private Class BasicDisposableFieldAnalyzer
+            Inherits DisposableFieldAnalyzer
+            Public Sub New(disposableTypeSymbol As INamedTypeSymbol)
+                MyBase.New(disposableTypeSymbol)
+            End Sub
+
+            Protected Overrides Function IsDisposableFieldCreation(node As SyntaxNode, model As SemanticModel, disposableFields As HashSet(Of ISymbol), cancellationToken As CancellationToken) As Boolean
+                If TypeOf node Is AssignmentStatementSyntax Then
+                    Dim assignment = DirectCast(node, AssignmentStatementSyntax)
+                    If TypeOf assignment.Right Is ObjectCreationExpressionSyntax AndAlso disposableFields.Contains(model.GetSymbolInfo(assignment.Left, cancellationToken).Symbol) Then
+                        Return True
+                    End If
+                ElseIf TypeOf node Is FieldDeclarationSyntax Then
+                    Dim fieldDecls = DirectCast(node, FieldDeclarationSyntax).Declarators
+                    For Each declarator As VariableDeclaratorSyntax In fieldDecls
+                        If declarator.Names.Count > 1 Then
+                            Continue For
+                        End If
+                        Dim fieldName = declarator.Names.First()
+                        If TypeOf declarator?.Initializer?.Value Is ObjectCreationExpressionSyntax AndAlso disposableFields.Contains(model.GetDeclaredSymbol(fieldName, cancellationToken)) Then
+                            Return True
+                        End If
+                    Next
+                ElseIf TypeOf node Is NamedFieldInitializerSyntax Then
+                    Dim fieldInit = DirectCast(node, NamedFieldInitializerSyntax)
+                    If TypeOf fieldInit.Expression Is ObjectCreationExpressionSyntax AndAlso disposableFields.Contains(model.GetSymbolInfo(fieldInit.Name, cancellationToken).Symbol) Then
+                        Return True
+                    End If
+                End If
+                Return False
+            End Function
+        End Class
+    End Class
+End Namespace
+

--- a/src/FxCop/System.Runtime.Analyzers/VisualBasic/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.vb
+++ b/src/FxCop/System.Runtime.Analyzers/VisualBasic/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace System.Runtime.Analyzers
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
-    Public Class BasicTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer
+    Public NotInheritable Class BasicTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer
         Inherits TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer(Of TypeBlockSyntax)
         Protected Overrides Function GetAnalyzer(disposableTypeSymbol As INamedTypeSymbol) As DisposableFieldAnalyzer
             Return New BasicDisposableFieldAnalyzer(disposableTypeSymbol)

--- a/src/FxCop/System.Runtime.Analyzers/VisualBasic/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.vb
+++ b/src/FxCop/System.Runtime.Analyzers/VisualBasic/Design/TypesThatOwnDisposableFieldsShouldBeDisposable.vb
@@ -29,6 +29,7 @@ Namespace System.Runtime.Analyzers
                 ElseIf TypeOf node Is FieldDeclarationSyntax Then
                     Dim fieldDecls = DirectCast(node, FieldDeclarationSyntax).Declarators
                     For Each declarator As VariableDeclaratorSyntax In fieldDecls
+                        'Explicit initialization is not permitted with multiple variables declared with a single type specifier
                         If declarator.Names.Count > 1 Then
                             Continue For
                         End If


### PR DESCRIPTION
CA1001 analyzer was triggering on non-disposable type declarations with any field that implements
`IDisposable`. This fix changes this behavior to resemble its FxCop counterpart, which only fires a warning if the disposable field member is created within the type definition (i.e. either initialized when field
is declared or an object is created by a `new` oprator and assigned to the field in this type's methods). Also modify fixer tests due to this change.

This fix partially addresses https://github.com/dotnet/roslyn-analyzers/issues/281.

@srivatsn @tmeschter @lgolding @mavasani 