### PR TITLE
Check if the syntax list has any elements before calling .First()

### DIFF
--- a/src/Roslyn/Core/Documentation/DoNotUseVerbatimCrefsAnalyzer.cs
+++ b/src/Roslyn/Core/Documentation/DoNotUseVerbatimCrefsAnalyzer.cs
@@ -37,6 +37,11 @@ namespace Roslyn.Diagnostics.Analyzers.Documentation
 
         protected void ProcessAttribute(SyntaxNodeAnalysisContext context, SyntaxTokenList textTokens)
         {
+            if (!textTokens.Any())
+            {
+                return;
+            }
+
             var token = textTokens.First();
 
             if (token.Span.Length >= 2)


### PR DESCRIPTION
Fixes #287