### PR TITLE
Unskip a unit test

### DIFF
--- a/src/FxCop/System.Runtime.Analyzers/Test/Performance/AvoidUnsealedAttributesTests.Fixer.cs
+++ b/src/FxCop/System.Runtime.Analyzers/Test/Performance/AvoidUnsealedAttributesTests.Fixer.cs
@@ -33,13 +33,17 @@ namespace System.Runtime.Analyzers.UnitTests
 
         #region CodeFix Tests
 
-        [Fact(Skip = "Bug 858655")]
+        [Fact]
         public void CA1813CSharpCodeFixProviderTestFired()
         {
             VerifyCSharpFix(@"
+using System;
+
 public class AttributeClass : Attribute
 {
 }", @"
+using System;
+
 public sealed class AttributeClass : Attribute
 {
 }");


### PR DESCRIPTION
Unskip a unit test. The underlying issue was fixed long ago, though
the test itself needed a little fixing up.