### PR TITLE
Add project-specific docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 .NET Compiler Platform ("Roslyn") Analyzers
 ===========================================
 
-This repository contains a number of [Roslyn](https://github.com/dotnet/roslyn) diagnostic analyzers initially developed to help flesh out the design and implementation of the static analysis APIs.
-
-Currently there are only a few projects here. Over time the collection will grow as more are migrated from the [dotnet/roslyn](https://github.com/dotnet/roslyn) repository.
+This repository contains a number of [Roslyn](https://github.com/dotnet/roslyn) diagnostic analyzers initially developed to help flesh out the design and implementation of the static analysis APIs. They have been migrated from the main [dotnet/roslyn](https://github.com/dotnet/roslyn) repository in order to continue and speed their further development.
 
 Debug | Release
 ------|--------
 [![Build Status](http://dotnet-ci.cloudapp.net/job/dotnet_roslyn-analyzers_windows_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_roslyn-analyzers_windows_debug/) | [![Build Status](http://dotnet-ci.cloudapp.net/job/dotnet_roslyn-analyzers_windows_release/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_roslyn-analyzers_windows_release/)
 
 [![Join the chat at https://gitter.im/dotnet/roslyn](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dotnet/roslyn?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 
 Projects
 ========
@@ -21,11 +20,15 @@ AsyncPackage
 
 The AsyncPackage analyzer enforces good practices when writing code that makes use of C#'s `async` and `await` language features.
 
+[More info](src/AsyncPackage/AsyncPackage.md)
+
 
 Desktop.Analyzers
 -----------------
 
 Analyzers for APIs specific to the desktop .NET Framework.
+
+[More info](src/FxCop/Desktop.Analyzers/Desktop.Analyzers.md)
 
 
 MetaCompilation
@@ -35,23 +38,27 @@ MetaCompilation
 
 The MetaCompilation Analyzer is an analyzer that functions as a tutorial to teach users how to write an analyzer. It uses diagnostics and code fixes to guide the user through the various steps required to create a simple analyzer. It is designed for a novice analyzer programmer with some previous programming experience.
 
-For instructions on using this tutorial, see [Instructions](https://github.com/dotnet/roslyn-analyzers/blob/master/src/MetaCompilation/MetaCompilation/MetaCompilation/ReadMe.md#instructions).
+For instructions on using this tutorial, see [Instructions](src/MetaCompilation/MetaCompilation/MetaCompilation/ReadMe.md#instructions).
 
 
 Microsoft.AnalyzerPowerPack
 ---------------------------
 
+*Latest stable version:* [1.0.1](https://www.nuget.org/packages/Microsoft.AnalyzerPowerPack/)
+
 General language rules implemented as analyzers using the .NET Compiler Platform ("Roslyn").
 
-*Latest stable version:* [1.0.1](https://www.nuget.org/packages/Microsoft.AnalyzerPowerPack/)
+[More info](src/AnalyzerPowerPack/AnalyzerPowerPack.md)
 
 
 Microsoft.CodeAnalysis.Analyzers
 --------------------------------
 
+*Latest stable version:* [1.0.0](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Analyzers/)
+
 Provides guidelines for using .NET Compiler Platform ("Roslyn") APIs.
 
-*Latest stable version:* [1.0.0](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Analyzers/)
+[More info](src/CodeAnalysis/Microsoft.CodeAnalysis.Analyzers.md)
 
 
 Microsoft.Net.RoslynDiagnostics
@@ -59,21 +66,27 @@ Microsoft.Net.RoslynDiagnostics
 
 Contains analyzers specific to the .NET Compiler Platform ("Roslyn") project.
 
+[More info](src/Roslyn/Microsoft.Net.RoslynDiagnostics.md)
+
 
 System.Runtime.Analyzers
 ------------------------
 
+*Latest stable version:* [1.0.1](https://www.nuget.org/packages/System.Runtime.Analyzers/)
+
 Provides guidelines for using APIs in the System.Runtime namespace.
 
-*Latest stable version:* [1.0.1](https://www.nuget.org/packages/System.Runtime.Analyzers/)
+[More info](src/FxCop/System.Runtime.Analyzers/System.Runtime.Analyzers.md)
 
 
 System.Runtime.InteropServices.Analyzers
 ----------------------------------------
 
+*Latest stable version:* [1.0.1](https://www.nuget.org/packages/System.Runtime.InteropServices.Analyzers/)
+
 Provides guidelines for using APIs in the System.Runtime.InteropServices namespace.
 
-*Latest stable version:* [1.0.1](https://www.nuget.org/packages/System.Runtime.InteropServices.Analyzers/)
+[More info](src/FxCop/System.Runtime.InteropServices.Analyzers/System.Runtime.InteropServices.Analyzers.md)
 
 
 Getting Started
@@ -82,6 +95,7 @@ Getting Started
 1. Clone the repository
 2. Install NuGet packages: `powershell -executionpolicy bypass src\.nuget\NuGetRestore.ps1`
 3. Build: `msbuild src\Analyzers.sln`
+
 
 Submitting Pull Requests
 ========================

--- a/src/AnalyzerPowerPack/AnalyzerPowerPack.md
+++ b/src/AnalyzerPowerPack/AnalyzerPowerPack.md
@@ -1,0 +1,109 @@
+### CA1008: Enums should have zero value. ###
+
+An enum should generally have a zero value. If the enum is not decorated with the Flags attribute, it should have a member with a value of zero that represents the empty state. Optionally, this value is named 'None'. For a Flags-attributed enum, a zero-valued member is optional and, if it exists, should always be named 'None'. This value should indicate that no values have been set in the enum. Using a zero-valued member for other purposes is contrary to the use of the Flags attribute in that the bitwise AND and OR operators are useless with the member.
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182149.aspx](http://msdn.microsoft.com/library/ms182149.aspx)
+
+### CA1012: Abstract classes should not have public constructors ###
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182126.aspx](http://msdn.microsoft.com/library/ms182126.aspx)
+
+### CA1024: Use properties where appropriate. ###
+
+Properties should be used instead of Get/Set methods in most situations. Methods are preferable to properties in the following situations: the operation is a conversion, is expensive or has an observable side-effect; the order of execution is important; calling the member twice in succession creates different results; a member is static but returns a mutable value; or the member returns an array.
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182181.aspx](http://msdn.microsoft.com/library/ms182181.aspx)
+
+### CA1033: Interface methods should be callable by child types ###
+
+An unsealed externally visible type provides an explicit method implementation of a public interface and does not provide an alternative externally visible method that has the same name.
+Consider a base type that explicitly implements a public interface method. A type that derives from the base type can access the inherited interface method only through a reference to the current instance that is cast to the interface. If the derived type re-implements (explicitly) the inherited interface method, the base implementation can no longer be accessed. The call through the current instance reference will invoke the derived implementation; this causes recursion and an eventual stack overflow.
+
+Category: Design
+Severity: Warning
+
+Help: [https://msdn.microsoft.com/library/ms182153.aspx](https://msdn.microsoft.com/library/ms182153.aspx)
+
+### CA1052: Static holder types should be Static or NotInheritable ###
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182168.aspx](http://msdn.microsoft.com/library/ms182168.aspx)
+
+### CA1708: Identifier names should differ by more than case ###
+
+Do not use names that require case sensitivity for uniqueness. Components must be fully usable from both case-sensitive and case-insensitive languages. Since case-insensitive languages cannot distinguish between two names within the same context that differ only by case, components must avoid this situation.
+
+Category: Naming
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182242.aspx](http://msdn.microsoft.com/library/ms182242.aspx)
+
+### CA1715: Interface names should be prefixed with 'I' ###
+
+Category: Naming
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182243.aspx](http://msdn.microsoft.com/library/ms182243.aspx)
+
+### CA1821: Remove empty finalizers ###
+
+Finalizers should be avoided where possible, to avoid the additional performance overhead involved in tracking object lifetime.
+
+Category: Performance
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/bb264476.aspx](http://msdn.microsoft.com/library/bb264476.aspx)
+
+### CA2200: Rethrow to preserve stack details. ###
+
+Category: Usage
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182363.aspx](http://msdn.microsoft.com/library/ms182363.aspx)
+
+### CA2214: Do not call overridable methods in constructors ###
+
+Virtual methods defined on the class should not be called from constructors. If a derived class has overridden the method, the derived class version will be called (before the derived class constructor is called).
+
+Category: Usage
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182331.aspx](http://msdn.microsoft.com/library/ms182331.aspx)
+
+### CA2229: Implement Serialization constructor ###
+
+The constructor signature accepts the same arguments as ISerializable.GetObjectData, namely, a SerializationInfo instance and a StreamingContext instance. The constructor should be protected for non-sealed classes and private for sealed classes. Failure to implement a serialization constructor will cause deserialization to fail, and throw a SerializationException.
+
+Category: Usage
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182343.aspx](http://msdn.microsoft.com/library/ms182343.aspx)
+
+### CA2235: Mark all non-serializable fields. ###
+
+All fields that cannot be serialized directly should have the NonSerializedAttribute. Types that have the SerializableAttribute should not have fields of types that do not have the SerializableAttribute unless the fields are marked with the NonSerializedAttribute.
+
+Category: Usage
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182349.aspx](http://msdn.microsoft.com/library/ms182349.aspx)
+
+### CA2237: Mark ISerializable types with SerializableAttribute. ###
+
+The System.Runtime.Serialization.ISerializable interface allows the type to customize its serialization, while the Serializable attribute enables the runtime to recognize the type as being serializable.
+
+Category: Usage
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182350.aspx](http://msdn.microsoft.com/library/ms182350.aspx)

--- a/src/AsyncPackage/AsyncPackage.md
+++ b/src/AsyncPackage/AsyncPackage.md
@@ -1,0 +1,29 @@
+### Async001: Avoid Async Void ###
+
+Category: Usage
+Severity: Warning
+
+### Async002: Async Method Names Should End in Async ###
+
+Category: Naming
+Severity: Warning
+
+### Async003: Don't Pass Async Lambdas as Void Returning Delegate Types ###
+
+Category: Usage
+Severity: Warning
+
+### Async004: Don't Store Async Lambdas as Void Returning Delegate Types ###
+
+Category: Usage
+Severity: Warning
+
+### Async005: Propagate CancellationTokens When Possible ###
+
+Category: Library
+Severity: Warning
+
+### Async006: Don't Mix Blocking and Async ###
+
+Category: Usage
+Severity: Warning

--- a/src/CodeAnalysis/Microsoft.CodeAnalysis.Analyzers.md
+++ b/src/CodeAnalysis/Microsoft.CodeAnalysis.Analyzers.md
@@ -1,0 +1,98 @@
+### RS1001: Missing diagnostic analyzer attribute. ###
+
+Non-abstract sub-types of DiagnosticAnalyzer should be marked with DiagnosticAnalyzerAttribute(s). The argument to this attribute(s), if any, determine the supported languages for the analyzer. Analyzer types without this attribute will be ignored by the analysis engine.
+
+Category: AnalyzerCorrectness
+Severity: Warning
+
+### RS1002: Missing kind argument while registering an analyzer action. ###
+
+You must specify at least one syntax/symbol kinds of interest while registering a syntax/symbol analyzer action. Otherwise, the registered action will be dead code and will never be invoked during analysis.
+
+Category: AnalyzerCorrectness
+Severity: Warning
+
+### RS1003: Unsupported SymbolKind argument while registering a symbol analyzer action. ###
+
+Category: AnalyzerCorrectness
+Severity: Warning
+
+### RS1004: Recommend adding language support to diagnostic analyzer. ###
+
+Diagnostic analyzer is marked as supporting only one language, but the analyzer assembly doesn't seem to refer to any language specific CodeAnalysis assemblies, and so is likely to work for more than one language. Consider adding an additional language argument to DiagnosticAnalyzerAttribute.
+
+Category: AnalyzerCorrectness
+Severity: Warning
+
+### RS1005: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor. ###
+
+ReportDiagnostic should only be invoked with supported DiagnosticDescriptors that are returned from DiagnosticAnalyzer.SupportedDiagnostics property. Otherwise, the reported diagnostic will be filtered out by the analysis engine.
+
+Category: AnalyzerCorrectness
+Severity: Warning
+
+### RS1006: Invalid type argument for DiagnosticAnalyzer's Register method. ###
+
+DiagnosticAnalyzer's language-specific Register methods, such as RegisterSyntaxNodeAction, RegisterCodeBlockStartAction and RegisterCodeBlockEndAction, expect a language-specific 'SyntaxKind' type argument for it's 'TLanguageKindEnumName' type parameter. Otherwise, the registered analyzer action can never be invoked during analysis.
+
+Category: AnalyzerCorrectness
+Severity: Warning
+
+### RS1007: Provide localizable arguments to diagnostic descriptor constructor. ###
+
+If your diagnostic analyzer and it's reported diagnostics need to be localizable, then the supported DiagnosticDescriptors used for constructing the diagnostics must also be localizable. If so, then localizable argument(s) must be provided for parameter 'title' (and optionally 'description') to the diagnostic descriptor constructor to ensure that the descriptor is localizable.
+
+Category: AnalyzerLocalization
+Severity: Warning
+
+### RS1008: Avoid storing per-compilation data into the fields of a diagnostic analyzer. ###
+
+Instance of a diagnostic analyzer might outlive the lifetime of compilation. Hence, storing per-compilation data, such as symbols, into the fields of a diagnostic analyzer might cause stale compilations to stay alive and cause memory leaks.  Instead, you should store this data on a separate type instantiated in a compilation start action, registered using 'AnalysisContext.RegisterCompilationStartAction' API. An instance of this type will be created per-compilation and it won't outlive compilation's lifetime, hence avoiding memory leaks.
+
+Category: AnalyzerPerformance
+Severity: Warning
+
+### RS1009: Only internal implementations of this interface are allowed. ###
+
+The author of this interface did not intend to have third party implementations of this interface and reserves the right to change it. Implementing this interface could therefore result in a source or binary compatibility issue with a future version of this interface.
+
+Category: Compatibility
+Severity: Error
+
+### RS1010: Create code actions should have a unique EquivalenceKey for FixAll occurrences support. ###
+
+A CodeFixProvider that intends to support fix all occurrences must classify the registered code actions into equivalence classes by assigning it an explicit, non-null equivalence key which is unique across all registered code actions by this fixer. This enables the FixAllProvider to fix all diagnostics in the required scope by applying code actions from this fixer that are in the equivalence class of the trigger code action.
+
+Category: Correctness
+Severity: Warning
+
+### RS1011: Use code actions that have a unique EquivalenceKey for FixAll occurrences support. ###
+
+A CodeFixProvider that intends to support fix all occurrences must classify the registered code actions into equivalence classes by assigning it an explicit, non-null equivalence key which is unique across all registered code actions by this fixer. This enables the FixAllProvider to fix all diagnostics in the required scope by applying code actions from this fixer that are in the equivalence class of the trigger code action.
+
+Category: Correctness
+Severity: Warning
+
+### RS1012: Start action has no registered actions. ###
+
+An analyzer start action enables performing stateful analysis over a given code unit, such as a code block, compilation, etc. Careful design is necessary to achieve efficient analyzer execution without memory leaks. Use the following guidelines for writing such analyzers:
+1. Define a new scope for the registered start action, possibly with a private nested type for analyzing each code unit.
+2. If required, define and initialize state in the start action.
+3. Register at least one non-end action that refers to this state in the start action. If no such action is necessary, consider replacing the start action with a non-start action. For example, a CodeBlockStartAction with no registered actions or only a registered CodeBlockEndAction should be replaced with a CodeBlockAction.
+4. If required, register an end action to report diagnostics based on the final state.
+
+
+Category: AnalyzerPerformance
+Severity: Warning
+
+### RS1013: Start action has no registered non-end actions. ###
+
+An analyzer start action enables performing stateful analysis over a given code unit, such as a code block, compilation, etc. Careful design is necessary to achieve efficient analyzer execution without memory leaks. Use the following guidelines for writing such analyzers:
+1. Define a new scope for the registered start action, possibly with a private nested type for analyzing each code unit.
+2. If required, define and initialize state in the start action.
+3. Register at least one non-end action that refers to this state in the start action. If no such action is necessary, consider replacing the start action with a non-start action. For example, a CodeBlockStartAction with no registered actions or only a registered CodeBlockEndAction should be replaced with a CodeBlockAction.
+4. If required, register an end action to report diagnostics based on the final state.
+
+
+Category: AnalyzerPerformance
+Severity: Warning

--- a/src/FxCop/Desktop.Analyzers/Desktop.Analyzers.md
+++ b/src/FxCop/Desktop.Analyzers/Desktop.Analyzers.md
@@ -1,0 +1,6 @@
+### CA2153: Do not catch corrupted state exceptions in general handlers. ###
+
+Do not author general catch handlers in code that receives corrupted state exceptions. Code that receives and intends to handle corrupted state exceptions should author distinct handlers for each exception type.
+
+Category: Microsoft.Security
+Severity: Warning

--- a/src/FxCop/System.Runtime.Analyzers/System.Runtime.Analyzers.md
+++ b/src/FxCop/System.Runtime.Analyzers/System.Runtime.Analyzers.md
@@ -1,0 +1,127 @@
+### CA1001: Types that own disposable fields should be disposable ###
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182172.aspx](http://msdn.microsoft.com/library/ms182172.aspx)
+
+### CA1003: Use System.EventHandler<T> where T inherits System.EventArgs or use System.EventHandler ###
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182178.aspx](http://msdn.microsoft.com/library/ms182178.aspx)
+
+### CA1014: Mark assemblies with CLSCompliantAttribute ###
+
+Assemblies should explicitly state their CLS compliance using the CLSCompliant attribute. An assembly without this attribute is not CLS-compliant. Assemblies, modules, and types can be CLS-compliant even if some parts of the assembly, module, or type are not CLS-compliant. The following rules apply: 1) If the element is marked CLSCompliant, any noncompliant members must have the CLSCompliant attribute present with its argument set to false. 2) A comparable CLS-compliant alternative member must be supplied for each member that is not CLS-compliant.
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182156.aspx](http://msdn.microsoft.com/library/ms182156.aspx)
+
+### CA1016: Assemblies should be marked with AssemblyVersionAttribute ###
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182155.aspx](http://msdn.microsoft.com/library/ms182155.aspx)
+
+### CA1017: Mark all assemblies with ComVisible ###
+
+The System.Runtime.InteropServices.ComVisible attribute indicates whether COM clients can use the library. Good design dictates that developers explicitly indicate COM visibility. The default value for this attribute is 'true'. However, the best design is to mark the assembly ComVisible false, and then mark types, interfaces, and individual members as ComVisible true, as appropriate.
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182157.aspx](http://msdn.microsoft.com/library/ms182157.aspx)
+
+### CA1018: Custom attributes should have AttributeUsage attribute defined. ###
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182158.aspx](http://msdn.microsoft.com/library/ms182158.aspx)
+
+### CA1019: Define accessors for attribute arguments. ###
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182136.aspx](http://msdn.microsoft.com/library/ms182136.aspx)
+
+### CA1027: Mark Enum with FlagsAttribute ###
+
+The enumeration appears to be made up of combinable flags. If this true, apply the Flags attribute to the enumeration.
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182159.aspx](http://msdn.microsoft.com/library/ms182159.aspx)
+
+### CA1036: Overload operator Equals and comparison operators when implementing System.IComparable ###
+
+Types that implement IComparable should redefine Equals and comparison operators to keep the meanings of less than, greater than, and equals consistent throughout the type.
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182163.aspx](http://msdn.microsoft.com/library/ms182163.aspx)
+
+### CA1309: String comparison should use StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase ###
+
+For non-linguistic comparisons, StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase should be used instead of the linguistically-sensitive StringComparison.InvariantCulture.
+
+Category: Globalization
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/bb385972.aspx](http://msdn.microsoft.com/library/bb385972.aspx)
+
+### CA1813: Avoid unsealed attributes. ###
+
+Category: Performance
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182267.aspx](http://msdn.microsoft.com/library/ms182267.aspx)
+
+### CA1820: Test for empty strings using 'string.Length' property or 'string.IsNullOrEmpty' method instead of an Equality check. ###
+
+Comparing strings using the string.Length property or the string.IsNullOrEmpty method is significantly faster than using string.Equals. This is because Equals executes significantly more MSIL instructions than either IsNullOrEmpty or the number of instructions executed to retrieve the Length property value and compare it to zero.
+
+Category: Performance
+Severity: Warning
+
+Help: [https://msdn.microsoft.com/library/ms182279.aspx](https://msdn.microsoft.com/library/ms182279.aspx)
+
+### CA2002: Do not lock on objects with weak identity. ###
+
+Category: Reliability
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182290.aspx](http://msdn.microsoft.com/library/ms182290.aspx)
+
+### CA2213: Disposable fields should be disposed ###
+
+Category: Usage
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182328.aspx](http://msdn.microsoft.com/library/ms182328.aspx)
+
+### CA2217: Do not mark Enum with FlagsAttribute ###
+
+The enumeration does not appear to contain a consistent set values that can be combined using  the OR (|) and AND (&amp;amp;amp;) operators. Using the Flags attribute on an enumeration suggests that the enumeration values are meant to be combined using the AND and OR operators. Typically, a flags enumeration uses values that are either powers of two, or combine other values that are powers of two.
+
+Category: Usage
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182335.aspx](http://msdn.microsoft.com/library/ms182335.aspx)
+
+### CA2231: Overload operator equals on overriding ValueType.Equals ###
+
+Value types that redefine System.ValueType.Equals should redefine the equality operator as well to ensure that these members return the same results. This helps ensure that types that rely on Equals (such as ArrayList and Hashtable) behave in a manner that is expected and consistent with the equality operator.
+
+Category: Usage
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182359.aspx](http://msdn.microsoft.com/library/ms182359.aspx)

--- a/src/FxCop/System.Runtime.InteropServices.Analyzers/System.Runtime.InteropServices.Analyzers.md
+++ b/src/FxCop/System.Runtime.InteropServices.Analyzers/System.Runtime.InteropServices.Analyzers.md
@@ -1,0 +1,22 @@
+### CA1060: Move P/Invokes to native methods class ###
+
+Category: Design
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182161.aspx](http://msdn.microsoft.com/library/ms182161.aspx)
+
+### CA1401: P/Invokes should not be visible. ###
+
+Category: Interoperability
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182209.aspx](http://msdn.microsoft.com/library/ms182209.aspx)
+
+### CA2101: Specify marshaling for P/Invoke string arguments ###
+
+When marshaling strings as ANSI (or as Auto on Win9x), some characters may be changed. If best-fit mapping is on, strings that appear different in Unicode will be marshaled to identical ANSI strings, which may lead to incorrect security decisions. Turning best-fit mapping off reduces this risk, as all characters without equivalents are mapped to '?'. Also, note that CharSet.Ansi is the default setting for all string marshaling; Unicode marshaling must be specified explicitly, either as a CharSet setting of DllImport or StructLayout, or as a MarshalAs attribute with a Unicode (or system-dependent) UnmanagedType.
+
+Category: Globalization
+Severity: Warning
+
+Help: [http://msdn.microsoft.com/library/ms182319.aspx](http://msdn.microsoft.com/library/ms182319.aspx)

--- a/src/Roslyn/Microsoft.Net.RoslynDiagnostics.md
+++ b/src/Roslyn/Microsoft.Net.RoslynDiagnostics.md
@@ -1,0 +1,141 @@
+### RS0001: Use SpecializedCollections.EmptyEnumerable<T>() ###
+
+Category: Performance
+Severity: Warning
+
+### RS0002: Use SpecializedCollections.SingletonEnumerable<T>() ###
+
+Category: Performance
+Severity: Warning
+
+### RS0003: Do not directly await a Task ###
+
+Category: Reliability
+Severity: Warning
+
+### RS0004: Invoke the correct property to ensure correct use site diagnostics. ###
+
+Telemetry
+
+Category: Usage
+Severity: Error
+
+### RS0005: Do not use generic CodeAction.Create to create CodeAction ###
+
+Category: Performance
+Severity: Warning
+
+### RS0006: Do not mix attributes from different versions of MEF ###
+
+Category: Reliability
+Severity: Error
+
+### RS0007: Avoid zero-length array allocations. ###
+
+Category: Performance
+Severity: Warning
+
+### RS0008: Implement IEquatable<T> when overriding Object.Equals ###
+
+Category: Performance
+Severity: Warning
+
+### RS0009: Override Object.Equals(object) when implementing IEquatable<T>  ###
+
+Category: Reliability
+Severity: Warning
+
+### RS0010: Avoid using cref tags with a prefix ###
+
+Use of cref tags with prefixes should be avoided, since it prevents the compiler from verifying references and the IDE from updating references during refactorings. It is permissible to suppress this error at a single documentation site if the cref must use a prefix because the type being mentioned is not findable by the compiler. For example, if a cref is mentioning a special attribute in the full framework but you're in a file that compiles against the portable framework, or if you want to reference a type at higher layer of Roslyn, you should suppress the error. You should not suppress the error just because you want to take a shortcut and avoid using the full syntax.
+
+Category: Documentation
+Severity: Warning
+
+### RS0011: CancellationToken parameters must come last ###
+
+Category: ApiDesign
+Severity: Warning
+
+### RS0012: Do not call ToImmutableArray on an ImmutableArray<T> value. ###
+
+Category: Reliability
+Severity: Warning
+
+### RS0013: Do not invoke Diagnostic.Descriptor ###
+
+Accessing the Descriptor property of Diagnostic in compiler layer leads to unnecessary string allocations for fields of the descriptor that are not utilized in command line compilation. Hence, you should avoid accessing the Descriptor of the compiler diagnostics here. Instead you should directly access these properties off the Diagnostic type.
+
+Category: Performance
+Severity: Warning
+
+### RS0014: Do not use Enumerable methods on indexable collections.  Instead use the collection directly. ###
+
+This collection is directly indexable.  Going through LINQ here causes unnecessary allocations and CPU work.
+
+Category: Performance
+Severity: Warning
+
+### RS0015: Always consume the value returned by methods marked with PreserveSigAttribute ###
+
+PreserveSigAttribute indicates that a method will return an HRESULT, rather than throwing an exception.  Therefore, it is important to consume the HRESULT returned by the method, so that errors can be detected.  Generally, this is done by calling Marshal.ThrowExceptionForHR.
+
+Category: Reliability
+Severity: Warning
+
+### RS0016: Add public types and members to the declared API ###
+
+All public types and members should be declared in PublicAPI.txt. This draws attention to API changes in the code reviews and source control history, and helps prevent breaking changes.
+
+Category: ApiDesign
+Severity: Error
+
+### RS0017: Remove deleted types and members from the declared API ###
+
+When removing a public type or member the corresponding entry in PublicAPI.txt should also be removed. This draws attention to API changes in the code reviews and source control history, and helps prevent breaking changes.
+
+Category: ApiDesign
+Severity: Error
+
+### RS0018: Do not create tasks without passing a TaskScheduler ###
+
+Do not create tasks unless you are using one of the overloads that takes a TaskScheduler. The default is to schedule on TaskScheduler.Current, which would lead to deadlocks. Either use TaskScheduler.Default to schedule on the thread pool, or explicitly pass TaskScheduler.Current to make your intentions clear.
+
+Category: Reliability
+Severity: Warning
+
+### RS0019: SymbolDeclaredEvent must be generated for source symbols ###
+
+Compilation event queue is required to generate symbol declared events for all declared source symbols. Hence, every source symbol type or one of it's base types must generate a symbol declared event.
+
+Category: Reliability
+Severity: Error
+
+### RS0020: unused code ###
+
+Category: Maintainability
+Severity: Warning
+
+### RS0021:  ###
+
+Category: 
+Severity: Hidden
+
+### RS0022: Constructor make noninheritable base class inheritable ###
+
+When a base class is noninheritable because its constructor is internal, a derived class should not make it inheritable by having a public or protected constructor.
+
+Category: ApiDesign
+Severity: Error
+
+### RS0023: Parts exported with MEFv2 must be marked as Shared. ###
+
+Category: Reliability
+Severity: Error
+
+### RS0024: The contents of the public API files are invalid: {0} ###
+
+The contents of the public API files are invalid: {0}
+
+Category: ApiDesign
+Severity: Error


### PR DESCRIPTION
Add project-specific documentation. At the moment this documentation
is just a list of diagnostics produced by a set of analyzers with
some basic information--ID, title, description, etc. A simple tool
was created to produce this documentation in Markdown format.

The main README.md has been updated to point to this information.