### PR TITLE
Look for duplicated symbols in public API files

### DIFF
--- a/src/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
+++ b/src/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
@@ -61,6 +61,15 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
+        internal static readonly DiagnosticDescriptor DuplicateSymbolInApiFiles = new DiagnosticDescriptor(
+            id: RoslynDiagnosticIds.DuplicatedSymbolInPublicApiFiles,
+            title: RoslynDiagnosticsResources.DuplicateSymbolsInPublicApiFilesTitle,
+            messageFormat: RoslynDiagnosticsResources.DuplicateSymbolsInPublicApiFilesMessage,
+            category: "ApiDesign",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
         internal static readonly SymbolDisplayFormat ShortSymbolNameFormat =
             new SymbolDisplayFormat(
                 globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
@@ -95,7 +104,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
                 miscellaneousOptions:
                     SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DeclareNewApiRule, RemoveDeletedApiRule, ExposedNoninstantiableType, PublicApiFilesInvalid);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DeclareNewApiRule, RemoveDeletedApiRule, ExposedNoninstantiableType, PublicApiFilesInvalid, DuplicateSymbolInApiFiles);
 
         private readonly ImmutableArray<AdditionalText> _extraAdditionalFiles;
 
@@ -257,15 +266,40 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             return shippedText != null && unshippedText != null;
         }
 
-        private bool ValidateApiFiles(ApiData shippedData, ApiData unshippedData, out List<Diagnostic> list)
+        private bool ValidateApiFiles(ApiData shippedData, ApiData unshippedData, out List<Diagnostic> errors)
         {
-            list = new List<Diagnostic>();
+            errors = new List<Diagnostic>();
             if (shippedData.RemovedApiList.Length > 0)
             {
-                list.Add(Diagnostic.Create(PublicApiFilesInvalid, Location.None, InvalidReasonShippedCantHaveRemoved));
+                errors.Add(Diagnostic.Create(PublicApiFilesInvalid, Location.None, InvalidReasonShippedCantHaveRemoved));
             }
 
-            return list.Count == 0;
+            var publicApiMap = new Dictionary<string, ApiLine>(StringComparer.Ordinal);
+            ValidateApiList(publicApiMap, shippedData.ApiList, errors);
+            ValidateApiList(publicApiMap, unshippedData.ApiList, errors);
+
+            return errors.Count == 0;
+        }
+
+        private static void ValidateApiList(Dictionary<string, ApiLine> publicApiMap, ImmutableArray<ApiLine> apiList, List<Diagnostic> errors)
+        {
+            foreach (var cur in apiList)
+            {
+                ApiLine existingLine;
+                if (publicApiMap.TryGetValue(cur.Text, out existingLine))
+                {
+                    var existingLinePositionSpan = existingLine.SourceText.Lines.GetLinePositionSpan(existingLine.Span);
+                    var existingLocation = Location.Create(existingLine.Path, existingLine.Span, existingLinePositionSpan);
+
+                    var duplicateLinePositionSpan = cur.SourceText.Lines.GetLinePositionSpan(cur.Span);
+                    var duplicateLocation = Location.Create(cur.Path, cur.Span, duplicateLinePositionSpan);
+                    errors.Add(Diagnostic.Create(DuplicateSymbolInApiFiles, duplicateLocation, new[] { existingLocation }, cur.Text));
+                }
+                else
+                {
+                    publicApiMap.Add(cur.Text, cur);
+                }
+            }
         }
     }
 }

--- a/src/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
+++ b/src/Roslyn/Core/ApiDesign/DeclarePublicAPIAnalyzer.cs
@@ -27,7 +27,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             title: RoslynDiagnosticsResources.DeclarePublicApiTitle,
             messageFormat: RoslynDiagnosticsResources.DeclarePublicApiMessage,
             category: "ApiDesign",
-            defaultSeverity: DiagnosticSeverity.Error,
+            defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: RoslynDiagnosticsResources.DeclarePublicApiDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
@@ -37,7 +37,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             title: RoslynDiagnosticsResources.RemoveDeletedApiTitle,
             messageFormat: RoslynDiagnosticsResources.RemoveDeletedApiMessage,
             category: "ApiDesign",
-            defaultSeverity: DiagnosticSeverity.Error,
+            defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: RoslynDiagnosticsResources.RemoveDeletedApiDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
@@ -47,7 +47,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             title: RoslynDiagnosticsResources.ExposedNoninstantiableTypeTitle,
             messageFormat: RoslynDiagnosticsResources.ExposedNoninstantiableTypeMessage,
             category: "ApiDesign",
-            defaultSeverity: DiagnosticSeverity.Error,
+            defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: RoslynDiagnosticsResources.ExposedNoninstantiableTypeDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
@@ -57,7 +57,7 @@ namespace Roslyn.Diagnostics.Analyzers.ApiDesign
             title: RoslynDiagnosticsResources.PublicApiFilesInvalidTitle,
             messageFormat: RoslynDiagnosticsResources.PublicApiFilesInvalidMessage,
             category: "ApiDesign",
-            defaultSeverity: DiagnosticSeverity.Error,
+            defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Roslyn/Core/RoslynDiagnosticIds.cs
+++ b/src/Roslyn/Core/RoslynDiagnosticIds.cs
@@ -28,5 +28,6 @@ namespace Roslyn.Diagnostics.Analyzers
         public const string ExposedNoninstantiableTypeRuleId = "RS0022";
         public const string MissingSharedAttributeRuleId = "RS0023";
         public const string PublicApiFilesInvalid = "RS0024";
+        public const string DuplicatedSymbolInPublicApiFiles = "RS0025";
     }
 }

--- a/src/Roslyn/Core/RoslynDiagnosticsResources.Designer.cs
+++ b/src/Roslyn/Core/RoslynDiagnosticsResources.Designer.cs
@@ -251,6 +251,24 @@ namespace Roslyn.Diagnostics.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The symbol &apos;{0}&apos; appears more than once in the public API files..
+        /// </summary>
+        internal static string DuplicateSymbolsInPublicApiFilesMessage {
+            get {
+                return ResourceManager.GetString("DuplicateSymbolsInPublicApiFilesMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not duplicate symbols in public API files.
+        /// </summary>
+        internal static string DuplicateSymbolsInPublicApiFilesTitle {
+            get {
+                return ResourceManager.GetString("DuplicateSymbolsInPublicApiFilesTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to When a base class is noninheritable because its constructor is internal, a derived class should not make it inheritable by having a public or protected constructor..
         /// </summary>
         internal static string ExposedNoninstantiableTypeDescription {

--- a/src/Roslyn/Core/RoslynDiagnosticsResources.resx
+++ b/src/Roslyn/Core/RoslynDiagnosticsResources.resx
@@ -282,4 +282,10 @@
   <data name="PublicApiFilesInvalidMessage" xml:space="preserve">
     <value>The contents of the public API files are invalid: {0}</value>
   </data>
+  <data name="DuplicateSymbolsInPublicApiFilesTitle" xml:space="preserve">
+    <value>Do not duplicate symbols in public API files</value>
+  </data>
+  <data name="DuplicateSymbolsInPublicApiFilesMessage" xml:space="preserve">
+    <value>The symbol '{0}' appears more than once in the public API files.</value>
+  </data>
 </root>

--- a/src/Test/Utilities/DiagnosticAnalyzerTests.Extensions.cs
+++ b/src/Test/Utilities/DiagnosticAnalyzerTests.Extensions.cs
@@ -140,10 +140,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
                         }
                         else
                         {
-                            Assert.True(location.IsInSource,
+                            Assert.False(location.IsInMetadata,
                                 string.Format("Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata:\r\n", diagnostics[i]));
 
-                            string resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ? "GetCSharpResultAt" : "GetBasicResultAt";
+                            string resultMethodName = GetResultMethodName(diagnostics[i]);
                             var linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
 
                             builder.AppendFormat("{0}({1}, {2}, {3}.{4})",
@@ -166,6 +166,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
 
             return builder.ToString();
+        }
+
+        private static string GetResultMethodName(Diagnostic diagnostic)
+        {
+            if (diagnostic.Location.IsInSource)
+            {
+                return diagnostic.Location.SourceTree.FilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ? "GetCSharpResultAt" : "GetBasicResultAt";
+            }
+
+            return "GetResultAt";
         }
 
         private static string FormatDiagnostics(DiagnosticAnalyzer analyzer, IEnumerable<Diagnostic> diagnostics)


### PR DESCRIPTION
Currently, the DeclarePublicAPIAnalyzer does not expect the same symbol
to occur more than once, either within a public API file or across
files. If this happens the analyzer throws an exception in its
compilation start action and fails to actually check the API.

This change updates the analyzer to look out for duplicated symbols and
create a diagnostic to bring the issue to the attention of the user.

Fixes #312.