### PR TITLE
Remove Rijndael according to security development adviser

### DIFF
--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
@@ -161,24 +161,6 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not use insecure cryptographic algorithm Rijndael..
-        /// </summary>
-        internal static string DoNotUseRijndael {
-            get {
-                return ResourceManager.GetString("DoNotUseRijndael", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This type implements Rijndael, a cryptographically insecure encryption algorithm. Replace this usage with an AES encryption algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits..
-        /// </summary>
-        internal static string DoNotUseRijndaelDescription {
-            get {
-                return ResourceManager.GetString("DoNotUseRijndaelDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Do not use insecure cryptographic algorithm RIPEMD160..
         /// </summary>
         internal static string DoNotUseRIPEMD160 {

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
@@ -144,12 +144,6 @@
   <data name="DoNotUseRC2Description" xml:space="preserve">
     <value>This type implements RC2, a cryptographically insecure encryption algorithm. Replace this usage with an AES encryption algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits.</value>
   </data>
-  <data name="DoNotUseRijndael" xml:space="preserve">
-    <value>Do not use insecure cryptographic algorithm Rijndael.</value>
-  </data>
-  <data name="DoNotUseRijndaelDescription" xml:space="preserve">
-    <value>This type implements Rijndael, a cryptographically insecure encryption algorithm. Replace this usage with an AES encryption algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits.</value>
-  </data>
   <data name="DoNotUseRIPEMD160" xml:space="preserve">
     <value>Do not use insecure cryptographic algorithm RIPEMD160.</value>
   </data>

--- a/src/FxCop/Desktop.Analyzers/Core/Security/CompilationSecurityTypes.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Security/CompilationSecurityTypes.cs
@@ -15,7 +15,6 @@ namespace Desktop.Analyzers.Common
         public INamedTypeSymbol DSASignatureFormatter { get; private set; } 
         public INamedTypeSymbol HMACMD5 { get; private set; }
         public INamedTypeSymbol RC2 { get; private set; }
-        public INamedTypeSymbol Rijndael { get; private set; }  
         public INamedTypeSymbol TripleDES { get; private set; }
         public INamedTypeSymbol RIPEMD160 { get; private set; }
         public INamedTypeSymbol HMACRIPEMD160 { get; private set; } 
@@ -32,7 +31,6 @@ namespace Desktop.Analyzers.Common
             DSASignatureFormatter = SecurityTypes.DSASignatureFormatter(compilation); 
             HMACMD5 = SecurityTypes.HMACMD5(compilation);
             RC2 = SecurityTypes.RC2(compilation);
-            Rijndael = SecurityTypes.Rijndael(compilation);
             TripleDES = SecurityTypes.TripleDES(compilation);
             RIPEMD160 = SecurityTypes.RIPEMD160(compilation);
             HMACRIPEMD160 = SecurityTypes.HMACRIPEMD160(compilation);

--- a/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
@@ -29,9 +29,6 @@ namespace Desktop.Analyzers
         private static readonly LocalizableString s_localizableDoNotUseRIPEMD160Description = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseRIPEMD160Description));
         private static readonly LocalizableString s_localizableDoNotUseDSATitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseDSA));
         private static readonly LocalizableString s_localizableDoNotUseDSADescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseDSADescription));
-        private static readonly LocalizableString s_localizableDoNotUseRijndaelTitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseRijndael));
-        private static readonly LocalizableString s_localizableDoNotUseRijndaelDescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseRijndaelDescription));
-
 
         internal static DiagnosticDescriptor DoNotUseMD5SpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
                                                                                           s_localizableDoNotUseMD5Title,
@@ -57,10 +54,6 @@ namespace Desktop.Analyzers
                                                                                           s_localizableDoNotUseDSATitle,
                                                                                           s_localizableDoNotUseDSADescription);
 
-        internal static DiagnosticDescriptor DoNotUseRijndaelSpecificRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
-                                                                                               s_localizableDoNotUseRijndaelTitle,
-                                                                                               s_localizableDoNotUseRijndaelDescription);
-
         protected abstract Analyzer GetAnalyzer(CompilationStartAnalysisContext context, CompilationSecurityTypes cryptTypes);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = ImmutableArray.Create(DoNotUseMD5SpecificRule,
@@ -68,8 +61,7 @@ namespace Desktop.Analyzers
                                                                                                                   DoNotUseRC2SpecificRule,
                                                                                                                   DoNotUseTripleDESSpecificRule, 
                                                                                                                   DoNotUseRIPEMD160SpecificRule,
-                                                                                                                  DoNotUseDSASpecificRule,
-                                                                                                                  DoNotUseRijndaelSpecificRule);
+                                                                                                                  DoNotUseDSASpecificRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => s_supportedDiagnostics;
@@ -107,7 +99,6 @@ namespace Desktop.Analyzers
                 || types.DSASignatureFormatter != null 
                 || types.HMACMD5 != null
                 || types.RC2 != null
-                || types.Rijndael != null
                 || types.TripleDES != null
                 || types.RIPEMD160 != null
                 || types.HMACRIPEMD160 != null;
@@ -154,10 +145,6 @@ namespace Desktop.Analyzers
                 else if (type.IsDerivedFrom(_cryptTypes.RC2, baseTypesOnly: true))
                 {
                     rule = DoNotUseRC2SpecificRule;
-                }
-                else if (type.IsDerivedFrom(_cryptTypes.Rijndael, baseTypesOnly: true))
-                {
-                    rule = DoNotUseRijndaelSpecificRule;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.TripleDES, baseTypesOnly: true))
                 {

--- a/src/FxCop/Desktop.Analyzers/Core/Security/SecurityTypes.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Security/SecurityTypes.cs
@@ -52,11 +52,6 @@ namespace Desktop.Analyzers.Common
             return compilation.GetTypeByMetadataName("System.Security.Cryptography.RC2");
         }
 
-        public static INamedTypeSymbol Rijndael(Compilation compilation)
-        {
-            return compilation.GetTypeByMetadataName("System.Security.Cryptography.Rijndael");
-        }
-
         public static INamedTypeSymbol TripleDES(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.Security.Cryptography.TripleDES");

--- a/src/FxCop/Desktop.Analyzers/Test/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
+++ b/src/FxCop/Desktop.Analyzers/Test/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
@@ -1917,7 +1917,7 @@ End Namespace" },
         } 
         
         [Fact]
-        public void CA5357RijndaelManagedInMethodDeclaration()
+        public void CA5357RijndaelManagedInMethodDeclarationShouldNotGenerateDiagnostics()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1931,8 +1931,8 @@ namespace TestNamespace
             var rc2 = new RijndaelManaged();
         }
     }
-}",
-            GetCSharpResultAt(10, 23, CA5350RuleName, DoNotUseRijndaelMessage));
+}"
+            );
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1941,12 +1941,12 @@ Module TestClass
     Sub TestMethod()
         Dim rijndaelalg As New RijndaelManaged
     End Sub
-End Module",
-GetBasicResultAt(6, 28, CA5350RuleName, DoNotUseRijndaelMessage));
+End Module"
+            );
         }
                                                    
         [Fact]
-        public void CA5357RijndaelManagedInGetDeclaration()
+        public void CA5357RijndaelManagedInGetDeclarationShouldNotGenerateDiagnostics()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1959,8 +1959,8 @@ namespace TestNamespace
             get { return new RijndaelManaged(); }
         }
     }
-}",
-            GetCSharpResultAt(9, 26, CA5350RuleName, DoNotUseRijndaelMessage));
+}"
+            );
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1972,12 +1972,12 @@ Namespace TestNamespace
 			End Get
 		End Property
 	End Class
-End Namespace",
-            GetBasicResultAt(7, 12, CA5350RuleName, DoNotUseRijndaelMessage));
+End Namespace"
+            );
         } 
                 
         [Fact]
-        public void CA5357RijndaelManagedInFieldDeclaration()
+        public void CA5357RijndaelManagedInFieldDeclarationShouldNotGenerateDiagnostics()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1987,8 +1987,8 @@ namespace TestNamespace
     {
         RijndaelManaged privateRijndael = new RijndaelManaged();
     }
-}",
-            GetCSharpResultAt(7, 43, CA5350RuleName, DoNotUseRijndaelMessage));
+}"
+            );
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1996,12 +1996,12 @@ Namespace TestNamespace
 	Class TestClass
 		Private privateRijndael As New RijndaelManaged()
 	End Class
-End Namespace",
-            GetBasicResultAt(5, 30, CA5350RuleName, DoNotUseRijndaelMessage));
+End Namespace"
+            );
         } 
 //No VB                    
         [Fact]
-        public void CA5357RijndaelManagedInLambdaExpression()
+        public void CA5357RijndaelManagedInLambdaExpressionShouldNotGenerateDiagnostics()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -2015,12 +2015,12 @@ namespace TestNamespace
             await Task.Run(() => { new RijndaelManaged(); });
         }
     }
-}",
-            GetCSharpResultAt(10, 36, CA5350RuleName, DoNotUseRijndaelMessage));
+}"
+            );
         }  
 //No VB        
         [Fact]
-        public void CA5357RijndaelManagedInAnonymousMethodExpression()
+        public void CA5357RijndaelManagedInAnonymousMethodExpressionShouldNotGenerateDiagnostics()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -2031,12 +2031,12 @@ namespace TestNamespace
         delegate void Del();
         Del d = delegate () { new RijndaelManaged(); };
     }
-}",
-            GetCSharpResultAt(8, 31, CA5350RuleName, DoNotUseRijndaelMessage));
+}"
+            );
         } 
         
         [Fact]
-        public void CA5357CreateObjectFromRijndaelDerivedClass()
+        public void CA5357CreateObjectFromRijndaelDerivedClassShouldNotGenerateDiagnostics()
         {
             VerifyCSharp( new[] {
 //Test0
@@ -2082,8 +2082,8 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-            GetCSharpResultAt(10, 23, CA5350RuleName, DoNotUseRijndaelMessage));
+}" }
+            );
 
             VerifyBasic(new[] {
 //Test0
@@ -2118,8 +2118,8 @@ Namespace TestNamespace
 			Throw New NotImplementedException()
 		End Sub
 	End Class
-End Namespace" },
-            GetBasicResultAt(6, 14, CA5350RuleName, DoNotUseRijndaelMessage));
+End Namespace" }
+            );
         }
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
@@ -2141,6 +2141,5 @@ End Namespace" },
         private readonly string DoNotUseTripleDESMessage = DesktopAnalyzersResources.DoNotUseTripleDES;  
         private readonly string DoNotUseRIPEMD160Message = DesktopAnalyzersResources.DoNotUseRIPEMD160;
         private readonly string DoNotUseDSAMessage = DesktopAnalyzersResources.DoNotUseDSA;
-        private readonly string DoNotUseRijndaelMessage = DesktopAnalyzersResources.DoNotUseRijndael;
     }
 }


### PR DESCRIPTION
Remove Rijndael according to security development adviser. The algorithm is not absolutely insecure. We will revisit it and need to collect more info to make a diagnostic.