### PR TITLE
Fix the location of target files used by shared analyzer utility project

### DIFF
--- a/PortFxCop/src/Analyzer.Utilities/Analyzer.Utilities.csproj
+++ b/PortFxCop/src/Analyzer.Utilities/Analyzer.Utilities.csproj
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
-    <Import Project="..\..\..\build\Targets\Analyzers.Settings.targets" />
+    <Import Project="..\..\build\Targets\Analyzers.Settings.targets" />
   </ImportGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
@@ -120,6 +120,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ImportGroup Label="Targets">
-    <Import Project="..\..\..\build\Targets\Analyzers.Imports.targets" />
+    <Import Project="..\..\build\Targets\Analyzers.Imports.targets" />
   </ImportGroup>
 </Project>


### PR DESCRIPTION
It was referring to target files used by existing projects.

@heejaechang 