### PR TITLE
Update the crypto rules strings and help links

### DIFF
--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
@@ -125,9 +125,7 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of it may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. 
-        /// 
-        ///HOW: Replace encryption uses with the AES algorithm (AES-25 [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of it may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. Replace encryption uses with the AES algorithm (AES-256, AES-192 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DoNotUseWeakCryptographicAlgorithmsDescription {
             get {
@@ -136,7 +134,7 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} uses an weak cryptographic algorithm {1}.
+        ///   Looks up a localized string similar to {0} uses a weak cryptographic algorithm {1}.
         /// </summary>
         internal static string DoNotUseWeakCryptographicAlgorithmsMessage {
             get {

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
@@ -62,7 +62,7 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not catch corrupted state exceptions in general handlers..
+        ///   Looks up a localized string similar to Do Not Catch Corrupted State Exceptions.
         /// </summary>
         internal static string DoNotCatchCorruptedStateExceptions {
             get {
@@ -80,7 +80,11 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Modify {0} to catch and handle a more specific set of exception type(s) than {1} or rethrow the exception. .
+        ///   Looks up a localized string similar to What: {0} is catching corrupted state exception.
+        ///
+        ///Why: This could mask errors (such as access violations), resulting in inconsistent state of execution or making it easier for attackers to compromise system.
+        ///
+        ///How: Modify {0} to catch and handle a more specific set of exception type(s) than {1} or re-throw the exception.
         /// </summary>
         internal static string DoNotCatchCorruptedStateExceptionsMessage {
             get {
@@ -104,9 +108,9 @@ namespace Desktop.Analyzers {
         /// 
         ///HOW: Replace encryption [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string DoNotUseBrokenCryptographicAlgorithmsDescription {
+        internal static string DoNotUseBrokenCryptographicAlgorithmsMessage {
             get {
-                return ResourceManager.GetString("DoNotUseBrokenCryptographicAlgorithmsDescription", resourceCulture);
+                return ResourceManager.GetString("DoNotUseBrokenCryptographicAlgorithmsMessage", resourceCulture);
             }
         }
         
@@ -126,9 +130,9 @@ namespace Desktop.Analyzers {
         /// 
         ///HOW: Re [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string DoNotUseWeakCryptographicAlgorithmsDescription {
+        internal static string DoNotUseWeakCryptographicAlgorithmsMessage {
             get {
-                return ResourceManager.GetString("DoNotUseWeakCryptographicAlgorithmsDescription", resourceCulture);
+                return ResourceManager.GetString("DoNotUseWeakCryptographicAlgorithmsMessage", resourceCulture);
             }
         }
     }

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
@@ -102,11 +102,16 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WHAT: {0} uses a broken cryptographic algorithm {1} 
-        /// 
-        ///WHY: An attack making it computationally feasible to break {1} exists. This allows attackers to break the cryptographic guarantees {1} is designed to provide. Depending on the type and application of this cryptographic algorithm, this may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 
-        /// 
-        ///HOW: Replace encryption [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to An attack making it computationally feasible to break this algorithm exists. This allows attackers to break the cryptographic guarantees it is designed to provide. Depending on the type and application of this cryptographic algorithm, this may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. Replace encryption uses with the AES algorithm (AES-256, AES-192 and  [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string DoNotUseBrokenCryptographicAlgorithmsDescription {
+            get {
+                return ResourceManager.GetString("DoNotUseBrokenCryptographicAlgorithmsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} uses a broken cryptographic algorithm {1}.
         /// </summary>
         internal static string DoNotUseBrokenCryptographicAlgorithmsMessage {
             get {
@@ -124,11 +129,18 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WHAT: {0} uses an weak cryptographic algorithm {1} 
+        ///   Looks up a localized string similar to Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of it may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. 
         /// 
-        ///WHY: Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of {1}  may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 
-        /// 
-        ///HOW: Re [rest of string was truncated]&quot;;.
+        ///HOW: Replace encryption uses with the AES algorithm (AES-25 [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string DoNotUseWeakCryptographicAlgorithmsDescription {
+            get {
+                return ResourceManager.GetString("DoNotUseWeakCryptographicAlgorithmsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} uses an weak cryptographic algorithm {1}.
         /// </summary>
         internal static string DoNotUseWeakCryptographicAlgorithmsMessage {
             get {

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
@@ -71,7 +71,7 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not author general catch handlers in code that receives corrupted state exceptions. Code that receives and intends to handle corrupted state exceptions should author distinct handlers for each exception type..
+        ///   Looks up a localized string similar to Catching corrupted state exceptions could mask errors (such as access violations), resulting in inconsistent state of execution or making it easier for attackers to compromise system. Instead, catch and handle a more specific set of exception type(s) or re-throw the exception.
         /// </summary>
         internal static string DoNotCatchCorruptedStateExceptionsDescription {
             get {
@@ -80,11 +80,7 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to What: {0} is catching corrupted state exception.
-        ///
-        ///Why: This could mask errors (such as access violations), resulting in inconsistent state of execution or making it easier for attackers to compromise system.
-        ///
-        ///How: Modify {0} to catch and handle a more specific set of exception type(s) than {1} or re-throw the exception.
+        ///   Looks up a localized string similar to {0} is catching corrupted state exception..
         /// </summary>
         internal static string DoNotCatchCorruptedStateExceptionsMessage {
             get {

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.Designer.cs
@@ -89,110 +89,46 @@ namespace Desktop.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not use insecure cryptographic algorithm DES..
+        ///   Looks up a localized string similar to Do Not Use Broken Cryptographic Algorithms.
         /// </summary>
-        internal static string DoNotUseDES {
+        internal static string DoNotUseBrokenCryptographicAlgorithms {
             get {
-                return ResourceManager.GetString("DoNotUseDES", resourceCulture);
+                return ResourceManager.GetString("DoNotUseBrokenCryptographicAlgorithms", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This type implements DES, a cryptographically insecure encryption algorithm. Replace this usage with an AES encryption algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits..
+        ///   Looks up a localized string similar to WHAT: {0} uses a broken cryptographic algorithm {1} 
+        /// 
+        ///WHY: An attack making it computationally feasible to break {1} exists. This allows attackers to break the cryptographic guarantees {1} is designed to provide. Depending on the type and application of this cryptographic algorithm, this may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 
+        /// 
+        ///HOW: Replace encryption [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string DoNotUseDESDescription {
+        internal static string DoNotUseBrokenCryptographicAlgorithmsDescription {
             get {
-                return ResourceManager.GetString("DoNotUseDESDescription", resourceCulture);
+                return ResourceManager.GetString("DoNotUseBrokenCryptographicAlgorithmsDescription", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not use insecure cryptographic algorithm DSA..
+        ///   Looks up a localized string similar to Do Not Use Weak Cryptographic Algorithms.
         /// </summary>
-        internal static string DoNotUseDSA {
+        internal static string DoNotUseWeakCryptographicAlgorithms {
             get {
-                return ResourceManager.GetString("DoNotUseDSA", resourceCulture);
+                return ResourceManager.GetString("DoNotUseWeakCryptographicAlgorithms", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This type implements DSA, a cryptographically insecure signature-creation mechanism. Replace this usage with RSA or Diffie-Hellman with a key length greater than or equal to 2048-bits, or ECDSA or ECDH with a key length greater than or equal 256 bits..
+        ///   Looks up a localized string similar to WHAT: {0} uses an weak cryptographic algorithm {1} 
+        /// 
+        ///WHY: Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of {1}  may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 
+        /// 
+        ///HOW: Re [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string DoNotUseDSADescription {
+        internal static string DoNotUseWeakCryptographicAlgorithmsDescription {
             get {
-                return ResourceManager.GetString("DoNotUseDSADescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Do not use insecure cryptographic algorithm MD5..
-        /// </summary>
-        internal static string DoNotUseMD5 {
-            get {
-                return ResourceManager.GetString("DoNotUseMD5", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This type implements MD5, a cryptographically insecure hashing function. Hash collisions are computationally feasible for the MD5 and HMACMD5 algorithms. Replace this usage with a SHA-2 family hash algorithm (SHA512, SHA384, SHA256)..
-        /// </summary>
-        internal static string DoNotUseMD5Description {
-            get {
-                return ResourceManager.GetString("DoNotUseMD5Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Do not use insecure cryptographic algorithm RC2..
-        /// </summary>
-        internal static string DoNotUseRC2 {
-            get {
-                return ResourceManager.GetString("DoNotUseRC2", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This type implements RC2, a cryptographically insecure encryption algorithm. Replace this usage with an AES encryption algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits..
-        /// </summary>
-        internal static string DoNotUseRC2Description {
-            get {
-                return ResourceManager.GetString("DoNotUseRC2Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Do not use insecure cryptographic algorithm RIPEMD160..
-        /// </summary>
-        internal static string DoNotUseRIPEMD160 {
-            get {
-                return ResourceManager.GetString("DoNotUseRIPEMD160", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This type implements RIPEMD160, a cryptographically insecure hashing function. Hash collisions are computationally feasible for the RIPEMD hash algorithms. Replace this usage with a SHA-2 family hash algorithm (SHA512, SHA384, SHA256)..
-        /// </summary>
-        internal static string DoNotUseRIPEMD160Description {
-            get {
-                return ResourceManager.GetString("DoNotUseRIPEMD160Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Do not use insecure cryptographic algorithm TripleDES..
-        /// </summary>
-        internal static string DoNotUseTripleDES {
-            get {
-                return ResourceManager.GetString("DoNotUseTripleDES", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This type implements TripleDES, a cryptographically insecure encryption algorithm. Replace this usage with an AES encryption algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits..
-        /// </summary>
-        internal static string DoNotUseTripleDESDescription {
-            get {
-                return ResourceManager.GetString("DoNotUseTripleDESDescription", resourceCulture);
+                return ResourceManager.GetString("DoNotUseWeakCryptographicAlgorithmsDescription", resourceCulture);
             }
         }
     }

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
@@ -126,40 +126,24 @@
   <data name="DoNotCatchCorruptedStateExceptionsMessage" xml:space="preserve">
     <value>Modify {0} to catch and handle a more specific set of exception type(s) than {1} or rethrow the exception. </value>
   </data>
-  <data name="DoNotUseDES" xml:space="preserve">
-    <value>Do not use insecure cryptographic algorithm DES.</value>
+  <data name="DoNotUseBrokenCryptographicAlgorithmsDescription" xml:space="preserve">
+    <value>WHAT: {0} uses a broken cryptographic algorithm {1} 
+ 
+WHY: An attack making it computationally feasible to break {1} exists. This allows attackers to break the cryptographic guarantees {1} is designed to provide. Depending on the type and application of this cryptographic algorithm, this may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 
+ 
+HOW: Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits. Replace hashing uses with a hashing function in the SHA-2 family, such as SHA512, SHA384, or SHA256. Replace digital signature uses with RSA with a key length greater than or equal to 2048-bits, or ECDSA with a key length greater than or equal to 256 bits.</value>
   </data>
-  <data name="DoNotUseDESDescription" xml:space="preserve">
-    <value>This type implements DES, a cryptographically insecure encryption algorithm. Replace this usage with an AES encryption algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits.</value>
+  <data name="DoNotUseBrokenCryptographicAlgorithms" xml:space="preserve">
+    <value>Do Not Use Broken Cryptographic Algorithms</value>
   </data>
-  <data name="DoNotUseMD5" xml:space="preserve">
-    <value>Do not use insecure cryptographic algorithm MD5.</value>
+  <data name="DoNotUseWeakCryptographicAlgorithms" xml:space="preserve">
+    <value>Do Not Use Weak Cryptographic Algorithms</value>
   </data>
-  <data name="DoNotUseMD5Description" xml:space="preserve">
-    <value>This type implements MD5, a cryptographically insecure hashing function. Hash collisions are computationally feasible for the MD5 and HMACMD5 algorithms. Replace this usage with a SHA-2 family hash algorithm (SHA512, SHA384, SHA256).</value>
-  </data>
-  <data name="DoNotUseRC2" xml:space="preserve">
-    <value>Do not use insecure cryptographic algorithm RC2.</value>
-  </data>
-  <data name="DoNotUseRC2Description" xml:space="preserve">
-    <value>This type implements RC2, a cryptographically insecure encryption algorithm. Replace this usage with an AES encryption algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits.</value>
-  </data>
-  <data name="DoNotUseRIPEMD160" xml:space="preserve">
-    <value>Do not use insecure cryptographic algorithm RIPEMD160.</value>
-  </data>
-  <data name="DoNotUseRIPEMD160Description" xml:space="preserve">
-    <value>This type implements RIPEMD160, a cryptographically insecure hashing function. Hash collisions are computationally feasible for the RIPEMD hash algorithms. Replace this usage with a SHA-2 family hash algorithm (SHA512, SHA384, SHA256).</value>
-  </data>
-  <data name="DoNotUseDSA" xml:space="preserve">
-    <value>Do not use insecure cryptographic algorithm DSA.</value>
-  </data>
-  <data name="DoNotUseDSADescription" xml:space="preserve">
-    <value>This type implements DSA, a cryptographically insecure signature-creation mechanism. Replace this usage with RSA or Diffie-Hellman with a key length greater than or equal to 2048-bits, or ECDSA or ECDH with a key length greater than or equal 256 bits.</value>
-  </data>
-  <data name="DoNotUseTripleDES" xml:space="preserve">
-    <value>Do not use insecure cryptographic algorithm TripleDES.</value>
-  </data>
-  <data name="DoNotUseTripleDESDescription" xml:space="preserve">
-    <value>This type implements TripleDES, a cryptographically insecure encryption algorithm. Replace this usage with an AES encryption algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits.</value>
+  <data name="DoNotUseWeakCryptographicAlgorithmsDescription" xml:space="preserve">
+    <value>WHAT: {0} uses an weak cryptographic algorithm {1} 
+ 
+WHY: Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of {1}  may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 
+ 
+HOW: Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits. Replace hashing uses with a hashing function in the SHA-2 family, such as SHA-2 512, SHA-2 384, or SHA-2 256.</value>
   </data>
 </root>

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
@@ -131,23 +131,23 @@ Why: This could mask errors (such as access violations), resulting in inconsiste
 How: Modify {0} to catch and handle a more specific set of exception type(s) than {1} or re-throw the exception</value>
   </data>
   <data name="DoNotUseBrokenCryptographicAlgorithmsMessage" xml:space="preserve">
-    <value>WHAT: {0} uses a broken cryptographic algorithm {1} 
- 
-WHY: An attack making it computationally feasible to break {1} exists. This allows attackers to break the cryptographic guarantees {1} is designed to provide. Depending on the type and application of this cryptographic algorithm, this may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 
- 
-HOW: Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits. Replace hashing uses with a hashing function in the SHA-2 family, such as SHA512, SHA384, or SHA256. Replace digital signature uses with RSA with a key length greater than or equal to 2048-bits, or ECDSA with a key length greater than or equal to 256 bits.</value>
+    <value>{0} uses a broken cryptographic algorithm {1}</value>
   </data>
   <data name="DoNotUseBrokenCryptographicAlgorithms" xml:space="preserve">
     <value>Do Not Use Broken Cryptographic Algorithms</value>
   </data>
+  <data name="DoNotUseBrokenCryptographicAlgorithmsDescription" xml:space="preserve">
+    <value>An attack making it computationally feasible to break this algorithm exists. This allows attackers to break the cryptographic guarantees it is designed to provide. Depending on the type and application of this cryptographic algorithm, this may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits. Replace hashing uses with a hashing function in the SHA-2 family, such as SHA512, SHA384, or SHA256. Replace digital signature uses with RSA with a key length greater than or equal to 2048-bits, or ECDSA with a key length greater than or equal to 256 bits.</value>
+  </data>
   <data name="DoNotUseWeakCryptographicAlgorithms" xml:space="preserve">
     <value>Do Not Use Weak Cryptographic Algorithms</value>
   </data>
-  <data name="DoNotUseWeakCryptographicAlgorithmsMessage" xml:space="preserve">
-    <value>WHAT: {0} uses an weak cryptographic algorithm {1} 
- 
-WHY: Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of {1}  may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 
+  <data name="DoNotUseWeakCryptographicAlgorithmsDescription" xml:space="preserve">
+    <value>Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of it may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. 
  
 HOW: Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits. Replace hashing uses with a hashing function in the SHA-2 family, such as SHA-2 512, SHA-2 384, or SHA-2 256.</value>
+  </data>
+  <data name="DoNotUseWeakCryptographicAlgorithmsMessage" xml:space="preserve">
+    <value>{0} uses an weak cryptographic algorithm {1}</value>
   </data>
 </root>

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
@@ -121,14 +121,10 @@
     <value>Do Not Catch Corrupted State Exceptions</value>
   </data>
   <data name="DoNotCatchCorruptedStateExceptionsDescription" xml:space="preserve">
-    <value>Do not author general catch handlers in code that receives corrupted state exceptions. Code that receives and intends to handle corrupted state exceptions should author distinct handlers for each exception type.</value>
+    <value>Catching corrupted state exceptions could mask errors (such as access violations), resulting in inconsistent state of execution or making it easier for attackers to compromise system. Instead, catch and handle a more specific set of exception type(s) or re-throw the exception</value>
   </data>
   <data name="DoNotCatchCorruptedStateExceptionsMessage" xml:space="preserve">
-    <value>What: {0} is catching corrupted state exception.
-
-Why: This could mask errors (such as access violations), resulting in inconsistent state of execution or making it easier for attackers to compromise system.
-
-How: Modify {0} to catch and handle a more specific set of exception type(s) than {1} or re-throw the exception</value>
+    <value>{0} is catching corrupted state exception.</value>
   </data>
   <data name="DoNotUseBrokenCryptographicAlgorithmsMessage" xml:space="preserve">
     <value>{0} uses a broken cryptographic algorithm {1}</value>

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
@@ -139,11 +139,9 @@
     <value>Do Not Use Weak Cryptographic Algorithms</value>
   </data>
   <data name="DoNotUseWeakCryptographicAlgorithmsDescription" xml:space="preserve">
-    <value>Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of it may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. 
- 
-HOW: Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits. Replace hashing uses with a hashing function in the SHA-2 family, such as SHA-2 512, SHA-2 384, or SHA-2 256.</value>
+    <value>Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of it may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits. Replace hashing uses with a hashing function in the SHA-2 family, such as SHA-2 512, SHA-2 384, or SHA-2 256.</value>
   </data>
   <data name="DoNotUseWeakCryptographicAlgorithmsMessage" xml:space="preserve">
-    <value>{0} uses an weak cryptographic algorithm {1}</value>
+    <value>{0} uses a weak cryptographic algorithm {1}</value>
   </data>
 </root>

--- a/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
+++ b/src/FxCop/Desktop.Analyzers/Core/DesktopAnalyzersResources.resx
@@ -118,15 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DoNotCatchCorruptedStateExceptions" xml:space="preserve">
-    <value>Do not catch corrupted state exceptions in general handlers.</value>
+    <value>Do Not Catch Corrupted State Exceptions</value>
   </data>
   <data name="DoNotCatchCorruptedStateExceptionsDescription" xml:space="preserve">
     <value>Do not author general catch handlers in code that receives corrupted state exceptions. Code that receives and intends to handle corrupted state exceptions should author distinct handlers for each exception type.</value>
   </data>
   <data name="DoNotCatchCorruptedStateExceptionsMessage" xml:space="preserve">
-    <value>Modify {0} to catch and handle a more specific set of exception type(s) than {1} or rethrow the exception. </value>
+    <value>What: {0} is catching corrupted state exception.
+
+Why: This could mask errors (such as access violations), resulting in inconsistent state of execution or making it easier for attackers to compromise system.
+
+How: Modify {0} to catch and handle a more specific set of exception type(s) than {1} or re-throw the exception</value>
   </data>
-  <data name="DoNotUseBrokenCryptographicAlgorithmsDescription" xml:space="preserve">
+  <data name="DoNotUseBrokenCryptographicAlgorithmsMessage" xml:space="preserve">
     <value>WHAT: {0} uses a broken cryptographic algorithm {1} 
  
 WHY: An attack making it computationally feasible to break {1} exists. This allows attackers to break the cryptographic guarantees {1} is designed to provide. Depending on the type and application of this cryptographic algorithm, this may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 
@@ -139,7 +143,7 @@ HOW: Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-12
   <data name="DoNotUseWeakCryptographicAlgorithms" xml:space="preserve">
     <value>Do Not Use Weak Cryptographic Algorithms</value>
   </data>
-  <data name="DoNotUseWeakCryptographicAlgorithmsDescription" xml:space="preserve">
+  <data name="DoNotUseWeakCryptographicAlgorithmsMessage" xml:space="preserve">
     <value>WHAT: {0} uses an weak cryptographic algorithm {1} 
  
 WHY: Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of {1}  may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on {1}. 

--- a/src/FxCop/Desktop.Analyzers/Core/Security/DoNotCatchCorruptedStateExceptionsAnalyzer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Security/DoNotCatchCorruptedStateExceptionsAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Desktop.Analyzers
                                                                              DiagnosticSeverity.Warning,
                                                                              isEnabledByDefault: true,
                                                                              description: s_localizableDescription,
-                                                                             helpLinkUri: null,
+                                                                             helpLinkUri: "http://aka.ms/CA2153",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
         protected abstract Analyzer GetAnalyzer(CompilationSecurityTypes compilationTypes, ISymbol owningSymbol, SyntaxNode codeBlock);

--- a/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
@@ -17,51 +17,23 @@ namespace Desktop.Analyzers
         internal const string DoNotUseWeakCryptographicRuleId = "CA5350";
         internal const string DoNotUseBrokenCryptographicRuleId = "CA5351";
 
-        private static readonly LocalizableString s_localizableDoNotUseMD5Title = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseMD5));
-        private static readonly LocalizableString s_localizableDoNotUseMD5Description = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseMD5Description));
-        private static readonly LocalizableString s_localizableDoNotUseDESTitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseDES));
-        private static readonly LocalizableString s_localizableDoNotUseDESDescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseDESDescription));
-        private static readonly LocalizableString s_localizableDoNotUseRC2Title = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseRC2));
-        private static readonly LocalizableString s_localizableDoNotUseRC2Description = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseRC2Description));
-        private static readonly LocalizableString s_localizableDoNotUseTripleDESTitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseTripleDES));
-        private static readonly LocalizableString s_localizableDoNotUseTripleDESDescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseTripleDESDescription));
-        private static readonly LocalizableString s_localizableDoNotUseRIPEMD160Title = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseRIPEMD160));
-        private static readonly LocalizableString s_localizableDoNotUseRIPEMD160Description = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseRIPEMD160Description));
-        private static readonly LocalizableString s_localizableDoNotUseDSATitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseDSA));
-        private static readonly LocalizableString s_localizableDoNotUseDSADescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseDSADescription));
+        private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsTitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithms));
+        private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsDescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithmsDescription));
+        private static readonly LocalizableString s_localizableDoNotUseBrokenAlgorithmsTitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithms));
+        private static readonly LocalizableString s_localizableDoNotUseBrokenAlgorithmsDescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithmsDescription));
 
-        internal static DiagnosticDescriptor DoNotUseMD5SpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
-                                                                                          s_localizableDoNotUseMD5Title,
-                                                                                          s_localizableDoNotUseMD5Description);
+        internal static DiagnosticDescriptor DoNotUseWeakAlgorithmsRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
+                                                                                  s_localizableDoNotUseWeakAlgorithmsTitle,
+                                                                                  s_localizableDoNotUseWeakAlgorithmsDescription);
 
-        internal static DiagnosticDescriptor DoNotUseDESSpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
-                                                                                          s_localizableDoNotUseDESTitle,
-                                                                                          s_localizableDoNotUseDESDescription);
-
-        internal static DiagnosticDescriptor DoNotUseRC2SpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
-                                                                                          s_localizableDoNotUseRC2Title,
-                                                                                          s_localizableDoNotUseRC2Description);
-
-        internal static DiagnosticDescriptor DoNotUseTripleDESSpecificRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
-                                                                                                s_localizableDoNotUseTripleDESTitle,
-                                                                                                s_localizableDoNotUseTripleDESDescription);
-
-        internal static DiagnosticDescriptor DoNotUseRIPEMD160SpecificRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
-                                                                                                s_localizableDoNotUseRIPEMD160Title,
-                                                                                                s_localizableDoNotUseRIPEMD160Description);
-
-        internal static DiagnosticDescriptor DoNotUseDSASpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
-                                                                                          s_localizableDoNotUseDSATitle,
-                                                                                          s_localizableDoNotUseDSADescription);
+        internal static DiagnosticDescriptor DoNotUseBrokenAlgorithmsRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsTitle,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsDescription);
 
         protected abstract Analyzer GetAnalyzer(CompilationStartAnalysisContext context, CompilationSecurityTypes cryptTypes);
 
-        private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = ImmutableArray.Create(DoNotUseMD5SpecificRule,
-                                                                                                                  DoNotUseDESSpecificRule,
-                                                                                                                  DoNotUseRC2SpecificRule,
-                                                                                                                  DoNotUseTripleDESSpecificRule, 
-                                                                                                                  DoNotUseRIPEMD160SpecificRule,
-                                                                                                                  DoNotUseDSASpecificRule);
+        private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = ImmutableArray.Create(DoNotUseWeakAlgorithmsRule,
+                                                                                                                    DoNotUseBrokenAlgorithmsRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => s_supportedDiagnostics;
@@ -79,6 +51,32 @@ namespace Desktop.Analyzers
                                             customTags: WellKnownDiagnosticTags.Telemetry);
         }
 
+        private static DiagnosticDescriptor CreateCA5350DiagnosticDescriptor(string type, string name)
+        {
+            return CreateDiagnosticDescriptor(
+                        DoNotUseWeakCryptographicRuleId,
+                        s_localizableDoNotUseWeakAlgorithmsTitle,
+                            DiagnosticHelpers.GetLocalizableResourceString(
+                                nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithmsDescription),
+                                type,
+                                name
+                            )
+                        );
+        }
+
+        private static DiagnosticDescriptor CreateCA5351DiagnosticDescriptor(string type, string name)
+        {
+            return CreateDiagnosticDescriptor(
+                        DoNotUseBrokenCryptographicRuleId,
+                        s_localizableDoNotUseBrokenAlgorithmsTitle,
+                            DiagnosticHelpers.GetLocalizableResourceString(
+                                nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithmsDescription),
+                                type,
+                                name
+                            )
+                        );
+        }
+        
         public override void Initialize(AnalysisContext analysisContext)
         {
             analysisContext.RegisterCompilationStartAction(
@@ -130,30 +128,33 @@ namespace Desktop.Analyzers
 
                 if (type.IsDerivedFrom(this._cryptTypes.DES, baseTypesOnly: true))
                 {
-                    rule = DoNotUseDESSpecificRule;
+                    rule = CreateCA5351DiagnosticDescriptor(type.Name, _cryptTypes.DES.Name);
                 }
                 else if (method.MatchMethodDerived(_cryptTypes.DSA, SecurityMemberNames.CreateSignature) ||
                          (type == _cryptTypes.DSASignatureFormatter &&
                           method.MatchMethodDerived(_cryptTypes.DSASignatureFormatter, WellKnownMemberNames.InstanceConstructorName)))
                 {
-                    rule = DoNotUseDSASpecificRule;
+                    rule = CreateCA5351DiagnosticDescriptor(type.Name, _cryptTypes.DSA.Name);
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.HMACMD5, baseTypesOnly: true))
                 {
-                    rule = DoNotUseMD5SpecificRule;
+                    rule = CreateCA5351DiagnosticDescriptor(type.Name, _cryptTypes.HMACMD5.Name);
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.RC2, baseTypesOnly: true))
                 {
-                    rule = DoNotUseRC2SpecificRule;
+                    rule = CreateCA5351DiagnosticDescriptor(type.Name, _cryptTypes.RC2.Name);
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.TripleDES, baseTypesOnly: true))
                 {
-                    rule = DoNotUseTripleDESSpecificRule;
+                    rule = CreateCA5350DiagnosticDescriptor(type.Name, _cryptTypes.TripleDES.Name);
                 }
-                else if (type.IsDerivedFrom(_cryptTypes.RIPEMD160, baseTypesOnly: true) ||
-                         type.IsDerivedFrom(_cryptTypes.HMACRIPEMD160, baseTypesOnly: true))
+                else if (type.IsDerivedFrom(_cryptTypes.RIPEMD160, baseTypesOnly: true))
                 {
-                    rule = DoNotUseRIPEMD160SpecificRule;
+                    rule = CreateCA5350DiagnosticDescriptor(type.Name, _cryptTypes.RIPEMD160.Name);
+                }
+                else if (type.IsDerivedFrom(_cryptTypes.HMACRIPEMD160, baseTypesOnly: true))
+                {
+                    rule = CreateCA5350DiagnosticDescriptor(type.Name, _cryptTypes.HMACRIPEMD160.Name);
                 }
 
                 if (rule != null)

--- a/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
@@ -21,26 +21,54 @@ namespace Desktop.Analyzers
 
         private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsTitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithms));
         private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsMessage = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithmsMessage));
+        private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsDescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithmsDescription));
         private static readonly LocalizableString s_localizableDoNotUseBrokenAlgorithmsTitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithms));
         private static readonly LocalizableString s_localizableDoNotUseBrokenAlgorithmsMessage = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithmsMessage));
+        private static readonly LocalizableString s_localizableDoNotUseBrokenAlgorithmsDescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithmsDescription));
 
-        internal static DiagnosticDescriptor DoNotUseWeakAlgorithmsRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
-                                                                                  s_localizableDoNotUseWeakAlgorithmsTitle,
-                                                                                  s_localizableDoNotUseWeakAlgorithmsMessage);
-
-        internal static DiagnosticDescriptor DoNotUseBrokenAlgorithmsRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
+        internal static DiagnosticDescriptor DoNotUseMD5SpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
                                                                                           s_localizableDoNotUseBrokenAlgorithmsTitle,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsMessage);
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsMessage,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsDescription);
+
+        internal static DiagnosticDescriptor DoNotUseDESSpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsTitle,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsMessage,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsDescription);
+
+        internal static DiagnosticDescriptor DoNotUseRC2SpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsTitle,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsMessage,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsDescription);
+
+        internal static DiagnosticDescriptor DoNotUseTripleDESSpecificRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
+                                                                                          s_localizableDoNotUseWeakAlgorithmsTitle,
+                                                                                          s_localizableDoNotUseWeakAlgorithmsMessage,
+                                                                                          s_localizableDoNotUseWeakAlgorithmsDescription);
+
+        internal static DiagnosticDescriptor DoNotUseRIPEMD160SpecificRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
+                                                                                          s_localizableDoNotUseWeakAlgorithmsTitle,
+                                                                                          s_localizableDoNotUseWeakAlgorithmsMessage,
+                                                                                          s_localizableDoNotUseWeakAlgorithmsDescription);
+
+        internal static DiagnosticDescriptor DoNotUseDSASpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsTitle,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsMessage,
+                                                                                          s_localizableDoNotUseBrokenAlgorithmsDescription);
 
         protected abstract Analyzer GetAnalyzer(CompilationStartAnalysisContext context, CompilationSecurityTypes cryptTypes);
 
-        private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = ImmutableArray.Create(DoNotUseWeakAlgorithmsRule,
-                                                                                                                    DoNotUseBrokenAlgorithmsRule);
+        private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = ImmutableArray.Create(DoNotUseMD5SpecificRule,
+                                                                                                                    DoNotUseDESSpecificRule,
+                                                                                                                    DoNotUseRC2SpecificRule,
+                                                                                                                    DoNotUseTripleDESSpecificRule,
+                                                                                                                    DoNotUseRIPEMD160SpecificRule,
+                                                                                                                    DoNotUseDSASpecificRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => s_supportedDiagnostics;
 
-        private static DiagnosticDescriptor CreateDiagnosticDescriptor(string ruleId, LocalizableString title, LocalizableString message, string uri = null)
+        private static DiagnosticDescriptor CreateDiagnosticDescriptor(string ruleId, LocalizableString title, LocalizableString message, LocalizableString description, string uri = null)
         {
             return new DiagnosticDescriptor(ruleId,
                                             title,
@@ -48,36 +76,9 @@ namespace Desktop.Analyzers
                                             DiagnosticCategory.Security,
                                             DiagnosticSeverity.Warning,
                                             isEnabledByDefault: true,
+                                            description: description,
                                             helpLinkUri: uri,
                                             customTags: WellKnownDiagnosticTags.Telemetry);
-        }
-
-        private static DiagnosticDescriptor CreateCA5350DiagnosticDescriptor(string type, string name)
-        {
-            return CreateDiagnosticDescriptor(
-                        DoNotUseWeakCryptographicRuleId,
-                        s_localizableDoNotUseWeakAlgorithmsTitle,
-                            DiagnosticHelpers.GetLocalizableResourceString(
-                                nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithmsMessage),
-                                type,
-                                name
-                            ),
-                        CA5350HelpLink
-                        );
-        }
-
-        private static DiagnosticDescriptor CreateCA5351DiagnosticDescriptor(string type, string name)
-        {
-            return CreateDiagnosticDescriptor(
-                        DoNotUseBrokenCryptographicRuleId,
-                        s_localizableDoNotUseBrokenAlgorithmsTitle,
-                            DiagnosticHelpers.GetLocalizableResourceString(
-                                nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithmsMessage),
-                                type,
-                                name
-                            ),
-                        CA5351HelpLink
-                        );
         }
         
         public override void Initialize(AnalysisContext analysisContext)
@@ -118,6 +119,17 @@ namespace Desktop.Analyzers
             {
                 SyntaxNode node = context.Node;
                 SemanticModel model = context.SemanticModel;
+                ISymbol symbol = SyntaxNodeHelper.GetSymbol(node, model);
+                IMethodSymbol method = symbol as IMethodSymbol;
+
+                if (method == null)
+                {
+                    return;
+                }
+
+                INamedTypeSymbol type = method.ContainingType;
+                DiagnosticDescriptor rule = null;
+                string[] messageArgs = new string[2];
                 string owningParentName = string.Empty;
                 SyntaxNode cur = node;
 
@@ -126,10 +138,10 @@ namespace Desktop.Analyzers
                     var pNode = cur.Parent;
                     ISymbol sym = SyntaxNodeHelper.GetSymbol(pNode, model);
 
-                    if(sym != null && 
-                        !string.IsNullOrEmpty(sym.Name) 
+                    if(sym != null &&
+                        !string.IsNullOrEmpty(sym.Name)
                         && (
-                            sym.Kind == SymbolKind.Method || 
+                            sym.Kind == SymbolKind.Method ||
                             sym.Kind == SymbolKind.NamedType
                            )
                     )
@@ -141,50 +153,49 @@ namespace Desktop.Analyzers
                     cur = pNode;
                 }
 
-                ISymbol symbol = SyntaxNodeHelper.GetSymbol(node, model);
-                IMethodSymbol method = symbol as IMethodSymbol;
-                if (method == null)
-                {
-                    return;
-                }
-
-                INamedTypeSymbol type = method.ContainingType;
-                DiagnosticDescriptor rule = null;
+                messageArgs[0] = owningParentName;
 
                 if (type.IsDerivedFrom(this._cryptTypes.DES, baseTypesOnly: true))
                 {
-                    rule = CreateCA5351DiagnosticDescriptor(owningParentName, _cryptTypes.DES.Name);
+                    rule = DoNotUseDESSpecificRule;                    
+                    messageArgs[1] = _cryptTypes.DES.Name;
                 }
                 else if (method.MatchMethodDerived(_cryptTypes.DSA, SecurityMemberNames.CreateSignature) ||
                          (type == _cryptTypes.DSASignatureFormatter &&
                           method.MatchMethodDerived(_cryptTypes.DSASignatureFormatter, WellKnownMemberNames.InstanceConstructorName)))
                 {
-                    rule = CreateCA5351DiagnosticDescriptor(owningParentName, _cryptTypes.DSA.Name);
+                    rule = DoNotUseDSASpecificRule;
+                    messageArgs[1] = _cryptTypes.DSA.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.HMACMD5, baseTypesOnly: true))
                 {
-                    rule = CreateCA5351DiagnosticDescriptor(owningParentName, _cryptTypes.HMACMD5.Name);
+                    rule = DoNotUseMD5SpecificRule;
+                    messageArgs[1] = _cryptTypes.HMACMD5.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.RC2, baseTypesOnly: true))
                 {
-                    rule = CreateCA5351DiagnosticDescriptor(owningParentName, _cryptTypes.RC2.Name);
+                    rule = DoNotUseRC2SpecificRule;
+                    messageArgs[1] = _cryptTypes.RC2.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.TripleDES, baseTypesOnly: true))
                 {
-                    rule = CreateCA5350DiagnosticDescriptor(owningParentName, _cryptTypes.TripleDES.Name);
+                    rule = DoNotUseTripleDESSpecificRule;
+                    messageArgs[1] = _cryptTypes.TripleDES.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.RIPEMD160, baseTypesOnly: true))
                 {
-                    rule = CreateCA5350DiagnosticDescriptor(owningParentName, _cryptTypes.RIPEMD160.Name);
+                    rule = DoNotUseRIPEMD160SpecificRule;
+                    messageArgs[1] = _cryptTypes.RIPEMD160.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.HMACRIPEMD160, baseTypesOnly: true))
                 {
-                    rule = CreateCA5350DiagnosticDescriptor(owningParentName, _cryptTypes.HMACRIPEMD160.Name);
+                    rule = DoNotUseRIPEMD160SpecificRule;
+                    messageArgs[1] = _cryptTypes.HMACRIPEMD160.Name;
                 }
 
                 if (rule != null)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(rule, node.GetLocation()));
+                    context.ReportDiagnostic(Diagnostic.Create(rule, node.GetLocation(), messageArgs));
                 }
             } 
         }

--- a/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
@@ -26,44 +26,19 @@ namespace Desktop.Analyzers
         private static readonly LocalizableString s_localizableDoNotUseBrokenAlgorithmsMessage = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithmsMessage));
         private static readonly LocalizableString s_localizableDoNotUseBrokenAlgorithmsDescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithmsDescription));
 
-        internal static DiagnosticDescriptor DoNotUseMD5SpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
+        internal static DiagnosticDescriptor DoNotUseBrokenCryptographicRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
                                                                                           s_localizableDoNotUseBrokenAlgorithmsTitle,
                                                                                           s_localizableDoNotUseBrokenAlgorithmsMessage,
                                                                                           s_localizableDoNotUseBrokenAlgorithmsDescription);
 
-        internal static DiagnosticDescriptor DoNotUseDESSpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsTitle,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsMessage,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsDescription);
-
-        internal static DiagnosticDescriptor DoNotUseRC2SpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsTitle,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsMessage,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsDescription);
-
-        internal static DiagnosticDescriptor DoNotUseTripleDESSpecificRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
+        internal static DiagnosticDescriptor DoNotUseWeakCryptographicRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
                                                                                           s_localizableDoNotUseWeakAlgorithmsTitle,
                                                                                           s_localizableDoNotUseWeakAlgorithmsMessage,
                                                                                           s_localizableDoNotUseWeakAlgorithmsDescription);
-
-        internal static DiagnosticDescriptor DoNotUseRIPEMD160SpecificRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographicRuleId,
-                                                                                          s_localizableDoNotUseWeakAlgorithmsTitle,
-                                                                                          s_localizableDoNotUseWeakAlgorithmsMessage,
-                                                                                          s_localizableDoNotUseWeakAlgorithmsDescription);
-
-        internal static DiagnosticDescriptor DoNotUseDSASpecificRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographicRuleId,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsTitle,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsMessage,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsDescription);
-
         protected abstract Analyzer GetAnalyzer(CompilationStartAnalysisContext context, CompilationSecurityTypes cryptTypes);
 
-        private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = ImmutableArray.Create(DoNotUseMD5SpecificRule,
-                                                                                                                    DoNotUseDESSpecificRule,
-                                                                                                                    DoNotUseRC2SpecificRule,
-                                                                                                                    DoNotUseTripleDESSpecificRule,
-                                                                                                                    DoNotUseRIPEMD160SpecificRule,
-                                                                                                                    DoNotUseDSASpecificRule);
+        private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = ImmutableArray.Create(DoNotUseWeakCryptographicRule,
+                                                                                                                    DoNotUseBrokenCryptographicRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => s_supportedDiagnostics;
@@ -157,39 +132,39 @@ namespace Desktop.Analyzers
 
                 if (type.IsDerivedFrom(this._cryptTypes.DES, baseTypesOnly: true))
                 {
-                    rule = DoNotUseDESSpecificRule;                    
+                    rule = DoNotUseBrokenCryptographicRule;                    
                     messageArgs[1] = _cryptTypes.DES.Name;
                 }
                 else if (method.MatchMethodDerived(_cryptTypes.DSA, SecurityMemberNames.CreateSignature) ||
                          (type == _cryptTypes.DSASignatureFormatter &&
                           method.MatchMethodDerived(_cryptTypes.DSASignatureFormatter, WellKnownMemberNames.InstanceConstructorName)))
                 {
-                    rule = DoNotUseDSASpecificRule;
+                    rule = DoNotUseBrokenCryptographicRule;
                     messageArgs[1] = _cryptTypes.DSA.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.HMACMD5, baseTypesOnly: true))
                 {
-                    rule = DoNotUseMD5SpecificRule;
+                    rule = DoNotUseBrokenCryptographicRule;
                     messageArgs[1] = _cryptTypes.HMACMD5.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.RC2, baseTypesOnly: true))
                 {
-                    rule = DoNotUseRC2SpecificRule;
+                    rule = DoNotUseBrokenCryptographicRule;
                     messageArgs[1] = _cryptTypes.RC2.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.TripleDES, baseTypesOnly: true))
                 {
-                    rule = DoNotUseTripleDESSpecificRule;
+                    rule = DoNotUseWeakCryptographicRule;
                     messageArgs[1] = _cryptTypes.TripleDES.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.RIPEMD160, baseTypesOnly: true))
                 {
-                    rule = DoNotUseRIPEMD160SpecificRule;
+                    rule = DoNotUseWeakCryptographicRule;
                     messageArgs[1] = _cryptTypes.RIPEMD160.Name;
                 }
                 else if (type.IsDerivedFrom(_cryptTypes.HMACRIPEMD160, baseTypesOnly: true))
                 {
-                    rule = DoNotUseRIPEMD160SpecificRule;
+                    rule = DoNotUseWeakCryptographicRule;
                     messageArgs[1] = _cryptTypes.HMACRIPEMD160.Name;
                 }
 

--- a/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
@@ -16,6 +16,8 @@ namespace Desktop.Analyzers
     {
         internal const string DoNotUseWeakCryptographicRuleId = "CA5350";
         internal const string DoNotUseBrokenCryptographicRuleId = "CA5351";
+        internal const string CA5350HelpLink = "http://aka.ms/CA5350";
+        internal const string CA5351HelpLink = "http://aka.ms/CA5351";
 
         private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsTitle = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithms));
         private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsDescription = DiagnosticHelpers.GetLocalizableResourceString(nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithmsDescription));
@@ -60,7 +62,8 @@ namespace Desktop.Analyzers
                                 nameof(DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithmsDescription),
                                 type,
                                 name
-                            )
+                            ),
+                        CA5350HelpLink
                         );
         }
 
@@ -73,7 +76,8 @@ namespace Desktop.Analyzers
                                 nameof(DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithmsDescription),
                                 type,
                                 name
-                            )
+                            ),
+                        CA5351HelpLink
                         );
         }
         

--- a/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithmsAnalyzer.cs
@@ -40,15 +40,14 @@ namespace Desktop.Analyzers
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => s_supportedDiagnostics;
 
-        private static DiagnosticDescriptor CreateDiagnosticDescriptor(string ruleId, LocalizableString title, LocalizableString description, string uri = null)
+        private static DiagnosticDescriptor CreateDiagnosticDescriptor(string ruleId, LocalizableString title, LocalizableString message, string uri = null)
         {
             return new DiagnosticDescriptor(ruleId,
                                             title,
-                                            title,
+                                            message,
                                             DiagnosticCategory.Security,
                                             DiagnosticSeverity.Warning,
                                             isEnabledByDefault: true,
-                                            description: description,
                                             helpLinkUri: uri,
                                             customTags: WellKnownDiagnosticTags.Telemetry);
         }

--- a/src/FxCop/Desktop.Analyzers/Core/Shared/DiagnosticHelpers.cs
+++ b/src/FxCop/Desktop.Analyzers/Core/Shared/DiagnosticHelpers.cs
@@ -122,6 +122,11 @@ namespace Desktop.Analyzers.Common
             return new LocalizableResourceString(resourceName, DesktopAnalyzersResources.ResourceManager, typeof(DesktopAnalyzersResources));
         }
 
+        public static LocalizableResourceString GetLocalizableResourceString(string resourceName, params string[] formatArguments)
+        {
+            return new LocalizableResourceString(resourceName, DesktopAnalyzersResources.ResourceManager, typeof(DesktopAnalyzersResources), formatArguments);
+        }
+
         private static bool IsInvisibleOutsideAssemblyAtSymbolLevel(ISymbol symbol)
         {
             return SymbolIsPrivateOrInternal(symbol)

--- a/src/FxCop/Desktop.Analyzers/Test/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
+++ b/src/FxCop/Desktop.Analyzers/Test/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the projecVerifyCSharp(t root for license information.
 
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.UnitTests;
 using Xunit;
@@ -24,7 +25,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 23, CA5351Rule, "TestMethod", "HMACMD5"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -36,7 +37,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-           GetBasicResultAt(7, 14, CA5351RuleName, CA5351RuleMessage));
+           GetBasicResultAt(7, 14, CA5351Rule, "TestMethod", "HMACMD5"));
         }        
         
         [Fact]
@@ -57,7 +58,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(12, 23, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(12, 23, CA5351Rule, "TestMethod", "HMACMD5"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -72,7 +73,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-           GetBasicResultAt(10, 14, CA5351RuleName, CA5351RuleMessage));
+           GetBasicResultAt(10, 14, CA5351Rule, "TestMethod", "HMACMD5"));
         }        
         
         [Fact]
@@ -90,7 +91,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(9, 26, CA5351Rule, "get_GetHMACMD5", "HMACMD5"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -103,7 +104,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-GetBasicResultAt(7, 12, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(7, 12, CA5351Rule, "get_GetHMACMD5", "HMACMD5"));
         }         
         
         [Fact]
@@ -118,7 +119,7 @@ namespace TestNamespace
         HMACMD5 privateMd5 = new HMACMD5();
     }
 }",
-            GetCSharpResultAt(7, 30, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(7, 30, CA5351Rule, "TestClass", "HMACMD5"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -127,7 +128,7 @@ Namespace TestNamespace
 		Private privateMd5 As New HMACMD5()
 	End Class
 End Namespace",
-GetBasicResultAt(5, 25, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(5, 25, CA5351Rule, "TestClass", "HMACMD5"));
         }         
    
         [Fact]
@@ -146,7 +147,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 36, CA5351Rule, "Run", "HMACMD5"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -158,7 +159,7 @@ Module TestClass
                        End Function)
     End Sub
 End Module",
-            GetBasicResultAt(7, 35, CA5351RuleName, CA5351RuleMessage));
+            GetBasicResultAt(7, 35, CA5351Rule, "TestMethod", "HMACMD5"));
         }
              
         [Fact]
@@ -174,7 +175,7 @@ namespace TestNamespace
         Del d = delegate () { new HMACMD5(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(8, 31, CA5351Rule, "TestClass", "HMACMD5"));
                                  
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -183,7 +184,7 @@ Module TestClass
     Delegate Function Del() As HashAlgorithm
     Dim d As Del = Function() New HMACMD5()
 End Module",
-            GetBasicResultAt(6, 31, CA5351RuleName, CA5351RuleMessage));
+            GetBasicResultAt(6, 31, CA5351Rule, "TestClass", "HMACMD5"));
         }        
         
         [Fact]
@@ -202,7 +203,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 23, CA5351Rule, "TestMethod", "DES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -212,7 +213,7 @@ Module TestClass
         Dim desalg As DES = DES.Create()
     End Sub
 End Module",
-GetBasicResultAt(6, 29, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(6, 29, CA5351Rule, "TestMethod", "DES"));
         }
 
         [Fact]
@@ -230,7 +231,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(9, 26, CA5351Rule, "get_GetDES", "DES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -244,7 +245,7 @@ Namespace TestNamespace
 	End Class
 End Namespace
 ",
-GetBasicResultAt(7, 12, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(7, 12, CA5351Rule, "get_GetDES", "DES"));
         }
 
         [Fact]
@@ -259,7 +260,7 @@ namespace TestNamespace
         DES privateDES = DES.Create();
     }
 }",
-            GetCSharpResultAt(7, 26, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(7, 26, CA5351Rule, "TestClass", "DES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -268,7 +269,7 @@ Namespace TestNamespace
 		Private privateDES As DES = DES.Create()
 	End Class
 End Namespace",
-GetBasicResultAt(5, 31, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(5, 31, CA5351Rule, "TestClass", "DES"));
         }
         
         [Fact]
@@ -287,7 +288,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 36, CA5351Rule, "Run", "DES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -301,7 +302,7 @@ End Function)
 		End Function
 	End Class
 End Namespace",
-GetBasicResultAt(8, 4, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(8, 4, CA5351Rule, "Run", "DES"));
         }
         
         [Fact]
@@ -317,7 +318,7 @@ namespace TestNamespace
         Del d = delegate () { DES.Create(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(8, 31, CA5351Rule, "TestClass", "DES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -327,7 +328,7 @@ Namespace TestNamespace
 		Private d As Del = Sub() DES.Create()
 	End Class
 End Namespace",
-GetBasicResultAt(6, 28, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(6, 28, CA5351Rule, "TestClass", "DES"));
         }
         
         [Fact]
@@ -346,7 +347,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 23, CA5351Rule, "TestMethod", "DES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -357,7 +358,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-            GetBasicResultAt(6, 21, CA5351RuleName, CA5351RuleMessage));
+            GetBasicResultAt(6, 21, CA5351Rule, "TestMethod", "DES"));
         }
         
         [Fact]
@@ -375,7 +376,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(9, 26, CA5351Rule, "get_GetDES", "DES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -388,7 +389,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-           GetBasicResultAt(7, 12, CA5351RuleName, CA5351RuleMessage));
+           GetBasicResultAt(7, 12, CA5351Rule, "get_GetDES", "DES"));
         }
         
         [Fact]
@@ -403,7 +404,7 @@ namespace TestNamespace
         DESCryptoServiceProvider privateDES = new DESCryptoServiceProvider();
     }
 }",
-            GetCSharpResultAt(7, 47, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(7, 47, CA5351Rule, "TestClass", "DES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -412,7 +413,7 @@ Namespace TestNamespace
 		Private privateDES As New DESCryptoServiceProvider()
 	End Class
 End Namespace",
-GetBasicResultAt(5, 25, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(5, 25, CA5351Rule, "TestClass", "DES"));
         }
 //No VB        
         [Fact]
@@ -431,7 +432,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 36, CA5351Rule, "Run", "DES"));
         }
 //No VB        
         [Fact]
@@ -447,7 +448,7 @@ namespace TestNamespace
         Del d = delegate () { new DESCryptoServiceProvider(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(8, 31, CA5351Rule, "TestClass", "DES"));
         }
                 
         [Fact]
@@ -499,8 +500,8 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 25, CA5351RuleName, CA5351RuleMessage),
-            GetCSharpResultAt(11, 13, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 25, CA5351Rule, "TestMethod", "DES"),
+            GetCSharpResultAt(11, 13, CA5351Rule, "TestMethod", "DES"));
 
             VerifyBasic(new[] {
 //Test0
@@ -538,8 +539,8 @@ Namespace TestNamespace
 	End Class
 End Namespace
 " },
-           GetBasicResultAt(6, 15, CA5351RuleName, CA5351RuleMessage),
-           GetBasicResultAt(7, 4, CA5351RuleName, CA5351RuleMessage));
+           GetBasicResultAt(6, 15, CA5351Rule, "TestMethod", "DES"),
+           GetBasicResultAt(7, 4, CA5351Rule, "TestMethod", "DES"));
         }                                          
         
         [Fact] 
@@ -558,7 +559,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 23, CA5351Rule, "TestMethod", "RC2"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -568,7 +569,7 @@ Module TestClass
         Dim rc2alg As New RC2CryptoServiceProvider
     End Sub
 End Module",
-GetBasicResultAt(6, 23, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(6, 23, CA5351Rule, "TestMethod", "RC2"));
         }        
         
         [Fact]
@@ -586,7 +587,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(9, 26, CA5351Rule, "get_GetRC2", "RC2"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -599,7 +600,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-GetBasicResultAt(7, 12, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(7, 12, CA5351Rule, "get_GetRC2", "RC2"));
         }        
         
         [Fact]
@@ -614,7 +615,7 @@ namespace TestNamespace
         RC2CryptoServiceProvider privateRC2 = new RC2CryptoServiceProvider();
     }
 }",
-            GetCSharpResultAt(7, 47, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(7, 47, CA5351Rule, "TestClass", "RC2"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -624,7 +625,7 @@ Namespace TestNamespace
 	End Class
 End Namespace
 ",
-GetBasicResultAt(5, 25, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(5, 25, CA5351Rule, "TestClass", "RC2"));
         }
 //No VB            
         [Fact]
@@ -643,7 +644,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 36, CA5351Rule, "Run", "RC2"));
         } 
 //No VB        
         [Fact]
@@ -659,7 +660,7 @@ namespace TestNamespace
         Del d = delegate () { new RC2CryptoServiceProvider(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(8, 31, CA5351Rule, "TestClass", "RC2"));
         }
         
         [Fact]
@@ -710,7 +711,7 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 23, CA5351Rule, "TestMethod", "RC2"));
 
             VerifyBasic(new[] {
 //Test0
@@ -747,7 +748,7 @@ Namespace TestNamespace
 	End Class
 End Namespace
 " },
-           GetBasicResultAt(6, 14, CA5351RuleName, CA5351RuleMessage));
+           GetBasicResultAt(6, 14, CA5351Rule, "TestMethod", "RC2"));
         }
                 
         [Fact]
@@ -766,7 +767,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 29, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 29, CA5350Rule, "TestMethod", "TripleDES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -777,7 +778,7 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(6, 23, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(6, 23, CA5350Rule, "TestMethod", "TripleDES"));
         } 
         
         [Fact]
@@ -795,7 +796,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(9, 26, CA5350Rule, "get_GetTripleDES", "TripleDES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -808,7 +809,7 @@ Namespace TestNamespace
         End Property
     End Class
 End Namespace",
-           GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
+           GetBasicResultAt(7, 12, CA5350Rule, "get_GetTripleDES", "TripleDES"));
         }
         
         [Fact]
@@ -823,7 +824,7 @@ namespace TestNamespace
         TripleDES privateDES = TripleDES.Create(""TripleDES"");
     }
 }",
-            GetCSharpResultAt(7, 32, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(7, 32, CA5350Rule, "TestClass", "TripleDES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -832,7 +833,7 @@ Namespace TestNamespace
 		Private privateDES As TripleDES = TripleDES.Create(""TripleDES"")
     End Class
 End Namespace",
-           GetBasicResultAt(5, 37, CA5350RuleName, CA5350RuleMessage));
+           GetBasicResultAt(5, 37, CA5350Rule, "TestClass", "TripleDES"));
         } 
 //No VB
         [Fact]
@@ -851,7 +852,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 36, CA5350Rule, "Run", "TripleDES"));
         }
         
         [Fact]
@@ -867,7 +868,7 @@ namespace TestNamespace
         Del d = delegate () { TripleDES.Create(""TripleDES""); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(8, 31, CA5350Rule, "TestClass", "TripleDES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -877,7 +878,7 @@ Namespace TestNamespace
 		Private d As Del = Sub() TripleDES.Create(""TripleDES"")
     End Class
 End Namespace",
-GetBasicResultAt(6, 28, CA5350RuleName, CA5350RuleMessage));
+GetBasicResultAt(6, 28, CA5350Rule, "TestClass", "TripleDES"));
         }
         
         [Fact]
@@ -896,7 +897,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 56, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 56, CA5350Rule, "TestMethod", "TripleDES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -906,7 +907,7 @@ Module TestClass
         Dim tDESalg As New TripleDESCryptoServiceProvider
     End Sub
 End Module",
-GetBasicResultAt(6, 24, CA5350RuleName, CA5350RuleMessage));
+GetBasicResultAt(6, 24, CA5350Rule, "TestMethod", "TripleDES"));
         }
         
         [Fact]
@@ -924,7 +925,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(9, 26, CA5350Rule, "get_GetDES", "TripleDES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -937,7 +938,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-            GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(7, 12, CA5350Rule, "get_GetDES", "TripleDES"));
         }
                 
         [Fact]
@@ -952,7 +953,7 @@ namespace TestNamespace
         TripleDESCryptoServiceProvider privateDES = new TripleDESCryptoServiceProvider();
     }
 }",
-            GetCSharpResultAt(7, 53, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(7, 53, CA5350Rule, "TestClass", "TripleDES"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -961,7 +962,7 @@ Namespace TestNamespace
 		Private privateDES As New TripleDESCryptoServiceProvider()
 	End Class
 End Namespace",
-GetBasicResultAt(5, 25, CA5350RuleName, CA5350RuleMessage));
+GetBasicResultAt(5, 25, CA5350Rule, "TestClass", "TripleDES"));
         }
 //No VB       
         [Fact]
@@ -980,7 +981,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 36, CA5350Rule, "Run", "TripleDES"));
         }  
 //No VB        
         [Fact]
@@ -996,7 +997,7 @@ namespace TestNamespace
         Del d = delegate () { new TripleDESCryptoServiceProvider(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(8, 31, CA5350Rule, "TestClass", "TripleDES"));
         }
         
         [Fact]
@@ -1048,8 +1049,8 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 26, CA5350RuleName, CA5350RuleMessage),
-            GetCSharpResultAt(11, 13, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 26, CA5350Rule, "TestMethod", "TripleDES"),
+            GetCSharpResultAt(11, 13, CA5350Rule, "TestMethod", "TripleDES"));
 
             VerifyBasic(new[] {
 //Test0
@@ -1089,13 +1090,13 @@ Namespace TestNamespace
 	End Class
 End Namespace
 " },
-            GetBasicResultAt(6, 17, CA5350RuleName, CA5350RuleMessage),
-            GetBasicResultAt(7, 4, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(6, 17, CA5350Rule, "TestMethod", "TripleDES"),
+            GetBasicResultAt(7, 4, CA5350Rule, "TestMethod", "TripleDES"));
 
         }
         
         [Fact]
-        public void CA5355RIPEMD160ManagedInMethodDeclaration()
+        public void CA5350RIPEMD160ManagedInMethodDeclaration()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1110,7 +1111,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 25, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 25, CA5350Rule, "TestMethod", "RIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1120,11 +1121,11 @@ Module TestClass
         Dim md1601alg As New RIPEMD160Managed
     End Sub
 End Module",
-GetBasicResultAt(6, 26, CA5350RuleName, CA5350RuleMessage));
+GetBasicResultAt(6, 26, CA5350Rule, "TestMethod", "RIPEMD160"));
         } 
         
         [Fact]
-        public void CA5355RIPEMD160ManagedInGetDeclaration()
+        public void CA5350RIPEMD160ManagedInGetDeclaration()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1138,7 +1139,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(9, 26, CA5350Rule, "get_GetRIPEMD160", "RIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1151,11 +1152,11 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-            GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(7, 12, CA5350Rule, "get_GetRIPEMD160", "RIPEMD160"));
         }
         
         [Fact]
-        public void CA5355RIPEMD160ManagedInFieldDeclaration()
+        public void CA5350RIPEMD160ManagedInFieldDeclaration()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1166,7 +1167,7 @@ namespace TestNamespace
         RIPEMD160Managed privateRIPEMD160 = new RIPEMD160Managed();
     }
 }",
-            GetCSharpResultAt(7, 45, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(7, 45, CA5350Rule, "TestClass", "RIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1176,11 +1177,11 @@ Namespace TestNamespace
 	End Class
 End Namespace
 ", 
-        GetBasicResultAt(5, 31, CA5350RuleName, CA5350RuleMessage));
+        GetBasicResultAt(5, 31, CA5350Rule, "TestClass", "RIPEMD160"));
         } 
 //No VB               
         [Fact]
-        public void CA5355RIPEMD160ManagedInLambdaExpression()
+        public void CA5350RIPEMD160ManagedInLambdaExpression()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1195,11 +1196,11 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 36, CA5350Rule, "Run", "RIPEMD160"));
         }
 //No VB        
         [Fact]
-        public void CA5355RIPEMD160ManagedInAnonymousMethodExpression()
+        public void CA5350RIPEMD160ManagedInAnonymousMethodExpression()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1211,11 +1212,11 @@ namespace TestNamespace
         Del d = delegate () { new RIPEMD160Managed(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(8, 31, CA5350Rule, "TestClass", "RIPEMD160"));
         }
         
         [Fact]
-        public void CA5355RIPEMD160CreateInMethodDeclaration()
+        public void CA5350RIPEMD160CreateInMethodDeclaration()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1230,7 +1231,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 31, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 31, CA5350Rule, "TestMethod", "RIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1241,11 +1242,11 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-            GetBasicResultAt(6, 29, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(6, 29, CA5350Rule, "TestMethod", "RIPEMD160"));
         }
         
         [Fact]
-        public void CA5355RIPEMD160CreateInGetDeclaration()
+        public void CA5350RIPEMD160CreateInGetDeclaration()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1259,7 +1260,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(9, 26, CA5350Rule, "get_GetRIPEMD160", "RIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1272,11 +1273,11 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
+GetBasicResultAt(7, 12, CA5350Rule, "get_GetRIPEMD160", "RIPEMD160"));
         }
         
         [Fact]
-        public void CA5355RIPEMD160CreateInFieldDeclaration()
+        public void CA5350RIPEMD160CreateInFieldDeclaration()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1287,7 +1288,7 @@ namespace TestNamespace
         RIPEMD160 privateRIPEMD160 = RIPEMD160.Create();
     }
 }",
-            GetCSharpResultAt(7, 38, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(7, 38, CA5350Rule, "TestClass", "RIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1296,11 +1297,11 @@ Namespace TestNamespace
 		Private privateRIPEMD160 As RIPEMD160 = RIPEMD160.Create()
 	End Class
 End Namespace",
-            GetBasicResultAt(5, 43, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(5, 43, CA5350Rule, "TestClass", "RIPEMD160"));
         }
 //No VB                
         [Fact]
-        public void CA5355RIPEMD160CreateInLambdaExpression()
+        public void CA5350RIPEMD160CreateInLambdaExpression()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1315,11 +1316,11 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 36, CA5350Rule, "Run", "RIPEMD160"));
         }
         
         [Fact]
-        public void CA5355RIPEMD160CreateInAnonymousMethodExpression()
+        public void CA5350RIPEMD160CreateInAnonymousMethodExpression()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1331,7 +1332,7 @@ namespace TestNamespace
         Del d = delegate () { RIPEMD160.Create(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(8, 31, CA5350Rule, "TestClass", "RIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1341,11 +1342,11 @@ Namespace TestNamespace
         Private d As Del = Sub() RIPEMD160.Create()
     End Class
 End Namespace",
-          GetBasicResultAt(6, 34, CA5350RuleName, CA5350RuleMessage));
+          GetBasicResultAt(6, 34, CA5350Rule, "TestClass", "RIPEMD160"));
         }
         
         [Fact]
-        public void CA5355HMACRIPEMD160InMethodDeclaration()
+        public void CA5350HMACRIPEMD160InMethodDeclaration()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1360,7 +1361,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 25, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 25, CA5350Rule, "TestMethod", "HMACRIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1371,11 +1372,11 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-            GetBasicResultAt(6, 16, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(6, 16, CA5350Rule, "TestMethod", "HMACRIPEMD160"));
         }
         
         [Fact]
-        public void CA5355HMACRIPEMD160InGetDeclaration()
+        public void CA5350HMACRIPEMD160InGetDeclaration()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1389,7 +1390,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(9, 26, CA5350Rule, "get_GetHMARIPEMD160", "HMACRIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1402,11 +1403,11 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-            GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(7, 12, CA5350Rule, "get_GetHMARIPEMD160", "HMACRIPEMD160"));
         }
         
         [Fact]
-        public void CA5355HMACRIPEMD160InFieldDeclaration()
+        public void CA5350HMACRIPEMD160InFieldDeclaration()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1417,7 +1418,7 @@ namespace TestNamespace
         HMACRIPEMD160 privateHMARIPEMD160 = new HMACRIPEMD160();
     }
 }",
-            GetCSharpResultAt(7, 45, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(7, 45, CA5350Rule, "TestClass", "HMACRIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1426,11 +1427,11 @@ Namespace TestNamespace
 		Private privateHMARIPEMD160 As New HMACRIPEMD160()
 	End Class
 End Namespace",
-           GetBasicResultAt(5, 34, CA5350RuleName, CA5350RuleMessage));
+           GetBasicResultAt(5, 34, CA5350Rule, "TestClass", "HMACRIPEMD160"));
         } 
 //No VB        
         [Fact]
-        public void CA5355HMACRIPEMD160InLambdaExpression()
+        public void CA5350HMACRIPEMD160InLambdaExpression()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1445,11 +1446,11 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 36, CA5350Rule, "Run", "HMACRIPEMD160"));
         }
 //No VB        
         [Fact]
-        public void CA5355HMACRIPEMD160InAnonymousMethodExpression()
+        public void CA5350HMACRIPEMD160InAnonymousMethodExpression()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1461,11 +1462,11 @@ namespace TestNamespace
         Del d = delegate () { new HMACRIPEMD160(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(8, 31, CA5350Rule, "TestClass", "HMACRIPEMD160"));
         }   
         
         [Fact]
-        public void CA5355CreateObjectFromRIPEMD160DerivedClass()
+        public void CA5350CreateObjectFromRIPEMD160DerivedClass()
         {
             VerifyCSharp( new[] {
 //Test0
@@ -1507,7 +1508,7 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 25, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 25, CA5350Rule, "TestMethod", "RIPEMD160"));
 
             VerifyBasic(new[] {
 //Test0
@@ -1539,11 +1540,11 @@ Namespace TestNamespace
 		End Function
 	End Class
 End Namespace" },
-            GetBasicResultAt(6, 16, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(6, 16, CA5350Rule, "TestMethod", "RIPEMD160"));
         }
         
         [Fact]
-        public void CA5355CreateObjectFromRIPEMD160ManagedDerivedClass()
+        public void CA5350CreateObjectFromRIPEMD160ManagedDerivedClass()
         {
             VerifyCSharp( new[] {
 //Test0
@@ -1585,7 +1586,7 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 25, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(10, 25, CA5350Rule, "TestMethod", "RIPEMD160"));
 
             VerifyBasic(new[] {
 //Test0
@@ -1618,11 +1619,11 @@ Namespace TestNamespace
 	End Class
 End Namespace
 " },
-            GetBasicResultAt(6, 16, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(6, 16, CA5350Rule, "TestMethod", "RIPEMD160"));
         } 
         
         [Fact]
-        public void CA5355CreateObjectFromHMACRIPEMD160DerivedClass()
+        public void CA5350CreateObjectFromHMACRIPEMD160DerivedClass()
         {
             VerifyCSharp(@"
 using System.Security.Cryptography;
@@ -1639,7 +1640,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(12, 25, CA5350RuleName, CA5350RuleMessage));
+            GetCSharpResultAt(12, 25, CA5350Rule, "TestMethod", "HMACRIPEMD160"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1654,7 +1655,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-            GetBasicResultAt(10, 16, CA5350RuleName, CA5350RuleMessage));
+            GetBasicResultAt(10, 16, CA5350Rule, "TestMethod", "HMACRIPEMD160"));
         }   
         
         [Fact]
@@ -1673,7 +1674,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 23, CA5351Rule, "TestMethod", "DSA"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1684,7 +1685,7 @@ Module TestClass
         Return dsa.CreateSignature(bytes)
     End Function
 End Module",
-GetBasicResultAt(7, 16, CA5351RuleName, CA5351RuleMessage));
+GetBasicResultAt(7, 16, CA5351Rule, "TestMethod", "DSA"));
         } 
         
         [Fact]
@@ -1705,7 +1706,7 @@ class TestClass
         }
     }
 }",
-            GetCSharpResultAt(12, 20, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(12, 20, CA5351Rule, "get_MyProperty", "DSA"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1719,7 +1720,7 @@ Class TestClass
 		End Get
 	End Property
 End Class",
-            GetBasicResultAt(9, 11, CA5351RuleName, CA5351RuleMessage));
+            GetBasicResultAt(9, 11, CA5351Rule, "get_MyProperty", "DSA"));
         }
         
         [Fact]
@@ -1739,8 +1740,8 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage),
-            GetCSharpResultAt(11, 23, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(10, 23, CA5351Rule, "TestMethod", "DSA"),
+            GetCSharpResultAt(11, 23, CA5351Rule, "TestMethod", "DSA"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1753,8 +1754,8 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-           GetBasicResultAt(7, 23, CA5351RuleName, CA5351RuleMessage),
-           GetBasicResultAt(8, 23, CA5351RuleName, CA5351RuleMessage));
+           GetBasicResultAt(7, 23, CA5351Rule, "TestMethod", "DSA"),
+           GetBasicResultAt(8, 23, CA5351Rule, "TestMethod", "DSA"));
         }  
      
         [Fact]
@@ -1776,8 +1777,8 @@ class TestClass
         }
     }
 }",
-            GetCSharpResultAt(12, 43, CA5351RuleName, CA5351RuleMessage),
-            GetCSharpResultAt(13, 25, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(12, 43, CA5351Rule, "get_MyProperty", "DSA"),
+            GetCSharpResultAt(13, 25, CA5351Rule, "get_MyProperty", "DSA"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1794,8 +1795,8 @@ Class TestClass
 		End Get
 	End Property
 End Class",
-            GetBasicResultAt(9, 12, CA5351RuleName, CA5351RuleMessage),
-            GetBasicResultAt(11, 12, CA5351RuleName, CA5351RuleMessage));
+            GetBasicResultAt(9, 12, CA5351Rule, "get_MyProperty", "DSA"),
+            GetBasicResultAt(11, 12, CA5351Rule, "get_MyProperty", "DSA"));
         }
         
         [Fact]
@@ -1863,7 +1864,7 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(11, 13, CA5351RuleName, CA5351RuleMessage));
+            GetCSharpResultAt(11, 13, CA5351Rule, "TestMethod", "DSA"));
 
             VerifyBasic(new[] {
 //Test0
@@ -1913,7 +1914,7 @@ Namespace TestNamespace
 		End Function
 	End Class
 End Namespace" },
-           GetBasicResultAt(7, 4, CA5351RuleName, CA5351RuleMessage));
+           GetBasicResultAt(7, 4, CA5351Rule, "TestMethod", "DSA"));
         } 
         
         [Fact]
@@ -2134,8 +2135,28 @@ End Namespace" }
 
         private const string CA5350RuleName = DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographicRuleId;
         private const string CA5351RuleName = DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographicRuleId;
+        private static readonly string CA5350RuleTitle = DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithms;
+        private static readonly string CA5351RuleTitle = DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithms;
 
-        private readonly string CA5350RuleMessage = DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithms;
-        private readonly string CA5351RuleMessage = DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithms;
+        private static readonly string CA5350RuleMessage = DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithmsMessage;
+        private static readonly string CA5351RuleMessage = DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithmsMessage;
+
+        private static DiagnosticDescriptor CA5350Rule =
+                                                new DiagnosticDescriptor(CA5350RuleName,
+                                                    CA5350RuleTitle,
+                                                    CA5350RuleMessage,
+                                                    Common.DiagnosticCategory.Security,
+                                                    DiagnosticSeverity.Warning,
+                                                    true
+                                                );
+
+        private static DiagnosticDescriptor CA5351Rule =
+                                                    new DiagnosticDescriptor(CA5351RuleName,
+                                                    CA5351RuleTitle,
+                                                    CA5351RuleMessage,
+                                                    Common.DiagnosticCategory.Security,
+                                                    DiagnosticSeverity.Warning,
+                                                    true
+                                                );
     }
 }

--- a/src/FxCop/Desktop.Analyzers/Test/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
+++ b/src/FxCop/Desktop.Analyzers/Test/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
@@ -24,7 +24,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, DoNotUseMD5Message));
+            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -36,7 +36,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-           GetBasicResultAt(7, 14, CA5351RuleName, DoNotUseMD5Message));
+           GetBasicResultAt(7, 14, CA5351RuleName, CA5351RuleMessage));
         }        
         
         [Fact]
@@ -57,7 +57,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(12, 23, CA5351RuleName, DoNotUseMD5Message));
+            GetCSharpResultAt(12, 23, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -72,7 +72,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-           GetBasicResultAt(10, 14, CA5351RuleName, DoNotUseMD5Message));
+           GetBasicResultAt(10, 14, CA5351RuleName, CA5351RuleMessage));
         }        
         
         [Fact]
@@ -90,7 +90,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5351RuleName, DoNotUseMD5Message));
+            GetCSharpResultAt(9, 26, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -103,7 +103,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-GetBasicResultAt(7, 12, CA5351RuleName, DoNotUseMD5Message));
+GetBasicResultAt(7, 12, CA5351RuleName, CA5351RuleMessage));
         }         
         
         [Fact]
@@ -118,7 +118,7 @@ namespace TestNamespace
         HMACMD5 privateMd5 = new HMACMD5();
     }
 }",
-            GetCSharpResultAt(7, 30, CA5351RuleName, DoNotUseMD5Message));
+            GetCSharpResultAt(7, 30, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -127,7 +127,7 @@ Namespace TestNamespace
 		Private privateMd5 As New HMACMD5()
 	End Class
 End Namespace",
-GetBasicResultAt(5, 25, CA5351RuleName, DoNotUseMD5Message));
+GetBasicResultAt(5, 25, CA5351RuleName, CA5351RuleMessage));
         }         
    
         [Fact]
@@ -146,7 +146,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5351RuleName, DoNotUseMD5Message));
+            GetCSharpResultAt(10, 36, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -158,7 +158,7 @@ Module TestClass
                        End Function)
     End Sub
 End Module",
-            GetBasicResultAt(7, 35, CA5351RuleName, DoNotUseMD5Message));
+            GetBasicResultAt(7, 35, CA5351RuleName, CA5351RuleMessage));
         }
              
         [Fact]
@@ -174,7 +174,7 @@ namespace TestNamespace
         Del d = delegate () { new HMACMD5(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5351RuleName, DoNotUseMD5Message));
+            GetCSharpResultAt(8, 31, CA5351RuleName, CA5351RuleMessage));
                                  
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -183,7 +183,7 @@ Module TestClass
     Delegate Function Del() As HashAlgorithm
     Dim d As Del = Function() New HMACMD5()
 End Module",
-            GetBasicResultAt(6, 31, CA5351RuleName, DoNotUseMD5Message));
+            GetBasicResultAt(6, 31, CA5351RuleName, CA5351RuleMessage));
         }        
         
         [Fact]
@@ -202,7 +202,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -212,7 +212,7 @@ Module TestClass
         Dim desalg As DES = DES.Create()
     End Sub
 End Module",
-GetBasicResultAt(6, 29, CA5351RuleName, DoNotUseDESMessage));
+GetBasicResultAt(6, 29, CA5351RuleName, CA5351RuleMessage));
         }
 
         [Fact]
@@ -230,7 +230,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(9, 26, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -244,7 +244,7 @@ Namespace TestNamespace
 	End Class
 End Namespace
 ",
-GetBasicResultAt(7, 12, CA5351RuleName, DoNotUseDESMessage));
+GetBasicResultAt(7, 12, CA5351RuleName, CA5351RuleMessage));
         }
 
         [Fact]
@@ -259,7 +259,7 @@ namespace TestNamespace
         DES privateDES = DES.Create();
     }
 }",
-            GetCSharpResultAt(7, 26, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(7, 26, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -268,7 +268,7 @@ Namespace TestNamespace
 		Private privateDES As DES = DES.Create()
 	End Class
 End Namespace",
-GetBasicResultAt(5, 31, CA5351RuleName, DoNotUseDESMessage));
+GetBasicResultAt(5, 31, CA5351RuleName, CA5351RuleMessage));
         }
         
         [Fact]
@@ -287,7 +287,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(10, 36, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -301,7 +301,7 @@ End Function)
 		End Function
 	End Class
 End Namespace",
-GetBasicResultAt(8, 4, CA5351RuleName, DoNotUseDESMessage));
+GetBasicResultAt(8, 4, CA5351RuleName, CA5351RuleMessage));
         }
         
         [Fact]
@@ -317,7 +317,7 @@ namespace TestNamespace
         Del d = delegate () { DES.Create(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(8, 31, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -327,7 +327,7 @@ Namespace TestNamespace
 		Private d As Del = Sub() DES.Create()
 	End Class
 End Namespace",
-GetBasicResultAt(6, 28, CA5351RuleName, DoNotUseDESMessage));
+GetBasicResultAt(6, 28, CA5351RuleName, CA5351RuleMessage));
         }
         
         [Fact]
@@ -346,7 +346,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -357,7 +357,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-            GetBasicResultAt(6, 21, CA5351RuleName, DoNotUseDESMessage));
+            GetBasicResultAt(6, 21, CA5351RuleName, CA5351RuleMessage));
         }
         
         [Fact]
@@ -375,7 +375,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(9, 26, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -388,7 +388,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-           GetBasicResultAt(7, 12, CA5351RuleName, DoNotUseDESMessage));
+           GetBasicResultAt(7, 12, CA5351RuleName, CA5351RuleMessage));
         }
         
         [Fact]
@@ -403,7 +403,7 @@ namespace TestNamespace
         DESCryptoServiceProvider privateDES = new DESCryptoServiceProvider();
     }
 }",
-            GetCSharpResultAt(7, 47, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(7, 47, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -412,7 +412,7 @@ Namespace TestNamespace
 		Private privateDES As New DESCryptoServiceProvider()
 	End Class
 End Namespace",
-GetBasicResultAt(5, 25, CA5351RuleName, DoNotUseDESMessage));
+GetBasicResultAt(5, 25, CA5351RuleName, CA5351RuleMessage));
         }
 //No VB        
         [Fact]
@@ -431,7 +431,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(10, 36, CA5351RuleName, CA5351RuleMessage));
         }
 //No VB        
         [Fact]
@@ -447,7 +447,7 @@ namespace TestNamespace
         Del d = delegate () { new DESCryptoServiceProvider(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(8, 31, CA5351RuleName, CA5351RuleMessage));
         }
                 
         [Fact]
@@ -499,8 +499,8 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 25, CA5351RuleName, DoNotUseDESMessage),
-            GetCSharpResultAt(11, 13, CA5351RuleName, DoNotUseDESMessage));
+            GetCSharpResultAt(10, 25, CA5351RuleName, CA5351RuleMessage),
+            GetCSharpResultAt(11, 13, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(new[] {
 //Test0
@@ -538,8 +538,8 @@ Namespace TestNamespace
 	End Class
 End Namespace
 " },
-           GetBasicResultAt(6, 15, CA5351RuleName, DoNotUseDESMessage),
-           GetBasicResultAt(7, 4, CA5351RuleName, DoNotUseDESMessage));
+           GetBasicResultAt(6, 15, CA5351RuleName, CA5351RuleMessage),
+           GetBasicResultAt(7, 4, CA5351RuleName, CA5351RuleMessage));
         }                                          
         
         [Fact] 
@@ -558,7 +558,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, DoNotUseRC2Message));
+            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -568,7 +568,7 @@ Module TestClass
         Dim rc2alg As New RC2CryptoServiceProvider
     End Sub
 End Module",
-GetBasicResultAt(6, 23, CA5351RuleName, DoNotUseRC2Message));
+GetBasicResultAt(6, 23, CA5351RuleName, CA5351RuleMessage));
         }        
         
         [Fact]
@@ -586,7 +586,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5351RuleName, DoNotUseRC2Message));
+            GetCSharpResultAt(9, 26, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -599,7 +599,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-GetBasicResultAt(7, 12, CA5351RuleName, DoNotUseRC2Message));
+GetBasicResultAt(7, 12, CA5351RuleName, CA5351RuleMessage));
         }        
         
         [Fact]
@@ -614,7 +614,7 @@ namespace TestNamespace
         RC2CryptoServiceProvider privateRC2 = new RC2CryptoServiceProvider();
     }
 }",
-            GetCSharpResultAt(7, 47, CA5351RuleName, DoNotUseRC2Message));
+            GetCSharpResultAt(7, 47, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -624,7 +624,7 @@ Namespace TestNamespace
 	End Class
 End Namespace
 ",
-GetBasicResultAt(5, 25, CA5351RuleName, DoNotUseRC2Message));
+GetBasicResultAt(5, 25, CA5351RuleName, CA5351RuleMessage));
         }
 //No VB            
         [Fact]
@@ -643,7 +643,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5351RuleName, DoNotUseRC2Message));
+            GetCSharpResultAt(10, 36, CA5351RuleName, CA5351RuleMessage));
         } 
 //No VB        
         [Fact]
@@ -659,7 +659,7 @@ namespace TestNamespace
         Del d = delegate () { new RC2CryptoServiceProvider(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5351RuleName, DoNotUseRC2Message));
+            GetCSharpResultAt(8, 31, CA5351RuleName, CA5351RuleMessage));
         }
         
         [Fact]
@@ -710,7 +710,7 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 23, CA5351RuleName, DoNotUseRC2Message));
+            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(new[] {
 //Test0
@@ -747,7 +747,7 @@ Namespace TestNamespace
 	End Class
 End Namespace
 " },
-           GetBasicResultAt(6, 14, CA5351RuleName, DoNotUseRC2Message));
+           GetBasicResultAt(6, 14, CA5351RuleName, CA5351RuleMessage));
         }
                 
         [Fact]
@@ -766,7 +766,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 29, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(10, 29, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -777,7 +777,7 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(6, 23, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetBasicResultAt(6, 23, CA5350RuleName, CA5350RuleMessage));
         } 
         
         [Fact]
@@ -795,7 +795,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -808,7 +808,7 @@ Namespace TestNamespace
         End Property
     End Class
 End Namespace",
-           GetBasicResultAt(7, 12, CA5350RuleName, DoNotUseTripleDESMessage));
+           GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -823,7 +823,7 @@ namespace TestNamespace
         TripleDES privateDES = TripleDES.Create(""TripleDES"");
     }
 }",
-            GetCSharpResultAt(7, 32, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(7, 32, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -832,7 +832,7 @@ Namespace TestNamespace
 		Private privateDES As TripleDES = TripleDES.Create(""TripleDES"")
     End Class
 End Namespace",
-           GetBasicResultAt(5, 37, CA5350RuleName, DoNotUseTripleDESMessage));
+           GetBasicResultAt(5, 37, CA5350RuleName, CA5350RuleMessage));
         } 
 //No VB
         [Fact]
@@ -851,7 +851,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -867,7 +867,7 @@ namespace TestNamespace
         Del d = delegate () { TripleDES.Create(""TripleDES""); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -877,7 +877,7 @@ Namespace TestNamespace
 		Private d As Del = Sub() TripleDES.Create(""TripleDES"")
     End Class
 End Namespace",
-GetBasicResultAt(6, 28, CA5350RuleName, DoNotUseTripleDESMessage));
+GetBasicResultAt(6, 28, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -896,7 +896,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 56, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(10, 56, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -906,7 +906,7 @@ Module TestClass
         Dim tDESalg As New TripleDESCryptoServiceProvider
     End Sub
 End Module",
-GetBasicResultAt(6, 24, CA5350RuleName, DoNotUseTripleDESMessage));
+GetBasicResultAt(6, 24, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -924,7 +924,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -937,7 +937,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-            GetBasicResultAt(7, 12, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
         }
                 
         [Fact]
@@ -952,7 +952,7 @@ namespace TestNamespace
         TripleDESCryptoServiceProvider privateDES = new TripleDESCryptoServiceProvider();
     }
 }",
-            GetCSharpResultAt(7, 53, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(7, 53, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -961,7 +961,7 @@ Namespace TestNamespace
 		Private privateDES As New TripleDESCryptoServiceProvider()
 	End Class
 End Namespace",
-GetBasicResultAt(5, 25, CA5350RuleName, DoNotUseTripleDESMessage));
+GetBasicResultAt(5, 25, CA5350RuleName, CA5350RuleMessage));
         }
 //No VB       
         [Fact]
@@ -980,7 +980,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
         }  
 //No VB        
         [Fact]
@@ -996,7 +996,7 @@ namespace TestNamespace
         Del d = delegate () { new TripleDESCryptoServiceProvider(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1048,8 +1048,8 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 26, CA5350RuleName, DoNotUseTripleDESMessage),
-            GetCSharpResultAt(11, 13, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetCSharpResultAt(10, 26, CA5350RuleName, CA5350RuleMessage),
+            GetCSharpResultAt(11, 13, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(new[] {
 //Test0
@@ -1089,8 +1089,8 @@ Namespace TestNamespace
 	End Class
 End Namespace
 " },
-            GetBasicResultAt(6, 17, CA5350RuleName, DoNotUseTripleDESMessage),
-            GetBasicResultAt(7, 4, CA5350RuleName, DoNotUseTripleDESMessage));
+            GetBasicResultAt(6, 17, CA5350RuleName, CA5350RuleMessage),
+            GetBasicResultAt(7, 4, CA5350RuleName, CA5350RuleMessage));
 
         }
         
@@ -1110,7 +1110,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 25, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(10, 25, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1120,7 +1120,7 @@ Module TestClass
         Dim md1601alg As New RIPEMD160Managed
     End Sub
 End Module",
-GetBasicResultAt(6, 26, CA5350RuleName, DoNotUseRIPEMD160Message));
+GetBasicResultAt(6, 26, CA5350RuleName, CA5350RuleMessage));
         } 
         
         [Fact]
@@ -1138,7 +1138,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1151,7 +1151,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-            GetBasicResultAt(7, 12, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1166,7 +1166,7 @@ namespace TestNamespace
         RIPEMD160Managed privateRIPEMD160 = new RIPEMD160Managed();
     }
 }",
-            GetCSharpResultAt(7, 45, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(7, 45, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1176,7 +1176,7 @@ Namespace TestNamespace
 	End Class
 End Namespace
 ", 
-        GetBasicResultAt(5, 31, CA5350RuleName, DoNotUseRIPEMD160Message));
+        GetBasicResultAt(5, 31, CA5350RuleName, CA5350RuleMessage));
         } 
 //No VB               
         [Fact]
@@ -1195,7 +1195,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
         }
 //No VB        
         [Fact]
@@ -1211,7 +1211,7 @@ namespace TestNamespace
         Del d = delegate () { new RIPEMD160Managed(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1230,7 +1230,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 31, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(10, 31, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1241,7 +1241,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-            GetBasicResultAt(6, 29, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetBasicResultAt(6, 29, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1259,7 +1259,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1272,7 +1272,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-GetBasicResultAt(7, 12, CA5350RuleName, DoNotUseRIPEMD160Message));
+GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1287,7 +1287,7 @@ namespace TestNamespace
         RIPEMD160 privateRIPEMD160 = RIPEMD160.Create();
     }
 }",
-            GetCSharpResultAt(7, 38, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(7, 38, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1296,7 +1296,7 @@ Namespace TestNamespace
 		Private privateRIPEMD160 As RIPEMD160 = RIPEMD160.Create()
 	End Class
 End Namespace",
-            GetBasicResultAt(5, 43, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetBasicResultAt(5, 43, CA5350RuleName, CA5350RuleMessage));
         }
 //No VB                
         [Fact]
@@ -1315,7 +1315,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1331,7 +1331,7 @@ namespace TestNamespace
         Del d = delegate () { RIPEMD160.Create(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1341,7 +1341,7 @@ Namespace TestNamespace
         Private d As Del = Sub() RIPEMD160.Create()
     End Class
 End Namespace",
-          GetBasicResultAt(6, 34, CA5350RuleName, DoNotUseRIPEMD160Message));
+          GetBasicResultAt(6, 34, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1360,7 +1360,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 25, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(10, 25, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1371,7 +1371,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-            GetBasicResultAt(6, 16, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetBasicResultAt(6, 16, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1389,7 +1389,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(9, 26, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(9, 26, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1402,7 +1402,7 @@ Namespace TestNamespace
 		End Property
 	End Class
 End Namespace",
-            GetBasicResultAt(7, 12, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetBasicResultAt(7, 12, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1417,7 +1417,7 @@ namespace TestNamespace
         HMACRIPEMD160 privateHMARIPEMD160 = new HMACRIPEMD160();
     }
 }",
-            GetCSharpResultAt(7, 45, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(7, 45, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1426,7 +1426,7 @@ Namespace TestNamespace
 		Private privateHMARIPEMD160 As New HMACRIPEMD160()
 	End Class
 End Namespace",
-           GetBasicResultAt(5, 34, CA5350RuleName, DoNotUseRIPEMD160Message));
+           GetBasicResultAt(5, 34, CA5350RuleName, CA5350RuleMessage));
         } 
 //No VB        
         [Fact]
@@ -1445,7 +1445,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 36, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(10, 36, CA5350RuleName, CA5350RuleMessage));
         }
 //No VB        
         [Fact]
@@ -1461,7 +1461,7 @@ namespace TestNamespace
         Del d = delegate () { new HMACRIPEMD160(); };
     }
 }",
-            GetCSharpResultAt(8, 31, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(8, 31, CA5350RuleName, CA5350RuleMessage));
         }   
         
         [Fact]
@@ -1507,7 +1507,7 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 25, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(10, 25, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(new[] {
 //Test0
@@ -1539,7 +1539,7 @@ Namespace TestNamespace
 		End Function
 	End Class
 End Namespace" },
-            GetBasicResultAt(6, 16, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetBasicResultAt(6, 16, CA5350RuleName, CA5350RuleMessage));
         }
         
         [Fact]
@@ -1585,7 +1585,7 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(10, 25, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(10, 25, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(new[] {
 //Test0
@@ -1618,7 +1618,7 @@ Namespace TestNamespace
 	End Class
 End Namespace
 " },
-            GetBasicResultAt(6, 16, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetBasicResultAt(6, 16, CA5350RuleName, CA5350RuleMessage));
         } 
         
         [Fact]
@@ -1639,7 +1639,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(12, 25, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetCSharpResultAt(12, 25, CA5350RuleName, CA5350RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1654,7 +1654,7 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace",
-            GetBasicResultAt(10, 16, CA5350RuleName, DoNotUseRIPEMD160Message));
+            GetBasicResultAt(10, 16, CA5350RuleName, CA5350RuleMessage));
         }   
         
         [Fact]
@@ -1673,7 +1673,7 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, DoNotUseDSAMessage));
+            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1684,7 +1684,7 @@ Module TestClass
         Return dsa.CreateSignature(bytes)
     End Function
 End Module",
-GetBasicResultAt(7, 16, CA5351RuleName, DoNotUseDSAMessage));
+GetBasicResultAt(7, 16, CA5351RuleName, CA5351RuleMessage));
         } 
         
         [Fact]
@@ -1705,7 +1705,7 @@ class TestClass
         }
     }
 }",
-            GetCSharpResultAt(12, 20, CA5351RuleName, DoNotUseDSAMessage));
+            GetCSharpResultAt(12, 20, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1719,7 +1719,7 @@ Class TestClass
 		End Get
 	End Property
 End Class",
-            GetBasicResultAt(9, 11, CA5351RuleName, DoNotUseDSAMessage));
+            GetBasicResultAt(9, 11, CA5351RuleName, CA5351RuleMessage));
         }
         
         [Fact]
@@ -1739,8 +1739,8 @@ namespace TestNamespace
         }
     }
 }",
-            GetCSharpResultAt(10, 23, CA5351RuleName, DoNotUseDSAMessage),
-            GetCSharpResultAt(11, 23, CA5351RuleName, DoNotUseDSAMessage));
+            GetCSharpResultAt(10, 23, CA5351RuleName, CA5351RuleMessage),
+            GetCSharpResultAt(11, 23, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1753,8 +1753,8 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-           GetBasicResultAt(7, 23, CA5351RuleName, DoNotUseDSAMessage),
-           GetBasicResultAt(8, 23, CA5351RuleName, DoNotUseDSAMessage));
+           GetBasicResultAt(7, 23, CA5351RuleName, CA5351RuleMessage),
+           GetBasicResultAt(8, 23, CA5351RuleName, CA5351RuleMessage));
         }  
      
         [Fact]
@@ -1776,8 +1776,8 @@ class TestClass
         }
     }
 }",
-            GetCSharpResultAt(12, 43, CA5351RuleName, DoNotUseDSAMessage),
-            GetCSharpResultAt(13, 25, CA5351RuleName, DoNotUseDSAMessage));
+            GetCSharpResultAt(12, 43, CA5351RuleName, CA5351RuleMessage),
+            GetCSharpResultAt(13, 25, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -1794,8 +1794,8 @@ Class TestClass
 		End Get
 	End Property
 End Class",
-            GetBasicResultAt(9, 12, CA5351RuleName, DoNotUseDSAMessage),
-            GetBasicResultAt(11, 12, CA5351RuleName, DoNotUseDSAMessage));
+            GetBasicResultAt(9, 12, CA5351RuleName, CA5351RuleMessage),
+            GetBasicResultAt(11, 12, CA5351RuleName, CA5351RuleMessage));
         }
         
         [Fact]
@@ -1863,7 +1863,7 @@ namespace TestNamespace
         }
     }
 }" },
-            GetCSharpResultAt(11, 13, CA5351RuleName, DoNotUseDSAMessage));
+            GetCSharpResultAt(11, 13, CA5351RuleName, CA5351RuleMessage));
 
             VerifyBasic(new[] {
 //Test0
@@ -1913,7 +1913,7 @@ Namespace TestNamespace
 		End Function
 	End Class
 End Namespace" },
-           GetBasicResultAt(7, 4, CA5351RuleName, DoNotUseDSAMessage));
+           GetBasicResultAt(7, 4, CA5351RuleName, CA5351RuleMessage));
         } 
         
         [Fact]
@@ -2135,11 +2135,7 @@ End Namespace" }
         private const string CA5350RuleName = DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographicRuleId;
         private const string CA5351RuleName = DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographicRuleId;
 
-        private readonly string DoNotUseMD5Message = DesktopAnalyzersResources.DoNotUseMD5;
-        private readonly string DoNotUseDESMessage = DesktopAnalyzersResources.DoNotUseDES;
-        private readonly string DoNotUseRC2Message = DesktopAnalyzersResources.DoNotUseRC2;
-        private readonly string DoNotUseTripleDESMessage = DesktopAnalyzersResources.DoNotUseTripleDES;  
-        private readonly string DoNotUseRIPEMD160Message = DesktopAnalyzersResources.DoNotUseRIPEMD160;
-        private readonly string DoNotUseDSAMessage = DesktopAnalyzersResources.DoNotUseDSA;
+        private readonly string CA5350RuleMessage = DesktopAnalyzersResources.DoNotUseWeakCryptographicAlgorithms;
+        private readonly string CA5351RuleMessage = DesktopAnalyzersResources.DoNotUseBrokenCryptographicAlgorithms;
     }
 }


### PR DESCRIPTION
@genlu @srivatsn 
This is the pull request to update the crypto rules' (CA5350, CA5351) message strings so that all algorithms have a same user-facing string pattern.

And also updated help link of CA2153.
See https://microsoft.sharepoint.com/teams/CESecEngineering/SecDevTools/_layouts/15/WopiFrame2.aspx?sourcedoc={3b7b7554-5f75-4db3-8a52-fa37d9a3713b}&action=edit&wd=target%28Crypto%2Eone%7C9ACEC449-841F-4EF2-A460-F4A5E6760B69%2F%29