### PR TITLE
Move NuGet authoring project Microsoft.FxCopAnalyzers over from dotne…

### DIFF
--- a/build/Targets/Analyzers.Imports.targets
+++ b/build/Targets/Analyzers.Imports.targets
@@ -42,6 +42,17 @@
     <NuGetPreReleaseVersion>$(NuGetReleaseVersion)-$(PreReleaseVersion)</NuGetPreReleaseVersion>
     <NuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberSuffix)' != ''">$(NuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</NuGetPerBuildPreReleaseVersion>
   </PropertyGroup>
+
+  <!-- Version range for package dependencies -->
+  <PropertyGroup Condition="'$(DependencyMinimumSemanticVersion)' != '' AND '$(DependencyNextSemanticVersion)' != ''">
+    <DependencyMinimumNuGetReleaseVersion>$(DependencyMinimumSemanticVersion)</DependencyMinimumNuGetReleaseVersion>
+    <DependencyMinimumNuGetPreReleaseVersion>$(DependencyMinimumNuGetReleaseVersion)-$(PreReleaseVersion)</DependencyMinimumNuGetPreReleaseVersion>
+    <DependencyMinimumNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberSuffix)' != ''">$(DependencyMinimumNuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</DependencyMinimumNuGetPerBuildPreReleaseVersion>
+
+    <DependencyNextNuGetReleaseVersion>$(DependencyNextSemanticVersion)</DependencyNextNuGetReleaseVersion>
+    <DependencyNextNuGetPreReleaseVersion>$(DependencyNextNuGetReleaseVersion)-$(PreReleaseVersion)</DependencyNextNuGetPreReleaseVersion>
+    <DependencyNextNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberSuffix)' != ''">$(DependencyNextNuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</DependencyNextNuGetPerBuildPreReleaseVersion>
+  </PropertyGroup>
   
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->
   <Target Name="GetBuildVersion" Outputs="$(BuildVersion)" />

--- a/build/Targets/Analyzers.NuGet.Imports.targets
+++ b/build/Targets/Analyzers.NuGet.Imports.targets
@@ -7,6 +7,7 @@
     <PropertyGroup>
       <NuGetOutDir>$(OutDir)NuGet\PerBuildPreRelease</NuGetOutDir>
       <NuGetArguments>$(SharedNuGetArguments) -prop currentVersion="$(NuGetPerBuildPreReleaseVersion.Trim())"</NuGetArguments>
+      <NuGetArguments Condition="'$(DependencyMinimumNuGetPerBuildPreReleaseVersion)' != '' AND '$(DependencyNextNuGetPerBuildPreReleaseVersion)' != ''">$(NuGetArguments) -prop dependencyMinVersion="$(DependencyMinimumNuGetPerBuildPreReleaseVersion.Trim())" -prop dependencyNextVersion="$(DependencyNextNuGetPerBuildPreReleaseVersion.Trim())"</NuGetArguments>
     </PropertyGroup>
     <!-- clean our output directory -->
     <MakeDir Directories="$(NuGetOutDir)" Condition="!Exists('$(NuGetOutDir)')" />
@@ -18,6 +19,7 @@
     <PropertyGroup>
       <NuGetOutDir>$(OutDir)NuGet\PreRelease</NuGetOutDir>
       <NuGetArguments>$(SharedNuGetArguments) -prop currentVersion="$(NuGetPreReleaseVersion.Trim())"</NuGetArguments>
+      <NuGetArguments Condition="'$(DependencyMinimumNuGetPreReleaseVersion)' != '' AND '$(DependencyNextNuGetPreReleaseVersion)' != ''">$(NuGetArguments) -prop dependencyMinVersion="$(DependencyMinimumNuGetPreReleaseVersion.Trim())" -prop dependencyNextVersion="$(DependencyNextNuGetPreReleaseVersion.Trim())"</NuGetArguments>      
     </PropertyGroup>
     <!-- clean our output directory -->
     <MakeDir Directories="$(NuGetOutDir)" Condition="!Exists('$(NuGetOutDir)')" />
@@ -29,6 +31,7 @@
     <PropertyGroup>
       <NuGetOutDir>$(OutDir)NuGet\Release</NuGetOutDir>
       <NuGetArguments>$(SharedNuGetArguments) -prop currentVersion="$(NuGetReleaseVersion.Trim())"</NuGetArguments>
+      <NuGetArguments Condition="'$(DependencyMinimumNuGetReleaseVersion)' != '' AND '$(DependencyNextNuGetReleaseVersion)' != ''">$(NuGetArguments) -prop dependencyMinVersion="$(DependencyMinimumNuGetReleaseVersion.Trim())" -prop dependencyNextVersion="$(DependencyNextNuGetReleaseVersion.Trim())"</NuGetArguments>
     </PropertyGroup>
     <!-- clean our output directory -->
     <MakeDir Directories="$(NuGetOutDir)" Condition="!Exists('$(NuGetOutDir)')" />

--- a/build/Targets/Analyzers.Versions.targets
+++ b/build/Targets/Analyzers.Versions.targets
@@ -9,28 +9,42 @@
     <MicrosoftCodeAnalysisAnalyzersSemanticVersion>1.0.1</MicrosoftCodeAnalysisAnalyzersSemanticVersion>
     <MicrosoftCodeAnalysisAnalyzersPreReleaseVersion>beta1</MicrosoftCodeAnalysisAnalyzersPreReleaseVersion>
 
-    <DesktopAnalyzersSemanticVersion>1.0.0</DesktopAnalyzersSemanticVersion>
-    <DesktopAnalyzersPreReleaseVersion>beta1</DesktopAnalyzersPreReleaseVersion>
-
-    <SystemRuntimeAnalyzersSemanticVersion>1.0.2</SystemRuntimeAnalyzersSemanticVersion>
-    <SystemRuntimeAnalyzersPreReleaseVersion>beta1</SystemRuntimeAnalyzersPreReleaseVersion>
-    
-    <SystemRuntimeInteropServicesAnalyzersSemanticVersion>1.0.2</SystemRuntimeInteropServicesAnalyzersSemanticVersion>
-    <SystemRuntimeInteropServicesAnalyzersPreReleaseVersion>beta1</SystemRuntimeInteropServicesAnalyzersPreReleaseVersion>
-    
-    <SystemSecurityCryptographyHashingAlgorithmsAnalyzersSemanticVersion>1.0.0</SystemSecurityCryptographyHashingAlgorithmsAnalyzersSemanticVersion>
-    <SystemSecurityCryptographyHashingAlgorithmsAnalyzersPreReleaseVersion>beta1</SystemSecurityCryptographyHashingAlgorithmsAnalyzersPreReleaseVersion>
-
     <SharedTestSemanticVersion>1.0.0</SharedTestSemanticVersion>
     <SharedTestPreReleaseVersion>beta1</SharedTestPreReleaseVersion>
 
-    <AnalyzerPowerPackSemanticVersion>1.0.2</AnalyzerPowerPackSemanticVersion>
-    <AnalyzerPowerPackPreReleaseVersion>beta1</AnalyzerPowerPackPreReleaseVersion>
-    
     <RoslynDiagnosticsAnalyzersSemanticVersion>1.1.1</RoslynDiagnosticsAnalyzersSemanticVersion>
     <RoslynDiagnosticsAnalyzersPreReleaseVersion>beta1</RoslynDiagnosticsAnalyzersPreReleaseVersion>
 
     <ToolsSemanticVersion>0.0.0</ToolsSemanticVersion>
     <ToolsPreReleaseVersion>beta1</ToolsPreReleaseVersion>
+  </PropertyGroup>
+
+  <!-- Version info for FxCop analyzer packages -->
+  <PropertyGroup>
+    <!-- Master FxCop analyzer package, which is just a collection of individual analyzer packages below. -->
+    <FxCopAnalyzersSemanticVersion>1.0.2</FxCopAnalyzersSemanticVersion>
+    <FxCopAnalyzersPreReleaseVersion>beta1</FxCopAnalyzersPreReleaseVersion>
+
+    <!-- Dependency version range for packages included in the master FxCop analyzer package: "[$(FxCopAnalyzersDependencyMinimumSemanticVersion) - $(FxCopAnalyzersDependencyNextSemanticVersion))" -->
+    <!-- Allow any version of dependent packages between minimum (inclusive) and next (exclusive) semantic versions. -->
+    <!-- For example, values of minimum = '1.0.0' and next = '1.2.0' will have a dependency range ">= 1.0.0 && < 1.2.0" -->
+    <FxCopAnalyzersDependencyMinimumSemanticVersion>1.0.0</FxCopAnalyzersDependencyMinimumSemanticVersion>
+    <FxCopAnalyzersDependencyNextSemanticVersion>1.2.0</FxCopAnalyzersDependencyNextSemanticVersion>
+    
+    <!-- All the versions below must be >= FxCopAnalyzersDependencyMinimumSemanticVersion && < FxCopAnalyzersDependencyNextSemanticVersion -->
+    <DesktopAnalyzersSemanticVersion>1.0.0</DesktopAnalyzersSemanticVersion>
+    <DesktopAnalyzersPreReleaseVersion>beta1</DesktopAnalyzersPreReleaseVersion>
+
+    <SystemRuntimeAnalyzersSemanticVersion>1.0.2</SystemRuntimeAnalyzersSemanticVersion>
+    <SystemRuntimeAnalyzersPreReleaseVersion>beta1</SystemRuntimeAnalyzersPreReleaseVersion>
+
+    <SystemRuntimeInteropServicesAnalyzersSemanticVersion>1.0.2</SystemRuntimeInteropServicesAnalyzersSemanticVersion>
+    <SystemRuntimeInteropServicesAnalyzersPreReleaseVersion>beta1</SystemRuntimeInteropServicesAnalyzersPreReleaseVersion>
+
+    <SystemSecurityCryptographyHashingAlgorithmsAnalyzersSemanticVersion>1.0.0</SystemSecurityCryptographyHashingAlgorithmsAnalyzersSemanticVersion>
+    <SystemSecurityCryptographyHashingAlgorithmsAnalyzersPreReleaseVersion>beta1</SystemSecurityCryptographyHashingAlgorithmsAnalyzersPreReleaseVersion>
+
+    <AnalyzerPowerPackSemanticVersion>1.0.2</AnalyzerPowerPackSemanticVersion>
+    <AnalyzerPowerPackPreReleaseVersion>beta1</AnalyzerPowerPackPreReleaseVersion>
   </PropertyGroup>
 </Project>

--- a/src/FxCop/NuGet/FxCopAnalyzers.NuGet.proj
+++ b/src/FxCop/NuGet/FxCopAnalyzers.NuGet.proj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="Settings">
+    <Import Project="..\..\..\build\Targets\Analyzers.Settings.targets" />
+    <Import Project="..\..\..\build\Targets\Analyzers.NuGet.Settings.targets" />
+  </ImportGroup>
+  <PropertyGroup>
+    <SemanticVersion>$(FxCopAnalyzersSemanticVersion)</SemanticVersion>
+    <PreReleaseVersion>$(FxCopAnalyzersPreReleaseVersion)</PreReleaseVersion>
+    <DependencyMinimumSemanticVersion>$(FxCopAnalyzersDependencyMinimumSemanticVersion)</DependencyMinimumSemanticVersion>
+    <DependencyNextSemanticVersion>$(FxCopAnalyzersDependencyNextSemanticVersion)</DependencyNextSemanticVersion>
+    <NuGetLicenseURL>$(NuGetLicenseURLRedist)</NuGetLicenseURL>  
+</PropertyGroup>
+  <ItemGroup>
+    <NuSpec Include=".\FxCopAnalyzers.nuspec" />
+  </ItemGroup>
+  <ImportGroup Label="Targets">
+    <Import Project="..\..\..\build\Targets\Analyzers.Imports.targets" />
+    <Import Project="..\..\..\build\Targets\Analyzers.NuGet.Imports.targets" />
+  </ImportGroup>
+</Project>

--- a/src/FxCop/NuGet/FxCopAnalyzers.nuspec
+++ b/src/FxCop/NuGet/FxCopAnalyzers.nuspec
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.CodeAnalysis.FxCopAnalyzers</id>
+    <summary>Microsoft FxCop Analyzers</summary>
+    <description>
+      Microsoft FxCop rules implemented as analyzers using the .NET Compiler Platform ("Roslyn").
+    </description>
+    <dependencies>
+      <dependency id="Desktop.Analyzers" version="[$dependencyMinVersion$,$dependencyNextVersion$)" />
+      <dependency id="Microsoft.AnalyzerPowerPack" version="[$dependencyMinVersion$,$dependencyNextVersion$)" />
+      <dependency id="System.Runtime.Analyzers" version="[$dependencyMinVersion$,$dependencyNextVersion$)" />
+      <dependency id="System.Runtime.InteropServices.Analyzers" version="[$dependencyMinVersion$,$dependencyNextVersion$)" />
+      <dependency id="System.Security.Cryptography.Hashing.Algorithms.Analyzers" version="[$dependencyMinVersion$,$dependencyNextVersion$)" />
+    </dependencies>
+    <language>en-US</language>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <version>$currentVersion$</version>
+    <authors>$authors$</authors>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$ analyzers</tags>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System" targetFramework="" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="ThirdPartyNotices.rtf" target="" />
+  </files>
+</package>

--- a/src/FxCop/NuGet/ThirdPartyNotices.rtf
+++ b/src/FxCop/NuGet/ThirdPartyNotices.rtf
@@ -1,0 +1,54 @@
+{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033\deflangfe1033{\fonttbl{\f0\fswiss\fprq2\fcharset0 Tahoma;}}
+{\colortbl ;\red0\green0\blue255;}
+{\*\generator Riched20 10.0.10037}{\*\mmathPr\mnaryLim0\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
+\pard\nowidctlpar\sb120\sa120\f0\fs19 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION\par
+Do Not Translate or Localize\par
+\par
+This file provides information regarding components that are being relicensed to you by Microsoft Corporation under Microsoft's software licensing terms. Microsoft Corporation reserves all rights not expressly granted herein.\par
+\par
+%% \caps .NET Compiler Platform\caps0  NOTICES AND INFORMATION BEGIN HERE\par
+=========================================\par
+Copyright (C) .NET Foundation. All rights reserved.\par
+\par
+Apache License, Version 2.0\par
+Apache License\par
+Version 2.0, January 2004\par
+{{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/ }}{\fldrslt{http://www.apache.org/licenses/\ul0\cf0}}}}\f0\fs19\par
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\par
+1. Definitions.\par
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.\par
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.\par
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.\par
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.\par
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.\par
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.\par
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).\par
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.\par
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."\par
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.\par
+2. Grant of Copyright License.\par
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.\par
+3. Grant of Patent License.\par
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.\par
+4. Redistribution.\par
+You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:\par
+1. You must give any other recipients of the Work or Derivative Works a copy of this License; and\par
+2. You must cause any modified files to carry prominent notices stating that You changed the files; and\par
+3. You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and\par
+4. If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.\par
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.\par
+5. Submission of Contributions.\par
+Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.\par
+6. Trademarks.\par
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.\par
+7. Disclaimer of Warranty.\par
+Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.\par
+8. Limitation of Liability.\par
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.\par
+9. Accepting Warranty or Additional Liability.\par
+While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.\par
+END OF TERMS AND CONDITIONS\par
+=========================================\par
+END OF \caps .NET Compiler Platform\caps0  NOTICES AND INFORMATION\par
+}
+ 

--- a/src/Packaging/Packaging.proj
+++ b/src/Packaging/Packaging.proj
@@ -6,11 +6,12 @@
   <ItemGroup>
     <Project Include="..\MetaCompilation\MetaCompilation\MetaCompilation.Nuget\MetaCompilation.Nuget.proj" />
     <Project Include="..\CodeAnalysis\NuGet\CodeAnalysisDiagnosticAnalyzers.NuGet.proj" />
+    <Project Include="..\AnalyzerPowerPack\NuGet\AnalyzerPowerPack.NuGet.proj" />
     <Project Include="..\FxCop\Desktop.Analyzers\NuGet\DesktopAnalyzers.NuGet.proj" />
     <Project Include="..\FxCop\System.Runtime.Analyzers\NuGet\SystemRuntimeAnalyzers.NuGet.proj" />
     <Project Include="..\FxCop\System.Runtime.InteropServices.Analyzers\NuGet\SystemRuntimeInteropServicesAnalyzers.NuGet.proj" />
     <Project Include="..\FxCop\System.Security.Cryptography.Hashing.Algorithms.Analyzers\NuGet\SystemSecurityCryptographyHashingAlgorithmsAnalyzers.NuGet.proj" />
-    <Project Include="..\AnalyzerPowerPack\NuGet\AnalyzerPowerPack.NuGet.proj" />
+    <Project Include="..\FxCop\NuGet\FxCopAnalyzers.NuGet.proj" />
     <Project Include="..\Roslyn\NuGet\RoslynDiagnosticAnalyzers.NuGet.proj" />
   </ItemGroup>
   <ImportGroup Label="Imports">


### PR DESCRIPTION
…t/roslyn

Generated FxCopAnalyzers nuget package will have a dependency range (currently >= 1.0.0 && < 1.2.0) for dependent packages.

Testing: Verified prerelease and release packages built locally and adding a nuget reference to the FxCopAnalyzers nupkg installs the dependent packages from nuget.

Fixes #251