### PR TITLE
Fixing up some resource strings that were hardcoded

### DIFF
--- a/PortFxCop/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
+++ b/PortFxCop/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
@@ -1189,7 +1189,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Implement IDisposable on {0} because it creates members of the following IDisposable types: {1}..
+        ///   Looks up a localized string similar to Type &apos;{0}&apos; owns disposable fields but is not disposable.
         /// </summary>
         internal static string TypesThatOwnDisposableFieldsShouldBeDisposableMessageNonBreaking {
             get {

--- a/PortFxCop/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/PortFxCop/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -181,7 +181,7 @@
     <value>Implement IDisposable on {0} because it creates members of the following IDisposable types: {1}. If {0} has previously shipped, adding new members that implement IDisposable to this type is considered a breaking change to existing consumers.</value>
   </data>
   <data name="TypesThatOwnDisposableFieldsShouldBeDisposableMessageNonBreaking" xml:space="preserve">
-    <value>Implement IDisposable on {0} because it creates members of the following IDisposable types: {1}.</value>
+    <value>Type '{0}' owns disposable fields but is not disposable</value>
   </data>
   <data name="UseGenericEventHandlerInstancesTitle" xml:space="preserve">
     <value>Use generic event handler instances</value>

--- a/PortFxCop/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.cs
+++ b/PortFxCop/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.cs
@@ -233,7 +233,7 @@ End Structure
         }
 
         internal static string CA2231Name = "CA2231";
-        internal static string CA2231Message = "Overload operator equals on overriding ValueType.Equals";
+        internal static string CA2231Message = MicrosoftApiDesignGuidelinesAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEqualsMessage;
 
         private static DiagnosticResult GetCA2231CSharpResultAt(int line, int column)
         {

--- a/PortFxCop/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.cs
+++ b/PortFxCop/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.cs
@@ -885,7 +885,7 @@ End Enum");
         }
 
         internal static string CA1036Name = "CA1036";
-        internal static string CA1036Message = "Overload operator Equals and comparison operators when implementing System.IComparable";
+        internal static string CA1036Message = MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideMethodsOnComparableTypesMessageEquals;
 
         private static DiagnosticResult GetCA1036CSharpResultAt(int line, int column)
         {


### PR DESCRIPTION
My previous change where I had simply copied files over broke some tests because the tests had hardcoded the message of the diagnostic to test instead of reading from the resource file. The stub generator created resource files with the original strings from FxCop and those are different from what the analyzers had implemented. Most tests are fine because they read the expected value from the resx files as well, expect for some tests below.

There was one more case where the number of holes in the strings differed between the FxCop string and the analyzer. I've restored it to the original analyzer's string