### PR TITLE
Tolerate non-source locations in DiagnosticExtensions

### DIFF
--- a/PortFxCop/src/Analyzer.Utilities/Extensions/DiagnosticExtensions.cs
+++ b/PortFxCop/src/Analyzer.Utilities/Extensions/DiagnosticExtensions.cs
@@ -114,12 +114,7 @@ namespace Analyzer.Utilities
             DiagnosticDescriptor rule,
             params object[] args)
         {
-            var location = locations.First(l => l.IsInSource);
-            var additionalLocations = locations.Where(l => l.IsInSource).Skip(1);
-            return Diagnostic.Create(rule,
-                     location: location,
-                     additionalLocations: additionalLocations,
-                     messageArgs: args);
+            return locations.CreateDiagnostic(rule, null, args);
         }
 
         public static Diagnostic CreateDiagnostic(
@@ -128,11 +123,15 @@ namespace Analyzer.Utilities
             ImmutableDictionary<string, string> properties,
             params object[] args)
         {
-            var location = locations.First(l => l.IsInSource);
-            var additionalLocations = locations.Where(l => l.IsInSource).Skip(1);
+            var inSource = locations.Where(l => l.IsInSource);
+            if (!inSource.Any())
+            {
+                return Diagnostic.Create(rule, null, args);
+            }
+
             return Diagnostic.Create(rule,
-                     location: location,
-                     additionalLocations: additionalLocations,
+                     location: inSource.First(),
+                     additionalLocations: inSource.Skip(1),
                      properties: properties,
                      messageArgs: args);
         }

--- a/src/AnalyzerPowerPack/Core/Shared/Extensions/DiagnosticExtensions.cs
+++ b/src/AnalyzerPowerPack/Core/Shared/Extensions/DiagnosticExtensions.cs
@@ -124,11 +124,15 @@ namespace Microsoft.AnalyzerPowerPack.Utilities
             DiagnosticDescriptor rule,
             params object[] args)
         {
-            var location = locations.First(l => l.IsInSource);
-            var additionalLocations = locations.Where(l => l.IsInSource).Skip(1);
+            var inSource = locations.Where(l => l.IsInSource);
+            if (!inSource.Any())
+            {
+                return Diagnostic.Create(rule, null, args);
+            }
+
             return Diagnostic.Create(rule,
-                     location: location,
-                     additionalLocations: additionalLocations,
+                     location: inSource.First(),
+                     additionalLocations: inSource.Skip(1),
                      messageArgs: args);
         }
     }


### PR DESCRIPTION
(Replaces #606, re-targeted at FxCop branch.)

We're experimenting with running symbol analysis against binaries and there were a couple of places in analyzer helpers that were assuming there was always a source location, which would cause some rules to crash just as they were reporting a diagnostic.

I've followed the precedent set by  CreateDiagnostic(Location, DiagnosticDescriptor, object[])  which coerces the location to null when it's not in source and done the same when the  IEnumerable<Location>  variant gets a sequence where none of the locations are in source. We probably want to think about letting metadata locations through, but I'm starting with the least invasive change.

@srivatsn @michaelcfanning 
