### PR TITLE
Add TestResults.xml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+# cibuild test results
+TestResults.xml


### PR DESCRIPTION
@srivatsn  This file shows up in git status after running cibuild.cmd so I thought it would be nice to add it to gitignore to avoid accidental check-in...