### PR TITLE
Fix label updates and improve logging in dry runs

### DIFF
--- a/PortFxCop/src/Tools/FileIssues/Resources.Designer.cs
+++ b/PortFxCop/src/Tools/FileIssues/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace FileIssues {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to --dry-run option specified; labels were not actually updated..
+        /// </summary>
+        internal static string InfoDryRunLabelsNotUpdated {
+            get {
+                return ResourceManager.GetString("InfoDryRunLabelsNotUpdated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Filing new issue for rule {0}....
         /// </summary>
         internal static string InfoFilingNewIssue {

--- a/PortFxCop/src/Tools/FileIssues/Resources.resx
+++ b/PortFxCop/src/Tools/FileIssues/Resources.resx
@@ -138,6 +138,9 @@
   <data name="InfoDryRunIssueNotUpdated" xml:space="preserve">
     <value>--dry-run option specified; issue was not actually updated.</value>
   </data>
+  <data name="InfoDryRunLabelsNotUpdated" xml:space="preserve">
+    <value>--dry-run option specified; labels were not actually updated.</value>
+  </data>
   <data name="InfoFilingNewIssue" xml:space="preserve">
     <value>Filing new issue for rule {0}...</value>
   </data>


### PR DESCRIPTION
* The logic for adding and removing labels from existing issues was wrong. It should only add a label if the label does not already exist on the issue. Instead, it was adding a label if the label did not already exist *in the list of labels to add* -- which was always!

    The `--dry-run` feature caught this.

* Wrap the "if dry run" test directly around the calls to the GitHub API, not around our helper methods. In dry runs, we were losing logging information about label changes and issue state changes.

    The `--dry-run` feature also caught this.

@srivatsn @nguerrera @mavasani @michaelcfanning 