### PR TITLE
Updating the version of the Roslyn packages to the latest from MyGet

### DIFF
--- a/src/.nuget/NuGet.Config
+++ b/src/.nuget/NuGet.Config
@@ -10,6 +10,7 @@
   </config>
   <packageSources>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="MyGet" value="https://www.myget.org/F/roslyn-nightly/" />
+    <add key="MyGet Roslyn" value="https://www.myget.org/F/roslyn-nightly/" />
+    <add key="MyGet CoreFX" value="https://www.myget.org/F/dotnet-core/" />
   </packageSources>
 </configuration>

--- a/src/Analyzer.Utilities/Analyzer.Utilities.csproj
+++ b/src/Analyzer.Utilities/Analyzer.Utilities.csproj
@@ -28,6 +28,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -55,32 +56,32 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -113,9 +114,9 @@
       <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Analyzer.Utilities/app.config
+++ b/src/Analyzer.Utilities/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Analyzer.Utilities/packages.config
+++ b/src/Analyzer.Utilities/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/ApiReview.Analyzers/CSharp/ApiReview.CSharp.Analyzers.csproj
+++ b/src/ApiReview.Analyzers/CSharp/ApiReview.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -82,9 +82,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -92,6 +92,7 @@
     <Content Include="ApiReview.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ApiReview.Analyzers/CSharp/app.config
+++ b/src/ApiReview.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/ApiReview.Analyzers/CSharp/packages.config
+++ b/src/ApiReview.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/ApiReview.Analyzers/Core/ApiReview.Analyzers.csproj
+++ b/src/ApiReview.Analyzers/Core/ApiReview.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="ApiReview.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/ApiReview.Analyzers/Core/app.config
+++ b/src/ApiReview.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/ApiReview.Analyzers/Core/packages.config
+++ b/src/ApiReview.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/ApiReview.Analyzers/Setup/ApiReview.Analyzers.Setup.csproj
+++ b/src/ApiReview.Analyzers/Setup/ApiReview.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/ApiReview.Analyzers/Setup/app.config
+++ b/src/ApiReview.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/ApiReview.Analyzers/UnitTests/ApiReview.Analyzers.UnitTests.csproj
+++ b/src/ApiReview.Analyzers/UnitTests/ApiReview.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ApiReview.Analyzers/UnitTests/app.config
+++ b/src/ApiReview.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/ApiReview.Analyzers/UnitTests/packages.config
+++ b/src/ApiReview.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/ApiReview.Analyzers/VisualBasic/ApiReview.VisualBasic.Analyzers.vbproj
+++ b/src/ApiReview.Analyzers/VisualBasic/ApiReview.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -81,9 +81,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -91,6 +91,7 @@
     <Content Include="ApiReview.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ApiReview.Analyzers/VisualBasic/app.config
+++ b/src/ApiReview.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/ApiReview.Analyzers/VisualBasic/packages.config
+++ b/src/ApiReview.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Desktop.Analyzers/CSharp/Desktop.CSharp.Analyzers.csproj
+++ b/src/Desktop.Analyzers/CSharp/Desktop.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -86,9 +86,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -96,6 +96,7 @@
     <Content Include="Desktop.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Desktop.Analyzers/CSharp/app.config
+++ b/src/Desktop.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Desktop.Analyzers/CSharp/packages.config
+++ b/src/Desktop.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Desktop.Analyzers/Core/Desktop.Analyzers.csproj
+++ b/src/Desktop.Analyzers/Core/Desktop.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="Desktop.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/Desktop.Analyzers/Core/app.config
+++ b/src/Desktop.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Desktop.Analyzers/Core/packages.config
+++ b/src/Desktop.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Desktop.Analyzers/Setup/Desktop.Analyzers.Setup.csproj
+++ b/src/Desktop.Analyzers/Setup/Desktop.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/Desktop.Analyzers/Setup/app.config
+++ b/src/Desktop.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Desktop.Analyzers/UnitTests/Desktop.Analyzers.UnitTests.csproj
+++ b/src/Desktop.Analyzers/UnitTests/Desktop.Analyzers.UnitTests.csproj
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -119,9 +119,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -145,6 +145,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Desktop.Analyzers/UnitTests/app.config
+++ b/src/Desktop.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Desktop.Analyzers/UnitTests/packages.config
+++ b/src/Desktop.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Desktop.Analyzers/VisualBasic/Desktop.VisualBasic.Analyzers.vbproj
+++ b/src/Desktop.Analyzers/VisualBasic/Desktop.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -85,9 +85,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -95,6 +95,7 @@
     <Content Include="Desktop.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Desktop.Analyzers/VisualBasic/app.config
+++ b/src/Desktop.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Desktop.Analyzers/VisualBasic/packages.config
+++ b/src/Desktop.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/MetaCompilation.Test.csproj
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/MetaCompilation.Test.csproj
@@ -36,27 +36,27 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -85,9 +85,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -117,6 +117,7 @@
     <Compile Include="UnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/app.config
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/packages.config
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -14,7 +14,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Vsix/MetaCompilation.Vsix.csproj
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Vsix/MetaCompilation.Vsix.csproj
@@ -40,6 +40,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Vsix/app.config
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Vsix/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/MetaCompilation.csproj
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/MetaCompilation.csproj
@@ -39,6 +39,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Diagnostic.nuspec">
       <SubType>Designer</SubType>
     </None>
@@ -54,22 +55,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -97,9 +98,9 @@
       <HintPath>..\..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/app.config
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/packages.config
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" userInstalled="true" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" userInstalled="true" />
   <package id="NuGet.CommandLine" version="2.8.2" targetFramework="portable45-net45+win8" userInstalled="true" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" userInstalled="true" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" userInstalled="true" />
 </packages>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/Microsoft.ApiDesignGuidelines.CSharp.Analyzers.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/Microsoft.ApiDesignGuidelines.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -86,9 +86,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -96,6 +96,7 @@
     <Content Include="Microsoft.ApiDesignGuidelines.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/app.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="Microsoft.ApiDesignGuidelines.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/app.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/packages.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Setup/Microsoft.ApiDesignGuidelines.Analyzers.Setup.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Setup/Microsoft.ApiDesignGuidelines.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Setup/app.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/app.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/packages.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers.vbproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -85,9 +85,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -95,6 +95,7 @@
     <Content Include="Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/app.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpCodeAnalysisDiagnosticAnalyzers.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpCodeAnalysisDiagnosticAnalyzers.csproj
@@ -37,6 +37,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -51,32 +52,32 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -109,9 +110,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/app.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticAnalyzers.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticAnalyzers.csproj
@@ -31,6 +31,7 @@
     <InternalsVisibleToTest Include="Microsoft.CodeAnalysis.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Diagnostic.nuspec" />
     <None Include="install.ps1" />
     <None Include="packages.config" />
@@ -68,32 +69,32 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -126,9 +127,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/app.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/packages.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Setup/CodeAnalysisDiagnosticsSetup.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Setup/CodeAnalysisDiagnosticsSetup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Setup/app.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/CodeAnalysisDiagnosticAnalyzersTest.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/CodeAnalysisDiagnosticAnalyzersTest.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/app.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/packages.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/BasicCodeAnalysisDiagnosticAnalyzers.vbproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/BasicCodeAnalysisDiagnosticAnalyzers.vbproj
@@ -35,6 +35,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -48,32 +49,32 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -106,9 +107,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/app.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.Composition.Analyzers/CSharp/Microsoft.Composition.CSharp.Analyzers.csproj
+++ b/src/Microsoft.Composition.Analyzers/CSharp/Microsoft.Composition.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -82,9 +82,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -92,6 +92,7 @@
     <Content Include="Microsoft.Composition.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Composition.Analyzers/CSharp/app.config
+++ b/src/Microsoft.Composition.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Composition.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.Composition.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.Composition.Analyzers/Core/Microsoft.Composition.Analyzers.csproj
+++ b/src/Microsoft.Composition.Analyzers/Core/Microsoft.Composition.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="Microsoft.Composition.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/Microsoft.Composition.Analyzers/Core/app.config
+++ b/src/Microsoft.Composition.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Composition.Analyzers/Core/packages.config
+++ b/src/Microsoft.Composition.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.Composition.Analyzers/Setup/Microsoft.Composition.Analyzers.Setup.csproj
+++ b/src/Microsoft.Composition.Analyzers/Setup/Microsoft.Composition.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/Microsoft.Composition.Analyzers/Setup/app.config
+++ b/src/Microsoft.Composition.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Composition.Analyzers/UnitTests/Microsoft.Composition.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.Composition.Analyzers/UnitTests/Microsoft.Composition.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Composition.Analyzers/UnitTests/app.config
+++ b/src/Microsoft.Composition.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Composition.Analyzers/UnitTests/packages.config
+++ b/src/Microsoft.Composition.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Microsoft.Composition.Analyzers/VisualBasic/Microsoft.Composition.VisualBasic.Analyzers.vbproj
+++ b/src/Microsoft.Composition.Analyzers/VisualBasic/Microsoft.Composition.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -81,9 +81,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -91,6 +91,7 @@
     <Content Include="Microsoft.Composition.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Composition.Analyzers/VisualBasic/app.config
+++ b/src/Microsoft.Composition.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Composition.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.Composition.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.Maintainability.Analyzers/CSharp/Microsoft.Maintainability.CSharp.Analyzers.csproj
+++ b/src/Microsoft.Maintainability.Analyzers/CSharp/Microsoft.Maintainability.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -86,9 +86,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -96,6 +96,7 @@
     <Content Include="Microsoft.Maintainability.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />

--- a/src/Microsoft.Maintainability.Analyzers/CSharp/app.config
+++ b/src/Microsoft.Maintainability.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Maintainability.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.Maintainability.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.Maintainability.Analyzers/Core/Microsoft.Maintainability.Analyzers.csproj
+++ b/src/Microsoft.Maintainability.Analyzers/Core/Microsoft.Maintainability.Analyzers.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -73,9 +73,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -85,6 +85,7 @@
     <InternalsVisibleToTest Include="Microsoft.Maintainability.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/Microsoft.Maintainability.Analyzers/Core/app.config
+++ b/src/Microsoft.Maintainability.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Maintainability.Analyzers/Core/packages.config
+++ b/src/Microsoft.Maintainability.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.Maintainability.Analyzers/Setup/Microsoft.Maintainability.Analyzers.Setup.csproj
+++ b/src/Microsoft.Maintainability.Analyzers/Setup/Microsoft.Maintainability.Analyzers.Setup.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/Microsoft.Maintainability.Analyzers/Setup/app.config
+++ b/src/Microsoft.Maintainability.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/Microsoft.Maintainability.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/Microsoft.Maintainability.Analyzers.UnitTests.csproj
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -119,9 +119,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -145,6 +145,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/app.config
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/packages.config
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Microsoft.Maintainability.Analyzers/VisualBasic/Microsoft.Maintainability.VisualBasic.Analyzers.vbproj
+++ b/src/Microsoft.Maintainability.Analyzers/VisualBasic/Microsoft.Maintainability.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -85,9 +85,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -95,6 +95,7 @@
     <Content Include="Microsoft.Maintainability.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Maintainability.Analyzers/VisualBasic/app.config
+++ b/src/Microsoft.Maintainability.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Maintainability.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.Maintainability.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.QualityGuidelines.Analyzers/CSharp/Microsoft.QualityGuidelines.CSharp.Analyzers.csproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/CSharp/Microsoft.QualityGuidelines.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -86,9 +86,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -96,6 +96,7 @@
     <Content Include="Microsoft.QualityGuidelines.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />

--- a/src/Microsoft.QualityGuidelines.Analyzers/CSharp/app.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.QualityGuidelines.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/Microsoft.QualityGuidelines.Analyzers.csproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/Microsoft.QualityGuidelines.Analyzers.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -73,9 +73,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -85,6 +85,7 @@
     <InternalsVisibleToTest Include="Microsoft.QualityGuidelines.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/app.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/packages.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Microsoft.QualityGuidelines.Analyzers/Setup/Microsoft.QualityGuidelines.Analyzers.Setup.csproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Setup/Microsoft.QualityGuidelines.Analyzers.Setup.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/Microsoft.QualityGuidelines.Analyzers/Setup/app.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/Microsoft.QualityGuidelines.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/Microsoft.QualityGuidelines.Analyzers.UnitTests.csproj
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -119,9 +119,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -145,6 +145,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/app.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/packages.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/Microsoft.QualityGuidelines.VisualBasic.Analyzers.vbproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/Microsoft.QualityGuidelines.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -85,9 +85,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -96,6 +96,7 @@
     <Content Include="Microsoft.QualityGuidelines.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/app.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/Roslyn.Diagnostics.CSharp.Analyzers.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/Roslyn.Diagnostics.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -82,9 +82,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -92,6 +92,7 @@
     <Content Include="Roslyn.Diagnostics.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/app.config
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/packages.config
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="Roslyn.Diagnostics.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/app.config
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/packages.config
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Roslyn.Diagnostics.Analyzers/Setup/Roslyn.Diagnostics.Analyzers.Setup.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/Setup/Roslyn.Diagnostics.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/Roslyn.Diagnostics.Analyzers/Setup/app.config
+++ b/src/Roslyn.Diagnostics.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/Roslyn.Diagnostics.Analyzers.UnitTests.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/Roslyn.Diagnostics.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/app.config
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/packages.config
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/Roslyn.Diagnostics.VisualBasic.Analyzers.vbproj
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/Roslyn.Diagnostics.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -81,9 +81,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -91,6 +91,7 @@
     <Content Include="Roslyn.Diagnostics.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/app.config
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/packages.config
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Collections.Immutable.Analyzers/CSharp/System.Collections.Immutable.CSharp.Analyzers.csproj
+++ b/src/System.Collections.Immutable.Analyzers/CSharp/System.Collections.Immutable.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -82,9 +82,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -92,6 +92,7 @@
     <Content Include="System.Collections.Immutable.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Collections.Immutable.Analyzers/CSharp/app.config
+++ b/src/System.Collections.Immutable.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Collections.Immutable.Analyzers/CSharp/packages.config
+++ b/src/System.Collections.Immutable.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Collections.Immutable.Analyzers/Core/System.Collections.Immutable.Analyzers.csproj
+++ b/src/System.Collections.Immutable.Analyzers/Core/System.Collections.Immutable.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="System.Collections.Immutable.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/System.Collections.Immutable.Analyzers/Core/app.config
+++ b/src/System.Collections.Immutable.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Collections.Immutable.Analyzers/Core/packages.config
+++ b/src/System.Collections.Immutable.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Collections.Immutable.Analyzers/Setup/System.Collections.Immutable.Analyzers.Setup.csproj
+++ b/src/System.Collections.Immutable.Analyzers/Setup/System.Collections.Immutable.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/System.Collections.Immutable.Analyzers/Setup/app.config
+++ b/src/System.Collections.Immutable.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Collections.Immutable.Analyzers/UnitTests/System.Collections.Immutable.Analyzers.UnitTests.csproj
+++ b/src/System.Collections.Immutable.Analyzers/UnitTests/System.Collections.Immutable.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Collections.Immutable.Analyzers/UnitTests/app.config
+++ b/src/System.Collections.Immutable.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Collections.Immutable.Analyzers/UnitTests/packages.config
+++ b/src/System.Collections.Immutable.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/System.Collections.Immutable.Analyzers/VisualBasic/System.Collections.Immutable.VisualBasic.Analyzers.vbproj
+++ b/src/System.Collections.Immutable.Analyzers/VisualBasic/System.Collections.Immutable.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -81,9 +81,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -91,6 +91,7 @@
     <Content Include="System.Collections.Immutable.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Collections.Immutable.Analyzers/VisualBasic/app.config
+++ b/src/System.Collections.Immutable.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Collections.Immutable.Analyzers/VisualBasic/packages.config
+++ b/src/System.Collections.Immutable.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Resources.Analyzers/CSharp/System.Resources.CSharp.Analyzers.csproj
+++ b/src/System.Resources.Analyzers/CSharp/System.Resources.CSharp.Analyzers.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -86,9 +86,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -96,6 +96,7 @@
     <Content Include="System.Resources.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />
@@ -103,7 +104,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CSharpMarkAssembliesWithNeutralResourcesLanguage.cs" />
     <Compile Include="CSharpMarkAssembliesWithNeutralResourcesLanguage.Fixer.cs" />
-
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\Analyzers.Imports.targets" />

--- a/src/System.Resources.Analyzers/CSharp/app.config
+++ b/src/System.Resources.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Resources.Analyzers/CSharp/packages.config
+++ b/src/System.Resources.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Resources.Analyzers/Core/System.Resources.Analyzers.csproj
+++ b/src/System.Resources.Analyzers/Core/System.Resources.Analyzers.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -73,9 +73,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -85,6 +85,7 @@
     <InternalsVisibleToTest Include="System.Resources.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
@@ -107,7 +108,6 @@
     <Compile Include="MarkAssembliesWithNeutralResourcesLanguage.cs" />
     <Compile Include="MarkAssembliesWithNeutralResourcesLanguage.Fixer.cs" />
     <Compile Include="DiagnosticCategory.cs" />
-
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="SystemResourcesAnalyzersResources.resx">

--- a/src/System.Resources.Analyzers/Core/app.config
+++ b/src/System.Resources.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Resources.Analyzers/Core/packages.config
+++ b/src/System.Resources.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Resources.Analyzers/Setup/System.Resources.Analyzers.Setup.csproj
+++ b/src/System.Resources.Analyzers/Setup/System.Resources.Analyzers.Setup.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/System.Resources.Analyzers/Setup/app.config
+++ b/src/System.Resources.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Resources.Analyzers/UnitTests/System.Resources.Analyzers.UnitTests.csproj
+++ b/src/System.Resources.Analyzers/UnitTests/System.Resources.Analyzers.UnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -119,9 +119,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -145,13 +145,13 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MarkAssembliesWithNeutralResourcesLanguageTests.cs" />
     <Compile Include="MarkAssembliesWithNeutralResourcesLanguageTests.Fixer.cs" />
-
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\Analyzers.Imports.targets" />

--- a/src/System.Resources.Analyzers/UnitTests/app.config
+++ b/src/System.Resources.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Resources.Analyzers/UnitTests/packages.config
+++ b/src/System.Resources.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/System.Resources.Analyzers/VisualBasic/System.Resources.VisualBasic.Analyzers.vbproj
+++ b/src/System.Resources.Analyzers/VisualBasic/System.Resources.VisualBasic.Analyzers.vbproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -85,9 +85,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -95,12 +95,12 @@
     <Content Include="System.Resources.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicMarkAssembliesWithNeutralResourcesLanguage.vb" />
     <Compile Include="BasicMarkAssembliesWithNeutralResourcesLanguage.Fixer.vb" />
-
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\Analyzers.Imports.targets" />

--- a/src/System.Resources.Analyzers/VisualBasic/app.config
+++ b/src/System.Resources.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Resources.Analyzers/VisualBasic/packages.config
+++ b/src/System.Resources.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Runtime.Analyzers/CSharp/System.Runtime.CSharp.Analyzers.csproj
+++ b/src/System.Runtime.Analyzers/CSharp/System.Runtime.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -86,9 +86,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -96,6 +96,7 @@
     <Content Include="System.Runtime.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.Analyzers/CSharp/app.config
+++ b/src/System.Runtime.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.Analyzers/CSharp/packages.config
+++ b/src/System.Runtime.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Runtime.Analyzers/Core/InstantiateArgumentExceptionsCorrectly.cs
+++ b/src/System.Runtime.Analyzers/Core/InstantiateArgumentExceptionsCorrectly.cs
@@ -91,8 +91,8 @@ namespace System.Runtime.Analyzers
                     {
                         continue;
                     }
-                 
-                    string value = argument.Value.ConstantValue as string;
+
+                    string value = argument.Value.ConstantValue.HasValue ? argument.Value.ConstantValue.Value as string : null;
                     if (value == null)
                     {
                         continue;

--- a/src/System.Runtime.Analyzers/Core/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/System.Runtime.Analyzers/Core/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -53,13 +53,13 @@ namespace System.Runtime.Analyzers
 
                     var formatStringArgument = invocation.ArgumentsInParameterOrder[info.FormatStringIndex];
                     if (!object.Equals(formatStringArgument?.Value?.ResultType, formatInfo.String) ||
-                        !(formatStringArgument?.Value?.ConstantValue is string))
+                        !(formatStringArgument?.Value?.ConstantValue.Value is string))
                     {
                         // wrong argument
                         return;
                     }
 
-                    var stringFormat = (string)formatStringArgument.Value.ConstantValue;
+                    var stringFormat = (string)formatStringArgument.Value.ConstantValue.Value;
                     var expectedStringFormatArgumentCount = GetFormattingArguments(stringFormat);
 
                     // explict parameter case

--- a/src/System.Runtime.Analyzers/Core/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/System.Runtime.Analyzers/Core/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -101,23 +101,6 @@ namespace System.Runtime.Analyzers
                         return;
                     }
 
-                    // explictly giving object array case.
-                    // this should go away once the bug is fixed
-                    if (invocation.Syntax.Language == LanguageNames.CSharp &&
-                        invocation.ArgumentsInParameterOrder.Count(a => a.Kind == ArgumentKind.ParamArray) ==
-                        invocation.ArgumentsInSourceOrder.Count(a => a.Kind == ArgumentKind.ParamArray))
-                    {
-                        // TODO: due to a bug - https://github.com/dotnet/roslyn/issues/7342
-                        //       currently this (explictly giving object array case) is not supported.
-                        //
-                        //       this check is only for CSharp, since VB correctly normalize explicit
-                        //       and implicit params array to one format. but VB has different issue where one can't
-                        //       distinguish explicit and implicit params argument since it is already normalized in one
-                        //       format in both ArgumentsInParameterOrder and ArgumentsInSourceOrder.
-                        //
-                        return;
-                    }
-
                     // compiler generating object array for params case
                     var dimensionInitializer = arrayCreation.ElementValues as IDimensionArrayInitializer;
                     if (dimensionInitializer == null)

--- a/src/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.csproj
+++ b/src/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="System.Runtime.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/System.Runtime.Analyzers/Core/app.config
+++ b/src/System.Runtime.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.Analyzers/Core/packages.config
+++ b/src/System.Runtime.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Runtime.Analyzers/Setup/System.Runtime.Analyzers.Setup.csproj
+++ b/src/System.Runtime.Analyzers/Setup/System.Runtime.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/System.Runtime.Analyzers/Setup/app.config
+++ b/src/System.Runtime.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.Analyzers/UnitTests/System.Runtime.Analyzers.UnitTests.csproj
+++ b/src/System.Runtime.Analyzers/UnitTests/System.Runtime.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.Analyzers/UnitTests/app.config
+++ b/src/System.Runtime.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.Analyzers/UnitTests/packages.config
+++ b/src/System.Runtime.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/System.Runtime.Analyzers/VisualBasic/System.Runtime.VisualBasic.Analyzers.vbproj
+++ b/src/System.Runtime.Analyzers/VisualBasic/System.Runtime.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -85,9 +85,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -95,6 +95,7 @@
     <Content Include="System.Runtime.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.Analyzers/VisualBasic/app.config
+++ b/src/System.Runtime.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.Analyzers/VisualBasic/packages.config
+++ b/src/System.Runtime.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Runtime.InteropServices.Analyzers/CSharp/System.Runtime.InteropServices.CSharp.Analyzers.csproj
+++ b/src/System.Runtime.InteropServices.Analyzers/CSharp/System.Runtime.InteropServices.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -82,9 +82,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -92,6 +92,7 @@
     <Content Include="System.Runtime.InteropServices.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.InteropServices.Analyzers/CSharp/app.config
+++ b/src/System.Runtime.InteropServices.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.InteropServices.Analyzers/CSharp/packages.config
+++ b/src/System.Runtime.InteropServices.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Runtime.InteropServices.Analyzers/Core/System.Runtime.InteropServices.Analyzers.csproj
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/System.Runtime.InteropServices.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="System.Runtime.InteropServices.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/System.Runtime.InteropServices.Analyzers/Core/app.config
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.InteropServices.Analyzers/Core/packages.config
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Runtime.InteropServices.Analyzers/Setup/System.Runtime.InteropServices.Analyzers.Setup.csproj
+++ b/src/System.Runtime.InteropServices.Analyzers/Setup/System.Runtime.InteropServices.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/System.Runtime.InteropServices.Analyzers/Setup/app.config
+++ b/src/System.Runtime.InteropServices.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.InteropServices.Analyzers/UnitTests/System.Runtime.InteropServices.Analyzers.UnitTests.csproj
+++ b/src/System.Runtime.InteropServices.Analyzers/UnitTests/System.Runtime.InteropServices.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.InteropServices.Analyzers/UnitTests/app.config
+++ b/src/System.Runtime.InteropServices.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.InteropServices.Analyzers/UnitTests/packages.config
+++ b/src/System.Runtime.InteropServices.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/System.Runtime.InteropServices.Analyzers/VisualBasic/System.Runtime.InteropServices.VisualBasic.Analyzers.vbproj
+++ b/src/System.Runtime.InteropServices.Analyzers/VisualBasic/System.Runtime.InteropServices.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -81,9 +81,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -91,6 +91,7 @@
     <Content Include="System.Runtime.InteropServices.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.InteropServices.Analyzers/VisualBasic/app.config
+++ b/src/System.Runtime.InteropServices.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Runtime.InteropServices.Analyzers/VisualBasic/packages.config
+++ b/src/System.Runtime.InteropServices.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/System.Security.Cryptography.Hashing.CSharp.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/System.Security.Cryptography.Hashing.CSharp.Algorithms.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -82,13 +82,14 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/app.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/packages.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/System.Security.Cryptography.Hashing.Algorithms.Analyzers.csproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/System.Security.Cryptography.Hashing.Algorithms.Analyzers.csproj
@@ -28,12 +28,12 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -66,9 +66,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -78,6 +78,7 @@
     <InternalsVisibleToTest Include="System.Security.Cryptography.Hashing.Algorithms.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="install.ps1" />
     <None Include="uninstall.ps1" />

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/app.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/packages.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/System.Security.Cryptography.Hashing.Algorithms.Analyzers.UnitTests.csproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/System.Security.Cryptography.Hashing.Algorithms.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/app.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/packages.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/System.Security.Cryptography.Hashing.Algorithms.VisualBasic.Analyzers.vbproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/System.Security.Cryptography.Hashing.Algorithms.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -81,13 +81,14 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/app.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/packages.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Threading.Tasks.Analyzers/CSharp/System.Threading.Tasks.CSharp.Analyzers.csproj
+++ b/src/System.Threading.Tasks.Analyzers/CSharp/System.Threading.Tasks.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -82,9 +82,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -92,6 +92,7 @@
     <Content Include="System.Threading.Tasks.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Threading.Tasks.Analyzers/CSharp/app.config
+++ b/src/System.Threading.Tasks.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Threading.Tasks.Analyzers/CSharp/packages.config
+++ b/src/System.Threading.Tasks.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Threading.Tasks.Analyzers/Core/System.Threading.Tasks.Analyzers.csproj
+++ b/src/System.Threading.Tasks.Analyzers/Core/System.Threading.Tasks.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="System.Threading.Tasks.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/System.Threading.Tasks.Analyzers/Core/app.config
+++ b/src/System.Threading.Tasks.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Threading.Tasks.Analyzers/Core/packages.config
+++ b/src/System.Threading.Tasks.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/System.Threading.Tasks.Analyzers/Setup/System.Threading.Tasks.Analyzers.Setup.csproj
+++ b/src/System.Threading.Tasks.Analyzers/Setup/System.Threading.Tasks.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/System.Threading.Tasks.Analyzers/Setup/app.config
+++ b/src/System.Threading.Tasks.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Threading.Tasks.Analyzers/UnitTests/System.Threading.Tasks.Analyzers.UnitTests.csproj
+++ b/src/System.Threading.Tasks.Analyzers/UnitTests/System.Threading.Tasks.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Threading.Tasks.Analyzers/UnitTests/app.config
+++ b/src/System.Threading.Tasks.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Threading.Tasks.Analyzers/UnitTests/packages.config
+++ b/src/System.Threading.Tasks.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/System.Threading.Tasks.Analyzers/VisualBasic/System.Threading.Tasks.VisualBasic.Analyzers.vbproj
+++ b/src/System.Threading.Tasks.Analyzers/VisualBasic/System.Threading.Tasks.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -81,9 +81,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -91,6 +91,7 @@
     <Content Include="System.Threading.Tasks.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Threading.Tasks.Analyzers/VisualBasic/app.config
+++ b/src/System.Threading.Tasks.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/System.Threading.Tasks.Analyzers/VisualBasic/packages.config
+++ b/src/System.Threading.Tasks.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Test/Utilities/DiagnosticsTestUtilities.csproj
+++ b/src/Test/Utilities/DiagnosticsTestUtilities.csproj
@@ -30,17 +30,17 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -50,22 +50,22 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -99,9 +99,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -139,6 +139,7 @@
     <Compile Include="WorkItemAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Test/Utilities/app.config
+++ b/src/Test/Utilities/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Test/Utilities/packages.config
+++ b/src/Test/Utilities/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -18,7 +18,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Text.Analyzers/CSharp/Text.CSharp.Analyzers.csproj
+++ b/src/Text.Analyzers/CSharp/Text.CSharp.Analyzers.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -86,9 +86,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -96,6 +96,7 @@
     <Content Include="Text.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />
@@ -103,7 +104,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CSharpIdentifiersShouldBeSpelledCorrectly.cs" />
     <Compile Include="CSharpIdentifiersShouldBeSpelledCorrectly.Fixer.cs" />
-
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\Analyzers.Imports.targets" />

--- a/src/Text.Analyzers/CSharp/app.config
+++ b/src/Text.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Text.Analyzers/CSharp/packages.config
+++ b/src/Text.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Text.Analyzers/Core/Text.Analyzers.csproj
+++ b/src/Text.Analyzers/Core/Text.Analyzers.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -73,9 +73,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -85,6 +85,7 @@
     <InternalsVisibleToTest Include="Text.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
@@ -107,7 +108,6 @@
     <Compile Include="IdentifiersShouldBeSpelledCorrectly.cs" />
     <Compile Include="IdentifiersShouldBeSpelledCorrectly.Fixer.cs" />
     <Compile Include="DiagnosticCategory.cs" />
-
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="TextAnalyzersResources.resx">

--- a/src/Text.Analyzers/Core/app.config
+++ b/src/Text.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Text.Analyzers/Core/packages.config
+++ b/src/Text.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Text.Analyzers/Setup/Text.Analyzers.Setup.csproj
+++ b/src/Text.Analyzers/Setup/Text.Analyzers.Setup.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/Text.Analyzers/Setup/app.config
+++ b/src/Text.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Text.Analyzers/UnitTests/Text.Analyzers.UnitTests.csproj
+++ b/src/Text.Analyzers/UnitTests/Text.Analyzers.UnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -119,9 +119,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -145,13 +145,13 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IdentifiersShouldBeSpelledCorrectlyTests.cs" />
     <Compile Include="IdentifiersShouldBeSpelledCorrectlyTests.Fixer.cs" />
-
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\Analyzers.Imports.targets" />

--- a/src/Text.Analyzers/UnitTests/app.config
+++ b/src/Text.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Text.Analyzers/UnitTests/packages.config
+++ b/src/Text.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Text.Analyzers/VisualBasic/Text.VisualBasic.Analyzers.vbproj
+++ b/src/Text.Analyzers/VisualBasic/Text.VisualBasic.Analyzers.vbproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -85,9 +85,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -95,12 +95,12 @@
     <Content Include="Text.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicIdentifiersShouldBeSpelledCorrectly.vb" />
     <Compile Include="BasicIdentifiersShouldBeSpelledCorrectly.Fixer.vb" />
-
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\Analyzers.Imports.targets" />

--- a/src/Text.Analyzers/VisualBasic/app.config
+++ b/src/Text.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Text.Analyzers/VisualBasic/packages.config
+++ b/src/Text.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/Tools/AnalyzersStatusGenerator/AnalyzersStatusGenerator.csproj
+++ b/src/Tools/AnalyzersStatusGenerator/AnalyzersStatusGenerator.csproj
@@ -24,31 +24,38 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
@@ -81,8 +88,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Tools/AnalyzersStatusGenerator/App.config
+++ b/src/Tools/AnalyzersStatusGenerator/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/Tools/AnalyzersStatusGenerator/packages.config
+++ b/src/Tools/AnalyzersStatusGenerator/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />
@@ -18,7 +18,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net46" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net46" />

--- a/src/Tools/a2md/App.config
+++ b/src/Tools/a2md/App.config
@@ -15,7 +15,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Tools/a2md/a2md.csproj
+++ b/src/Tools/a2md/a2md.csproj
@@ -26,17 +26,17 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -45,9 +45,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Tools/a2md/packages.config
+++ b/src/Tools/a2md/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net46" />
@@ -12,7 +12,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net46" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net46" />

--- a/src/XmlDocumentationComments.Analyzers/CSharp/XmlDocumentationComments.CSharp.Analyzers.csproj
+++ b/src/XmlDocumentationComments.Analyzers/CSharp/XmlDocumentationComments.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -82,9 +82,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -92,6 +92,7 @@
     <Content Include="XmlDocumentationComments.CSharp.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/XmlDocumentationComments.Analyzers/CSharp/app.config
+++ b/src/XmlDocumentationComments.Analyzers/CSharp/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/XmlDocumentationComments.Analyzers/CSharp/packages.config
+++ b/src/XmlDocumentationComments.Analyzers/CSharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/XmlDocumentationComments.Analyzers/Core/XmlDocumentationComments.Analyzers.csproj
+++ b/src/XmlDocumentationComments.Analyzers/Core/XmlDocumentationComments.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,9 +69,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -81,6 +81,7 @@
     <InternalsVisibleToTest Include="XmlDocumentationComments.Analyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="install.ps1" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/XmlDocumentationComments.Analyzers/Core/app.config
+++ b/src/XmlDocumentationComments.Analyzers/Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/XmlDocumentationComments.Analyzers/Core/packages.config
+++ b/src/XmlDocumentationComments.Analyzers/Core/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>

--- a/src/XmlDocumentationComments.Analyzers/Setup/XmlDocumentationComments.Analyzers.Setup.csproj
+++ b/src/XmlDocumentationComments.Analyzers/Setup/XmlDocumentationComments.Analyzers.Setup.csproj
@@ -36,6 +36,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/XmlDocumentationComments.Analyzers/Setup/app.config
+++ b/src/XmlDocumentationComments.Analyzers/Setup/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/XmlDocumentationComments.Analyzers/UnitTests/XmlDocumentationComments.Analyzers.UnitTests.csproj
+++ b/src/XmlDocumentationComments.Analyzers/UnitTests/XmlDocumentationComments.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,9 +115,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/XmlDocumentationComments.Analyzers/UnitTests/app.config
+++ b/src/XmlDocumentationComments.Analyzers/UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/XmlDocumentationComments.Analyzers/UnitTests/packages.config
+++ b/src/XmlDocumentationComments.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
@@ -17,7 +17,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/XmlDocumentationComments.Analyzers/VisualBasic/XmlDocumentationComments.VisualBasic.Analyzers.vbproj
+++ b/src/XmlDocumentationComments.Analyzers/VisualBasic/XmlDocumentationComments.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta-20151118-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -81,9 +81,9 @@
       <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.1.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0-rc2-23629\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -91,6 +91,7 @@
     <Content Include="XmlDocumentationComments.VisualBasic.Analyzers.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/XmlDocumentationComments.Analyzers/VisualBasic/app.config
+++ b/src/XmlDocumentationComments.Analyzers/VisualBasic/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/XmlDocumentationComments.Analyzers/VisualBasic/packages.config
+++ b/src/XmlDocumentationComments.Analyzers/VisualBasic/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta-20151118-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />
 </packages>


### PR DESCRIPTION
The build of Roslyn that this repo currently depends on has been delisted from MyGet. MyGet keeps only the last 6 or so builds and our build got deleted. This changes simply moves to the latest available to unblock the build. This means that every week such a change would need to be made or we need to find some other solution to keep uptodate. 

This PR has the following changes:
- Add a new package source to the corefx MyGet feed so that we can get the version 1.2+ of System.Reflection.Metadata since the latest Roslyn depends on that.
- Update Roslyn references to the latest 1.2 build.
- Fix up one API breaking change in IOperation and remove a workaround for a bug that's now been fixed.
- VS insists on adding App.Config files for all the projects with binding redirects. Since these are libraries, the binding redirects have no effect and are not needed but since its a manual operation to delete them only for VS to add them back, I've just kept them.