### PR TITLE
Upgrade to Roslyn 1.2.0-beta1-20160106-03

### DIFF
--- a/src/Analyzer.Utilities/Analyzer.Utilities.csproj
+++ b/src/Analyzer.Utilities/Analyzer.Utilities.csproj
@@ -56,32 +56,32 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Analyzer.Utilities/packages.config
+++ b/src/Analyzer.Utilities/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/ApiReview.Analyzers/CSharp/ApiReview.CSharp.Analyzers.csproj
+++ b/src/ApiReview.Analyzers/CSharp/ApiReview.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/ApiReview.Analyzers/CSharp/packages.config
+++ b/src/ApiReview.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/ApiReview.Analyzers/Core/ApiReview.Analyzers.csproj
+++ b/src/ApiReview.Analyzers/Core/ApiReview.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/ApiReview.Analyzers/Core/packages.config
+++ b/src/ApiReview.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/ApiReview.Analyzers/UnitTests/ApiReview.Analyzers.UnitTests.csproj
+++ b/src/ApiReview.Analyzers/UnitTests/ApiReview.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/ApiReview.Analyzers/UnitTests/packages.config
+++ b/src/ApiReview.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/ApiReview.Analyzers/VisualBasic/ApiReview.VisualBasic.Analyzers.vbproj
+++ b/src/ApiReview.Analyzers/VisualBasic/ApiReview.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/ApiReview.Analyzers/VisualBasic/packages.config
+++ b/src/ApiReview.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Desktop.Analyzers/CSharp/Desktop.CSharp.Analyzers.csproj
+++ b/src/Desktop.Analyzers/CSharp/Desktop.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Desktop.Analyzers/CSharp/packages.config
+++ b/src/Desktop.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Desktop.Analyzers/Core/Desktop.Analyzers.csproj
+++ b/src/Desktop.Analyzers/Core/Desktop.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Desktop.Analyzers/Core/packages.config
+++ b/src/Desktop.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Desktop.Analyzers/UnitTests/Desktop.Analyzers.UnitTests.csproj
+++ b/src/Desktop.Analyzers/UnitTests/Desktop.Analyzers.UnitTests.csproj
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Desktop.Analyzers/UnitTests/packages.config
+++ b/src/Desktop.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/Desktop.Analyzers/VisualBasic/Desktop.VisualBasic.Analyzers.vbproj
+++ b/src/Desktop.Analyzers/VisualBasic/Desktop.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Desktop.Analyzers/VisualBasic/packages.config
+++ b/src/Desktop.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/MetaCompilation.Test.csproj
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/MetaCompilation.Test.csproj
@@ -36,27 +36,27 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/packages.config
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/MetaCompilation.csproj
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/MetaCompilation.csproj
@@ -55,22 +55,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/packages.config
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" userInstalled="true" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" userInstalled="true" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" userInstalled="true" />
   <package id="NuGet.CommandLine" version="2.8.2" targetFramework="portable45-net45+win8" userInstalled="true" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" userInstalled="true" />

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/Microsoft.ApiDesignGuidelines.CSharp.Analyzers.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/Microsoft.ApiDesignGuidelines.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/packages.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/packages.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers.vbproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -96,7 +96,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicAvoidAsyncVoid.vb" />

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpCodeAnalysisDiagnosticAnalyzers.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpCodeAnalysisDiagnosticAnalyzers.csproj
@@ -52,32 +52,32 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticAnalyzers.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticAnalyzers.csproj
@@ -69,32 +69,32 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/packages.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/CodeAnalysisDiagnosticAnalyzersTest.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/CodeAnalysisDiagnosticAnalyzersTest.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/packages.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/BasicCodeAnalysisDiagnosticAnalyzers.vbproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/BasicCodeAnalysisDiagnosticAnalyzers.vbproj
@@ -49,32 +49,32 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.Composition.Analyzers/CSharp/Microsoft.Composition.CSharp.Analyzers.csproj
+++ b/src/Microsoft.Composition.Analyzers/CSharp/Microsoft.Composition.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.Composition.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.Composition.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.Composition.Analyzers/Core/Microsoft.Composition.Analyzers.csproj
+++ b/src/Microsoft.Composition.Analyzers/Core/Microsoft.Composition.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.Composition.Analyzers/Core/packages.config
+++ b/src/Microsoft.Composition.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.Composition.Analyzers/UnitTests/Microsoft.Composition.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.Composition.Analyzers/UnitTests/Microsoft.Composition.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Microsoft.Composition.Analyzers/UnitTests/packages.config
+++ b/src/Microsoft.Composition.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/Microsoft.Composition.Analyzers/VisualBasic/Microsoft.Composition.VisualBasic.Analyzers.vbproj
+++ b/src/Microsoft.Composition.Analyzers/VisualBasic/Microsoft.Composition.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.Composition.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.Composition.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.Maintainability.Analyzers/CSharp/Microsoft.Maintainability.CSharp.Analyzers.csproj
+++ b/src/Microsoft.Maintainability.Analyzers/CSharp/Microsoft.Maintainability.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.Maintainability.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.Maintainability.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.Maintainability.Analyzers/Core/Microsoft.Maintainability.Analyzers.csproj
+++ b/src/Microsoft.Maintainability.Analyzers/Core/Microsoft.Maintainability.Analyzers.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.Maintainability.Analyzers/Core/packages.config
+++ b/src/Microsoft.Maintainability.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/Microsoft.Maintainability.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/Microsoft.Maintainability.Analyzers.UnitTests.csproj
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/packages.config
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/Microsoft.Maintainability.Analyzers/VisualBasic/Microsoft.Maintainability.VisualBasic.Analyzers.vbproj
+++ b/src/Microsoft.Maintainability.Analyzers/VisualBasic/Microsoft.Maintainability.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.Maintainability.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.Maintainability.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.QualityGuidelines.Analyzers/CSharp/Microsoft.QualityGuidelines.CSharp.Analyzers.csproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/CSharp/Microsoft.QualityGuidelines.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.QualityGuidelines.Analyzers/CSharp/packages.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/Microsoft.QualityGuidelines.Analyzers.csproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/Microsoft.QualityGuidelines.Analyzers.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/packages.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/Microsoft.QualityGuidelines.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/Microsoft.QualityGuidelines.Analyzers.UnitTests.csproj
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/packages.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/Microsoft.QualityGuidelines.VisualBasic.Analyzers.vbproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/Microsoft.QualityGuidelines.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/packages.config
+++ b/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/Roslyn.Diagnostics.CSharp.Analyzers.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/Roslyn.Diagnostics.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/packages.config
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Roslyn.Diagnostics.Analyzers/Core/packages.config
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/Roslyn.Diagnostics.Analyzers.UnitTests.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/Roslyn.Diagnostics.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/packages.config
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/Roslyn.Diagnostics.VisualBasic.Analyzers.vbproj
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/Roslyn.Diagnostics.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/packages.config
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Collections.Immutable.Analyzers/CSharp/System.Collections.Immutable.CSharp.Analyzers.csproj
+++ b/src/System.Collections.Immutable.Analyzers/CSharp/System.Collections.Immutable.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Collections.Immutable.Analyzers/CSharp/packages.config
+++ b/src/System.Collections.Immutable.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Collections.Immutable.Analyzers/Core/System.Collections.Immutable.Analyzers.csproj
+++ b/src/System.Collections.Immutable.Analyzers/Core/System.Collections.Immutable.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Collections.Immutable.Analyzers/Core/packages.config
+++ b/src/System.Collections.Immutable.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Collections.Immutable.Analyzers/UnitTests/System.Collections.Immutable.Analyzers.UnitTests.csproj
+++ b/src/System.Collections.Immutable.Analyzers/UnitTests/System.Collections.Immutable.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/System.Collections.Immutable.Analyzers/UnitTests/packages.config
+++ b/src/System.Collections.Immutable.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/System.Collections.Immutable.Analyzers/VisualBasic/System.Collections.Immutable.VisualBasic.Analyzers.vbproj
+++ b/src/System.Collections.Immutable.Analyzers/VisualBasic/System.Collections.Immutable.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Collections.Immutable.Analyzers/VisualBasic/packages.config
+++ b/src/System.Collections.Immutable.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Resources.Analyzers/CSharp/System.Resources.CSharp.Analyzers.csproj
+++ b/src/System.Resources.Analyzers/CSharp/System.Resources.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Resources.Analyzers/CSharp/packages.config
+++ b/src/System.Resources.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Resources.Analyzers/Core/System.Resources.Analyzers.csproj
+++ b/src/System.Resources.Analyzers/Core/System.Resources.Analyzers.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Resources.Analyzers/Core/packages.config
+++ b/src/System.Resources.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Resources.Analyzers/UnitTests/System.Resources.Analyzers.UnitTests.csproj
+++ b/src/System.Resources.Analyzers/UnitTests/System.Resources.Analyzers.UnitTests.csproj
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/System.Resources.Analyzers/UnitTests/packages.config
+++ b/src/System.Resources.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/System.Resources.Analyzers/VisualBasic/System.Resources.VisualBasic.Analyzers.vbproj
+++ b/src/System.Resources.Analyzers/VisualBasic/System.Resources.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Resources.Analyzers/VisualBasic/packages.config
+++ b/src/System.Resources.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Runtime.Analyzers/CSharp/System.Runtime.CSharp.Analyzers.csproj
+++ b/src/System.Runtime.Analyzers/CSharp/System.Runtime.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Runtime.Analyzers/CSharp/packages.config
+++ b/src/System.Runtime.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.csproj
+++ b/src/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Runtime.Analyzers/Core/packages.config
+++ b/src/System.Runtime.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Runtime.Analyzers/UnitTests/System.Runtime.Analyzers.UnitTests.csproj
+++ b/src/System.Runtime.Analyzers/UnitTests/System.Runtime.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/System.Runtime.Analyzers/UnitTests/packages.config
+++ b/src/System.Runtime.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/System.Runtime.Analyzers/VisualBasic/System.Runtime.VisualBasic.Analyzers.vbproj
+++ b/src/System.Runtime.Analyzers/VisualBasic/System.Runtime.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Runtime.Analyzers/VisualBasic/packages.config
+++ b/src/System.Runtime.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Runtime.InteropServices.Analyzers/CSharp/System.Runtime.InteropServices.CSharp.Analyzers.csproj
+++ b/src/System.Runtime.InteropServices.Analyzers/CSharp/System.Runtime.InteropServices.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Runtime.InteropServices.Analyzers/CSharp/packages.config
+++ b/src/System.Runtime.InteropServices.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Runtime.InteropServices.Analyzers/Core/System.Runtime.InteropServices.Analyzers.csproj
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/System.Runtime.InteropServices.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Runtime.InteropServices.Analyzers/Core/packages.config
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Runtime.InteropServices.Analyzers/UnitTests/System.Runtime.InteropServices.Analyzers.UnitTests.csproj
+++ b/src/System.Runtime.InteropServices.Analyzers/UnitTests/System.Runtime.InteropServices.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/System.Runtime.InteropServices.Analyzers/UnitTests/packages.config
+++ b/src/System.Runtime.InteropServices.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/System.Runtime.InteropServices.Analyzers/VisualBasic/System.Runtime.InteropServices.VisualBasic.Analyzers.vbproj
+++ b/src/System.Runtime.InteropServices.Analyzers/VisualBasic/System.Runtime.InteropServices.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Runtime.InteropServices.Analyzers/VisualBasic/packages.config
+++ b/src/System.Runtime.InteropServices.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/System.Security.Cryptography.Hashing.CSharp.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/System.Security.Cryptography.Hashing.CSharp.Algorithms.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/packages.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/System.Security.Cryptography.Hashing.Algorithms.Analyzers.csproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/System.Security.Cryptography.Hashing.Algorithms.Analyzers.csproj
@@ -28,12 +28,12 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/packages.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/System.Security.Cryptography.Hashing.Algorithms.Analyzers.UnitTests.csproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/System.Security.Cryptography.Hashing.Algorithms.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/packages.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/System.Security.Cryptography.Hashing.Algorithms.VisualBasic.Analyzers.vbproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/System.Security.Cryptography.Hashing.Algorithms.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/packages.config
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Threading.Tasks.Analyzers/CSharp/System.Threading.Tasks.CSharp.Analyzers.csproj
+++ b/src/System.Threading.Tasks.Analyzers/CSharp/System.Threading.Tasks.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Threading.Tasks.Analyzers/CSharp/packages.config
+++ b/src/System.Threading.Tasks.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Threading.Tasks.Analyzers/Core/System.Threading.Tasks.Analyzers.csproj
+++ b/src/System.Threading.Tasks.Analyzers/Core/System.Threading.Tasks.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Threading.Tasks.Analyzers/Core/packages.config
+++ b/src/System.Threading.Tasks.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/System.Threading.Tasks.Analyzers/UnitTests/System.Threading.Tasks.Analyzers.UnitTests.csproj
+++ b/src/System.Threading.Tasks.Analyzers/UnitTests/System.Threading.Tasks.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/System.Threading.Tasks.Analyzers/UnitTests/packages.config
+++ b/src/System.Threading.Tasks.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/System.Threading.Tasks.Analyzers/VisualBasic/System.Threading.Tasks.VisualBasic.Analyzers.vbproj
+++ b/src/System.Threading.Tasks.Analyzers/VisualBasic/System.Threading.Tasks.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Threading.Tasks.Analyzers/VisualBasic/packages.config
+++ b/src/System.Threading.Tasks.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Test/Utilities/DiagnosticsTestUtilities.csproj
+++ b/src/Test/Utilities/DiagnosticsTestUtilities.csproj
@@ -30,17 +30,17 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -50,22 +50,22 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Test/Utilities/packages.config
+++ b/src/Test/Utilities/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/Text.Analyzers/CSharp/Text.CSharp.Analyzers.csproj
+++ b/src/Text.Analyzers/CSharp/Text.CSharp.Analyzers.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Text.Analyzers/CSharp/packages.config
+++ b/src/Text.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Text.Analyzers/Core/Text.Analyzers.csproj
+++ b/src/Text.Analyzers/Core/Text.Analyzers.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Text.Analyzers/Core/packages.config
+++ b/src/Text.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Text.Analyzers/UnitTests/Text.Analyzers.UnitTests.csproj
+++ b/src/Text.Analyzers/UnitTests/Text.Analyzers.UnitTests.csproj
@@ -56,37 +56,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Text.Analyzers/UnitTests/packages.config
+++ b/src/Text.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/Text.Analyzers/VisualBasic/Text.VisualBasic.Analyzers.vbproj
+++ b/src/Text.Analyzers/VisualBasic/Text.VisualBasic.Analyzers.vbproj
@@ -37,22 +37,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Text.Analyzers/VisualBasic/packages.config
+++ b/src/Text.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/Tools/AnalyzersStatusGenerator/AnalyzersStatusGenerator.csproj
+++ b/src/Tools/AnalyzersStatusGenerator/AnalyzersStatusGenerator.csproj
@@ -25,37 +25,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/src/Tools/AnalyzersStatusGenerator/packages.config
+++ b/src/Tools/AnalyzersStatusGenerator/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />

--- a/src/Tools/a2md/a2md.csproj
+++ b/src/Tools/a2md/a2md.csproj
@@ -26,17 +26,17 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Tools/a2md/packages.config
+++ b/src/Tools/a2md/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net46" />

--- a/src/XmlDocumentationComments.Analyzers/CSharp/XmlDocumentationComments.CSharp.Analyzers.csproj
+++ b/src/XmlDocumentationComments.Analyzers/CSharp/XmlDocumentationComments.CSharp.Analyzers.csproj
@@ -34,22 +34,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/XmlDocumentationComments.Analyzers/CSharp/packages.config
+++ b/src/XmlDocumentationComments.Analyzers/CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/XmlDocumentationComments.Analyzers/Core/XmlDocumentationComments.Analyzers.csproj
+++ b/src/XmlDocumentationComments.Analyzers/Core/XmlDocumentationComments.Analyzers.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
@@ -36,7 +36,7 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/XmlDocumentationComments.Analyzers/Core/packages.config
+++ b/src/XmlDocumentationComments.Analyzers/Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />

--- a/src/XmlDocumentationComments.Analyzers/UnitTests/XmlDocumentationComments.Analyzers.UnitTests.csproj
+++ b/src/XmlDocumentationComments.Analyzers/UnitTests/XmlDocumentationComments.Analyzers.UnitTests.csproj
@@ -52,37 +52,37 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/XmlDocumentationComments.Analyzers/UnitTests/packages.config
+++ b/src/XmlDocumentationComments.Analyzers/UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/XmlDocumentationComments.Analyzers/VisualBasic/XmlDocumentationComments.VisualBasic.Analyzers.vbproj
+++ b/src/XmlDocumentationComments.Analyzers/VisualBasic/XmlDocumentationComments.VisualBasic.Analyzers.vbproj
@@ -33,22 +33,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20151230-02\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0-beta1-20160106-03\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/XmlDocumentationComments.Analyzers/VisualBasic/packages.config
+++ b/src/XmlDocumentationComments.Analyzers/VisualBasic/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20151230-02" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0-beta1-20160106-03" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.2.0-rc2-23629" targetFramework="portable45-net45+win8" />


### PR DESCRIPTION
The projects in this repo depended on Roslyn 1.2.0-beta1-20151230-02, which no longer exists on MyGet feed https://www.myget.org/F/roslyn-nightly. Update to the latest version.

@srivatsn @sharwell @michaelcfanning @heejaechang 