### PR TITLE
Fix build break in AnalyzersStatusGenerator tool

### DIFF
--- a/src/Tools/AnalyzersStatusGenerator/AnalyzersStatusGenerator.csproj
+++ b/src/Tools/AnalyzersStatusGenerator/AnalyzersStatusGenerator.csproj
@@ -68,23 +68,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Composition.Convention, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Composition.Hosting, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Composition.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Composition.TypedParts, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />


### PR DESCRIPTION
If you did `git clean -xdf` followed by `cibuild.cmd`, you would get a build break in the `AnalyzersStatusGenerator` project, because MSBuild couldn't resolve the reference to the assembly `System.Composition.AttributedModel`.

The problem was that the `.csproj` file specified a `HintPath` for this assembly in `..\packages`, but actually the packages directory is three levels up (`..\..\..\packages`). Several other assembly references in this project file had the same problem, but those assemblies weren't actually needed.

So I corrected the `HintPath` for `System.Composition.AttributedModel`, and removed the unncessary assembly references. All the remaining assembly references in this project file correctly specified `..\..\..\packages`.

The odd thing is that if you built a second time, the build would succeed. Apparently on the second attempt it didn't bother to try building this project (that must be so, or else it would have failed again for the same reason).

@srivatsn @twsouthwick
