### PR TITLE
Fix #359: "Project site" link on NuGet.org is wrong

### DIFF
--- a/build/Targets/Analyzers.NuGet.Settings.targets
+++ b/build/Targets/Analyzers.NuGet.Settings.targets
@@ -5,8 +5,8 @@
     <NuGetLicenseURLNonRedist>http://go.microsoft.com/fwlink/?LinkId=529444</NuGetLicenseURLNonRedist>
     <NuGetLicenseURLTest>http://go.microsoft.com/fwlink/?LinkID=529445</NuGetLicenseURLTest>
     <NuGetAuthors>Microsoft</NuGetAuthors>
-    <NuGetProjectURL>http://msdn.com/roslyn</NuGetProjectURL>
-    <NuGetReleaseNotes>Preview of Microsoft .NET Compiler Platform ("Roslyn")</NuGetReleaseNotes>
-    <NuGetTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics</NuGetTags>
+    <NuGetProjectURL>https://github.com/dotnet/roslyn-analyzers</NuGetProjectURL>
+    <NuGetReleaseNotes>Diagnostic analyzers for the Microsoft .NET Compiler Platform ("Roslyn")</NuGetReleaseNotes>
+    <NuGetTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</NuGetTags>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fix the link in the generated .nuspec file. Fix up the release notes and tags while we're at it.

@srivatsn @tmeschter 