### PR TITLE
CA1304: Only complain if nested type is visible outside assembly

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NestedTypesShouldNotBeVisible.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NestedTypesShouldNotBeVisible.cs
@@ -81,6 +81,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                                 return;
                             }
 
+                            // Even if the nested type is declared public, don't complain if it's within
+                            // a type that's not visible outside the assembly.
+                            if (containingType.GetResultantVisibility() != SymbolVisibility.Public)
+                            {
+                                return;
+                            }
+
                             // By the design guidelines, nested enumerators are exempt.
                             if (nestedType.AllInterfaces.Contains(enumeratorType))
                             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/NestedTypesShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/NestedTypesShouldNotBeVisibleTests.cs
@@ -259,6 +259,32 @@ public class Outer
         }
 
         [Fact]
+        public void CSharpNoDiagnosticPublicTypeNestedInInternalType()
+        {
+            var code = @"
+internal class Outer
+{
+    public class Inner
+    {
+    }
+}
+";
+            VerifyCSharp(code);
+        }
+
+        [Fact]
+        public void BasicNoDiagnosticPublicTypeNestedInFriendType()
+        {
+            var code = @"
+Friend Class Outer
+    Public Class Inner
+    End Class
+End Class
+";
+            VerifyBasic(code);
+        }
+
+        [Fact]
         public void BasicNoDiagnosticPublicNestedEnumerator()
         {
             var code = @"


### PR DESCRIPTION
Fixes a bug in my implementation of CA1304 noted by @nguerrera.

@nguerrera @srivatsn 