### PR TITLE
Change CA1309 to analyze operation nodes.

### DIFF
--- a/src/System.Runtime.Analyzers/CSharp/CSharpUseOrdinalStringComparison.cs
+++ b/src/System.Runtime.Analyzers/CSharp/CSharpUseOrdinalStringComparison.cs
@@ -12,85 +12,28 @@ namespace System.Runtime.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class CSharpUseOrdinalStringComparisonAnalyzer : UseOrdinalStringComparisonAnalyzer
     {
-        protected override void GetAnalyzer(CompilationStartAnalysisContext context, INamedTypeSymbol stringComparisonType)
+        protected override Location GetMethodNameLocation(SyntaxNode invocationNode)
         {
-            context.RegisterSyntaxNodeAction(new Analyzer(stringComparisonType).AnalyzeNode, SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression, SyntaxKind.InvocationExpression);
+            Debug.Assert(invocationNode.IsKind(SyntaxKind.InvocationExpression));
+
+            var invocation = invocationNode as InvocationExpressionSyntax;
+            if (invocation.Expression.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+            {
+                return ((MemberAccessExpressionSyntax)invocation.Expression).Name.GetLocation();
+            }
+            else if (invocation.Expression.IsKind(SyntaxKind.ConditionalAccessExpression))
+            {
+                return ((ConditionalAccessExpressionSyntax)invocation.Expression).WhenNotNull.GetLocation();
+            }
+
+            return invocation.GetLocation();
         }
 
-        private sealed class Analyzer : AbstractCodeBlockAnalyzer
+        protected override Location GetOperatorTokenLocation(SyntaxNode binaryOperationNode)
         {
-            public Analyzer(INamedTypeSymbol stringComparisonType)
-                : base(stringComparisonType)
-            {
-            }
+            Debug.Assert(binaryOperationNode is BinaryExpressionSyntax);
 
-            public void AnalyzeNode(SyntaxNodeAnalysisContext context)
-            {
-                var kind = context.Node.Kind();
-                if (kind == SyntaxKind.InvocationExpression)
-                {
-                    AnalyzeInvocationExpression((InvocationExpressionSyntax)context.Node, context.SemanticModel, context.ReportDiagnostic);
-                }
-                else if (kind == SyntaxKind.EqualsExpression || kind == SyntaxKind.NotEqualsExpression)
-                {
-                    AnalyzeBinaryExpression((BinaryExpressionSyntax)context.Node, context.SemanticModel, context.ReportDiagnostic);
-                }
-            }
-
-            private void AnalyzeInvocationExpression(InvocationExpressionSyntax node, SemanticModel model, Action<Diagnostic> reportDiagnostic)
-            {
-                if (node.Expression.Kind() == SyntaxKind.SimpleMemberAccessExpression)
-                {
-                    var memberAccess = (MemberAccessExpressionSyntax)node.Expression;
-                    if (memberAccess.Name != null && IsEqualsOrCompare(memberAccess.Name.Identifier.ValueText))
-                    {
-                        var methodSymbol = model.GetSymbolInfo(memberAccess.Name).Symbol as IMethodSymbol;
-                        if (methodSymbol != null && methodSymbol.ContainingType.SpecialType == SpecialType.System_String)
-                        {
-                            Debug.Assert(IsEqualsOrCompare(methodSymbol.Name));
-
-                            if (!IsAcceptableOverload(methodSymbol, model))
-                            {
-                                // wrong overload
-                                reportDiagnostic(memberAccess.Name.GetLocation().CreateDiagnostic(Rule));
-                            }
-                            else
-                            {
-                                var lastArgument = node.ArgumentList.Arguments.Last();
-                                var lastArgSymbol = model.GetSymbolInfo(lastArgument.Expression).Symbol;
-                                if (lastArgSymbol != null && lastArgSymbol.ContainingType != null &&
-                                    lastArgSymbol.ContainingType.Equals(StringComparisonType) &&
-                                    !IsOrdinalOrOrdinalIgnoreCase(lastArgument, model))
-                                {
-                                    // right overload, wrong value
-                                    reportDiagnostic(lastArgument.GetLocation().CreateDiagnostic(Rule));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            private static void AnalyzeBinaryExpression(BinaryExpressionSyntax node, SemanticModel model, Action<Diagnostic> addDiagnostic)
-            {
-                var leftType = model.GetTypeInfo(node.Left).Type;
-                var rightType = model.GetTypeInfo(node.Right).Type;
-                if (leftType != null && rightType != null && leftType.SpecialType == SpecialType.System_String && rightType.SpecialType == SpecialType.System_String)
-                {
-                    addDiagnostic(node.OperatorToken.GetLocation().CreateDiagnostic(Rule));
-                }
-            }
-
-            private static bool IsOrdinalOrOrdinalIgnoreCase(ArgumentSyntax argumentSyntax, SemanticModel model)
-            {
-                var argumentSymbol = model.GetSymbolInfo(argumentSyntax.Expression).Symbol;
-                if (argumentSymbol != null)
-                {
-                    return IsOrdinalOrOrdinalIgnoreCase(argumentSymbol.Name);
-                }
-
-                return false;
-            }
+            return ((BinaryExpressionSyntax)binaryOperationNode).OperatorToken.GetLocation();
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/UseOrdinalStringComparison.cs
+++ b/src/System.Runtime.Analyzers/Core/UseOrdinalStringComparison.cs
@@ -129,9 +129,10 @@ namespace System.Runtime.Analyzers
                 switch (methodSymbol.Parameters.Length)
                 {
                     case 1:
-                        // the instance method .Equals(object) is OK
+                        // the instance method .Equals(object) is acceptable
                         return methodSymbol.Parameters[0].Type.SpecialType == SpecialType.System_Object;
                     case 2:
+                        // .Equals(string, System.StringComparison) is acceptable
                         return methodSymbol.Parameters[0].Type.SpecialType == SpecialType.System_String &&
                             methodSymbol.Parameters[1].Type.Equals(stringComparisonType);
                 }


### PR DESCRIPTION
This one is interesting. The analysis that was duplicated for C#\VB can be combined by analyzing operation nodes. However, the original analyzer was being very specific in the location of the diagnostics. For something like `a.Equals(b)`, it was squiggling just the Equals identifier instead of the whole invocation expression to point out that the overload of Equals is wrong. While analyzing operation nodes, we only have the invocation operation and therefore the invocation syntax. To go any finer than that I have to dive into syntax which is language specific. 

So I have a couple of abstract methods to get the locations for each language but all other analysis is common.