### PR TITLE
Partial #451: CA1716: IdentifiersShouldNotMatchKeywords (type names)

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
@@ -72,11 +72,33 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.RegisterSymbolAction(AnalyzeTypeRule,
+                SymbolKind.NamedType);
+
             analysisContext.RegisterSymbolAction(AnalyzeMemberRule,
                 SymbolKind.Event, SymbolKind.Method, SymbolKind.Property);
 
             analysisContext.RegisterSymbolAction(AnalyzeMemberParameterRule,
                 SymbolKind.Method);
+        }
+
+        private void AnalyzeTypeRule(SymbolAnalysisContext context)
+        {
+            INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
+            if (type.GetResultantVisibility() != SymbolVisibility.Public)
+            {
+                return;
+            }
+
+            string matchingKeyword;
+            if (IsKeyword(type.Name, out matchingKeyword))
+            { 
+                context.ReportDiagnostic(
+                    type.CreateDiagnostic(
+                        TypeRule,
+                        type.Name,
+                        matchingKeyword));
+            }
         }
 
         private void AnalyzeMemberRule(SymbolAnalysisContext context)

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.UnitTests;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using Xunit;
 
 namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.UnitTests;
 using Xunit;
 
 namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
@@ -11,7 +8,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
     /// Contains those unit tests for the IdentifiersShouldNotMatchKeywords analyzer that
     /// pertain to the MemberRule, which applies to the names of type members.
     /// </summary>
-    public partial class IdentifiersShouldNotMatchKeywordsTests : DiagnosticAnalyzerTestBase
+    public partial class IdentifiersShouldNotMatchKeywordsTests
     {
         [Fact]
         public void CSharpDiagnosticForKeywordNamedPublicVirtualMethodInPublicClass()
@@ -69,7 +66,7 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForCaseInsensitiveKeywordPublicVirtualNamedMethodInPublicClass()
+        public void BasicDiagnosticForCaseInsensitiveKeywordNamedPublicVirtualMethodInPublicClass()
         {
             VerifyBasic(@"
 Public Class C
@@ -600,16 +597,6 @@ Public Class C(Of T As Class)
 End Class",
                 // Include the type parameter name but not the constraint.
                 GetBasicResultAt(3, 28, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C(Of T).for()", "for"));
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTests.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.UnitTests;
+
+namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
+{
+    public partial class IdentifiersShouldNotMatchKeywordsTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
+        }
+    }
+}

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
+{
+    public partial class IdentifiersShouldNotMatchKeywordsTests
+    {
+        [Fact]
+        public void CSharpDiagnosticForKeywordNamedPublicType()
+        {
+            VerifyCSharp(@"
+public class @class {}
+",
+                GetCSharpResultAt(2, 14, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "class", "class"));
+        }
+
+        [Fact]
+        public void BasicDiagnosticForKeywordNamedPublicType()
+        {
+            VerifyBasic(@"
+Public Class [Class]
+End Class
+",
+                GetBasicResultAt(2, 14, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "Class", "Class"));
+        }
+
+        [Fact]
+        public void CSharpNoDiagnosticForCaseSensitiveKeywordNamedPublicTypeWithDifferentCasing()
+        {
+            VerifyCSharp(@"
+public class iNtErNaL {}
+");
+        }
+
+        [Fact]
+        public void BasicNoDiagnosticForCaseSensitiveKeywordNamedPublicTypeWithDifferentCasing()
+        {
+            VerifyBasic(@"
+Public Class iNtErNaL
+End Class");
+        }
+
+        [Fact]
+        public void CSharpDiagnosticForCaseInsensitiveKeywordNamedPublicType()
+        {
+            VerifyCSharp(@"
+public struct aDdHaNdLeR {}
+",
+                GetCSharpResultAt(2, 15, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "aDdHaNdLeR", "AddHandler"));
+        }
+
+        [Fact]
+        public void BasicDiagnosticForCaseInsensitiveKeywordNamedPublicType()
+        {
+            VerifyBasic(@"
+Public Structure aDdHaNdLeR
+End Structure",
+                GetBasicResultAt(2, 18, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "aDdHaNdLeR", "AddHandler"));
+        }
+
+        [Fact]
+        public void CSharpNoDiagnosticForKeywordNamedInternalype()
+        {
+            VerifyCSharp(@"
+internal class @class {}
+");
+        }
+
+        [Fact]
+        public void BasicNoDiagnosticForKeywordNamedInternalType()
+        {
+            VerifyBasic(@"
+Friend Class [Class]
+End Class
+");
+        }
+
+        [Fact]
+        public void CSharpNoDiagnosticForNonKeywordNamedPublicType()
+        {
+            VerifyCSharp(@"
+public class classic {}
+");
+        }
+
+        [Fact]
+        public void BasicNoDiagnosticForNonKeywordNamedPublicType()
+        {
+            VerifyBasic(@"
+Public Class Classic
+End Class
+");
+        }
+
+        [Fact]
+        public void CSharpDiagnosticForKeywordNamedPublicTypeInNamespace()
+        {
+            VerifyCSharp(@"
+namespace N
+{
+    public enum @enum {}
+}
+",
+                GetCSharpResultAt(4, 17, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "enum", "enum"));
+        }
+
+        [Fact]
+        public void BasicDiagnosticForKeywordNamedPublicTypeInNamespace()
+        {
+            VerifyBasic(@"
+Namespace N
+    Public Enum [Enum]
+    End Class
+End Namespace
+",
+                GetBasicResultAt(3, 17, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "Enum", "Enum"));
+        }
+    }
+}

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
@@ -4,6 +4,10 @@ using Xunit;
 
 namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 {
+    /// <summary>
+    /// Contains those unit tests for the IdentifiersShouldNotMatchKeywords analyzer that
+    /// pertain to the TypeRule, which applies to the names of types.
+    /// </summary>
     public partial class IdentifiersShouldNotMatchKeywordsTests
     {
         [Fact]

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
@@ -151,6 +151,8 @@
     <Compile Include="EnumWithFlagsAttributeTests.Fixer.cs" />
     <Compile Include="EquatableAnalyzerTests.cs" />
     <Compile Include="IdentifiersShouldNotContainTypeNamesTests.cs" />
+    <Compile Include="IdentifiersShouldNotMatchKeywordsTests.cs" />
+    <Compile Include="IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AvoidAsyncVoidTests.cs" />
     <Compile Include="AvoidAsyncVoidTests.Fixer.cs" />


### PR DESCRIPTION
We add the implementation of the type name rule.

Also:
* Refactor: Place the code that applies to all the partial test classes in a separate file.
* Remove using declarations that become unnecessary once the common code is moved to the separate file.
* Remove unnecessary base class declarations from all but one of the partial classes.
* Add missing copyright notice to one file.
* Rename one misnamed test.

@srivatsn @nguerrera @michaelcfanning @dotnet/roslyn-analysis 