### PR TITLE
CA1716: Test nested types

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 context.ReportDiagnostic(
                     type.CreateDiagnostic(
                         TypeRule,
-                        type.Name,
+                        FormatSymbolName(type),
                         matchingKeyword));
             }
         }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
@@ -378,5 +378,32 @@ Public Class C
 End Class",
                 GetBasicResultAt(3, 44, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberParameterRule, "C.P(Integer)", "int", "int"));
         }
+
+        [Fact]
+        public void CSharpDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    protected class D
+    {
+        protected virtual void F(int @int) {}
+    }
+}",
+                GetCSharpResultAt(6, 38, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberParameterRule, "C.D.F(int)", "int", "int"));
+        }
+
+        [Fact]
+        public void BasicDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
+        {
+            VerifyBasic(@"
+Public Class C
+    Protected Class D
+        Protected Overridable Sub F([iNtEgEr] As Integer)
+        End Sub
+    End Class
+End Class",
+                GetBasicResultAt(4, 37, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberParameterRule, "C.D.F(Integer)", "iNtEgEr", "Integer"));
+        }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
@@ -530,6 +530,33 @@ End Class",
         }
 
         [Fact]
+        public void CSharpDiagnosticForKeywordNamedProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    protected class D
+    {
+        protected virtual void @protected() {}
+    }
+}",
+                GetCSharpResultAt(6, 32, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.D.protected()", "protected"));
+        }
+
+        [Fact]
+        public void BasicDiagnosticForKeywordNamedProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
+        {
+            VerifyBasic(@"
+Public Class C
+    Protected Class D
+        Protected Overridable Sub [Protected]()
+        End Sub
+    End Class
+End Class",
+                GetBasicResultAt(4, 35, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.D.Protected()", "Protected"));
+        }
+
+        [Fact]
         public void CSharpDiagnosticForKeywordNamedPublicVirtualEventInPublicClass()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
@@ -120,5 +120,29 @@ End Namespace
 ",
                 GetBasicResultAt(3, 17, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "Enum", "Enum"));
         }
+
+        [Fact]
+        public void CSharpDiagnosticForKeywordNamedProtectedTypeNestedInPublicClass()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    protected class @protected {}
+}
+",
+                GetCSharpResultAt(4, 21, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "C.protected", "protected"));
+        }
+
+        [Fact]
+        public void BasicDiagnosticForKeywordNamedProtectedTypeNestedInPublicClass()
+        {
+            VerifyBasic(@"
+Public Class C
+    Protected Class [Protected]
+    End Class
+End Class
+",
+                GetBasicResultAt(3, 21, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "C.Protected", "Protected"));
+        }
     }
 }


### PR DESCRIPTION
Per suggestion from @nguerrera, add unit tests for nested types to ensure that nobody accidentally "simplifies" the code by replacing the usage of `GetResultantVisibility` with `DeclaredVisibility`.

Adding these tests revealed a bug, namely that in the TypeRule, I was not properly formatting the type name for nested classes; that is, I was displaying "D" instead of "C.D".

@nguerrera @dotnet/roslyn-analysis 