### PR TITLE
Fix #451: CA1716: IdentifiersShouldNotMatchKeywords (namespace rule)

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
@@ -114,6 +114,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         private void AnalyzeNamespaceRule(SymbolAnalysisContext context, HashSet<string> keywordNamedNamespaces)
         {
             INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
+
+            // Don't complain about a namespace unless it contains at least one public type.
             if (type.GetResultantVisibility() != SymbolVisibility.Public)
             {
                 return;
@@ -128,6 +130,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             string namespaceDisplayString = containingNamespace.ToDisplayString(s_namespaceDisplayFormat);
             if (keywordNamedNamespaces.Contains(namespaceDisplayString))
             {
+                // We've already reported a diagnostic for this namespace.
                 return;
             }
 
@@ -143,7 +146,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 {
                     foundKeyword = true;
 
-                    // Don't report the diagnostic at a specific location. 
+                    // Don't report the diagnostic at a specific location. See
+                    // dotnet/roslyn#8643.
                     context.ReportDiagnostic(
                         Diagnostic.Create(
                             NamespaceRule,
@@ -246,12 +250,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         private static string FormatMemberName(ISymbol member)
         {
             return member.ToDisplayString(s_memberDisplayFormat);
-        }
-
-        // Format namespace names in a way consistent with FxCop's display for this rule.
-        private static string FormatNamespaceName(INamespaceSymbol @namespace)
-        {
-            return @namespace.ToDisplayString(s_namespaceDisplayFormat);
         }
 
         private ImmutableHashSet<string> s_caseSensitiveKeywords = new string[]

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -68,10 +70,37 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                                                                              helpLinkUri: HelpLinkUri,
                                                                              customTags: CustomTags);
 
+        // Define the format in which this rule displays member names. The format is chosen to be
+        // consistent with FxCop's display format for this rule.
+        private static readonly SymbolDisplayFormat s_memberDisplayFormat =
+            // This format omits the namespace.
+            SymbolDisplayFormat.CSharpShortErrorMessageFormat
+                // Turn off the EscapeKeywordIdentifiers flag (which is on by default), so that
+                // a method named "@for" is displayed as "for".
+                // Turn on the UseSpecialTypes flat (which is off by default), so that parameter
+                // names of "special" types such as Int32 are displayed as their language alias,
+                // such as int for C# and Integer for VB.
+                .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+        // Define the format in which this rule displays namespace names. The format is chosen to be
+        // consistent with FxCop's display format for this rule.
+        private static readonly SymbolDisplayFormat s_namespaceDisplayFormat =
+            SymbolDisplayFormat.CSharpErrorMessageFormat
+                // Turn off the EscapeKeywordIdentifiers flag (which is on by default), so that
+                // a method named "@for" is displayed as "for"
+                .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.None);
+
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(MemberParameterRule, MemberRule, TypeRule, NamespaceRule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            var keywordNamedNamespaces = new HashSet<string>();
+
+            analysisContext.RegisterSymbolAction(
+                context => AnalyzeNamespaceRule(context, keywordNamedNamespaces),
+                SymbolKind.NamedType);
+
             analysisContext.RegisterSymbolAction(AnalyzeTypeRule,
                 SymbolKind.NamedType);
 
@@ -80,6 +109,54 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             analysisContext.RegisterSymbolAction(AnalyzeMemberParameterRule,
                 SymbolKind.Method);
+        }
+
+        private void AnalyzeNamespaceRule(SymbolAnalysisContext context, HashSet<string> keywordNamedNamespaces)
+        {
+            INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
+            if (type.GetResultantVisibility() != SymbolVisibility.Public)
+            {
+                return;
+            }
+
+            INamespaceSymbol containingNamespace = type.ContainingNamespace;
+            if (containingNamespace.IsGlobalNamespace)
+            {
+                return;
+            }
+
+            string namespaceDisplayString = containingNamespace.ToDisplayString(s_namespaceDisplayFormat);
+            if (keywordNamedNamespaces.Contains(namespaceDisplayString))
+            {
+                return;
+            }
+
+            IEnumerable<string> namespaceNameComponents = containingNamespace.ToDisplayParts(s_namespaceDisplayFormat)
+                .Where(dp => dp.Kind == SymbolDisplayPartKind.NamespaceName)
+                .Select(dp => dp.ToString());
+
+            bool foundKeyword = false;
+            foreach (string component in namespaceNameComponents)
+            {
+                string matchingKeyword;
+                if (IsKeyword(component, out matchingKeyword))
+                {
+                    foundKeyword = true;
+
+                    // Don't report the diagnostic at a specific location. 
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(
+                            NamespaceRule,
+                            Location.None,
+                            namespaceDisplayString,
+                            matchingKeyword));
+                }
+            }
+
+            if (foundKeyword)
+            {
+                keywordNamedNamespaces.Add(namespaceDisplayString);
+            }
         }
 
         private void AnalyzeTypeRule(SymbolAnalysisContext context)
@@ -96,7 +173,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 context.ReportDiagnostic(
                     type.CreateDiagnostic(
                         TypeRule,
-                        FormatSymbolName(type),
+                        FormatMemberName(type),
                         matchingKeyword));
             }
         }
@@ -121,7 +198,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 context.ReportDiagnostic(
                     symbol.CreateDiagnostic(
                         MemberRule,
-                        FormatSymbolName(symbol),
+                        FormatMemberName(symbol),
                         matchingKeyword));
             }
         }
@@ -148,7 +225,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                     context.ReportDiagnostic(
                         parameter.CreateDiagnostic(
                             MemberParameterRule,
-                            FormatSymbolName(method),
+                            FormatMemberName(method),
                             parameter.Name,
                             matchingKeyword));
                 }
@@ -165,18 +242,16 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return s_caseInsensitiveKeywords.TryGetKey(name, out keyword);
         }
 
-        // Format the symbol name in a way consistent with FxCop's display for this rule.
-        private static string FormatSymbolName(ISymbol symbol)
+        // Format member names in a way consistent with FxCop's display for this rule.
+        private static string FormatMemberName(ISymbol member)
         {
-            return symbol.ToDisplayString(
-                // This format omits the namespace.
-                SymbolDisplayFormat.CSharpShortErrorMessageFormat
-                    // Turn off the EscapeKeywordIdentifiers flag (which is on by default), so that
-                    // a method named "@for" is displayed as "for".
-                    // Turn on the UseSpecialTypes flat (which is off by default), so that parameter
-                    // names of "special" types such as Int32 are displayed as their language alias,
-                    // such as int for C# and Integer for VB.
-                    .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+            return member.ToDisplayString(s_memberDisplayFormat);
+        }
+
+        // Format namespace names in a way consistent with FxCop's display for this rule.
+        private static string FormatNamespaceName(INamespaceSymbol @namespace)
+        {
+            return @namespace.ToDisplayString(s_namespaceDisplayFormat);
         }
 
         private ImmutableHashSet<string> s_caseSensitiveKeywords = new string[]

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
@@ -1,0 +1,176 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.UnitTests;
+using Xunit;
+
+namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
+{
+    /// <summary>
+    /// Contains those unit tests for the IdentifiersShouldNotMatchKeywords analyzer that
+    /// pertain to the NamespaceRule, which applies to the names of type namespaces.
+    /// </summary>
+    /// <remarks>
+    /// FxCop does not report a violation unless the namespace contains a publicly visible
+    /// class, and we follow that implementation.
+    /// </remarks>
+    public partial class IdentifiersShouldNotMatchKeywordsTests
+    {
+        [Fact]
+        public void CSharpDiagnosticForKeywordNamedNamespaceContainingPublicClass()
+        {
+            VerifyCSharp(@"
+namespace @namespace
+{
+    public class C {}
+}
+",
+                GetResultNoLocation(IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "namespace", "namespace"));
+        }
+
+        [Fact]
+        public void BasicDiagnosticForKeywordNamedNamespaceContainingPublicClass()
+        {
+            VerifyBasic(@"
+Namespace [Namespace]
+    Public Class C
+    End Class
+End Namespace
+",
+                GetResultNoLocation(IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "Namespace", "Namespace"));
+        }
+
+        [Fact]
+        public void CSharpNoDiagnosticForNonKeywordNamedNamespaceContainingPublicClass()
+        {
+            VerifyCSharp(@"
+namespace namespace2
+{
+    public class C {}
+}
+");
+        }
+
+        [Fact]
+        public void BasicNoDiagnosticForNonKeywordNamedNamespaceContainingPublicClass()
+        {
+            VerifyBasic(@"
+Namespace Namespace2
+    Public Class C
+    End Class
+End Namespace
+");
+        }
+
+        [Fact]
+        public void CSharpNoDiagnosticForKeywordNamedNamespaceContainingInternalClass()
+        {
+            VerifyCSharp(@"
+namespace @namespace
+{
+    internal class C {}
+}
+");
+        }
+
+        [Fact]
+        public void BasicNoDiagnosticForKeywordNamedNamespaceContainingInternalClass()
+        {
+            VerifyBasic(@"
+Namespace [Namespace]
+    Friend Class C
+    End Class
+End Namespace
+");
+        }
+
+        [Fact]
+        public void CSharpDiagnosticForKeywordNamedMultiComponentNamespaceContainingPublicClass()
+        {
+            VerifyCSharp(@"
+namespace N1.@namespace.N2.@for.N3
+{
+    public class C {}
+}
+",
+                GetResultNoLocation(IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "N1.namespace.N2.for.N3", "namespace"),
+                GetResultNoLocation(IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "N1.namespace.N2.for.N3", "for"));
+        }
+
+        [Fact]
+        public void BasicDiagnosticForKeywordNamedMultiComponentNamespaceContainingPublicClass()
+        {
+            VerifyBasic(@"
+Namespace N1.[Namespace].N2.[For].N3
+    Public Class C
+    End Class
+End Namespace
+",
+                GetResultNoLocation(IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "N1.Namespace.N2.For.N3", "Namespace"),
+                GetResultNoLocation(IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "N1.Namespace.N2.For.N3", "For"));
+        }
+
+        [Fact]
+        public void CSharpNoDiagnosticForPublicClassInGlobalNamespace()
+        {
+            VerifyCSharp(@"
+public class C {}
+");
+        }
+
+        [Fact]
+        public void BasicNoDiagnosticForPublicClassInGlobalNamespace()
+        {
+            VerifyBasic(@"
+Public Class C
+End Class
+");
+        }
+
+        [Fact]
+        public void CSharpNoDiagnosticForRepeatedOccurrencesOfSameKeywordNamedNamespace()
+        {
+            VerifyCSharp(@"
+namespace @namespace
+{
+    public class C {}
+}
+
+namespace @namespace
+{
+    public class D {}
+}",
+                // Diagnostic for only one of the two occurrences.
+                GetResultNoLocation(IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "namespace", "namespace"));
+        }
+
+        [Fact]
+        public void BasicNoDiagnosticForRepeatedOccurrencesOfSameKeywordNamedNamespace()
+        {
+            VerifyBasic(@"
+Namespace [Namespace]
+    Public Class C
+    End Class
+End Namespace
+
+Namespace [Namespace]
+    Public Class D
+    End Class
+End Namespace
+",
+                // Diagnostic for only one of the two occurrences.
+                GetResultNoLocation(IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "Namespace", "Namespace"));
+        }
+
+        private DiagnosticResult GetResultNoLocation(DiagnosticDescriptor rule, params object[] messageArguments)
+        {
+            return new DiagnosticResult
+            {
+                Locations = new DiagnosticResultLocation[0],
+                Id = rule.Id,
+                Severity = rule.DefaultSeverity,
+                Message = string.Format(rule.MessageFormat.ToString(), messageArguments)
+            };
+        }
+    }
+}

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
@@ -151,6 +151,7 @@
     <Compile Include="EnumWithFlagsAttributeTests.Fixer.cs" />
     <Compile Include="EquatableAnalyzerTests.cs" />
     <Compile Include="IdentifiersShouldNotContainTypeNamesTests.cs" />
+    <Compile Include="IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs" />
     <Compile Include="IdentifiersShouldNotMatchKeywordsTests.cs" />
     <Compile Include="IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Conclude the odyssey by implementing the rule that namespaces names should not match keyword names.

Per discussion with @srivatsn, we don't report a location for this rule. The reason is that you can open a namespace in multiple locations. We only want to report a violation for a given namespace once, so we keep track of which namespaces we've reported. But which of the multiple occurrences the analyzer will find first, and report, is not deterministic.

Why does that matter? Suppose the namespace occurs in both A.cs and B.cs. Suppose the compiler reports the violation in A.cs, and the user suppresses it. In contrast to the way it treats partial classes, Roslyn does _not_ suppress a namespace-scoped diagnostic across all occurrences
of the namespace. So if, in a future compilation, the compiler decides to report the violation in B.cs, the user will see the diagnostic that he has suppressed reappear.

I filed this as dotnet/roslyn#8643.

@dotnet/roslyn-analysis @nguerrera @michaelcfanning 