### PR TITLE
Fix issues identified during binary analysis prototyping

### DIFF
--- a/src/Desktop.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.cs
+++ b/src/Desktop.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.cs
@@ -63,7 +63,7 @@ namespace Desktop.Analyzers
                     {
                         var namedTypeSymbol = saContext.Symbol as INamedTypeSymbol;
 
-                        if (badBaseTypes.Contains(namedTypeSymbol.BaseType))
+                        if (namedTypeSymbol.BaseType != null && badBaseTypes.Contains(namedTypeSymbol.BaseType))
                         {
                             string baseTypeName = namedTypeSymbol.BaseType.ToDisplayString();
                             Debug.Assert(s_badBaseTypesToMessage.ContainsKey(baseTypeName));

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ExceptionsShouldBePublic.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ExceptionsShouldBePublic.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                     if (symbol.IsPublic()) return;
 
                     // only report if base type matches 
-                    if (exceptionTypes.Contains(symbol.BaseType))
+                    if (symbol.BaseType != null && exceptionTypes.Contains(symbol.BaseType))
                     {
                         saContext.ReportDiagnostic(symbol.CreateDiagnostic(Rule));
                     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MovePInvokesToNativeMethodsClass.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MovePInvokesToNativeMethodsClass.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             if (symbol.GetMembers().Any(member => IsDllImport(member)) && !IsTypeNamedCorrectly(symbol.Name))
             {
-                addDiagnostic(Diagnostic.Create(Rule, symbol.Locations.First(l => l.IsInSource)));
+                addDiagnostic(symbol.CreateDiagnostic(Rule));
             }
         }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/StaticHolderTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/StaticHolderTypes.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 return false;
             }
 
-            if (symbol.BaseType.SpecialType != SpecialType.System_Object)
+            if (symbol.BaseType == null || symbol.BaseType.SpecialType != SpecialType.System_Object)
             {
                 return false;
             }

--- a/src/System.Runtime.InteropServices.Analyzers/Core/PInvokeDiagnosticAnalyzer.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/PInvokeDiagnosticAnalyzer.cs
@@ -2,8 +2,11 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+
+using Analyzer.Utilities;
 
 namespace System.Runtime.InteropServices.Analyzers
 {
@@ -120,7 +123,7 @@ namespace System.Runtime.InteropServices.Analyzers
                 // CA1401 - PInvoke methods should not be visible
                 if (methodSymbol.DeclaredAccessibility == Accessibility.Public || methodSymbol.DeclaredAccessibility == Accessibility.Protected)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(RuleCA1401, context.Symbol.Locations.First(l => l.IsInSource), methodSymbol.Name));
+                    context.ReportDiagnostic(context.Symbol.CreateDiagnostic(RuleCA1401, methodSymbol.Name));
                 }
 
                 // CA2101 - Specify marshalling for PInvoke string arguments


### PR DESCRIPTION
1. Do not assume type.BaseType != null. This is not the
case for System.Object itself.

2. Use CreateDiagnostic from analyzer utilities to get
source location for diagnostic without crashing if there
is none.

@srivatsn @lgolding @dotnet/roslyn-analysis 