### PR TITLE
Fix #865: EquatableAnalyzer does not have help URL(s)

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EquatableAnalyzer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EquatableAnalyzer.cs
@@ -17,6 +17,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         private static readonly LocalizableString s_localizableTitleImplementIEquatable = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsTitle), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
         private static readonly LocalizableString s_localizableMessageImplementIEquatable = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsMessage), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescriptionImplementIEquatable = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
 
         private static readonly DiagnosticDescriptor s_implementIEquatableDescriptor = new DiagnosticDescriptor(
             ImplementIEquatableRuleId,
@@ -24,10 +25,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             s_localizableMessageImplementIEquatable,
             DiagnosticCategory.Design,
             DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
+            isEnabledByDefault: true,
+            description: s_localizableDescriptionImplementIEquatable,
+            helpLinkUri: "http://go.microsoft.com/fwlink/?LinkId=734907");
 
         private static readonly LocalizableString s_localizableTitleOverridesObjectEquals = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsTitle), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
         private static readonly LocalizableString s_localizableMessageOverridesObjectEquals = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsMessage), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescriptionOverridesObjectEquals = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
 
         private static readonly DiagnosticDescriptor s_overridesObjectEqualsDescriptor = new DiagnosticDescriptor(
             OverrideObjectEqualsRuleId,
@@ -35,7 +39,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             s_localizableMessageOverridesObjectEquals,
             DiagnosticCategory.Design,
             DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
+            isEnabledByDefault: true,
+            description: s_localizableDescriptionOverridesObjectEquals,
+            helpLinkUri: "http://go.microsoft.com/fwlink/?LinkId=734909");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
@@ -1288,6 +1288,15 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance..
+        /// </summary>
+        internal static string ImplementIEquatableWhenOverridingObjectEqualsDescription {
+            get {
+                return ResourceManager.GetString("ImplementIEquatableWhenOverridingObjectEqualsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Implement IEquatable when overriding Object.Equals.
         /// </summary>
         internal static string ImplementIEquatableWhenOverridingObjectEqualsMessage {
@@ -1959,6 +1968,15 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers {
         internal static string OverrideMethodsOnComparableTypesTitle {
             get {
                 return ResourceManager.GetString("OverrideMethodsOnComparableTypesTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When a type T implements the interface IEquatable&lt;T&gt;, it suggests to a user who sees a call to the Equals method in source code that an instance of the type can be equated with an instance of any other type. The user might be confused if their attempt to equate the type with an instance of another type fails to compile. This violates the &quot;principle of least surprise&quot;..
+        /// </summary>
+        internal static string OverrideObjectEqualsDescription {
+            get {
+                return ResourceManager.GetString("OverrideObjectEqualsDescription", resourceCulture);
             }
         }
         

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -973,4 +973,10 @@ Names of parameters and members are better used to communicate their meaning tha
   <data name="AppendConfigureAwaitFalse" xml:space="preserve">
     <value>Append .ConfigureAwait(false)</value>
   </data>
+  <data name="ImplementIEquatableWhenOverridingObjectEqualsDescription" xml:space="preserve">
+    <value>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</value>
+  </data>
+  <data name="OverrideObjectEqualsDescription" xml:space="preserve">
+    <value>When a type T implements the interface IEquatable&lt;T&gt;, it suggests to a user who sees a call to the Equals method in source code that an instance of the type can be equated with an instance of any other type. The user might be confused if their attempt to equate the type with an instance of another type fails to compile. This violates the "principle of least surprise".</value>
+  </data>
 </root>


### PR DESCRIPTION
In preparation for this change, I did the following:

* Added a document "Documenting your analyzers", containing guidance for creating analyzer reference pages, to the docs directory.
* Added a template for the analyzer reference pages to docs directory of the repo https://github.com/Microsoft/sarif-sdk.
* Wrote reference pages for CA1066 and CA1067.

Then, with this change, I:

* Set the helpLinkUris of the two DiagnosticDescriptors in this analyzer to the new reference pages, using stable URIs.
* Populated the Description properties of the two DiagnosticDescriptors with information taken from the reference pages.

@srivatsn @nguerrera @michaelcfanning 
cc: @dotnet/roslyn-analysis 