### PR TITLE
Pretty print Actual Diagnostics on Test failure

### DIFF
--- a/src/Test/Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test/Utilities/DiagnosticAnalyzerTestBase.cs
@@ -18,6 +18,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
 {
     public abstract class DiagnosticAnalyzerTestBase
     {
+        // It is assumed to be of the format, Get<RuleId>CSharpResultAt(line: {0}, column: {1}, message: {3})
+        private string _expectedDiagnosticsAssertionTemplate = null;
+        private bool _printActualDiagnosticsOnFailure = false;
+
         private static readonly MetadataReference s_corlibReference = MetadataReference.CreateFromAssemblyInternal(typeof(object).Assembly);
         private static readonly MetadataReference s_systemCoreReference = MetadataReference.CreateFromAssemblyInternal(typeof(Enumerable).Assembly);
         private static readonly MetadataReference s_systemXmlReference = MetadataReference.CreateFromAssemblyInternal(typeof(System.Xml.XmlDocument).Assembly);
@@ -84,6 +88,21 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
+        protected bool PrintActualDiagnosticsOnFailure
+        {
+            set
+            {
+                _printActualDiagnosticsOnFailure = value;
+            }
+        }
+
+        public string ExpectedDiagnosticsAssertionTemplate
+        {
+            set
+            {
+                _expectedDiagnosticsAssertionTemplate = value;
+            }
+        }
 
         protected static DiagnosticResult GetGlobalResult(string id, string message)
         {
@@ -262,7 +281,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         protected void Verify(FileAndSource[] sources, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
         {
-            GetSortedDiagnostics(sources, language, analyzer).Verify(analyzer, expected);
+            GetSortedDiagnostics(sources, language, analyzer).Verify(analyzer, _printActualDiagnosticsOnFailure, _expectedDiagnosticsAssertionTemplate, expected);
         }
 
         protected void Verify(string[] sources, string language, DiagnosticAnalyzer analyzer, bool addLanguageSpecificCodeAnalysisReference, params DiagnosticResult[] expected)
@@ -272,7 +291,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         protected void Verify(FileAndSource[] sources, string language, DiagnosticAnalyzer analyzer, bool addLanguageSpecificCodeAnalysisReference, params DiagnosticResult[] expected)
         {
-            GetSortedDiagnostics(sources, language, analyzer, addLanguageSpecificCodeAnalysisReference).Verify(analyzer, expected);
+            GetSortedDiagnostics(sources, language, analyzer, addLanguageSpecificCodeAnalysisReference).Verify(analyzer, _printActualDiagnosticsOnFailure, _expectedDiagnosticsAssertionTemplate, expected);
         }
 
         protected static Diagnostic[] GetSortedDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer, bool addLanguageSpecificCodeAnalysisReference = true)


### PR DESCRIPTION
This change adds a helper to Test base to pretty print the actual diagnostics when the test assertion fails.
This will be helpfully to write unittest cases fast.

Working:
1. The user writes a testcase with empty(or any failing expected) diagnostics
2. Set PrintActualDiagnosticsOnFailure to true
3. Run the testcase
4. The console will display the actual diagnostics that were generated in a format that can pasted into the testcase with minimal change
5. Care should be taken by the user to verify if the values reported at accurate

There is also an option for the user to mention a template for diagnostics display. The format which will take 3 arguments.
Arg1 : Line number
Arg2 : Column number
Arg3 : Message of the diagnostics

This can be used like below,
ExpectedDiagnosticsAssertionTemplate = "CSharpCA1707ResultAt(line: {0}, column: {1}, message: {2})"

The resultant will look like,
CSharpCA1707ResultAt(line: 3, column: 4, message: "On method 'Class1.Method1(int)', remove the underscores from the parameter 'arg_'.")