### PR TITLE
Report CA1815 (OverrideEqualsAndOperatorEqualsOnValueTypesAnalyzer) o…

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             analysisContext.RegisterSymbolAction(context =>
             {
                 var namedType = (INamedTypeSymbol)context.Symbol;
-                if (namedType.IsValueType)
+                if (namedType.IsValueType && namedType.GetResultantVisibility() == SymbolVisibility.Public)
                 {
                     if (!namedType.OverridesEquals())
                     {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -3,6 +3,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.UnitTests;
+using Roslyn.Diagnostics.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
@@ -18,6 +19,24 @@ public struct A
 }",
                 GetCSharpOverrideEqualsDiagnostic(2, 15, "A"),
                 GetCSharpOperatorEqualsDiagnostic(2, 15, "A"));
+        }
+
+        [WorkItem(895, "https://github.com/dotnet/roslyn-analyzers/issues/895")]
+        [Fact]
+        public void CSharpNoDiagnosticForInternalAndPrivateStruct()
+        {
+            VerifyCSharp(@"
+internal struct A
+{
+}
+
+public class B
+{
+    private struct C
+    {
+    }
+}
+");
         }
 
         [Fact]
@@ -109,6 +128,21 @@ End Structure
 ",
                 GetBasicOverrideEqualsDiagnostic(2, 18, "A"),
                 GetBasicOperatorEqualsDiagnostic(2, 18, "A"));
+        }
+
+        [WorkItem(895, "https://github.com/dotnet/roslyn-analyzers/issues/895")]
+        [Fact]
+        public void BasicNoDiagnosticsForInternalAndPrivateStructure()
+        {
+            VerifyBasic(@"
+Friend Structure A
+End Structure
+
+Public Class B
+    Private Structure C
+    End Structure
+End Class
+");
         }
 
         [Fact]


### PR DESCRIPTION
…nly on types with public resultant visibility.

Fixes https://github.com/dotnet/roslyn-analyzers/issues/895