### PR TITLE
Partially address https://github.com/dotnet/roslyn-analyzers/issues/8…

### DIFF
--- a/src/Analyzer.Utilities/WellKnownTypes.cs
+++ b/src/Analyzer.Utilities/WellKnownTypes.cs
@@ -21,9 +21,19 @@ namespace Analyzer.Utilities
             return compilation.GetTypeByMetadataName("System.Collections.IEnumerable");
         }
 
+        public static INamedTypeSymbol IEnumerator(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Collections.IEnumerator");
+        }
+
         public static INamedTypeSymbol GenericIEnumerable(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1");
+        }
+
+        public static INamedTypeSymbol GenericIEnumerator(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerator`1");
         }
 
         public static INamedTypeSymbol IList(Compilation compilation)

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.Fixer.cs
@@ -15,12 +15,15 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             VerifyCSharpFix(@"
 public struct A
 {
+    public int X;
 }
 ",
 
 @"
 public struct A
 {
+    public int X;
+
     public override bool Equals(object obj)
     {
         throw new System.NotImplementedException();
@@ -190,11 +193,14 @@ public struct A
         {
             VerifyBasicFix(@"
 Public Structure A
+    Public X As Integer
 End Structure
 ",
 
 @"
 Public Structure A
+    Public X As Integer
+
     Public Overrides Function Equals(obj As Object) As Boolean
         Throw New System.NotImplementedException()
     End Function

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             VerifyCSharp(@"
 public struct A
 {
+    public int X;
 }",
                 GetCSharpOverrideEqualsDiagnostic(2, 15, "A"),
                 GetCSharpOperatorEqualsDiagnostic(2, 15, "A"));
@@ -28,12 +29,101 @@ public struct A
             VerifyCSharp(@"
 internal struct A
 {
+    public int X;
 }
 
 public class B
 {
     private struct C
     {
+        public int X;
+    }
+}
+");
+        }
+
+        [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
+        [Fact]
+        public void CSharpNoDiagnosticForEnum()
+        {
+            VerifyCSharp(@"
+public enum E
+{
+    F = 0
+}
+");
+        }
+
+        [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
+        [Fact]
+        public void CSharpNoDiagnosticForStructsWithoutMembers()
+        {
+            VerifyCSharp(@"
+public struct EmptyStruct
+{
+}
+");
+        }
+
+        [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
+        [Fact(Skip = "899")]
+        public void CSharpNoDiagnosticForEnumerators()
+        {
+            VerifyCSharp(@"
+using System;
+
+public struct MyEnumerator : System.Collections.IEnumerator
+{
+    public object Current
+    {
+        get
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public bool MoveNext()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Reset()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public struct MyGenericEnumerator<T> : System.Collections.Generic.IEnumerator<T>
+{
+    public T Current
+    {
+        get
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    object IEnumerator.Current
+    {
+        get
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool MoveNext()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Reset()
+    {
+        throw new NotImplementedException();
     }
 }
 ");
@@ -45,6 +135,7 @@ public class B
             VerifyCSharp(@"
 public class A
 {
+    public int X;
 }");
         }
 
@@ -124,6 +215,7 @@ public struct A
         {
             VerifyBasic(@"
 Public Structure A
+    Public X As Integer
 End Structure
 ",
                 GetBasicOverrideEqualsDiagnostic(2, 18, "A"),
@@ -136,12 +228,88 @@ End Structure
         {
             VerifyBasic(@"
 Friend Structure A
+    Public X As Integer
 End Structure
 
 Public Class B
     Private Structure C
+        Public X As Integer
     End Structure
 End Class
+");
+        }
+
+        [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
+        [Fact]
+        public void BasicNoDiagnosticForEnum()
+        {
+            VerifyBasic(@"
+Public Enum E
+    F = 0
+End Enum
+");
+        }
+
+        [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
+        [Fact]
+        public void BasicNoDiagnosticForStructsWithoutMembers()
+        {
+            VerifyBasic(@"
+Public Structure EmptyStruct
+End Structure
+");
+        }
+
+        [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
+        [Fact(Skip = "899")]
+        public void BasicNoDiagnosticForEnumerators()
+        {
+            VerifyBasic(@"
+Imports System
+
+Public Structure MyEnumerator
+	Implements System.Collections.IEnumerator
+	Public ReadOnly Property Current() As Object
+		Get
+			Throw New NotImplementedException()
+		End Get
+	End Property
+
+	Public Function MoveNext() As Boolean
+		Throw New NotImplementedException()
+	End Function
+
+	Public Sub Reset()
+		Throw New NotImplementedException()
+	End Sub
+End Structure
+
+Public Structure MyGenericEnumerator(Of T)
+	Implements System.Collections.Generic.IEnumerator(Of T)
+	Public ReadOnly Property Current() As T
+		Get
+			Throw New NotImplementedException()
+		End Get
+	End Property
+
+	Private ReadOnly Property IEnumerator_Current() As Object Implements IEnumerator.Current
+		Get
+			Throw New NotImplementedException()
+		End Get
+	End Property
+
+	Public Sub Dispose()
+		Throw New NotImplementedException()
+	End Sub
+
+	Public Function MoveNext() As Boolean
+		Throw New NotImplementedException()
+	End Function
+
+	Public Sub Reset()
+		Throw New NotImplementedException()
+	End Sub
+End Structure
 ");
         }
 


### PR DESCRIPTION
…99: CA1815 doesn't match FxCop implementation

1. Do not fire for enums.
2. Do not fire for enumerators (needs IsAssignableTo helper that Larry is soon going to add).
3. Do not fire for value types without members.