### PR TITLE
Updating the fxcop props files with all the newly implemented rules.

### DIFF
--- a/src/Desktop.Analyzers/Core/Desktop.Analyzers.props
+++ b/src/Desktop.Analyzers/Core/Desktop.Analyzers.props
@@ -9,10 +9,11 @@
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
         $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Design#CA1058;
+        
         -Microsoft.Usage#CA2229;
         -Microsoft.Usage#CA2235;
         -Microsoft.Usage#CA2237;
-        -Microsoft.Usage#CA1058;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/Microsoft.ApiDesignGuidelines.CSharp.Analyzers.props
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/Microsoft.ApiDesignGuidelines.CSharp.Analyzers.props
@@ -13,11 +13,11 @@
         -Microsoft.Design#CA1003;
         -Microsoft.Design#CA1009;
         -Microsoft.Design#CA1019;
+        -Microsoft.Design#CA1032;
+        -Microsoft.Design#CA1040;
 
-        -Microsoft.Reliability#CA2002;
-
-        -Microsoft.Globalization#CA1309;
-
+        -Microsoft.Usage#CA2218;
+        -Microsoft.Usage#CA2224;
         -Microsoft.Usage#CA2234;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/Microsoft.ApiDesignGuidelines.CSharp.Analyzers.props
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/Microsoft.ApiDesignGuidelines.CSharp.Analyzers.props
@@ -16,8 +16,6 @@
         -Microsoft.Design#CA1032;
         -Microsoft.Design#CA1040;
 
-        -Microsoft.Usage#CA2218;
-        -Microsoft.Usage#CA2224;
         -Microsoft.Usage#CA2234;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainTypeNames.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainTypeNames.cs
@@ -71,7 +71,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessage,
-                                                                             DiagnosticCategory.Design,
+                                                                             DiagnosticCategory.Naming,
                                                                              DiagnosticSeverity.Warning,
                                                                              isEnabledByDefault: true,
                                                                              description: s_localizableDescription,

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.props
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.props
@@ -25,6 +25,7 @@
         -Microsoft.Design#CA1034;
         -Microsoft.Design#CA1036;
         -Microsoft.Design#CA1041;
+        -Microsoft.Design#CA1043;
         -Microsoft.Design#CA1050;
         -Microsoft.Design#CA1051;
         -Microsoft.Design#CA1052;
@@ -35,11 +36,6 @@
         -Microsoft.Design#CA1063;
         -Microsoft.Design#CA1064;
         -Microsoft.Design#CA1065;
-        -Microsoft.Design#CA1066;
-        -Microsoft.Design#CA1067;
-        -Microsoft.Design#CA1068;
-        -Microsoft.Design#CA1720;
-        -Microsoft.Design#CA1721;
 
         -Microsoft.Naming#CA1707;
         -Microsoft.Naming#CA1708;
@@ -48,15 +44,14 @@
         -Microsoft.Naming#CA1715;
         -Microsoft.Naming#CA1716;
         -Microsoft.Naming#CA1717;
+        -Microsoft.Naming#CA1720;
+        -Microsoft.Naming#CA1721;
         -Microsoft.Naming#CA1724;
         -Microsoft.Naming#CA1725;
-        
-        -Microsoft.Performance#CA1043;
+
         -Microsoft.Performance#CA1815;
         -Microsoft.Performance#CA1819;
 
-        -Microsoft.Reliability#CA2007;
-        
         -Microsoft.Usage#CA2211;
         -Microsoft.Usage#CA2217;
         -Microsoft.Usage#CA2222;

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.props
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.props
@@ -9,24 +9,61 @@
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
         $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Design#CA1000;
         -Microsoft.Design#CA1008;
+        -Microsoft.Design#CA1010;
         -Microsoft.Design#CA1012;
+        -Microsoft.Design#CA1014;
+        -Microsoft.Design#CA1016;
         -Microsoft.Design#CA1017;
         -Microsoft.Design#CA1018;
         -Microsoft.Design#CA1024;
         -Microsoft.Design#CA1027;
+        -Microsoft.Design#CA1028;
         -Microsoft.Design#CA1030;
+        -Microsoft.Design#CA1033;
+        -Microsoft.Design#CA1034;
         -Microsoft.Design#CA1036;
-        -Microsoft.Design#CA1060;
+        -Microsoft.Design#CA1041;
+        -Microsoft.Design#CA1050;
+        -Microsoft.Design#CA1051;
+        -Microsoft.Design#CA1052;
         -Microsoft.Design#CA1054;
         -Microsoft.Design#CA1055;
         -Microsoft.Design#CA1056;
+        -Microsoft.Design#CA1060;
+        -Microsoft.Design#CA1063;
+        -Microsoft.Design#CA1064;
+        -Microsoft.Design#CA1065;
+        -Microsoft.Design#CA1066;
+        -Microsoft.Design#CA1067;
+        -Microsoft.Design#CA1068;
+        -Microsoft.Design#CA1720;
+        -Microsoft.Design#CA1721;
 
-        -Microsoft.Naming#CA1720;
+        -Microsoft.Naming#CA1707;
+        -Microsoft.Naming#CA1708;
+        -Microsoft.Naming#CA1710;
+        -Microsoft.Naming#CA1714;
+        -Microsoft.Naming#CA1715;
+        -Microsoft.Naming#CA1716;
+        -Microsoft.Naming#CA1717;
+        -Microsoft.Naming#CA1724;
+        -Microsoft.Naming#CA1725;
+        
+        -Microsoft.Performance#CA1043;
+        -Microsoft.Performance#CA1815;
+        -Microsoft.Performance#CA1819;
 
+        -Microsoft.Reliability#CA2007;
+        
+        -Microsoft.Usage#CA2211;
+        -Microsoft.Usage#CA2217;
+        -Microsoft.Usage#CA2222;
+        -Microsoft.Usage#CA2225;
+        -Microsoft.Usage#CA2226;
         -Microsoft.Usage#CA2227;
         -Microsoft.Usage#CA2231;
-        -Microsoft.Usage#CA2217;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertyNamesShouldNotMatchGetMethods.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessage,
-                                                                             DiagnosticCategory.Design,
+                                                                             DiagnosticCategory.Naming,
                                                                              DiagnosticSeverity.Warning,
                                                                              isEnabledByDefault: true,
                                                                              description: s_localizableDescription,

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseIntegralOrStringArgumentForIndexers.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseIntegralOrStringArgumentForIndexers.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessage,
-                                                                             DiagnosticCategory.Performance,
+                                                                             DiagnosticCategory.Design,
                                                                              DiagnosticSeverity.Warning,
                                                                              isEnabledByDefault: true,
                                                                              description: s_localizableDescription,

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers.props
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers.props
@@ -13,11 +13,11 @@
         -Microsoft.Design#CA1003;
         -Microsoft.Design#CA1009;
         -Microsoft.Design#CA1019;
+        -Microsoft.Design#CA1032;
+        -Microsoft.Design#CA1040;
 
-        -Microsoft.Reliability#CA2002;
-
-        -Microsoft.Globalization#CA1309;
-
+        -Microsoft.Usage#CA2218;
+        -Microsoft.Usage#CA2224;
         -Microsoft.Usage#CA2234;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>

--- a/src/Microsoft.Maintainability.Analyzers/Core/Microsoft.Maintainability.Analyzers.props
+++ b/src/Microsoft.Maintainability.Analyzers/Core/Microsoft.Maintainability.Analyzers.props
@@ -8,8 +8,10 @@
   -->
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
-         $(CodeAnalysisRuleSetOverrides);
-         <!--INSERTRULESETOVERRIDES-->
+        $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Performance#CA1801;
+        -Microsoft.Performance#CA1806;
+        -Microsoft.Performance#CA1823;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/Microsoft.Maintainability.Analyzers/VisualBasic/Microsoft.Maintainability.VisualBasic.Analyzers.props
+++ b/src/Microsoft.Maintainability.Analyzers/VisualBasic/Microsoft.Maintainability.VisualBasic.Analyzers.props
@@ -8,8 +8,8 @@
   -->
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
-         $(CodeAnalysisRuleSetOverrides);
-         <!--INSERTRULESETOVERRIDES-->
+        $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Performance#CA1804;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/Microsoft.QualityGuidelines.Analyzers/CSharp/Microsoft.QualityGuidelines.CSharp.Analyzers.props
+++ b/src/Microsoft.QualityGuidelines.Analyzers/CSharp/Microsoft.QualityGuidelines.CSharp.Analyzers.props
@@ -8,8 +8,8 @@
   -->
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
-         $(CodeAnalysisRuleSetOverrides);
-         <!--INSERTRULESETOVERRIDES-->
+        $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Usage#CA2200;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/Microsoft.QualityGuidelines.Analyzers.props
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/Microsoft.QualityGuidelines.Analyzers.props
@@ -8,8 +8,14 @@
   -->
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
-         $(CodeAnalysisRuleSetOverrides);
-         <!--INSERTRULESETOVERRIDES-->
+        $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Performance#CA1802;
+        -Microsoft.Performance#CA1814;
+        -Microsoft.Performance#CA1821;
+        -Microsoft.Performance#CA1822;
+
+        -Microsoft.Usage#CA2214;
+        -Microsoft.Usage#CA2219;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/Microsoft.QualityGuidelines.VisualBasic.Analyzers.props
+++ b/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/Microsoft.QualityGuidelines.VisualBasic.Analyzers.props
@@ -8,8 +8,8 @@
   -->
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
-         $(CodeAnalysisRuleSetOverrides);
-         <!--INSERTRULESETOVERRIDES-->
+        $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Usage#CA2200;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/System.Resources.Analyzers/CSharp/System.Resources.CSharp.Analyzers.props
+++ b/src/System.Resources.Analyzers/CSharp/System.Resources.CSharp.Analyzers.props
@@ -8,8 +8,8 @@
   -->
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
-         $(CodeAnalysisRuleSetOverrides);
-         <!--INSERTRULESETOVERRIDES-->
+        $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Performance#CA1824;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/System.Resources.Analyzers/Core/System.Resources.Analyzers.props
+++ b/src/System.Resources.Analyzers/Core/System.Resources.Analyzers.props
@@ -9,7 +9,6 @@
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
          $(CodeAnalysisRuleSetOverrides);
-         -Microsoft.Design#CA1824;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/System.Resources.Analyzers/VisualBasic/System.Resources.VisualBasic.Analyzers.props
+++ b/src/System.Resources.Analyzers/VisualBasic/System.Resources.VisualBasic.Analyzers.props
@@ -8,8 +8,8 @@
   -->
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
-         $(CodeAnalysisRuleSetOverrides);
-         <!--INSERTRULESETOVERRIDES-->
+        $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Performance#CA1824;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Analyzers/CSharp/System.Runtime.CSharp.Analyzers.props
+++ b/src/System.Runtime.Analyzers/CSharp/System.Runtime.CSharp.Analyzers.props
@@ -8,9 +8,14 @@
   -->
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
-         $(CodeAnalysisRuleSetOverrides);
-         -Microsoft.Performance#CA1820;
-         -Microsoft.Usage#CA2241;
+        $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Globalization#CA1309;
+        
+        -Microsoft.Performance#CA1810;
+        -Microsoft.Performance#CA1825;
+        
+        -Microsoft.Usage#CA2201;
+        -Microsoft.Usage#CA2207;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.props
+++ b/src/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.props
@@ -9,12 +9,20 @@
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
         $(CodeAnalysisRuleSetOverrides);
+        -Microsoft.Globalization#CA1304;
+        -Microsoft.Globalization#CA1305;
+        -Microsoft.Globalization#CA1307;
         -Microsoft.Globalization#CA1308;
 
-        -Microsoft.Performance#CA1810;
+        -Microsoft.Performance#CA1813;
+        -Microsoft.Performance#CA1820;
 
-        -Microsoft.Usage#CA2201;
-        -Microsoft.Usage#CA2207;
+        -Microsoft.Reliability#CA2002;
+
+        -Microsoft.Usage#CA2208;
+        -Microsoft.Usage#CA2216;
+        -Microsoft.Usage#CA2241;
+        -Microsoft.Usage#CA2242;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Analyzers/VisualBasic/System.Runtime.VisualBasic.Analyzers.props
+++ b/src/System.Runtime.Analyzers/VisualBasic/System.Runtime.VisualBasic.Analyzers.props
@@ -9,7 +9,11 @@
    <PropertyGroup>
       <CodeAnalysisRuleSetOverrides>
         $(CodeAnalysisRuleSetOverrides);
-        -Microsoft.Performance#CA1820;
+        -Microsoft.Globalization#CA1309;
+        -Microsoft.Performance#CA1810;
+        -Microsoft.Performance#CA1825;
+        -Microsoft.Usage#CA2201;
+        -Microsoft.Usage#CA2207;
       </CodeAnalysisRuleSetOverrides>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
All of the analyzer packages have a props file that turns off the FxCop implementation of the rules implemented by that package so that issues are not reported twice in VS. Updating that list with all the rules that have been implemented so far. I modified the a2md tool to spit out the lines that go into the file. 

If there are any rules that are disabled in the props file that FxCop doesn't understand then it complains. Verified by installing all the packages that all the rules mentioned in the props files do exist in FxCop. (We've added some new ones that I had to remove).

Fixes #306 

@dotnet/roslyn-analysis @mavasani 