### PR TITLE
Fix CA1043 to not report in a couple of cases

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseIntegralOrStringArgumentForIndexers.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseIntegralOrStringArgumentForIndexers.cs
@@ -57,6 +57,17 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 if (symbol.GetParameters().Length == 1)
                 {
                     ITypeSymbol paramType = symbol.GetParameters()[0].Type;
+
+                    if (paramType.TypeKind == TypeKind.TypeParameter)
+                    {
+                        return;
+                    }
+
+                    if (paramType.TypeKind == TypeKind.Enum)
+                    {
+                        paramType = ((INamedTypeSymbol)paramType).EnumUnderlyingType;
+                    }
+
                     if (!s_allowedTypes.Contains(paramType.SpecialType))
                     {
                         context.ReportDiagnostic(symbol.CreateDiagnostic(Rule));

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/UseIntegralOrStringArgumentForIndexersTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/UseIntegralOrStringArgumentForIndexersTests.cs
@@ -81,6 +81,70 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
     }");
         }
 
+        [Fact]
+        public void TestCSharpGenericIndexer()
+        {
+            VerifyCSharp(@"
+    public class Months<T>
+    {
+        public string this[T index]
+        {
+            get
+            {
+                return null;
+            }
+        }
+    }");
+        }
+
+        [Fact]
+        public void TestBasicGenericIndexer()
+        {
+            VerifyBasic(@"
+    Public Class Months(Of T)
+        Default Public ReadOnly Property Item(index As T)
+            Get
+                Return Nothing
+            End Get
+        End Property
+    End Class");
+        }
+
+        [Fact]
+        public void TestCSharpEnumIndexer()
+        {
+            VerifyCSharp(@"
+    public class Months<T>
+    {
+        public enum Foo { }
+
+        public string this[Foo index]
+        {
+            get
+            {
+                return null;
+            }
+        }
+    }");
+        }
+
+        [Fact]
+        public void TestBasicEnumIndexer()
+        {
+            VerifyBasic(@"
+    Public Class Months(Of T)
+        Public Enum Foo
+            Val1
+        End Enum
+
+        Default Public ReadOnly Property Item(index As Foo)
+            Get
+                Return Nothing
+            End Get
+        End Property
+    End Class");
+        }
+
         private static DiagnosticResult CreateCSharpResult(int line, int col)
         {
             return GetCSharpResultAt(line, col, UseIntegralOrStringArgumentForIndexersAnalyzer.RuleId, MicrosoftApiDesignGuidelinesAnalyzersResources.UseIntegralOrStringArgumentForIndexersMessage);


### PR DESCRIPTION
While testing something unrelated I noticed that indexer with generic parameters were being flagged as incorrect (CA1043 says Indexers should have either integer or string parameters). The FxCop implementation excludes type parameters and for enums it checks the underlying type. I've made both those changes in this PR.

@dotnet/roslyn-analysis 