### PR TITLE
Consume the newly added analyzer APIs in all our analyzers

### DIFF
--- a/src/ApiReview.Analyzers/Core/AvoidCallingProblematicMethods.cs
+++ b/src/ApiReview.Analyzers/Core/AvoidCallingProblematicMethods.cs
@@ -122,8 +122,11 @@ namespace ApiReview.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/ApiReview.Analyzers/Core/AvoidCallingProblematicMethods.cs
+++ b/src/ApiReview.Analyzers/Core/AvoidCallingProblematicMethods.cs
@@ -122,6 +122,8 @@ namespace ApiReview.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/AvoidDuplicateAccelerators.cs
+++ b/src/Desktop.Analyzers/Core/AvoidDuplicateAccelerators.cs
@@ -33,6 +33,8 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/AvoidDuplicateAccelerators.cs
+++ b/src/Desktop.Analyzers/Core/AvoidDuplicateAccelerators.cs
@@ -33,8 +33,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.cs
+++ b/src/Desktop.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.cs
@@ -33,6 +33,8 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.cs
+++ b/src/Desktop.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.cs
@@ -33,8 +33,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
+++ b/src/Desktop.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
@@ -47,6 +47,11 @@ namespace Desktop.Analyzers
         /// <param name="analysisContext">Analyzer Context.</param>
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Make analyzer thread-safe.
+            //analysisContext.EnableConcurrentExecution();
+
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {

--- a/src/Desktop.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.cs
+++ b/src/Desktop.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.cs
@@ -33,6 +33,8 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.cs
+++ b/src/Desktop.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.cs
@@ -33,8 +33,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/DoNotUseInsecureCryptographicAlgorithms.cs
+++ b/src/Desktop.Analyzers/Core/DoNotUseInsecureCryptographicAlgorithms.cs
@@ -55,6 +55,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+
+            // Security analyzer - analyze and report diagnostics in generated code.
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {

--- a/src/Desktop.Analyzers/Core/DoNotUseInsecureDTDProcessing.cs
+++ b/src/Desktop.Analyzers/Core/DoNotUseInsecureDTDProcessing.cs
@@ -55,6 +55,12 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Make analyzer thread-safe
+            //analysisContext.EnableConcurrentExecution();
+
+            // Security analyzer - analyze and report diagnostics in generated code.
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {

--- a/src/Desktop.Analyzers/Core/DoNotUseInsecureDtdProcessingInApiDesign.cs
+++ b/src/Desktop.Analyzers/Core/DoNotUseInsecureDtdProcessingInApiDesign.cs
@@ -34,6 +34,12 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Make analyzer thread-safe.
+            //analysisContext.EnableConcurrentExecution();
+
+            // Security analyzer - analyze and report diagnostics in generated code.
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {

--- a/src/Desktop.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
+++ b/src/Desktop.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
@@ -31,6 +31,12 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Make analyzer thread-safe.
+            //analysisContext.EnableConcurrentExecution();
+
+            // Security analyzer - analyze and report diagnostics in generated code.
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {

--- a/src/Desktop.Analyzers/Core/ImplementISerializableCorrectly.cs
+++ b/src/Desktop.Analyzers/Core/ImplementISerializableCorrectly.cs
@@ -53,8 +53,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/ImplementISerializableCorrectly.cs
+++ b/src/Desktop.Analyzers/Core/ImplementISerializableCorrectly.cs
@@ -53,6 +53,8 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/ImplementSerializationMethodsCorrectly.cs
+++ b/src/Desktop.Analyzers/Core/ImplementSerializationMethodsCorrectly.cs
@@ -73,6 +73,8 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/ImplementSerializationMethodsCorrectly.cs
+++ b/src/Desktop.Analyzers/Core/ImplementSerializationMethodsCorrectly.cs
@@ -73,8 +73,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.cs
+++ b/src/Desktop.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.cs
@@ -33,6 +33,8 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.cs
+++ b/src/Desktop.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.cs
@@ -33,8 +33,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.cs
+++ b/src/Desktop.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.cs
@@ -43,6 +43,8 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.cs
+++ b/src/Desktop.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.cs
@@ -43,8 +43,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/SerializationDiagnosticAnalyzer.cs
+++ b/src/Desktop.Analyzers/Core/SerializationDiagnosticAnalyzer.cs
@@ -89,6 +89,9 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {

--- a/src/Desktop.Analyzers/Core/SetLocaleForDataTypes.cs
+++ b/src/Desktop.Analyzers/Core/SetLocaleForDataTypes.cs
@@ -33,6 +33,8 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/SetLocaleForDataTypes.cs
+++ b/src/Desktop.Analyzers/Core/SetLocaleForDataTypes.cs
@@ -33,8 +33,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/SpecifyMessageBoxOptions.cs
+++ b/src/Desktop.Analyzers/Core/SpecifyMessageBoxOptions.cs
@@ -33,6 +33,8 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/SpecifyMessageBoxOptions.cs
+++ b/src/Desktop.Analyzers/Core/SpecifyMessageBoxOptions.cs
@@ -33,8 +33,11 @@ namespace Desktop.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.cs
+++ b/src/Desktop.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.cs
@@ -33,7 +33,7 @@ namespace Desktop.Analyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        private static readonly Dictionary<string, string> s_badBaseTypesToMessage = new Dictionary<string, string>
+        private static readonly ImmutableDictionary<string, string> s_badBaseTypesToMessage = new Dictionary<string, string>
                                                     {
                                                         {"System.ApplicationException", DesktopAnalyzersResources.TypesShouldNotExtendCertainBaseTypesMessageSystemApplicationException},
                                                         {"System.Xml.XmlDocument", DesktopAnalyzersResources.TypesShouldNotExtendCertainBaseTypesMessageSystemXmlXmlDocument},
@@ -43,14 +43,17 @@ namespace Desktop.Analyzers
                                                         {"System.Collections.ReadOnlyCollectionBase", DesktopAnalyzersResources.TypesShouldNotExtendCertainBaseTypesMessageSystemCollectionsReadOnlyCollectionBase},
                                                         {"System.Collections.SortedList", DesktopAnalyzersResources.TypesShouldNotExtendCertainBaseTypesMessageSystemCollectionsSortedList},
                                                         {"System.Collections.Stack", DesktopAnalyzersResources.TypesShouldNotExtendCertainBaseTypesMessageSystemCollectionsStack},
-                                                    };
+                                                    }.ToImmutableDictionary();
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(AnalyzeCompilationStart);
         }
 
-        private void AnalyzeCompilationStart(CompilationStartAnalysisContext context)
+        private static void AnalyzeCompilationStart(CompilationStartAnalysisContext context)
         {
             ImmutableHashSet<INamedTypeSymbol> badBaseTypes = s_badBaseTypesToMessage.Keys
                                 .Select(bt => context.Compilation.GetTypeByMetadataName(bt))

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/CSharpDonTMixBlockingAndAsync.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/CSharpDonTMixBlockingAndAsync.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// Async006: Don't Mix Blocking and Async
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class CSharpDonTMixBlockingAndAsyncAnalyzer : DonTMixBlockingAndAsyncAnalyzer
+    public sealed class CSharpDonTMixBlockingAndAsyncAnalyzer : DontMixBlockingAndAsyncAnalyzer
     {
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/CSharpDonTPassAsyncLambdasAsVoidReturningDelegateTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/CSharpDonTPassAsyncLambdasAsVoidReturningDelegateTypes.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// Async003: Don't Pass Async Lambdas as Void Returning Delegate Types
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class CSharpDonTPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer : DonTPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
+    public sealed class CSharpDonTPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer : DontPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
     {
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/CSharpDonTStoreAsyncLambdasAsVoidReturningDelegateTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/CSharp/CSharpDonTStoreAsyncLambdasAsVoidReturningDelegateTypes.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// Async004: Don't Store Async Lambdas as Void Returning Delegate Types
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class CSharpDonTStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer : DonTStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
+    public sealed class CSharpDonTStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer : DontStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
     {
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AbstractTypesShouldNotHaveConstructors.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AbstractTypesShouldNotHaveConstructors.cs
@@ -33,6 +33,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
         }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidAsyncVoid.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidAsyncVoid.cs
@@ -33,8 +33,11 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidAsyncVoid.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidAsyncVoid.cs
@@ -33,6 +33,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidEmptyInterfaces.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidEmptyInterfaces.cs
@@ -34,10 +34,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(AnalyzeInterface, SymbolKind.NamedType);
         }
 
-        private void AnalyzeInterface(SymbolAnalysisContext context)
+        private static void AnalyzeInterface(SymbolAnalysisContext context)
         {
             var symbol = (INamedTypeSymbol)context.Symbol;
             if (symbol.TypeKind == TypeKind.Interface && !symbol.GetMembers().Any() && !symbol.AllInterfaces.SelectMany(s => s.GetMembers()).Any())

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CancellationTokenParametersMustComeLast.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CancellationTokenParametersMustComeLast.cs
@@ -31,6 +31,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol cancellationTokenType = compilationContext.Compilation.GetTypeByMetadataName("System.Threading.CancellationToken");

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CollectionPropertiesShouldBeReadOnly.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CollectionPropertiesShouldBeReadOnly.cs
@@ -48,6 +48,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {
@@ -63,7 +66,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 });
         }
 
-        public void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol iCollectionType, INamedTypeSymbol arrayType)
+        public static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol iCollectionType, INamedTypeSymbol arrayType)
         {
             var property = (IPropertySymbol)context.Symbol;
 
@@ -83,7 +86,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             context.ReportDiagnostic(property.CreateDiagnostic(Rule));
         }
 
-        private bool Inherits(ITypeSymbol symbol, ITypeSymbol baseType)
+        private static bool Inherits(ITypeSymbol symbol, ITypeSymbol baseType)
         {
             return symbol == null ? false : symbol.Inherits(baseType);
         }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CollectionsShouldImplementGenericInterface.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CollectionsShouldImplementGenericInterface.cs
@@ -50,6 +50,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                (context) =>
                {
@@ -75,13 +78,17 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                });
         }
 
-        public void AnalyzeSymbol(SymbolAnalysisContext context,
-                                   INamedTypeSymbol iCollectionType, INamedTypeSymbol gCollectionType,
-                                   INamedTypeSymbol iEnumerableType, INamedTypeSymbol gEnumerableType,
-                                   INamedTypeSymbol iListType, INamedTypeSymbol gListType)
+        private static void AnalyzeSymbol(
+            SymbolAnalysisContext context,
+            INamedTypeSymbol iCollectionType,
+            INamedTypeSymbol gCollectionType,
+            INamedTypeSymbol iEnumerableType,
+            INamedTypeSymbol gEnumerableType,
+            INamedTypeSymbol iListType,
+            INamedTypeSymbol gListType)
         {
             var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
-            System.Collections.Generic.IEnumerable<INamedTypeSymbol> allInterfaces = namedTypeSymbol.AllInterfaces.Select(t => t.OriginalDefinition);
+            var allInterfaces = namedTypeSymbol.AllInterfaces.Select(t => t.OriginalDefinition).ToImmutableHashSet();
 
             foreach (INamedTypeSymbol @interface in allInterfaces)
             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DeclareTypesInNamespaces.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DeclareTypesInNamespaces.cs
@@ -34,10 +34,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(context => AnalyzeSymbol(context), SymbolKind.NamedType);
         }
 
-        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
         {
             ISymbol type = context.Symbol;
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DefineAccessorsForAttributeArguments.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DefineAccessorsForAttributeArguments.cs
@@ -65,6 +65,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol attributeType = WellKnownTypes.Attribute(compilationContext.Compilation);

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDeclareStaticMembersOnGenericTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDeclareStaticMembersOnGenericTypes.cs
@@ -33,6 +33,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(
                 symbolAnalysisContext =>
                 {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDeclareVisibleInstanceFields.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDeclareVisibleInstanceFields.cs
@@ -34,6 +34,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(obj =>
             {
                 var field = (IFieldSymbol)obj.Symbol;

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDecreaseInheritedMemberVisibility.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDecreaseInheritedMemberVisibility.cs
@@ -35,12 +35,15 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             // It may be interesting to flag field, property, and event symbols for this analyzer, but don't for now in order
             // to maintain compatibility with the old FxCop CA2222 rule which only analyzed methods.
             analysisContext.RegisterSymbolAction(CheckForDecreasedVisibility, SymbolKind.Method /*, SymbolKind.Field, SymbolKind.Property, SymbolKind.Event*/);
         }
 
-        private void CheckForDecreasedVisibility(SymbolAnalysisContext context)
+        private static void CheckForDecreasedVisibility(SymbolAnalysisContext context)
         {
             ISymbol symbol = context.Symbol;
 
@@ -63,8 +66,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
 
             // Find members on base types that share the member's name
-            System.Collections.Generic.IEnumerable<INamedTypeSymbol> ancestorTypes = symbol?.ContainingType?.GetBaseTypes() ?? Enumerable.Empty<INamedTypeSymbol>();
-            System.Collections.Generic.IEnumerable<ISymbol> hiddenOrOverriddenMembers = ancestorTypes.SelectMany(t => t.GetMembers(symbol.Name));
+            var ancestorTypes = symbol?.ContainingType?.GetBaseTypes() ?? Enumerable.Empty<INamedTypeSymbol>();
+            var hiddenOrOverriddenMembers = ancestorTypes.SelectMany(t => t.GetMembers(symbol.Name));
 
             if (hiddenOrOverriddenMembers.Any(IsVisibleOutsideAssembly))
             {
@@ -72,7 +75,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
         }
 
-        private bool IsVisibleOutsideAssembly(ISymbol symbol)
+        private static bool IsVisibleOutsideAssembly(ISymbol symbol)
         {
             // If the containing type is not visible, then neither is the contained symbol
             if (symbol.ContainingType != null && !IsVisibleOutsideAssembly(symbol.ContainingType))

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDirectlyAwaitATask.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDirectlyAwaitATask.cs
@@ -35,6 +35,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(context =>
             {
                 ImmutableArray<INamedTypeSymbol> taskTypes = GetTaskTypes(context.Compilation);
@@ -47,7 +50,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             });
         }
 
-        private void AnalyzeOperation(OperationAnalysisContext context, ImmutableArray<INamedTypeSymbol> taskTypes)
+        private static void AnalyzeOperation(OperationAnalysisContext context, ImmutableArray<INamedTypeSymbol> taskTypes)
         {
             IAwaitExpression awaitExpression = context.Operation as IAwaitExpression;
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotRaiseExceptionsInUnexpectedLocations.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotRaiseExceptionsInUnexpectedLocations.cs
@@ -59,6 +59,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationStartContext =>
             {
                 Compilation compilation = compilationStartContext.Compilation;

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTMixBlockingAndAsync.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTMixBlockingAndAsync.Fixer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// </summary>
     public abstract class DonTMixBlockingAndAsyncFixer : CodeFixProvider
     {
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DonTMixBlockingAndAsyncAnalyzer.RuleId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DontMixBlockingAndAsyncAnalyzer.RuleId);
 
         public sealed override FixAllProvider GetFixAllProvider()
         {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTMixBlockingAndAsync.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTMixBlockingAndAsync.cs
@@ -33,8 +33,11 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTMixBlockingAndAsync.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTMixBlockingAndAsync.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// <summary>
     /// Async006: Don't Mix Blocking and Async
     /// </summary>
-    public abstract class DonTMixBlockingAndAsyncAnalyzer : DiagnosticAnalyzer
+    public abstract class DontMixBlockingAndAsyncAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "Async006";
 
@@ -33,6 +33,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTPassAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTPassAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// </summary>
     public abstract class DonTPassAsyncLambdasAsVoidReturningDelegateTypesFixer : CodeFixProvider
     {
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DonTPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer.RuleId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DontPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer.RuleId);
 
         public sealed override FixAllProvider GetFixAllProvider()
         {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTPassAsyncLambdasAsVoidReturningDelegateTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTPassAsyncLambdasAsVoidReturningDelegateTypes.cs
@@ -33,8 +33,11 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTPassAsyncLambdasAsVoidReturningDelegateTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTPassAsyncLambdasAsVoidReturningDelegateTypes.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// <summary>
     /// Async003: Don't Pass Async Lambdas as Void Returning Delegate Types
     /// </summary>
-    public abstract class DonTPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer : DiagnosticAnalyzer
+    public abstract class DontPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "Async003";
 
@@ -33,6 +33,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTStoreAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTStoreAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// </summary>
     public abstract class DonTStoreAsyncLambdasAsVoidReturningDelegateTypesFixer : CodeFixProvider
     {
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DonTStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer.RuleId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DontStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer.RuleId);
 
         public sealed override FixAllProvider GetFixAllProvider()
         {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTStoreAsyncLambdasAsVoidReturningDelegateTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTStoreAsyncLambdasAsVoidReturningDelegateTypes.cs
@@ -33,8 +33,11 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTStoreAsyncLambdasAsVoidReturningDelegateTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DonTStoreAsyncLambdasAsVoidReturningDelegateTypes.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// <summary>
     /// Async004: Don't Store Async Lambdas as Void Returning Delegate Types
     /// </summary>
-    public abstract class DonTStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer : DiagnosticAnalyzer
+    public abstract class DontStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "Async004";
 
@@ -33,6 +33,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumStorageShouldBeInt32.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumStorageShouldBeInt32.cs
@@ -39,14 +39,22 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol flagsAttribute = WellKnownTypes.FlagsAttribute(compilationContext.Compilation);
+                if (flagsAttribute == null)
+                {
+                    return;
+                }
+
                 compilationContext.RegisterSymbolAction(symbolContext => AnalyzeSymbol(symbolContext, flagsAttribute), SymbolKind.NamedType);
             });
         }
 
-        private void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol flagsAttribute)
+        private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol flagsAttribute)
         {
             var symbol = (INamedTypeSymbol)context.Symbol;
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumWithFlagsAttribute.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumWithFlagsAttribute.cs
@@ -66,24 +66,31 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSymbolAction(symbolContext =>
-            {
-                AnalyzeSymbol((INamedTypeSymbol)symbolContext.Symbol, symbolContext.Compilation, symbolContext.ReportDiagnostic);
-            }, SymbolKind.NamedType);
-        }
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        private void AnalyzeSymbol(INamedTypeSymbol symbol, Compilation compilation, Action<Diagnostic> addDiagnostic)
-        {
-            if (symbol != null &&
-                symbol.TypeKind == TypeKind.Enum &&
-                symbol.DeclaredAccessibility == Accessibility.Public)
+            context.RegisterCompilationStartAction(compilationStartContext =>
             {
-                INamedTypeSymbol flagsAttributeType = WellKnownTypes.FlagsAttribute(compilation);
+                var flagsAttributeType = WellKnownTypes.FlagsAttribute(compilationStartContext.Compilation);
                 if (flagsAttributeType == null)
                 {
                     return;
                 }
 
+                compilationStartContext.RegisterSymbolAction(symbolContext =>
+                {
+                    AnalyzeSymbol((INamedTypeSymbol)symbolContext.Symbol, flagsAttributeType, symbolContext.ReportDiagnostic);
+                }, SymbolKind.NamedType);
+            });
+            
+        }
+
+        private static void AnalyzeSymbol(INamedTypeSymbol symbol, INamedTypeSymbol flagsAttributeType, Action<Diagnostic> addDiagnostic)
+        {
+            if (symbol != null &&
+                symbol.TypeKind == TypeKind.Enum &&
+                symbol.DeclaredAccessibility == Accessibility.Public)
+            {
                 IList<ulong> memberValues;
                 if (EnumHelpers.TryGetEnumMemberValues(symbol, out memberValues))
                 {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumsShouldHavePluralNames.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumsShouldHavePluralNames.cs
@@ -90,6 +90,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol flagsAttribute = WellKnownTypes.FlagsAttribute(compilationContext.Compilation);

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumsShouldHaveZeroValue.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumsShouldHaveZeroValue.cs
@@ -79,6 +79,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol flagsAttribute = WellKnownTypes.FlagsAttribute(compilationContext.Compilation);

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EquatableAnalyzer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EquatableAnalyzer.cs
@@ -53,10 +53,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterCompilationStartAction(InitializeCore);
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(OnCompilationStart);
         }
 
-        private void InitializeCore(CompilationStartAnalysisContext context)
+        private static void OnCompilationStart(CompilationStartAnalysisContext context)
         {
             INamedTypeSymbol objectType = context.Compilation.GetSpecialType(SpecialType.System_Object);
             INamedTypeSymbol equatableType = context.Compilation.GetTypeByMetadataName(IEquatableMetadataName);
@@ -66,7 +69,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
         }
 
-        private void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol equatableType)
+        private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol equatableType)
         {
             var namedType = context.Symbol as INamedTypeSymbol;
             if (namedType == null || !(namedType.TypeKind == TypeKind.Struct || namedType.TypeKind == TypeKind.Class))

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ExceptionsShouldBePublic.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ExceptionsShouldBePublic.cs
@@ -43,10 +43,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(AnalyzeCompilationStart);
         }
 
-        private void AnalyzeCompilationStart(CompilationStartAnalysisContext csContext)
+        private static void AnalyzeCompilationStart(CompilationStartAnalysisContext csContext)
         {
             // Get named type symbols for targetted exception types
             ImmutableHashSet<INamedTypeSymbol> exceptionTypes = s_exceptionTypeNames

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldDifferByMoreThanCase.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldDifferByMoreThanCase.cs
@@ -35,11 +35,14 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationAction(AnalyzeCompilation);
             analysisContext.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
         }
 
-        private void AnalyzeCompilation(CompilationAnalysisContext context)
+        private static void AnalyzeCompilation(CompilationAnalysisContext context)
         {
             IEnumerable<INamespaceSymbol> globalNamespaces = context.Compilation.GlobalNamespace.GetNamespaceMembers()
                 .Where(item => item.ContainingAssembly == context.Compilation.Assembly);
@@ -77,7 +80,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
         }
 
-        private void CheckNamespaceMembers(IEnumerable<INamespaceSymbol> namespaces, Compilation compilation, Action<Diagnostic> addDiagnostic)
+        private static void CheckNamespaceMembers(IEnumerable<INamespaceSymbol> namespaces, Compilation compilation, Action<Diagnostic> addDiagnostic)
         {
             HashSet<INamespaceSymbol> excludedNamespaces = new HashSet<INamespaceSymbol>();
             foreach (INamespaceSymbol @namespace in namespaces)

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectPrefix.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectPrefix.cs
@@ -42,6 +42,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(
                 (context) =>
             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainTypeNames.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainTypeNames.cs
@@ -82,6 +82,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             // Analyze named types and fields.
             analysisContext.RegisterSymbolAction(symbolContext =>
             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainUnderscores.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainUnderscores.cs
@@ -108,6 +108,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(symbolAnalysisContext =>
             {
                 var symbol = symbolAnalysisContext.Symbol;
@@ -195,13 +198,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             });
         }
 
-        private bool IsInvalidSymbol(ISymbol symbol)
+        private static bool IsInvalidSymbol(ISymbol symbol)
         {
             return (!(symbol.GetResultantVisibility() == SymbolVisibility.Public && !symbol.IsOverride)) ||
                 symbol.IsAccessorMethod() || symbol.IsImplementationOfAnyInterfaceMember();
         }
 
-        private void AnalyzeParameters(SymbolAnalysisContext symbolAnalysisContext, IEnumerable<IParameterSymbol> parameters)
+        private static void AnalyzeParameters(SymbolAnalysisContext symbolAnalysisContext, IEnumerable<IParameterSymbol> parameters)
         {
             foreach (var parameter in parameters)
             {
@@ -225,7 +228,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
         }
 
-        private void AnalyzeTypeParameters(SymbolAnalysisContext symbolAnalysisContext, IEnumerable<ITypeParameterSymbol> typeParameters)
+        private static void AnalyzeTypeParameters(SymbolAnalysisContext symbolAnalysisContext, IEnumerable<ITypeParameterSymbol> typeParameters)
         {
             foreach (var typeParameter in typeParameters)
             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotHaveIncorrectSuffix.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotHaveIncorrectSuffix.cs
@@ -116,9 +116,12 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             // Analyze type names.
             analysisContext.RegisterCompilationStartAction(
-                (CompilationStartAnalysisContext compilationStartAnalysisContext) =>
+                compilationStartAnalysisContext =>
                 {
                     var suffixToBaseTypeDictionaryBuilder = ImmutableDictionary.CreateBuilder<string, ImmutableArray<INamedTypeSymbol>>();
 
@@ -250,7 +253,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 }, SymbolKind.Event, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
         }
 
-        private bool MemberNameExistsInHierarchy(string memberName, INamedTypeSymbol containingType, SymbolKind kind)
+        private static bool MemberNameExistsInHierarchy(string memberName, INamedTypeSymbol containingType, SymbolKind kind)
         {
             for (INamedTypeSymbol baseType = containingType; baseType != null; baseType = baseType.BaseType)
             {
@@ -263,7 +266,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return false;
         }
 
-        private bool IsNotChildOfAnyButHasSuffix(INamedTypeSymbol namedTypeSymbol, IEnumerable<INamedTypeSymbol> parentTypes, string suffix)
+        private static bool IsNotChildOfAnyButHasSuffix(INamedTypeSymbol namedTypeSymbol, IEnumerable<INamedTypeSymbol> parentTypes, string suffix)
         {
             return namedTypeSymbol.Name.HasSuffix(suffix)
                 && !parentTypes.Any(parentType => namedTypeSymbol.DerivesFromOrImplementsAnyConstructionOf(parentType));

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.cs
@@ -95,6 +95,11 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Make this analyzer thread-safe.
+            //analysisContext.EnableConcurrentExecution();
+
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             var keywordNamedNamespaces = new HashSet<string>();
 
             analysisContext.RegisterSymbolAction(

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ImplementIDisposableCorrectly.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ImplementIDisposableCorrectly.cs
@@ -121,6 +121,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                 context =>
                 {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/InterfaceMethodsShouldBeCallableByChildTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/InterfaceMethodsShouldBeCallableByChildTypes.cs
@@ -44,14 +44,22 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public sealed override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol iDisposableTypeSymbol = WellKnownTypes.IDisposable(compilationContext.Compilation);
+                if (iDisposableTypeSymbol == null)
+                {
+                    return;
+                }
+
                 compilationContext.RegisterOperationBlockAction(operationBlockContext => AnalyzeOperationBlock(operationBlockContext, iDisposableTypeSymbol));
             });
         }
 
-        private bool ShouldExcludeOperationBlock(ImmutableArray<IOperation> operationBlocks)
+        private static bool ShouldExcludeOperationBlock(ImmutableArray<IOperation> operationBlocks)
         {
             if (operationBlocks != null && operationBlocks.Length == 1)
             {
@@ -74,7 +82,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return false;
         }
 
-        private void AnalyzeOperationBlock(OperationBlockAnalysisContext context, INamedTypeSymbol iDisposableTypeSymbol)
+        private static void AnalyzeOperationBlock(OperationBlockAnalysisContext context, INamedTypeSymbol iDisposableTypeSymbol)
         {
             if (context.OwningSymbol.Kind != SymbolKind.Method)
             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithAttributesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithAttributesDiagnosticAnalyzer.cs
@@ -42,10 +42,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationAction(AnalyzeCompilation);
         }
 
-        private void AnalyzeCompilation(CompilationAnalysisContext context)
+        private static void AnalyzeCompilation(CompilationAnalysisContext context)
         {
             INamedTypeSymbol assemblyVersionAttributeSymbol = WellKnownTypes.AssemblyVersionAttribute(context.Compilation);
             INamedTypeSymbol assemblyComplianceAttributeSymbol = WellKnownTypes.CLSCompliantAttribute(context.Compilation);
@@ -73,29 +76,14 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 }
             }
 
-            // Check for the case where we do not have the target attribute defined at all in our metadata references. If so, how can they reference it
-            if (assemblyVersionAttributeSymbol == null)
+            if (!assemblyVersionAttributeFound && assemblyVersionAttributeSymbol != null)
             {
-                assemblyVersionAttributeFound = false;
+                context.ReportDiagnostic(Diagnostic.Create(CA1016Rule, Location.None));
             }
 
-            if (assemblyComplianceAttributeSymbol == null)
+            if (!assemblyComplianceAttributeFound && assemblyComplianceAttributeSymbol != null)
             {
-                assemblyComplianceAttributeFound = false;
-            }
-
-            // If there's at least one diagnostic to report, let's report them
-            if (!assemblyComplianceAttributeFound || !assemblyVersionAttributeFound)
-            {
-                if (!assemblyVersionAttributeFound)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(CA1016Rule, Location.None));
-                }
-
-                if (!assemblyComplianceAttributeFound)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(CA1014Rule, Location.None));
-                }
+                context.ReportDiagnostic(Diagnostic.Create(CA1014Rule, Location.None));
             }
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithComVisible.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithComVisible.cs
@@ -48,10 +48,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationAction(AnalyzeCompilation);
         }
 
-        private void AnalyzeCompilation(CompilationAnalysisContext context)
+        private static void AnalyzeCompilation(CompilationAnalysisContext context)
         {
             if (AssemblyHasPublicTypes(context.Compilation.Assembly))
             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAttributesWithAttributeUsage.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAttributesWithAttributeUsage.cs
@@ -32,6 +32,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol attributeType = WellKnownTypes.Attribute(compilationContext.Compilation);
@@ -56,7 +59,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 return;
             }
 
-            bool hasAttributeUsageAttribute = symbol.GetAttributes().Any(attribute => attribute.AttributeClass == attributeUsageAttributeType);
+            bool hasAttributeUsageAttribute = symbol.GetAttributes().Any(attribute => attribute.AttributeClass.Equals(attributeUsageAttributeType));
             if (!hasAttributeUsageAttribute)
             {
                 addDiagnostic(symbol.CreateDiagnostic(Rule, symbol.Name));

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MovePInvokesToNativeMethodsClass.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MovePInvokesToNativeMethodsClass.cs
@@ -38,13 +38,16 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterSymbolAction(symbolContext =>
             {
                 AnalyzeSymbol((INamedTypeSymbol)symbolContext.Symbol, symbolContext.ReportDiagnostic);
             }, SymbolKind.NamedType);
         }
 
-        private void AnalyzeSymbol(INamedTypeSymbol symbol, Action<Diagnostic> addDiagnostic)
+        private static void AnalyzeSymbol(INamedTypeSymbol symbol, Action<Diagnostic> addDiagnostic)
         {
             if (symbol.GetMembers().Any(member => IsDllImport(member)) && !IsTypeNamedCorrectly(symbol.Name))
             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NestedTypesShouldNotBeVisible.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NestedTypesShouldNotBeVisible.cs
@@ -52,6 +52,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                 compilationStartContext =>
                 {
@@ -119,7 +122,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         // When you use the Visual Studio Dataset Designer to add a DataTable to a DataSet, the
         // designer generates two public nested types within the DataSet: a DataTable and a DataRow.
         // Since these are generated code, we don't want to fire on them.
-        private bool IsDataSetSpecialCase(
+        private static bool IsDataSetSpecialCase(
             INamedTypeSymbol containingType,
             INamedTypeSymbol nestedType,
             INamedTypeSymbol dataSetType,
@@ -131,8 +134,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 return false;
             }
 
-            System.Collections.Generic.List<INamedTypeSymbol> nestedTypeBases = nestedType.GetBaseTypes().ToList();
-
+            var nestedTypeBases = nestedType.GetBaseTypes().ToList();
             return nestedTypeBases.Contains(dataTableType) || nestedTypeBases.Contains(dataRowType);
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NonConstantFieldsShouldNotBeVisible.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NonConstantFieldsShouldNotBeVisible.cs
@@ -34,6 +34,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(obj =>
             {
                 var field = (IFieldSymbol)obj.Symbol;

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OperatorOverloadsHaveNamedAlternates.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OperatorOverloadsHaveNamedAlternates.cs
@@ -74,10 +74,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.RegisterSymbolAction(DoAnalysis, SymbolKind.Method);
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            analysisContext.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Method);
         }
 
-        private static void DoAnalysis(SymbolAnalysisContext symbolContext)
+        private static void AnalyzeSymbol(SymbolAnalysisContext symbolContext)
         {
             var methodSymbol = (IMethodSymbol)symbolContext.Symbol;
             var typeSymbol = methodSymbol.ContainingSymbol as ITypeSymbol;

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OperatorsShouldHaveSymmetricalOverloads.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OperatorsShouldHaveSymmetricalOverloads.cs
@@ -39,6 +39,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(symbolAnalysisContext =>
             {
                 var namedType = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
@@ -51,7 +54,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }, SymbolKind.NamedType);
         }
 
-        private void CheckOperators(
+        private static void CheckOperators(
             SymbolAnalysisContext analysisContext, INamedTypeSymbol namedType,
             string memberName1, string memberName2,
             string opName1, string opName2)
@@ -62,7 +65,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             CheckOperators(analysisContext, namedType, operators2, operators1, opName2, opName1);
         }
 
-        private void CheckOperators(SymbolAnalysisContext analysisContext,
+        private static void CheckOperators(SymbolAnalysisContext analysisContext,
             INamedTypeSymbol namedType,
             ImmutableArray<ISymbol> operators1, ImmutableArray<ISymbol> operators2,
             string opName1, string opName2)
@@ -91,7 +94,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
         }
 
-        private bool HasSymmetricOperator(ISymbol operator1, ImmutableArray<ISymbol> operators2)
+        private static bool HasSymmetricOperator(ISymbol operator1, ImmutableArray<ISymbol> operators2)
         {
             foreach (var operator2 in operators2)
             {
@@ -110,7 +113,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return false;
         }
 
-        private bool HasSameParameterTypes(ISymbol operator1, ISymbol operator2)
+        private static bool HasSameParameterTypes(ISymbol operator1, ISymbol operator2)
         {
             var parameters1 = operator1.GetParameters();
             var parameters2 = operator2.GetParameters();

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
@@ -32,19 +32,18 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(context =>
             {
-                AnalyzeSymbol((INamedTypeSymbol)context.Symbol, context.ReportDiagnostic);
+                var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+                if (namedTypeSymbol.IsValueType && namedTypeSymbol.OverridesEquals() && !namedTypeSymbol.ImplementsEqualityOperators())
+                {
+                    context.ReportDiagnostic(namedTypeSymbol.CreateDiagnostic(Rule));
+                }
             },
             SymbolKind.NamedType);
-        }
-
-        private static void AnalyzeSymbol(INamedTypeSymbol namedTypeSymbol, Action<Diagnostic> addDiagnostic)
-        {
-            if (namedTypeSymbol.IsValueType && namedTypeSymbol.OverridesEquals() && !namedTypeSymbol.ImplementsEqualityOperators())
-            {
-                addDiagnostic(namedTypeSymbol.CreateDiagnostic(Rule));
-            }
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
@@ -55,6 +55,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var iEnumerator = WellKnownTypes.IEnumerator(compilationStartContext.Compilation);

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.cs
@@ -37,6 +37,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol comparableType = WellKnownTypes.IComparable(compilationContext.Compilation);

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropagateCancellationTokensWhenPossible.cs
@@ -33,8 +33,11 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropagateCancellationTokensWhenPossible.cs
@@ -33,6 +33,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertiesShouldNotBeWriteOnly.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertiesShouldNotBeWriteOnly.cs
@@ -44,13 +44,16 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.RegisterSymbolAction(symbolContext => AnalyzeSymbol(symbolContext), SymbolKind.Property);
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            analysisContext.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property);
         }
 
         /// <summary>
         /// Implementation for CA1044: Properties should not be write only
         /// </summary>
-        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
         {
             var property = context.Symbol as IPropertySymbol;
             if (property == null)

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertiesShouldNotReturnArrays.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertiesShouldNotReturnArrays.cs
@@ -34,10 +34,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property);
         }
 
-        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
         {
             var symbol = (IPropertySymbol)context.Symbol;
             if (symbol.Type.TypeKind == TypeKind.Array && !symbol.IsOverride)

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ProvideObsoleteAttributeMessage.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ProvideObsoleteAttributeMessage.cs
@@ -35,6 +35,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol obsoleteAttributeType = compilationContext.Compilation.GetTypeByMetadataName("System.ObsoleteAttribute");

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/StaticHolderTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/StaticHolderTypes.cs
@@ -65,7 +65,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public override void Initialize(AnalysisContext context) => context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        }
 
         private static void AnalyzeSymbol(SymbolAnalysisContext context)
         {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypeNamesShouldNotMatchNamespaces.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypeNamesShouldNotMatchNamespaces.cs
@@ -51,6 +51,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         public override void Initialize(AnalysisContext analysisContext)
         {
             analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
             analysisContext.RegisterCompilationStartAction(
                 compilationStartAnalysisContext =>
                 {
@@ -102,7 +104,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 });
         }
 
-        private void AddNamespacesFromCompilation(ConcurrentBag<string> namespaceNamesInCompilation, INamespaceSymbol @namespace)
+        private static void AddNamespacesFromCompilation(ConcurrentBag<string> namespaceNamesInCompilation, INamespaceSymbol @namespace)
         {
             namespaceNamesInCompilation.Add(@namespace.ToDisplayString());
 
@@ -112,7 +114,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
         }
 
-        private void InitializeWellKnownSystemNamespaceTable()
+        private static void InitializeWellKnownSystemNamespaceTable()
         {
             if (s_wellKnownSystemNamespaceTable == null)
             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -33,21 +33,19 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol disposableType = WellKnownTypes.IDisposable(compilationContext.Compilation);
-
                 if (disposableType == null)
                 {
                     return;
                 }
 
                 DisposableFieldAnalyzer analyzer = GetAnalyzer(disposableType);
-                compilationContext.RegisterSymbolAction(context =>
-                {
-                    analyzer.AnalyzeSymbol(context);
-                },
-                SymbolKind.NamedType);
+                compilationContext.RegisterSymbolAction(analyzer.AnalyzeSymbol, SymbolKind.NamedType);
             });
         }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseEventsWhereAppropriate.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseEventsWhereAppropriate.cs
@@ -42,6 +42,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(symbolContext =>
             {
                 var method = (IMethodSymbol)symbolContext.Symbol;

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseGenericEventHandlerInstances.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseGenericEventHandlerInstances.cs
@@ -43,6 +43,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {
@@ -135,7 +138,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             protected bool IsGenericEventHandlerInstance(INamedTypeSymbol type)
             {
-                return type.OriginalDefinition == _genericEventHandler &&
+                return type.OriginalDefinition.Equals(_genericEventHandler) &&
                     type.TypeArguments.Length == 1;
             }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseIntegralOrStringArgumentForIndexers.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseIntegralOrStringArgumentForIndexers.cs
@@ -46,6 +46,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property);
         }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePreferredTerms.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePreferredTerms.cs
@@ -183,8 +183,11 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePreferredTerms.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePreferredTerms.cs
@@ -183,6 +183,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePropertiesWhereAppropriate.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePropertiesWhereAppropriate.cs
@@ -38,6 +38,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterOperationBlockStartAction(context =>
             {
                 var methodSymbol = context.OwningSymbol as IMethodSymbol;

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicDonTMixBlockingAndAsync.vb
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicDonTMixBlockingAndAsync.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.ApiDesignGuidelines.Analyzers
     ''' </summary>
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public NotInheritable Class BasicDonTMixBlockingAndAsyncAnalyzer
-        Inherits DonTMixBlockingAndAsyncAnalyzer
+        Inherits DontMixBlockingAndAsyncAnalyzer
 
     End Class
 End Namespace

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicDonTPassAsyncLambdasAsVoidReturningDelegateTypes.vb
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicDonTPassAsyncLambdasAsVoidReturningDelegateTypes.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.ApiDesignGuidelines.Analyzers
     ''' </summary>
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public NotInheritable Class BasicDonTPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
-        Inherits DonTPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
+        Inherits DontPassAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
 
     End Class
 End Namespace

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicDonTStoreAsyncLambdasAsVoidReturningDelegateTypes.vb
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicDonTStoreAsyncLambdasAsVoidReturningDelegateTypes.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.ApiDesignGuidelines.Analyzers
     ''' </summary>
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public NotInheritable Class BasicDonTStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
-        Inherits DonTStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
+        Inherits DontStoreAsyncLambdasAsVoidReturningDelegateTypesAnalyzer
 
     End Class
 End Namespace

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicOverrideEqualsOnOverloadingOperatorEquals.vb
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicOverrideEqualsOnOverloadingOperatorEquals.vb
@@ -37,6 +37,9 @@ Namespace Microsoft.ApiDesignGuidelines.Analyzers
         Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor) = ImmutableArray.Create(Rule)
 
         Public Overrides Sub Initialize(analysisContext As AnalysisContext)
+            analysisContext.EnableConcurrentExecution()
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)
+
             analysisContext.RegisterSymbolAction(
                 Sub(symbolContext)
                     Dim method = DirectCast(symbolContext.Symbol, IMethodSymbol)

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicOverrideGetHashCodeOnOverridingEquals.vb
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/VisualBasic/BasicOverrideGetHashCodeOnOverridingEquals.vb
@@ -37,6 +37,9 @@ Namespace Microsoft.ApiDesignGuidelines.Analyzers
         Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor) = ImmutableArray.Create(Rule)
 
         Public Overrides Sub Initialize(analysisContext As AnalysisContext)
+            analysisContext.EnableConcurrentExecution()
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)
+
             analysisContext.RegisterSymbolAction(
                 Sub(symbolContext)
                     Dim type = DirectCast(symbolContext.Symbol, INamedTypeSymbol)

--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpImmutableObjectMethodAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpImmutableObjectMethodAnalyzer.cs
@@ -43,6 +43,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol solutionSymbol = compilationContext.Compilation.GetTypeByMetadataName(SolutionFullName);
@@ -57,6 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers
                 {
                     return;
                 }
+
                 compilationContext.RegisterSyntaxNodeAction(sc => AnalyzeInvocationForIgnoredReturnValue(sc, immutableSymbols), SyntaxKind.InvocationExpression);
             });
         }
@@ -93,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers
                 return;
             }
 
-            System.Collections.Generic.List<INamedTypeSymbol> baseTypesAndSelf = methodSymbol.ReceiverType.GetBaseTypes().ToList();
+            var baseTypesAndSelf = methodSymbol.ReceiverType.GetBaseTypes().ToList();
             baseTypesAndSelf.Add(parentType);
 
             if (!baseTypesAndSelf.Any(n => immutableTypeSymbols.Contains(n)))

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -62,6 +62,12 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            // TODO: Make analyzer thread-safe.
+            //context.EnableConcurrentExecution();
+
+            // We need to analyze generated code, but don't intend to report diagnostics on generated code.
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
             context.RegisterCompilationStartAction(CreateAnalyzerWithinCompilation);
         }
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/InternalImplementationOnlyAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/InternalImplementationOnlyAnalyzer.cs
@@ -27,7 +27,13 @@ namespace Microsoft.CodeAnalysis.Analyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public override void Initialize(AnalysisContext context) => context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        }
 
         private static void AnalyzeSymbol(SymbolAnalysisContext context)
         {

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAttributeAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAttributeAnalyzer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 bool supportsCSharp = false;
                 bool supportsVB = false;
 
-                System.Collections.Generic.IEnumerable<AttributeData> namedTypeAttributes = namedType.GetApplicableAttributes();
+                var namedTypeAttributes = namedType.GetApplicableAttributes();
                 foreach (AttributeData attribute in namedTypeAttributes)
                 {
                     if (attribute.AttributeClass.DerivesFrom(DiagnosticAnalyzerAttribute))

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerCorrectnessAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerCorrectnessAnalyzer.cs
@@ -44,6 +44,11 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            // CONSIDER: Make all the subtypes thread safe to enable concurrent analyzer callbacks.
+            //context.EnableConcurrentExecution();
+
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol diagnosticAnalyzer = compilationContext.Compilation.GetTypeByMetadataName(DiagnosticAnalyzerTypeFullName);

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -38,6 +38,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol diagnosticDescriptorType = compilationContext.Compilation.GetTypeByMetadataName(DiagnosticAnalyzerCorrectnessAnalyzer.DiagnosticDescriptorFullName);

--- a/src/Microsoft.Composition.Analyzers/Core/DoNotMixAttributesFromDifferentVersionsOfMEF.cs
+++ b/src/Microsoft.Composition.Analyzers/Core/DoNotMixAttributesFromDifferentVersionsOfMEF.cs
@@ -38,6 +38,9 @@ namespace Microsoft.Composition.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 var exportAttributes = new List<INamedTypeSymbol>();
@@ -59,7 +62,7 @@ namespace Microsoft.Composition.Analyzers
             });
         }
 
-        private void AnalyzeSymbol(SymbolAnalysisContext symbolContext, IEnumerable<INamedTypeSymbol> exportAttributes)
+        private static void AnalyzeSymbol(SymbolAnalysisContext symbolContext, IEnumerable<INamedTypeSymbol> exportAttributes)
         {
             var namedType = (INamedTypeSymbol)symbolContext.Symbol;
             var namedTypeAttributes = namedType.GetApplicableAttributes();

--- a/src/Microsoft.Composition.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
+++ b/src/Microsoft.Composition.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Composition.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 var exportAttribute = compilationContext.Compilation.GetTypeByMetadataName("System.Composition.ExportAttribute");

--- a/src/Microsoft.Maintainability.Analyzers/Core/AvoidUninstantiatedInternalClasses.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/AvoidUninstantiatedInternalClasses.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Maintainability.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.Maintainability.Analyzers/Core/AvoidUninstantiatedInternalClasses.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/AvoidUninstantiatedInternalClasses.cs
@@ -32,8 +32,11 @@ namespace Microsoft.Maintainability.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.Maintainability.Analyzers/Core/AvoidUnusedPrivateFields.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/AvoidUnusedPrivateFields.cs
@@ -35,6 +35,12 @@ namespace Microsoft.Maintainability.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Make analyzer thread safe
+            //analysisContext.EnableConcurrentExecution();
+
+            // We need to analyze generated code, but don't intend to report diagnostics for generated code fields.
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
             analysisContext.RegisterCompilationStartAction(
                 (compilationContext) =>
                 {

--- a/src/Microsoft.Maintainability.Analyzers/Core/DoNotIgnoreMethodResults.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/DoNotIgnoreMethodResults.cs
@@ -92,6 +92,9 @@ namespace Microsoft.Maintainability.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterOperationBlockStartAction(osContext =>
             {
                 var method = osContext.OwningSymbol as IMethodSymbol;

--- a/src/Microsoft.Maintainability.Analyzers/Core/ReviewUnusedParameters.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/ReviewUnusedParameters.cs
@@ -37,6 +37,11 @@ namespace Microsoft.Maintainability.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            // TODO: Consider making this analyzer thread-safe.
+            //context.EnableConcurrentExecution();
+
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 INamedTypeSymbol eventsArgSymbol = compilationStartContext.Compilation.GetTypeByMetadataName("System.EventArgs");

--- a/src/Microsoft.Maintainability.Analyzers/Core/VariableNamesShouldNotMatchFieldNames.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/VariableNamesShouldNotMatchFieldNames.cs
@@ -42,8 +42,11 @@ namespace Microsoft.Maintainability.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.Maintainability.Analyzers/Core/VariableNamesShouldNotMatchFieldNames.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/VariableNamesShouldNotMatchFieldNames.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Maintainability.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/CSharp/CSharpRethrowToPreserveStackDetails.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/CSharp/CSharpRethrowToPreserveStackDetails.cs
@@ -12,10 +12,13 @@ namespace Microsoft.QualityGuidelines.Analyzers
     {
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSyntaxNodeAction<SyntaxKind>(AnalyzeNode, SyntaxKind.ThrowStatement);
         }
 
-        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var throwStatement = (ThrowStatementSyntax)context.Node;
             ExpressionSyntax expr = throwStatement.Expression;

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/DisposeObjectsBeforeLosingScope.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/DisposeObjectsBeforeLosingScope.cs
@@ -33,8 +33,11 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/DisposeObjectsBeforeLosingScope.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/DisposeObjectsBeforeLosingScope.cs
@@ -33,6 +33,8 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/DoNotCallOverridableMethodsInConstructors.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/DoNotCallOverridableMethodsInConstructors.cs
@@ -38,6 +38,9 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol webUiControlType = compilationContext.Compilation.GetTypeByMetadataName("System.Web.UI.Control");
@@ -55,7 +58,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
             });
         }
 
-        private void AnalyzeOperation(OperationAnalysisContext context, INamedTypeSymbol containingType)
+        private static void AnalyzeOperation(OperationAnalysisContext context, INamedTypeSymbol containingType)
         {
             var operation = context.Operation as IInvocationExpression;
             IMethodSymbol method = operation.TargetMethod;

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/DoNotRaiseExceptionsInExceptionClauses.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/DoNotRaiseExceptionsInExceptionClauses.cs
@@ -43,6 +43,9 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterOperationBlockAction(operationBlockContext =>
             {
                 foreach (var block in operationBlockContext.OperationBlocks)

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/MarkMembersAsStatic.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/MarkMembersAsStatic.cs
@@ -37,6 +37,9 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Consider making this analyzer thread-safe.
+            //analysisContext.EnableConcurrentExecution();
+
             // Don't report in generated code since that's not actionable.
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/PreferJaggedArraysOverMultidimensional.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/PreferJaggedArraysOverMultidimensional.cs
@@ -57,13 +57,13 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(AnalyzeField, SymbolKind.Field);
             analysisContext.RegisterSymbolAction(AnalyzeProperty, SymbolKind.Property);
             analysisContext.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
-            analysisContext.RegisterOperationBlockStartAction(blockContext =>
-            {
-                blockContext.RegisterOperationAction(oc => AnalyzeObjectCreation(oc, blockContext.OwningSymbol), OperationKind.ArrayCreationExpression);
-            });
+            analysisContext.RegisterOperationAction(AnalyzeObjectCreation, OperationKind.ArrayCreationExpression);
         }
 
         private static void AnalyzeField(SymbolAnalysisContext context)
@@ -109,13 +109,13 @@ namespace Microsoft.QualityGuidelines.Analyzers
             }
         }
 
-        private static void AnalyzeObjectCreation(OperationAnalysisContext context, ISymbol owningSymbol)
+        private static void AnalyzeObjectCreation(OperationAnalysisContext context)
         {
             var arrayCreationExpression = (IArrayCreationExpression)context.Operation;
 
             if (IsMultiDimensionalArray(arrayCreationExpression.Type))
             {
-                context.ReportDiagnostic(arrayCreationExpression.Syntax.CreateDiagnostic(BodyRule, owningSymbol.Name, arrayCreationExpression.Type));
+                context.ReportDiagnostic(arrayCreationExpression.Syntax.CreateDiagnostic(BodyRule, context.ContainingSymbol.Name, arrayCreationExpression.Type));
             }
         }
 

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/RemoveEmptyFinalizers.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/RemoveEmptyFinalizers.cs
@@ -31,6 +31,9 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(compilationContext.Compilation);
@@ -56,7 +59,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
             });
         }
 
-        private bool IsEmptyFinalizer(ImmutableArray<IOperation> operationBlocks, ISymbol conditionalAttributeSymbol)
+        private static bool IsEmptyFinalizer(ImmutableArray<IOperation> operationBlocks, ISymbol conditionalAttributeSymbol)
         {
             if (operationBlocks != null && operationBlocks.Length == 1)
             {

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/RethrowToPreserveStackDetails.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/RethrowToPreserveStackDetails.cs
@@ -30,7 +30,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
             }
         }
 
-        protected Diagnostic CreateDiagnostic(SyntaxNode node)
+        protected static Diagnostic CreateDiagnostic(SyntaxNode node)
         {
             return node.CreateDiagnostic(Rule);
         }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/ReviewVisibleEventHandlers.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/ReviewVisibleEventHandlers.cs
@@ -43,8 +43,11 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/ReviewVisibleEventHandlers.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/ReviewVisibleEventHandlers.cs
@@ -43,6 +43,8 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/SealMethodsThatSatisfyPrivateInterfaces.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/SealMethodsThatSatisfyPrivateInterfaces.cs
@@ -35,10 +35,13 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(CheckTypes, SymbolKind.NamedType);
         }
 
-        private void CheckTypes(SymbolAnalysisContext context)
+        private static void CheckTypes(SymbolAnalysisContext context)
         {
             var type = (ITypeSymbol)context.Symbol;
 

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/UseLiteralsWhereAppropriate.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/UseLiteralsWhereAppropriate.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
 using System.Linq;
@@ -47,6 +47,9 @@ namespace Microsoft.QualityGuidelines.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterOperationAction(saContext =>
             {
                 var fieldInitializer = saContext.Operation as IFieldInitializer;
@@ -67,7 +70,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
                 // Though null is const we dont fire the diagnostic to be FxCop Compact
                 if (initializerValue != null)
                 {
-                    if (fieldInitializerValue.Type == saContext.Compilation.GetSpecialType(SpecialType.System_String) &&
+                    if (fieldInitializerValue.Type?.SpecialType == SpecialType.System_String &&
                         ((string)initializerValue)?.Length == 0)
                     {
                         saContext.ReportDiagnostic(lastField.CreateDiagnostic(EmptyStringRule, lastField.Name));

--- a/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/BasicRethrowToPreserveStackDetails.vb
+++ b/src/Microsoft.QualityGuidelines.Analyzers/VisualBasic/BasicRethrowToPreserveStackDetails.vb
@@ -11,10 +11,13 @@ Namespace Microsoft.QualityGuidelines.Analyzers
         Inherits RethrowToPreserveStackDetailsAnalyzer
 
         Public Overrides Sub Initialize(analysisContext As AnalysisContext)
+            analysisContext.EnableConcurrentExecution()
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)
+
             analysisContext.RegisterSyntaxNodeAction(AddressOf AnalyzeNode, SyntaxKind.ThrowStatement)
         End Sub
 
-        Public Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
+        Public Shared Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
             Dim node As SyntaxNode = context.Node
             Dim throwStatement = DirectCast(node, ThrowStatementSyntax)
             Dim throwExpression = throwStatement.Expression

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.cs
@@ -120,6 +120,12 @@ namespace Roslyn.Diagnostics.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            // TODO: Make the analyzer thread-safe.
+            //context.EnableConcurrentExecution();
+
+            // Analyzer needs to get callbacks for generated code, and might report diagnostics in generated code.
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             context.RegisterCompilationStartAction(OnCompilationStart);
         }
 

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DoNotUseGenericCodeActionCreateToCreateCodeAction.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DoNotUseGenericCodeActionCreateToCreateCodeAction.cs
@@ -33,20 +33,23 @@ namespace Roslyn.Diagnostics.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterCompilationStartAction(CreateAnalyzerWithinCompilation);
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(OnCompilationStart);
         }
 
-        private void CreateAnalyzerWithinCompilation(CompilationStartAnalysisContext context)
+        private void OnCompilationStart(CompilationStartAnalysisContext context)
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 
-            INamedTypeSymbol codeActionSymbol = context.Compilation.GetTypeByMetadataName(CodeActionMetadataName);
+            var codeActionSymbol = context.Compilation.GetTypeByMetadataName(CodeActionMetadataName);
             if (codeActionSymbol == null)
             {
                 return;
             }
 
-            System.Collections.Generic.IEnumerable<ISymbol> createSymbols = codeActionSymbol.GetMembers(CreateMethodName).Where(m => m is IMethodSymbol);
+            var createSymbols = codeActionSymbol.GetMembers(CreateMethodName).Where(m => m is IMethodSymbol);
             if (createSymbols == null)
             {
                 return;

--- a/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
@@ -49,6 +49,11 @@ namespace Roslyn.Diagnostics.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Confirm if the analyzer is thread-safe and uncomment below.
+            //analysisContext.EnableConcurrentExecution();
+
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {

--- a/src/Roslyn.Diagnostics.Analyzers/Core/SymbolDeclaredEventMustBeGeneratedForSourceSymbols.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/SymbolDeclaredEventMustBeGeneratedForSourceSymbols.cs
@@ -41,6 +41,12 @@ namespace Roslyn.Diagnostics.Analyzers
 
         public sealed override void Initialize(AnalysisContext context)
         {
+            // TODO: Make the analyzer thread-safe
+            //context.EnableConcurrentExecution();
+
+            // We need to analyze generated code, but don't intend to report diagnostics on generated code.
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol symbolType = compilationContext.Compilation.GetTypeByMetadataName(s_fullNameOfSymbol);

--- a/src/System.Collections.Immutable.Analyzers/Core/DoNotCallToImmutableArrayOnAnImmutableArrayValue.cs
+++ b/src/System.Collections.Immutable.Analyzers/Core/DoNotCallToImmutableArrayOnAnImmutableArrayValue.cs
@@ -33,6 +33,9 @@ namespace System.Collections.Immutable.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var immutableArrayType = compilationStartContext.Compilation.GetTypeByMetadataName(ImmutableArrayMetadataName);

--- a/src/System.Runtime.Analyzers/Core/AttributeStringLiteralsShouldParseCorrectly.cs
+++ b/src/System.Runtime.Analyzers/Core/AttributeStringLiteralsShouldParseCorrectly.cs
@@ -76,11 +76,14 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(saContext =>
             {
                 var symbol = saContext.Symbol;
                 AnalyzeSymbol(saContext.ReportDiagnostic, symbol);
-                switch(symbol.Kind)
+                switch (symbol.Kind)
                 {
                     case SymbolKind.NamedType:
                         {
@@ -109,7 +112,7 @@ namespace System.Runtime.Analyzers
                         }
 
                     case SymbolKind.Property:
-                        { 
+                        {
                             var propertySymbol = symbol as IPropertySymbol;
                             AnalyzeSymbols(saContext.ReportDiagnostic, propertySymbol.Parameters);
                             return;
@@ -126,15 +129,15 @@ namespace System.Runtime.Analyzers
             });
         }
 
-        private void AnalyzeSymbols(Action<Diagnostic> reportDiagnostic, IEnumerable<ISymbol> symbols)
+        private static void AnalyzeSymbols(Action<Diagnostic> reportDiagnostic, IEnumerable<ISymbol> symbols)
         {
-           foreach(var symbol in symbols)
+            foreach (var symbol in symbols)
             {
                 AnalyzeSymbol(reportDiagnostic, symbol);
             }
         }
 
-        private void AnalyzeSymbol(Action<Diagnostic> reportDiagnostic, ISymbol symbol)
+        private static void AnalyzeSymbol(Action<Diagnostic> reportDiagnostic, ISymbol symbol)
         {
             var attributes = symbol.GetAttributes();
 
@@ -144,7 +147,7 @@ namespace System.Runtime.Analyzers
             }
         }
 
-        private void Analyze(Action<Diagnostic> reportDiagnostic, AttributeData attributeData)
+        private static void Analyze(Action<Diagnostic> reportDiagnostic, AttributeData attributeData)
         {
             var attributeConstructor = attributeData.AttributeConstructor;
             var constructorArguments = attributeData.ConstructorArguments;
@@ -180,7 +183,7 @@ namespace System.Runtime.Analyzers
                                 parameter.Name,
                                 valueValidator.TypeName));
                         }
-                        else if(!valueValidator.IsValidValue(value))
+                        else if (!valueValidator.IsValidValue(value))
                         {
                             reportDiagnostic(syntax.CreateDiagnostic(DefaultRule,
                                 classDisplayString,
@@ -224,7 +227,7 @@ namespace System.Runtime.Analyzers
             }
         }
 
-        private ValueValidator GetValueValidator(string name)
+        private static ValueValidator GetValueValidator(string name)
         {
             foreach (var valueValidator in s_tokensToValueValidator)
             {

--- a/src/System.Runtime.Analyzers/Core/AvoidUnsealedAttributes.cs
+++ b/src/System.Runtime.Analyzers/Core/AvoidUnsealedAttributes.cs
@@ -33,6 +33,9 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol attributeType = WellKnownTypes.Attribute(compilationContext.Compilation);

--- a/src/System.Runtime.Analyzers/Core/AvoidZeroLengthArrayAllocations.cs
+++ b/src/System.Runtime.Analyzers/Core/AvoidZeroLengthArrayAllocations.cs
@@ -40,6 +40,9 @@ namespace System.Runtime.Analyzers
 
         public sealed override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             // When compilation begins, check whether Array.Empty<T> is available.
             // Only if it is, register the syntax node action provided by the derived implementations.
             context.RegisterCompilationStartAction(ctx =>
@@ -59,11 +62,16 @@ namespace System.Runtime.Analyzers
 
         private void AnalyzeOperation(OperationAnalysisContext context)
         {
+            AnalyzeOperation(context, IsAttributeSyntax);
+        }
+
+        private static void AnalyzeOperation(OperationAnalysisContext context, Func<SyntaxNode, bool> isAttributeSytnax)
+        {
             IArrayCreationExpression arrayCreationExpression = context.Operation as IArrayCreationExpression;
 
             // We can't replace array allocations in attributes, as they're persisted to metadata
             // TODO: Once we have operation walkers, we can replace this syntactic check with an operation-based check.
-            if (arrayCreationExpression.Syntax.Ancestors().Any(IsAttributeSyntax))
+            if (arrayCreationExpression.Syntax.Ancestors().Any(isAttributeSytnax))
             {
                 return;
             }

--- a/src/System.Runtime.Analyzers/Core/CallGCSuppressFinalizeCorrectly.cs
+++ b/src/System.Runtime.Analyzers/Core/CallGCSuppressFinalizeCorrectly.cs
@@ -66,6 +66,11 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Make analyzer thread safe.
+            //analysisContext.EnableConcurrentExecution();
+
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 var gcSuppressFinalizeMethodSymbol = compilationContext.Compilation

--- a/src/System.Runtime.Analyzers/Core/DisposableTypesShouldDeclareFinalizer.cs
+++ b/src/System.Runtime.Analyzers/Core/DisposableTypesShouldDeclareFinalizer.cs
@@ -37,17 +37,20 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                 compilationStartAnalysisContext =>
                 {
                     Compilation compilation = compilationStartAnalysisContext.Compilation;
 
-                    INamedTypeSymbol[] nativeResourceTypes = new[]
-                    {
+                    ImmutableHashSet<INamedTypeSymbol> nativeResourceTypes = ImmutableHashSet.Create(
                         WellKnownTypes.IntPtr(compilation),
                         WellKnownTypes.UIntPtr(compilation),
                         WellKnownTypes.HandleRef(compilation)
-                    };
+                    );
+                    var disposableType = WellKnownTypes.IDisposable(compilation);
 
                     compilationStartAnalysisContext.RegisterOperationAction(
                         operationAnalysisContext =>
@@ -84,7 +87,7 @@ namespace System.Runtime.Analyzers
                                 return;
                             }
 
-                            if (!containingType.AllInterfaces.Contains(WellKnownTypes.IDisposable(compilation)))
+                            if (!containingType.AllInterfaces.Contains(disposableType))
                             {
                                 return;
                             }

--- a/src/System.Runtime.Analyzers/Core/DisposeMethodsShouldCallBaseClassDispose.cs
+++ b/src/System.Runtime.Analyzers/Core/DisposeMethodsShouldCallBaseClassDispose.cs
@@ -33,6 +33,8 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/DisposeMethodsShouldCallBaseClassDispose.cs
+++ b/src/System.Runtime.Analyzers/Core/DisposeMethodsShouldCallBaseClassDispose.cs
@@ -33,8 +33,11 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/DoNotLockOnObjectsWithWeakIdentity.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotLockOnObjectsWithWeakIdentity.cs
@@ -41,6 +41,9 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationStartContext =>
             {
                 Compilation compilation = compilationStartContext.Compilation;
@@ -57,7 +60,7 @@ namespace System.Runtime.Analyzers
             });
         }
 
-        private bool TypeHasWeakIdentity(ITypeSymbol type, Compilation compilation)
+        private static bool TypeHasWeakIdentity(ITypeSymbol type, Compilation compilation)
         {
             switch (type.TypeKind)
             {

--- a/src/System.Runtime.Analyzers/Core/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.cs
@@ -42,10 +42,13 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(OnCompilationStart);
         }
 
-        private void OnCompilationStart(CompilationStartAnalysisContext context)
+        private static void OnCompilationStart(CompilationStartAnalysisContext context)
         {
             var listType = context.Compilation.GetTypeByMetadataName(IListMetadataName);
             var readonlyListType = context.Compilation.GetTypeByMetadataName(IReadOnlyListMetadataName);
@@ -92,7 +95,7 @@ namespace System.Runtime.Analyzers
         /// At this point it only identifies <see cref="IReadOnlyList{T}"/> directly but could easily be extended to support
         /// any type which has an index and count property.  
         /// </summary>
-        private bool IsTypeWithInefficientLinqMethods(ITypeSymbol targetType, ITypeSymbol readonlyListType, ITypeSymbol listType)
+        private static bool IsTypeWithInefficientLinqMethods(ITypeSymbol targetType, ITypeSymbol readonlyListType, ITypeSymbol listType)
         {
             // If this type is simply IReadOnlyList<T> then no further checking is needed.  
             if (targetType.TypeKind == TypeKind.Interface && targetType.OriginalDefinition.Equals(readonlyListType))
@@ -126,7 +129,7 @@ namespace System.Runtime.Analyzers
         /// completely appropriate to use such methods even with <see cref="IReadOnlyList{T}" />.  Only the single parameter
         /// ones are suspect
         /// </remarks>
-        private bool IsSingleParameterLinqMethod(IMethodSymbol methodSymbol, ITypeSymbol enumerableType)
+        private static bool IsSingleParameterLinqMethod(IMethodSymbol methodSymbol, ITypeSymbol enumerableType)
         {
             Debug.Assert(methodSymbol.ReducedFrom == null);
             return

--- a/src/System.Runtime.Analyzers/Core/DoNotUseTimersThatPreventPowerStateChanges.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotUseTimersThatPreventPowerStateChanges.cs
@@ -33,6 +33,8 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/DoNotUseTimersThatPreventPowerStateChanges.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotUseTimersThatPreventPowerStateChanges.cs
@@ -33,8 +33,11 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/InitializeStaticFieldsInline.cs
+++ b/src/System.Runtime.Analyzers/Core/InitializeStaticFieldsInline.cs
@@ -52,6 +52,9 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCodeBlockStartAction<TLanguageKindEnum>(codeBlockStartContext =>
             {
                 var methodSym = codeBlockStartContext.OwningSymbol as IMethodSymbol;

--- a/src/System.Runtime.Analyzers/Core/InstantiateArgumentExceptionsCorrectly.cs
+++ b/src/System.Runtime.Analyzers/Core/InstantiateArgumentExceptionsCorrectly.cs
@@ -39,6 +39,9 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                 compilationContext =>
                 {
@@ -63,7 +66,7 @@ namespace System.Runtime.Analyzers
                 });
         }
 
-        private void AnalyzeObjectCreation(
+        private static void AnalyzeObjectCreation(
             OperationAnalysisContext context,
             ISymbol owningSymbol,
             ITypeSymbol argumentExceptionType)
@@ -101,7 +104,7 @@ namespace System.Runtime.Analyzers
                 }
             }
         }
-        private void CheckArgument(
+        private static void CheckArgument(
             ISymbol targetSymbol,
             ITypeSymbol exceptionType,
             IParameterSymbol parameter,

--- a/src/System.Runtime.Analyzers/Core/NormalizeStringsToUppercase.cs
+++ b/src/System.Runtime.Analyzers/Core/NormalizeStringsToUppercase.cs
@@ -41,6 +41,9 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var stringType = WellKnownTypes.String(compilationStartContext.Compilation);

--- a/src/System.Runtime.Analyzers/Core/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/System.Runtime.Analyzers/Core/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -35,6 +35,9 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 var formatInfo = new StringFormatInfo(compilationContext.Compilation);
@@ -118,7 +121,7 @@ namespace System.Runtime.Analyzers
             });
         }
 
-        private int GetFormattingArguments(string format)
+        private static int GetFormattingArguments(string format)
         {
             // code is from mscorlib
             // https://github.com/dotnet/coreclr/blob/bc146608854d1db9cdbcc0b08029a87754e12b49/src/mscorlib/src/System/Text/StringBuilder.cs#L1312
@@ -348,7 +351,7 @@ namespace System.Runtime.Analyzers
                 return null;
             }
 
-            private void AddStringFormatMap(ImmutableDictionary<IMethodSymbol, Info>.Builder builder, INamedTypeSymbol type, string methodName)
+            private static void AddStringFormatMap(ImmutableDictionary<IMethodSymbol, Info>.Builder builder, INamedTypeSymbol type, string methodName)
             {
                 if (type == null)
                 {
@@ -369,7 +372,7 @@ namespace System.Runtime.Analyzers
                 }
             }
 
-            private int GetExpectedNumberOfArguments(ImmutableArray<IParameterSymbol> parameters, int formatIndex)
+            private static int GetExpectedNumberOfArguments(ImmutableArray<IParameterSymbol> parameters, int formatIndex)
             {
                 // check params
                 IParameterSymbol nextParameter = parameters[formatIndex + 1];
@@ -381,7 +384,7 @@ namespace System.Runtime.Analyzers
                 return parameters.Length - formatIndex - 1;
             }
 
-            private int FindParameterIndexOfName(ImmutableArray<IParameterSymbol> parameters, string name)
+            private static int FindParameterIndexOfName(ImmutableArray<IParameterSymbol> parameters, string name)
             {
                 for (var i = 0; i < parameters.Length; i++)
                 {

--- a/src/System.Runtime.Analyzers/Core/SpecifyCultureInfo.cs
+++ b/src/System.Runtime.Analyzers/Core/SpecifyCultureInfo.cs
@@ -38,6 +38,9 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(csaContext =>
             {
                 var cultureInfoType = csaContext.Compilation.GetTypeByMetadataName("System.Globalization.CultureInfo");

--- a/src/System.Runtime.Analyzers/Core/SpecifyIFormatProvider.cs
+++ b/src/System.Runtime.Analyzers/Core/SpecifyIFormatProvider.cs
@@ -69,6 +69,9 @@ namespace System.Runtime.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(csaContext =>
             {
                 #region "Get All the WellKnown Types and Members"
@@ -221,7 +224,7 @@ namespace System.Runtime.Analyzers
             });
         }
 
-        private IEnumerable<int> GetIndexesOfParameterType(IMethodSymbol targetMethod, INamedTypeSymbol formatProviderType)
+        private static IEnumerable<int> GetIndexesOfParameterType(IMethodSymbol targetMethod, INamedTypeSymbol formatProviderType)
         {
             return targetMethod.Parameters
                 .Select((Parameter, Index) => new { Parameter, Index })
@@ -229,7 +232,7 @@ namespace System.Runtime.Analyzers
                 .Select(x => x.Index);
         }
 
-        private ParameterInfo GetParameterInfo(INamedTypeSymbol type, bool isArray = false, int arrayRank = 0, bool isParams = false)
+        private static ParameterInfo GetParameterInfo(INamedTypeSymbol type, bool isArray = false, int arrayRank = 0, bool isParams = false)
         {
             return ParameterInfo.GetParameterInfo(type, isArray, arrayRank, isParams);
         }

--- a/src/System.Runtime.Analyzers/Core/TestForEmptyStringsUsingStringLength.cs
+++ b/src/System.Runtime.Analyzers/Core/TestForEmptyStringsUsingStringLength.cs
@@ -38,7 +38,13 @@ namespace System.Runtime.Analyzers
 
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
 
-        public sealed override void Initialize(AnalysisContext context) => context.RegisterOperationAction(AnalyzeNode, OperationKind.InvocationExpression, OperationKind.BinaryOperatorExpression);
+        public sealed override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterOperationAction(AnalyzeNode, OperationKind.InvocationExpression, OperationKind.BinaryOperatorExpression);
+        }
 
         private static void AnalyzeNode(OperationAnalysisContext context)
         {

--- a/src/System.Runtime.InteropServices.Analyzers/Core/MarkBooleanPInvokeArgumentsWithMarshalAs.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/MarkBooleanPInvokeArgumentsWithMarshalAs.cs
@@ -42,8 +42,11 @@ namespace System.Runtime.InteropServices.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/System.Runtime.InteropServices.Analyzers/Core/MarkBooleanPInvokeArgumentsWithMarshalAs.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/MarkBooleanPInvokeArgumentsWithMarshalAs.cs
@@ -42,6 +42,8 @@ namespace System.Runtime.InteropServices.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/System.Runtime.InteropServices.Analyzers/Core/PInvokeDiagnosticAnalyzer.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/PInvokeDiagnosticAnalyzer.cs
@@ -53,6 +53,9 @@ namespace System.Runtime.InteropServices.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {

--- a/src/System.Runtime.InteropServices.Analyzers/Core/UseManagedEquivalentsOfWin32Api.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/UseManagedEquivalentsOfWin32Api.cs
@@ -32,6 +32,8 @@ namespace System.Runtime.InteropServices.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/System.Runtime.InteropServices.Analyzers/Core/UseManagedEquivalentsOfWin32Api.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/UseManagedEquivalentsOfWin32Api.cs
@@ -32,8 +32,11 @@ namespace System.Runtime.InteropServices.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/DoNotUseInsecureCryptographicAlgorithms.cs
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/DoNotUseInsecureCryptographicAlgorithms.cs
@@ -49,6 +49,12 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            // TODO: Make analyzer thread-safe.
+            //analysisContext.EnableConcurrentExecution();
+
+            // Security analyzer - analyze and report diagnostics on generated code.
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {

--- a/src/System.Threading.Tasks.Analyzers/Core/DoNotCreateTasksWithoutPassingATaskScheduler.cs
+++ b/src/System.Threading.Tasks.Analyzers/Core/DoNotCreateTasksWithoutPassingATaskScheduler.cs
@@ -35,6 +35,9 @@ namespace System.Threading.Tasks.Analyzers
 
         public sealed override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 // Check if TPL is available before actually doing the searches
@@ -70,7 +73,7 @@ namespace System.Threading.Tasks.Analyzers
             });
         }
 
-        private bool IsMethodOfInterest(IMethodSymbol methodSymbol, INamedTypeSymbol taskType, INamedTypeSymbol taskFactoryType)
+        private static bool IsMethodOfInterest(IMethodSymbol methodSymbol, INamedTypeSymbol taskType, INamedTypeSymbol taskFactoryType)
         {
             // Check if it's a method of Task or a derived type (for Task<T>)
             if ((taskType.Equals(methodSymbol.ContainingType) ||

--- a/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
+++ b/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
@@ -182,8 +182,11 @@ namespace Text.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Enable concurrent execution of analyzer actions.
+            //analysisContext.EnableConcurrentExecution();
+
+            // TODO: Configure generated code analysis.
+            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
+++ b/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
@@ -182,6 +182,8 @@ namespace Text.Analyzers
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         }
     }
 }

--- a/src/XmlDocumentationComments.Analyzers/CSharp/CSharpAvoidUsingCrefTagsWithAPrefix.cs
+++ b/src/XmlDocumentationComments.Analyzers/CSharp/CSharpAvoidUsingCrefTagsWithAPrefix.cs
@@ -15,10 +15,13 @@ namespace XmlDocumentationComments.Analyzers
     {
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterSyntaxNodeAction(AnalyzeXmlAttribute, SyntaxKind.XmlTextAttribute);
         }
 
-        private void AnalyzeXmlAttribute(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeXmlAttribute(SyntaxNodeAnalysisContext context)
         {
             var textAttribute = (XmlTextAttributeSyntax)context.Node;
 

--- a/src/XmlDocumentationComments.Analyzers/Core/AvoidUsingCrefTagsWithAPrefix.cs
+++ b/src/XmlDocumentationComments.Analyzers/Core/AvoidUsingCrefTagsWithAPrefix.cs
@@ -30,7 +30,7 @@ namespace XmlDocumentationComments.Analyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        protected void ProcessAttribute(SyntaxNodeAnalysisContext context, SyntaxTokenList textTokens)
+        protected static void ProcessAttribute(SyntaxNodeAnalysisContext context, SyntaxTokenList textTokens)
         {
             if (!textTokens.Any())
             {

--- a/src/XmlDocumentationComments.Analyzers/VisualBasic/BasicAvoidUsingCrefTagsWithAPrefix.vb
+++ b/src/XmlDocumentationComments.Analyzers/VisualBasic/BasicAvoidUsingCrefTagsWithAPrefix.vb
@@ -14,10 +14,13 @@ Namespace XmlDocumentationComments.Analyzers
         Inherits AvoidUsingCrefTagsWithAPrefixAnalyzer
 
         Public Overrides Sub Initialize(context As AnalysisContext)
+            context.EnableConcurrentExecution()
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)
+
             context.RegisterSyntaxNodeAction(AddressOf AnalyzeXmlAttribute, SyntaxKind.XmlAttribute)
         End Sub
 
-        Private Sub AnalyzeXmlAttribute(context As SyntaxNodeAnalysisContext)
+        Private Shared Sub AnalyzeXmlAttribute(context As SyntaxNodeAnalysisContext)
             Dim node = DirectCast(context.Node, XmlAttributeSyntax)
 
             If DirectCast(node.Name, XmlNameSyntax).LocalName.Text = "cref" Then


### PR DESCRIPTION
1. EnableConcurrentExecution - few analyzers which are not thread-safe have been marked as consider for making thread-safe.
2. ConfigureGeneratedCodeAnalysis - most analyzers have been configured to not run or report diagnostics on generated code - except for security analyzers and DeclarePublicAPI analyzer (Analyze and ReportDiagnostics in generated code) and compilation end analyzers (Analyze but do not report diagnostics in generated code).

I plan to build NuGet packages with this change, and run it on some RWC code (maybe just move Analyzers.sln to newer analyzers) to confirm no regressions.