### PR TITLE
Fix couple of analyzer bugs

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypeNamesShouldNotMatchNamespaces.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypeNamesShouldNotMatchNamespaces.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         public override void Initialize(AnalysisContext analysisContext)
         {
             analysisContext.EnableConcurrentExecution();
-            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
             analysisContext.RegisterCompilationStartAction(
                 compilationStartAnalysisContext =>


### PR DESCRIPTION
1. Fix DoNotDecreaseInheritedMemberVisibilityAnalyzer to match few more cases with binary FxCop 
Fixes #940

2. Fix TypeNamesShouldNotMatchNamespacesAnalyzer to not report analyze/report diagnostics on generated code.
Fixes #949
Seems like invoking `analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze)`, which should suppress all diagnostics on generated code, still allows the analyzer to report compilation end diagnostics on generated code. I'll file a separate bug on roslyn repo to fix the driver.
