### PR TITLE
Allow type parameter names with single letter, for example Foo<K, V>

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectPrefix.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectPrefix.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             foreach (ITypeParameterSymbol parameter in symbol.TypeParameters)
             {
-                if (!HasCorrectPrefix(parameter, 'T'))
+                if (parameter.Name.Length > 1 && !HasCorrectPrefix(parameter, 'T'))
                 {
                     addDiagnostic(parameter.CreateDiagnostic(TypeParameterRule, parameter.Name));
                 }
@@ -85,7 +85,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             foreach (ITypeParameterSymbol parameter in symbol.TypeParameters)
             {
-                if (!HasCorrectPrefix(parameter, 'T'))
+                if (parameter.Name.Length > 1 && !HasCorrectPrefix(parameter, 'T'))
                 {
                     addDiagnostic(parameter.CreateDiagnostic(TypeParameterRule, parameter.Name));
                 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldHaveCorrectPrefixTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldHaveCorrectPrefixTests.cs
@@ -145,11 +145,7 @@ public class Class6<TTypeParameter>
 {
 }
 ",
-                GetCA1715CSharpResultAt(4, 25, CA1715TypeParameterMessage, "V"),
                 GetCA1715CSharpResultAt(8, 32, CA1715TypeParameterMessage, "\u672C\u8A9E"),
-                GetCA1715CSharpResultAt(12, 31, CA1715TypeParameterMessage, "V"),
-                GetCA1715CSharpResultAt(14, 21, CA1715TypeParameterMessage, "V"),
-                GetCA1715CSharpResultAt(18, 24, CA1715TypeParameterMessage, "V"),
                 GetCA1715CSharpResultAt(22, 21, CA1715TypeParameterMessage, "Type"),
                 GetCA1715CSharpResultAt(26, 24, CA1715TypeParameterMessage, "Type"),
                 GetCA1715CSharpResultAt(30, 19, CA1715TypeParameterMessage, "Key"),
@@ -159,8 +155,6 @@ public class Class6<TTypeParameter>
                 GetCA1715CSharpResultAt(38, 21, CA1715TypeParameterMessage, "Type1"),
                 GetCA1715CSharpResultAt(40, 31, CA1715TypeParameterMessage, "Type2"),
                 GetCA1715CSharpResultAt(45, 24, CA1715TypeParameterMessage, "Type2"),
-                GetCA1715CSharpResultAt(50, 24, CA1715TypeParameterMessage, "K"),
-                GetCA1715CSharpResultAt(50, 27, CA1715TypeParameterMessage, "V"),
                 GetCA1715CSharpResultAt(56, 21, CA1715TypeParameterMessage, "_Type1"),
                 GetCA1715CSharpResultAt(58, 24, CA1715TypeParameterMessage, "_K"),
                 GetCA1715CSharpResultAt(58, 28, CA1715TypeParameterMessage, "_V"));
@@ -269,11 +263,7 @@ End Class
 Public Class Class6(Of TTypeParameter)
 End Class
 ",
-                GetCA1715BasicResultAt(4, 28, CA1715TypeParameterMessage, "V"),
                 GetCA1715BasicResultAt(7, 35, CA1715TypeParameterMessage, "\u672C\u8A9E"),
-                GetCA1715BasicResultAt(10, 33, CA1715TypeParameterMessage, "V"),
-                GetCA1715BasicResultAt(12, 24, CA1715TypeParameterMessage, "V"),
-                GetCA1715BasicResultAt(15, 27, CA1715TypeParameterMessage, "V"),
                 GetCA1715BasicResultAt(18, 24, CA1715TypeParameterMessage, "Type"),
                 GetCA1715BasicResultAt(21, 27, CA1715TypeParameterMessage, "Type"),
                 GetCA1715BasicResultAt(24, 22, CA1715TypeParameterMessage, "Key"),
@@ -283,8 +273,6 @@ End Class
                 GetCA1715BasicResultAt(31, 24, CA1715TypeParameterMessage, "Type1"),
                 GetCA1715BasicResultAt(32, 33, CA1715TypeParameterMessage, "Type2"),
                 GetCA1715BasicResultAt(36, 26, CA1715TypeParameterMessage, "Type2"),
-                GetCA1715BasicResultAt(40, 26, CA1715TypeParameterMessage, "K"),
-                GetCA1715BasicResultAt(40, 29, CA1715TypeParameterMessage, "V"),
                 GetCA1715BasicResultAt(45, 24, CA1715TypeParameterMessage, "_Type1"),
                 GetCA1715BasicResultAt(46, 26, CA1715TypeParameterMessage, "_K"),
                 GetCA1715BasicResultAt(46, 30, CA1715TypeParameterMessage, "_V"));

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldHaveCorrectPrefixTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldHaveCorrectPrefixTests.cs
@@ -81,7 +81,7 @@ public interface IAmAnInterface
             VerifyCSharp(@"
 using System;
 
-public class IInterface<V>
+public class IInterface<VSome>
 {
 }
 
@@ -89,13 +89,13 @@ public class IAnotherInterface<本語>
 {
 }
 
-public delegate void Callback<V>();
+public delegate void Callback<VSome>();
 
-public class Class2<V>
+public class Class2<VSome>
 {
 }
 
-public class Class2<T, V>
+public class Class2<T, VSome>
 {
 }
 
@@ -127,7 +127,7 @@ public class Class4<Type1>
         Console.WriteLine(type);
     }
 
-    public void Method<K, V>(K key, V value)
+    public void Method<KType, VType>(KType key, VType value)
     {
         Console.WriteLine(key.ToString() + value.ToString());
     }
@@ -145,7 +145,11 @@ public class Class6<TTypeParameter>
 {
 }
 ",
+                GetCA1715CSharpResultAt(4, 25, CA1715TypeParameterMessage, "VSome"),
                 GetCA1715CSharpResultAt(8, 32, CA1715TypeParameterMessage, "\u672C\u8A9E"),
+                GetCA1715CSharpResultAt(12, 31, CA1715TypeParameterMessage, "VSome"),
+                GetCA1715CSharpResultAt(14, 21, CA1715TypeParameterMessage, "VSome"),
+                GetCA1715CSharpResultAt(18, 24, CA1715TypeParameterMessage, "VSome"),
                 GetCA1715CSharpResultAt(22, 21, CA1715TypeParameterMessage, "Type"),
                 GetCA1715CSharpResultAt(26, 24, CA1715TypeParameterMessage, "Type"),
                 GetCA1715CSharpResultAt(30, 19, CA1715TypeParameterMessage, "Key"),
@@ -155,9 +159,41 @@ public class Class6<TTypeParameter>
                 GetCA1715CSharpResultAt(38, 21, CA1715TypeParameterMessage, "Type1"),
                 GetCA1715CSharpResultAt(40, 31, CA1715TypeParameterMessage, "Type2"),
                 GetCA1715CSharpResultAt(45, 24, CA1715TypeParameterMessage, "Type2"),
+                GetCA1715CSharpResultAt(50, 24, CA1715TypeParameterMessage, "KType"),
+                GetCA1715CSharpResultAt(50, 31, CA1715TypeParameterMessage, "VType"),
                 GetCA1715CSharpResultAt(56, 21, CA1715TypeParameterMessage, "_Type1"),
                 GetCA1715CSharpResultAt(58, 24, CA1715TypeParameterMessage, "_K"),
                 GetCA1715CSharpResultAt(58, 28, CA1715TypeParameterMessage, "_V"));
+        }
+
+        [Fact]
+        public void TestTypeParameterNamesCSharp_NoDiagnosticCases()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class IInterface<V>
+{
+}
+
+public delegate void Callback<V>();
+
+public class Class2<T, V>
+{
+}
+
+public class Class4<T>
+{
+    public void Method<K, V>(K key, V value)
+    {
+        Console.WriteLine(key.ToString() + value.ToString());
+    }
+}
+
+public class Class6<TTypeParameter>
+{
+}
+");
         }
 
         [Fact]
@@ -213,18 +249,18 @@ End Interface
             VerifyBasic(@"
 Import System
 
-Public Class IInterface(Of V)
+Public Class IInterface(Of VSome)
 End Class
 
 Public Class IAnotherInterface(Of 本語)
 End Class
 
-Public Delegate Sub Callback(Of V)()
+Public Delegate Sub Callback(Of VSome)()
 
-Public Class Class2(Of V)
+Public Class Class2(Of VSome)
 End Class
 
-Public Class Class2(Of T, V)
+Public Class Class2(Of T, VSome)
 End Class
 
 Public Class Class3(Of Type)
@@ -249,7 +285,7 @@ Public Class Class4(Of Type1)
         Console.WriteLine(type)
     End Sub
 
-    Public Sub Method(Of K, V)(key As K, value As V)
+    Public Sub Method(Of KType, VType)(key As KType, value As VType)
         Console.WriteLine(key.ToString() + value.ToString())
     End Sub
 End Class
@@ -263,7 +299,11 @@ End Class
 Public Class Class6(Of TTypeParameter)
 End Class
 ",
+                GetCA1715BasicResultAt(4, 28, CA1715TypeParameterMessage, "VSome"),
                 GetCA1715BasicResultAt(7, 35, CA1715TypeParameterMessage, "\u672C\u8A9E"),
+                GetCA1715BasicResultAt(10, 33, CA1715TypeParameterMessage, "VSome"),
+                GetCA1715BasicResultAt(12, 24, CA1715TypeParameterMessage, "VSome"),
+                GetCA1715BasicResultAt(15, 27, CA1715TypeParameterMessage, "VSome"),
                 GetCA1715BasicResultAt(18, 24, CA1715TypeParameterMessage, "Type"),
                 GetCA1715BasicResultAt(21, 27, CA1715TypeParameterMessage, "Type"),
                 GetCA1715BasicResultAt(24, 22, CA1715TypeParameterMessage, "Key"),
@@ -273,9 +313,36 @@ End Class
                 GetCA1715BasicResultAt(31, 24, CA1715TypeParameterMessage, "Type1"),
                 GetCA1715BasicResultAt(32, 33, CA1715TypeParameterMessage, "Type2"),
                 GetCA1715BasicResultAt(36, 26, CA1715TypeParameterMessage, "Type2"),
+                GetCA1715BasicResultAt(40, 26, CA1715TypeParameterMessage, "KType"),
+                GetCA1715BasicResultAt(40, 33, CA1715TypeParameterMessage, "VType"),
                 GetCA1715BasicResultAt(45, 24, CA1715TypeParameterMessage, "_Type1"),
                 GetCA1715BasicResultAt(46, 26, CA1715TypeParameterMessage, "_K"),
                 GetCA1715BasicResultAt(46, 30, CA1715TypeParameterMessage, "_V"));
+        }
+
+        [Fact]
+        public void TestTypeParameterNamesBasic_NoDiagnosticCases()
+        {
+            VerifyBasic(@"
+Import System
+
+Public Class IInterface(Of V)
+End Class
+
+Public Delegate Sub Callback(Of V)()
+
+Public Class Class2(Of T, V)
+End Class
+
+Public Class Class4(Of T)
+    Public Sub Method(Of K, V)(key As K, value As V)
+        Console.WriteLine(key.ToString() + value.ToString())
+    End Sub
+End Class
+
+Public Class Class6(Of TTypeParameter)
+End Class
+");
         }
 
         internal static readonly string CA1715InterfaceMessage = MicrosoftApiDesignGuidelinesAnalyzersResources.IdentifiersShouldHaveCorrectPrefixMessageInterface;


### PR DESCRIPTION
Fixes #937.