### PR TITLE
Misc analyzer NRE bug fixes

### DIFF
--- a/src/Analyzer.Utilities/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/ITypeSymbolExtensions.cs
@@ -80,7 +80,7 @@ namespace Analyzer.Utilities
 
         public static bool DerivesFrom(this ITypeSymbol symbol, ITypeSymbol candidateBaseType, bool baseTypesOnly = false)
         {
-            if (candidateBaseType == null)
+            if (candidateBaseType == null || symbol == null)
             {
                 return false;
             }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAttributeAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAttributeAnalyzer.cs
@@ -80,10 +80,17 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 bool supportsVB = false;
 
                 var namedTypeAttributes = namedType.GetApplicableAttributes();
+
                 foreach (AttributeData attribute in namedTypeAttributes)
                 {
                     if (attribute.AttributeClass.DerivesFrom(DiagnosticAnalyzerAttribute))
                     {
+                        // Bail out for the case where analyzer type derives from a sub-type in different assembly, and the sub-type has the diagnostic analyzer attribute.
+                        if (attribute.ApplicationSyntaxReference == null)
+                        {
+                            return;
+                        }
+
                         hasAttribute = true;
 
                         // The attribute constructor's signature is "(string, params string[])",


### PR DESCRIPTION
1. commit https://github.com/dotnet/roslyn-analyzers/commit/1d64947f23c8fb361df77b1228390778ea75a75b -   Add a null check in ITypeSymbolExtensions.DerivesFrom. Fixes #939 
2. commit https://github.com/dotnet/roslyn-analyzers/commit/47610b093d65bde9f0a1366de55a6e346e153c17 -   Fix NRE in DiagnosticAnalyzerAttributeAnalyzer. Fixes #847 
3. commit https://github.com/dotnet/roslyn-analyzers/commit/e1560b49ef7ef28d2cd1c79dea8c64f2aef7a1a5 - Fix NRE in IdentifiersShouldNotHaveIncorrectSuffixAnalyzer encountered during dogfooding.
Handle null well-known types in compilation. No bug.
