### PR TITLE
Resolved TODO

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AbstractTypesShouldNotHaveConstructors.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AbstractTypesShouldNotHaveConstructors.cs
@@ -44,11 +44,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             var symbol = context.Symbol as INamedTypeSymbol;
             if (symbol.IsAbstract)
             {
-                // TODO: Should we also check symbol.GetResultantVisibility() == SymbolVisibility.Public?
-
                 bool hasAnyPublicConstructors =
                     symbol.InstanceConstructors.Any(
-                        (constructor) => constructor.DeclaredAccessibility == Accessibility.Public);
+                        constructor => constructor.DeclaredAccessibility == Accessibility.Public);
 
                 if (hasAnyPublicConstructors)
                 {


### PR DESCRIPTION
Using `GetResultantVisibility` returns non-public when any of the outer types is non-public. Even in that case, this diagnostic should be reported.

For example:

```csharp
internal class C
{
    public abstract class D
    {
        public D() { }
    }
}
```

Therefore I believe `GetResultantVisibility` should not be used here and the TODO can be removed.