### PR TITLE
Added concurrent execution for CA2153

### DIFF
--- a/src/Desktop.Analyzers/CSharp/CSharpDoNotCatchCorruptedStateExceptions.cs
+++ b/src/Desktop.Analyzers/CSharp/CSharpDoNotCatchCorruptedStateExceptions.cs
@@ -23,21 +23,9 @@ namespace Desktop.Analyzers
                 : base(compilationTypes, owningSymbol, codeBlock)
             { }
 
-            public override SyntaxKind CatchClauseKind
-            {
-                get
-                {
-                    return SyntaxKind.CatchClause;
-                }
-            }
+            public override SyntaxKind CatchClauseKind => SyntaxKind.CatchClause;
 
-            public override SyntaxKind ThrowStatementKind
-            {
-                get
-                {
-                    return SyntaxKind.ThrowStatement;
-                }
-            }
+            public override SyntaxKind ThrowStatementKind => SyntaxKind.ThrowStatement;
 
             protected override ISymbol GetExceptionTypeSymbolFromCatchClause(CatchClauseSyntax catchNode, SemanticModel model)
             {


### PR DESCRIPTION
Although unittests succeed, I tend to believe this can only work correctly if all calls to `RegisterSyntaxNodeAction` inside a `RegisterCodeBlockStartAction` block are executed in-order, sequentially. I'm not sure if that's guaranteed or even the case today.