### PR TITLE
Fixed running unittests from within VS

### DIFF
--- a/src/ApiReview.Analyzers/UnitTests/ApiReview.Analyzers.UnitTests.csproj
+++ b/src/ApiReview.Analyzers/UnitTests/ApiReview.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Desktop.Analyzers/UnitTests/Desktop.Analyzers.UnitTests.csproj
+++ b/src/Desktop.Analyzers/UnitTests/Desktop.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/MetaCompilation.Test.csproj
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation.Test/MetaCompilation.Test.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)\..\..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/Microsoft.ApiDesignGuidelines.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/CodeAnalysisDiagnosticAnalyzersTest.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/CodeAnalysisDiagnosticAnalyzersTest.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)\..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Microsoft.Composition.Analyzers/UnitTests/Microsoft.Composition.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.Composition.Analyzers/UnitTests/Microsoft.Composition.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/Microsoft.Maintainability.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/Microsoft.Maintainability.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/Microsoft.QualityGuidelines.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/Microsoft.QualityGuidelines.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/Roslyn.Diagnostics.Analyzers.UnitTests.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/Roslyn.Diagnostics.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/System.Collections.Immutable.Analyzers/UnitTests/System.Collections.Immutable.Analyzers.UnitTests.csproj
+++ b/src/System.Collections.Immutable.Analyzers/UnitTests/System.Collections.Immutable.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/System.Resources.Analyzers/UnitTests/System.Resources.Analyzers.UnitTests.csproj
+++ b/src/System.Resources.Analyzers/UnitTests/System.Resources.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/System.Runtime.Analyzers/UnitTests/System.Runtime.Analyzers.UnitTests.csproj
+++ b/src/System.Runtime.Analyzers/UnitTests/System.Runtime.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/System.Runtime.InteropServices.Analyzers/UnitTests/System.Runtime.InteropServices.Analyzers.UnitTests.csproj
+++ b/src/System.Runtime.InteropServices.Analyzers/UnitTests/System.Runtime.InteropServices.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/System.Security.Cryptography.Hashing.Algorithms.Analyzers.UnitTests.csproj
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/UnitTests/System.Security.Cryptography.Hashing.Algorithms.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)\..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/System.Threading.Tasks.Analyzers/UnitTests/System.Threading.Tasks.Analyzers.UnitTests.csproj
+++ b/src/System.Threading.Tasks.Analyzers/UnitTests/System.Threading.Tasks.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Text.Analyzers/UnitTests/Text.Analyzers.UnitTests.csproj
+++ b/src/Text.Analyzers/UnitTests/Text.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Tools/AnalyzerCodeGenerator/template/src/REPLACE.ME/UnitTests/REPLACE.ME.Analyzers.UnitTests.csproj
+++ b/src/Tools/AnalyzerCodeGenerator/template/src/REPLACE.ME/UnitTests/REPLACE.ME.Analyzers.UnitTests.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Unfactored/AsyncPackage/AsyncPackage.Test/AsyncPackage.Test.csproj
+++ b/src/Unfactored/AsyncPackage/AsyncPackage.Test/AsyncPackage.Test.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)\..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Unfactored/Roslyn/Test/RoslynDiagnosticAnalyzersTest.csproj
+++ b/src/Unfactored/Roslyn/Test/RoslynDiagnosticAnalyzersTest.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)\..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/XmlDocumentationComments.Analyzers/UnitTests/XmlDocumentationComments.Analyzers.UnitTests.csproj
+++ b/src/XmlDocumentationComments.Analyzers/UnitTests/XmlDocumentationComments.Analyzers.UnitTests.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Start settings">
     <StartAction>Program</StartAction>
-    <StartProgram>$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe</StartProgram>
+    <StartProgram>$(NuGetPackageRoot)\xunit.runner.console\2.0.0\tools\xunit.console.x86.exe</StartProgram>
     <StartArguments>$(AssemblyName).dll -noshadow -wait</StartArguments>
     <StartWorkingDirectory>$(OutDir)</StartWorkingDirectory>
   </PropertyGroup>


### PR DESCRIPTION
After a fresh clone, the `.\packages` folder containing `xunit.console.x86.exe` no longer existed, which caused F5 on UnitTest projects to fail.
Since the `cibuild` still worked, I updated project files to use the same location for `xunit.console.x86.exe`.