### PR TITLE
Public API Analyzer: Add support for catching compat break due to optional parameters in public API

### DIFF
--- a/src/Analyzer.Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -171,6 +173,22 @@ namespace Analyzer.Utilities
         public static bool IsOperator(this IMethodSymbol methodSymbol)
         {
             return methodSymbol.MethodKind == MethodKind.UserDefinedOperator || methodSymbol.MethodKind == MethodKind.BuiltinOperator;
+        }
+
+        public static bool HasOptionalParameters(this IMethodSymbol methodSymbol)
+        {
+            return methodSymbol.Parameters.Any(p => p.IsOptional);
+        }
+
+        public static IEnumerable<IMethodSymbol> GetOverloads(this IMethodSymbol method)
+        {
+            foreach (var member in method?.ContainingType?.GetMembers(method.Name).OfType<IMethodSymbol>())
+            {
+                if (!member.Equals(method))
+                {
+                    yield return member;
+                }
+            }
         }
     }
 }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
@@ -29,5 +29,7 @@ namespace Roslyn.Diagnostics.Analyzers
         // public const string MissingSharedAttributeRuleId = "RS0023";                 // Now RS0023 => Microsoft.Composition.Analyzers.PartsExportedWithMEFv2MustBeMarkedAsSharedAnalyzer
         public const string PublicApiFilesInvalid = "RS0024";
         public const string DuplicatedSymbolInPublicApiFiles = "RS0025";
+        public const string AvoidMultipleOverloadsWithOptionalParameters = "RS0026";
+        public const string OverloadWithOptionalParametersShouldHaveMostParameters = "RS0027";
     }
 }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.Designer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.Designer.cs
@@ -62,6 +62,24 @@ namespace Roslyn.Diagnostics.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Symbol &apos;{0}&apos; violates the backcompat requirement: &apos;Do not add multiple overloads with optional parameters&apos;. See &apos;{1}&apos; for details..
+        /// </summary>
+        internal static string AvoidMultipleOverloadsWithOptionalParametersMessage {
+            get {
+                return ResourceManager.GetString("AvoidMultipleOverloadsWithOptionalParametersMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not add multiple public overloads with optional parameters.
+        /// </summary>
+        internal static string AvoidMultipleOverloadsWithOptionalParametersTitle {
+            get {
+                return ResourceManager.GetString("AvoidMultipleOverloadsWithOptionalParametersTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All public types and members should be declared in PublicAPI.txt. This draws attention to API changes in the code reviews and source control history, and helps prevent breaking changes..
         /// </summary>
         internal static string DeclarePublicApiDescription {
@@ -202,6 +220,24 @@ namespace Roslyn.Diagnostics.Analyzers {
         internal static string InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTitle {
             get {
                 return ResourceManager.GetString("InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Symbol &apos;{0}&apos; violates the backcompat requirement: &apos;Public API with optional parameter(s) should have the most parameters amongst its public overloads&apos;. See &apos;{1}&apos; for details..
+        /// </summary>
+        internal static string OverloadWithOptionalParametersShouldHaveMostParametersMessage {
+            get {
+                return ResourceManager.GetString("OverloadWithOptionalParametersShouldHaveMostParametersMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Public API with optional parameter(s) should have the most parameters amongst its public overloads..
+        /// </summary>
+        internal static string OverloadWithOptionalParametersShouldHaveMostParametersTitle {
+            get {
+                return ResourceManager.GetString("OverloadWithOptionalParametersShouldHaveMostParametersTitle", resourceCulture);
             }
         }
         

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.resx
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.resx
@@ -220,4 +220,16 @@
   <data name="PublicImplicitConstructorErroMessageName" xml:space="preserve">
     <value>implicit constructor for {0}</value>
   </data>
+  <data name="AvoidMultipleOverloadsWithOptionalParametersTitle" xml:space="preserve">
+    <value>Do not add multiple public overloads with optional parameters</value>
+  </data>
+  <data name="AvoidMultipleOverloadsWithOptionalParametersMessage" xml:space="preserve">
+    <value>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</value>
+  </data>
+  <data name="OverloadWithOptionalParametersShouldHaveMostParametersTitle" xml:space="preserve">
+    <value>Public API with optional parameter(s) should have the most parameters amongst its public overloads.</value>
+  </data>
+  <data name="OverloadWithOptionalParametersShouldHaveMostParametersMessage" xml:space="preserve">
+    <value>Symbol '{0}' violates the backcompat requirement: 'Public API with optional parameter(s) should have the most parameters amongst its public overloads'. See '{1}' for details.</value>
+  </data>
 </root>


### PR DESCRIPTION
See https://github.com/dotnet/roslyn/blob/master/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md for backcompat requirements.

This change flags the following 2 cases:
1) Unshipped public API with optional parameters, if it has any other public API overloads with optional parameters.
2) Public API with optional parameters (shipped or unshipped), if it does not have more pamareters than any other unshipped public API overload without optional parameters.