### PR TITLE
Couple of analyzer bug fixes

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
@@ -47,12 +47,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(EqualsRule, OpEqualityRule);
 
-        protected virtual bool IsAssignableTo(INamedTypeSymbol type, INamedTypeSymbol assignableToType)
-        {
-            // TODO: Use the language specific helper for IsAssignableTo.
-            return false;
-        }
-
         public override void Initialize(AnalysisContext analysisContext)
         {
             analysisContext.EnableConcurrentExecution();
@@ -80,8 +74,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                     }
 
                     // Enumerators are often ValueTypes to prevent heap allocation when enumerating
-                    if (iEnumerator != null && IsAssignableTo(namedType, iEnumerator) ||
-                        genericIEnumerator != null && IsAssignableTo(namedType, genericIEnumerator))
+                    if (iEnumerator != null && namedType.DerivesFromOrImplementsAnyConstructionOf(iEnumerator) ||
+                        genericIEnumerator != null && namedType.DerivesFromOrImplementsAnyConstructionOf(genericIEnumerator))
                     {
                         return;
                     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -66,7 +66,7 @@ public struct EmptyStruct
         }
 
         [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
-        [Fact(Skip = "899")]
+        [Fact]
         public void CSharpNoDiagnosticForEnumerators()
         {
             VerifyCSharp(@"
@@ -261,7 +261,7 @@ End Structure
         }
 
         [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
-        [Fact(Skip = "899")]
+        [Fact]
         public void BasicNoDiagnosticForEnumerators()
         {
             VerifyBasic(@"

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/MicrosoftQualityGuidelinesAnalyzersResources.Designer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/MicrosoftQualityGuidelinesAnalyzersResources.Designer.cs
@@ -369,7 +369,7 @@ namespace Microsoft.QualityGuidelines.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Field {0} is declared as &apos;static readonly&apos; but is initialized with a constant value &apos;{1}&apos;. Mark this field as &apos;const&apos; instead..
+        ///   Looks up a localized string similar to Field &apos;{0}&apos; is declared as &apos;static readonly&apos; but is initialized with a constant value. Mark this field as &apos;const&apos; instead..
         /// </summary>
         internal static string UseLiteralsWhereAppropriateMessageDefault {
             get {
@@ -378,7 +378,7 @@ namespace Microsoft.QualityGuidelines.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Field {0} is declared as &apos;static readonly&apos; but is initialized with an empty string (&quot;&quot;). Mark this field as &apos;const&apos; instead..
+        ///   Looks up a localized string similar to Field &apos;{0}&apos; is declared as &apos;static readonly&apos; but is initialized with an empty string (&quot;&quot;). Mark this field as &apos;const&apos; instead..
         /// </summary>
         internal static string UseLiteralsWhereAppropriateMessageEmptyString {
             get {

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/MicrosoftQualityGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/MicrosoftQualityGuidelinesAnalyzersResources.resx
@@ -124,10 +124,10 @@
     <value>A field is declared static and read-only (Shared and ReadOnly in Visual Basic), and is initialized by using a value that is computable at compile time. Because the value that is assigned to the targeted field is computable at compile time, change the declaration to a const (Const in Visual Basic) field so that the value is computed at compile time instead of at run?time.</value>
   </data>
   <data name="UseLiteralsWhereAppropriateMessageDefault" xml:space="preserve">
-    <value>Field {0} is declared as 'static readonly' but is initialized with a constant value '{1}'. Mark this field as 'const' instead.</value>
+    <value>Field '{0}' is declared as 'static readonly' but is initialized with a constant value. Mark this field as 'const' instead.</value>
   </data>
   <data name="UseLiteralsWhereAppropriateMessageEmptyString" xml:space="preserve">
-    <value>Field {0} is declared as 'static readonly' but is initialized with an empty string (""). Mark this field as 'const' instead.</value>
+    <value>Field '{0}' is declared as 'static readonly' but is initialized with an empty string (""). Mark this field as 'const' instead.</value>
   </data>
   <data name="DoNotInitializeUnnecessarilyTitle" xml:space="preserve">
     <value>Do not initialize unnecessarily</value>

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/UseLiteralsWhereAppropriate.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/UseLiteralsWhereAppropriate.cs
@@ -77,7 +77,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
                         return;
                     }
 
-                    saContext.ReportDiagnostic(lastField.CreateDiagnostic(DefaultRule, lastField.Name, initializerValue));
+                    saContext.ReportDiagnostic(lastField.CreateDiagnostic(DefaultRule, lastField.Name));
                 }
             },
             OperationKind.FieldInitializerAtDeclaration);

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/UseLiteralsWhereAppropriateTests.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/UseLiteralsWhereAppropriateTests.cs
@@ -33,11 +33,11 @@ public class Class1
     internal static readonly int f8 = 8 + f6;
 }",
         GetCSharpEmptyStringResultAt(line: 4, column: 28, symbolName: "f1"),
-        GetCSharpDefaultResultAt(line: 5, column: 28, symbolName: "f2", value: "Nothing"),
-        GetCSharpDefaultResultAt(line: 6, column: 31, symbolName: "f4", value: "Message is shown only for f4"),
-        GetCSharpDefaultResultAt(line: 7, column: 25, symbolName: "f5", value: "3"),
-        GetCSharpDefaultResultAt(line: 9, column: 25, symbolName: "f7", value: "11"),
-        GetCSharpDefaultResultAt(line: 10, column: 34, symbolName: "f8", value: "11"));
+        GetCSharpDefaultResultAt(line: 5, column: 28, symbolName: "f2"),
+        GetCSharpDefaultResultAt(line: 6, column: 31, symbolName: "f4"),
+        GetCSharpDefaultResultAt(line: 7, column: 25, symbolName: "f5"),
+        GetCSharpDefaultResultAt(line: 9, column: 25, symbolName: "f7"),
+        GetCSharpDefaultResultAt(line: 10, column: 34, symbolName: "f8"));
         }
 
         [Fact]
@@ -69,11 +69,11 @@ Public Class Class1
     Friend Shared ReadOnly f8 As Integer = 8 + f6
 End Class",
         GetBasicEmptyStringResultAt(line: 3, column: 21, symbolName: "f1"),
-        GetBasicDefaultResultAt(line: 4, column: 21, symbolName: "f2", value: "Nothing"),
-        GetBasicDefaultResultAt(line: 5, column: 35, symbolName: "f4", value: "Message is shown only for f4"),
-        GetBasicDefaultResultAt(line: 6, column: 21, symbolName: "f5", value: "3"),
-        GetBasicDefaultResultAt(line: 8, column: 21, symbolName: "f7", value: "11"),
-        GetBasicDefaultResultAt(line: 9, column: 28, symbolName: "f8", value: "11"));
+        GetBasicDefaultResultAt(line: 4, column: 21, symbolName: "f2"),
+        GetBasicDefaultResultAt(line: 5, column: 35, symbolName: "f4"),
+        GetBasicDefaultResultAt(line: 6, column: 21, symbolName: "f5"),
+        GetBasicDefaultResultAt(line: 8, column: 21, symbolName: "f7"),
+        GetBasicDefaultResultAt(line: 9, column: 28, symbolName: "f8"));
         }
 
         [Fact]
@@ -96,9 +96,9 @@ Public Class Class1
 End Class");
         }
 
-        private DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName, string value)
+        private DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)
         {
-            return GetCSharpResultAt(line, column, UseLiteralsWhereAppropriateAnalyzer.DefaultRule, symbolName, value);
+            return GetCSharpResultAt(line, column, UseLiteralsWhereAppropriateAnalyzer.DefaultRule, symbolName);
         }
 
         private DiagnosticResult GetCSharpEmptyStringResultAt(int line, int column, string symbolName)
@@ -106,9 +106,9 @@ End Class");
             return GetCSharpResultAt(line, column, UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule, symbolName);
         }
 
-        private DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName, string value)
+        private DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName)
         {
-            return GetBasicResultAt(line, column, UseLiteralsWhereAppropriateAnalyzer.DefaultRule, symbolName, value);
+            return GetBasicResultAt(line, column, UseLiteralsWhereAppropriateAnalyzer.DefaultRule, symbolName);
         }
 
         private DiagnosticResult GetBasicEmptyStringResultAt(int line, int column, string symbolName)


### PR DESCRIPTION
1. commit https://github.com/dotnet/roslyn-analyzers/commit/9180eaba61c505b3ef15488ac5626cbe5b7ef9db: Ensure that we don't report CA1815 for types assignable to IEnumerator (FxCop compat)
Fixes #899.

2. commit https://github.com/dotnet/roslyn-analyzers/commit/872592c991407491681114df1834dcf23658ccfd: Don't display the constant value in the diagnostic message for CA1802 - this can be extremely large string.
See #936 for an example.
Fixes #936


