### PR TITLE
Move Analyzers.sln to Microsoft.CodeAnalysis 1.2.2 packages, so that …

### DIFF
--- a/build/Targets/Analyzers.Settings.targets
+++ b/build/Targets/Analyzers.Settings.targets
@@ -35,7 +35,7 @@
   <!-- Import the global NuGet packages -->
   <PropertyGroup>
     <ToolsetCompilerPackageName>Microsoft.Net.Compilers</ToolsetCompilerPackageName>
-    <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.1\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
+    <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.2\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
   </PropertyGroup>
   
   <!-- Use the compiler server -->

--- a/src/Dependencies/CodeAnalysis/project.json
+++ b/src/Dependencies/CodeAnalysis/project.json
@@ -1,8 +1,8 @@
 ﻿{
   "dependencies": {
-    "Microsoft.CodeAnalysis": "1.2",
+    "Microsoft.CodeAnalysis": "1.2.2",
     "FakeSign": "0.9.2",
-    "Microsoft.Net.Compilers": "1.2.1",
+    "Microsoft.Net.Compilers": "1.2.2",
     "Microsoft.CodeAnalysis.Analyzers": "1.2.0-beta1",
     "Microsoft.CodeAnalysis.FxCopAnalyzers": "1.2.0-beta1"
   },


### PR DESCRIPTION
…we can move Roslyn.sln forward to Microsoft.Net.Compilers 1.2.2 when moving to newer analyzer packages.