### PR TITLE
Couple of fixes to DeclarePublicAPI analyzer

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
@@ -215,13 +215,9 @@ namespace Roslyn.Diagnostics.Analyzers
 
             private static string GetErrorMessageName(ISymbol symbol, bool isImplicitlyDeclaredConstructor)
             {
-                string errorMessageName = symbol.ToDisplayString(ShortSymbolNameFormat);
-                if (isImplicitlyDeclaredConstructor)
-                {
-                    errorMessageName = string.Format(RoslynDiagnosticsAnalyzersResources.PublicImplicitConstructorErroMessageName, errorMessageName);
-                }
-
-                return errorMessageName;
+                return isImplicitlyDeclaredConstructor ?
+                    string.Format(RoslynDiagnosticsAnalyzersResources.PublicImplicitConstructorErroMessageName, symbol.ContainingSymbol.ToDisplayString(ShortSymbolNameFormat)) :
+                    symbol.ToDisplayString(ShortSymbolNameFormat);
             }
 
             private string GetSiblingNamesToRemoveFromUnshippedText(ISymbol symbol)
@@ -267,7 +263,7 @@ namespace Roslyn.Diagnostics.Analyzers
                             continue;
                         }
 
-                        if (!ContainsPublicApiName(apiLineText, containingSymbolPublicApiName))
+                        if (!ContainsPublicApiName(apiLineText, containingSymbolPublicApiName + "."))
                         {
                             // Doesn't contain containingSymbol public API name - not a sibling of symbol.
                             continue;

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
@@ -223,7 +223,7 @@ namespace Roslyn.Diagnostics.Analyzers
             private static string GetErrorMessageName(ISymbol symbol, bool isImplicitlyDeclaredConstructor)
             {
                 return isImplicitlyDeclaredConstructor ?
-                    string.Format(RoslynDiagnosticsAnalyzersResources.PublicImplicitConstructorErroMessageName, symbol.ContainingSymbol.ToDisplayString(ShortSymbolNameFormat)) :
+                    string.Format(RoslynDiagnosticsAnalyzersResources.PublicImplicitConstructorErrorMessageName, symbol.ContainingSymbol.ToDisplayString(ShortSymbolNameFormat)) :
                     symbol.ToDisplayString(ShortSymbolNameFormat);
             }
 

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
@@ -170,6 +170,13 @@ namespace Roslyn.Diagnostics.Analyzers
                                 continue;
                             }
 
+                            // Don't flag overloads which have identical params (e.g. overloading a generic and non-generic method with same parameter types).
+                            if (overload.Parameters.Length == method.Parameters.Length &&
+                                overload.Parameters.Select(p => p.Type).SequenceEqual(method.Parameters.Select(p => p.Type)))
+                            {
+                                continue;
+                            }
+
                             // RS0026: Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.
                             var overloadHasOptionalParams = overload.HasOptionalParameters();
                             if (overloadHasOptionalParams)

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.Designer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.Designer.cs
@@ -289,9 +289,9 @@ namespace Roslyn.Diagnostics.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to implicit constructor for {0}.
         /// </summary>
-        internal static string PublicImplicitConstructorErroMessageName {
+        internal static string PublicImplicitConstructorErrorMessageName {
             get {
-                return ResourceManager.GetString("PublicImplicitConstructorErroMessageName", resourceCulture);
+                return ResourceManager.GetString("PublicImplicitConstructorErrorMessageName", resourceCulture);
             }
         }
         

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.resx
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.resx
@@ -217,7 +217,7 @@
   <data name="DuplicateSymbolsInPublicApiFilesMessage" xml:space="preserve">
     <value>The symbol '{0}' appears more than once in the public API files.</value>
   </data>
-  <data name="PublicImplicitConstructorErroMessageName" xml:space="preserve">
+  <data name="PublicImplicitConstructorErrorMessageName" xml:space="preserve">
     <value>implicit constructor for {0}</value>
   </data>
   <data name="AvoidMultipleOverloadsWithOptionalParametersTitle" xml:space="preserve">

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
@@ -571,6 +571,10 @@ public class C
     public void Method5(int p1 = 0) { }
     public void Method5(char p1 = 'a') { }
     public void Method5(string p1 = null) { }
+
+    // ok - multiple overloads with optional params, but all have same params (differ only by generic vs non-generic).
+    public object Method6(int p1 = 0) { return Method6<object>(p1); }
+    public T Method6<T>(int p1 = 0) { return default(T); }
 }
 ";
 
@@ -589,6 +593,8 @@ C.Method2(int p1 = 0) -> void
 C.Method4(int p1 = 0) -> void
 C.Method5(char p1 = 'a') -> void
 C.Method5(string p1 = null) -> void
+C.Method6(int p1 = 0) -> object
+C.Method6<T>(int p1 = 0) -> T
 ";
 
             VerifyCSharp(source, shippedText, unshippedText,

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
@@ -225,7 +225,6 @@ C
 C.C() -> void";
             var unshippedText = @"";
 
-            var arg = string.Format(RoslynDiagnosticsAnalyzersResources.PublicImplicitConstructorErroMessageName, "C");
             VerifyCSharp(source, shippedText, unshippedText);
         }
 
@@ -243,7 +242,6 @@ C";
             var unshippedText = @"
 C.C() -> void";
 
-            var arg = string.Format(RoslynDiagnosticsAnalyzersResources.PublicImplicitConstructorErroMessageName, "C");
             VerifyCSharp(source, shippedText, unshippedText);
         }
 
@@ -260,7 +258,7 @@ public class C
 C";
             var unshippedText = @"";
 
-            var arg = string.Format(RoslynDiagnosticsAnalyzersResources.PublicImplicitConstructorErroMessageName, "C");
+            var arg = string.Format(RoslynDiagnosticsAnalyzersResources.PublicImplicitConstructorErrorMessageName, "C");
             VerifyCSharp(source, shippedText, unshippedText,
                 // Test0.cs(2,14): warning RS0016: Symbol 'implicit constructor for C' is not part of the declared API.
                 GetCSharpResultAt(2, 14, DeclarePublicAPIAnalyzer.DeclareNewApiRule, arg));
@@ -281,7 +279,6 @@ C
 C.C() -> void";
             var unshippedText = @"";
 
-            var arg = string.Format(RoslynDiagnosticsAnalyzersResources.PublicImplicitConstructorErroMessageName, "C");
             VerifyCSharp(source, shippedText, unshippedText,
                 // PublicAPI.Shipped.txt(3,1): warning RS0017: Symbol 'C.C() -> void' is part of the declared API, but is either not public or could not be found
                 GetAdditionalFileResultAt(3, 1, DeclarePublicAPIAnalyzer.ShippedFileName, DeclarePublicAPIAnalyzer.RemoveDeletedApiRule, "C.C() -> void"));

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
@@ -979,6 +979,42 @@ C2.C2() -> void";
         }
 
         [Fact]
+        public void TestWithExistingUnshippedNestedGenericMembers_Fix()
+        {
+            var source = @"
+public class C
+{
+    private C() { }
+    public class CC
+    {
+        public int Field;
+    }
+
+    public class CC<T>
+    {
+        private CC() { }
+        public int Field;
+    }
+}
+";
+
+            var shippedText = @"";
+            var unshippedText = @"C
+C.CC
+C.CC.Field -> int
+C.CC<T>
+C.CC<T>.Field -> int";
+            var fixedUnshippedText = @"C
+C.CC
+C.CC.CC() -> void
+C.CC.Field -> int
+C.CC<T>
+C.CC<T>.Field -> int";
+
+            VerifyCSharpAdditionalFileFix(source, shippedText, unshippedText, fixedUnshippedText, onlyFixFirstFixableDiagnostic: true);
+        }
+
+        [Fact]
         public void TestWithExistingShippedNestedMembers_Fix()
         {
             var source = @"


### PR DESCRIPTION
1. When computing stale sibling symbol entries to remove in public API text (e.g. signature change of unshipped public API), handle generic type with same name as a non-generic sibling.
2. Fix error message name for code fix to add public API entry for implicit constructor to use containging symbol's name.