### PR TITLE
Fixed compiler errors in Microsoft.Maintainability.Analyzers.UnitTests

### DIFF
--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/AvoidUnusedPrivateFieldsTests.cs
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/AvoidUnusedPrivateFieldsTests.cs
@@ -59,11 +59,11 @@ Public Class Class1
         Return filename
     End Function
 
-    Public Property MyValue As Integer
+    Public ReadOnly Property MyValue As Integer
         Get
             Return Used1 + Used2
         End Get
-    End Function
+    End Property
 End Class
 ",
             GetCA1823BasicResultAt(6, 13, "Unused1"),

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/DoNotIgnoreMethodResultsTests.cs
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/DoNotIgnoreMethodResultsTests.cs
@@ -94,6 +94,7 @@ class C
     GetCSharpStringCreationResultAt(11, 9, "DoesNotAssignStringToVariable", "ToLower"));
 
             VerifyBasic(@"
+Imports System
 Imports System.Globalization
 
 Class C
@@ -105,7 +106,7 @@ Class C
     End Sub
 End Class
 ",
-    GetBasicStringCreationResultAt(8, 9, "DoesNotAssignStringToVariable", "ToLower"));
+    GetBasicStringCreationResultAt(9, 9, "DoesNotAssignStringToVariable", "ToLower"));
         }
 
         [Fact]
@@ -151,7 +152,7 @@ public class C
     private static void M(string x, out int y)
     {
         // Try parse
-        int.TryParse(x, out y));
+        int.TryParse(x, out y);
     }
 }
 ",
@@ -181,6 +182,7 @@ public class C
 {
     private static void M(string x, out int y)
     {
+        y = 1;
         NativeMethod();
     }
 
@@ -188,7 +190,7 @@ public class C
     private static extern int NativeMethod();
 }
 ",
-    GetCSharpHResultOrErrorCodeResultAt(8, 9, "M", "NativeMethod"));
+    GetCSharpHResultOrErrorCodeResultAt(9, 9, "M", "NativeMethod"));
 
             VerifyBasic(@"
 Imports System.Runtime.InteropServices

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/RemoveUnusedLocalsTests.cs
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/RemoveUnusedLocalsTests.cs
@@ -58,6 +58,8 @@ End Class");
         public void UnusedLocal_VisualBasic()
         {
             VerifyBasic(@"
+Imports System
+
 Public Class Tester
     Public Sub Testing()
         Dim c as Integer
@@ -75,9 +77,9 @@ Public Class Tester
         debt = debt + (debt * rate / 100)
     End Sub
 End Class", 
-            GetBasicResultAt(4, 13, CA1804RuleId, _CA1804RemoveUnusedLocalMessage),
             GetBasicResultAt(6, 13, CA1804RuleId, _CA1804RemoveUnusedLocalMessage),
-            GetBasicResultAt(7, 40, CA1804RuleId, _CA1804RemoveUnusedLocalMessage));
+            GetBasicResultAt(8, 13, CA1804RuleId, _CA1804RemoveUnusedLocalMessage),
+            GetBasicResultAt(9, 40, CA1804RuleId, _CA1804RemoveUnusedLocalMessage));
         }
     }
 }

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/ReviewUnusedParametersTests.cs
@@ -260,7 +260,7 @@ public abstract class Derived : Base, I
     {
     }
 
-    private class MyEventArgs : EventArgs { }
+    public class MyEventArgs : EventArgs { }
 }
 
 public class Base
@@ -306,7 +306,7 @@ Public MustInherit Class Derived
     Public Sub MyEventHandler2(o As Object, e As MyEventArgs)
     End Sub
 
-    Private Class MyEventArgs
+    Public Class MyEventArgs
         Inherits EventArgs
     End Class
 End Class
@@ -329,11 +329,11 @@ End Interface
         public void NoDiagnosticForMethodsWithSpecialAttributesTest()
         {
             VerifyCSharp(@"
+#define CONDITION_1
+
 using System;
 using System.Diagnostics;
 using System.Runtime.Serialization;
-
-#define CONDITION_1
 
 public class ConditionalMethodsClass
 {
@@ -379,11 +379,11 @@ public class SerializableMethodsClass
 ");
 
             VerifyBasic(@"
+#Const CONDITION_1 = 5
+
 Imports System
 Imports System.Diagnostics
 Imports System.Runtime.Serialization
-
-#Define CONDITION_1
 
 Public Class ConditionalMethodsClass
     <Conditional(""CONDITION_1"")> _


### PR DESCRIPTION
Overview of typical issues in unittest code fragments:
* Copy/paste errors
* Missing imports
* Scoping errors (use private type in public signature)
* Poor translations from C# to VB
* `out` variables not assigned