### PR TITLE
Fixed compiler errors in Microsoft.QualityGuidelines.Analyzers.UnitTests

### DIFF
--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/DoNotCallOverridableMethodsInConstructorsTests.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/DoNotCallOverridableMethodsInConstructorsTests.cs
@@ -32,7 +32,7 @@ class C
         Foo();
     }
 
-    protected virtual Foo() { }
+    protected virtual void Foo() { }
 }
 ",
             GetCA2214CSharpResultAt(6, 9));
@@ -49,7 +49,7 @@ class C
         Foo();
     }
 
-    [|protected virtual Foo() { }|]
+    [|protected virtual void Foo() { }|]
 }
 ");
         }
@@ -87,14 +87,14 @@ End Class
         public void CA2214AbstractMethodCSharp()
         {
             VerifyCSharp(@"
-class C
+abstract class C
 {
     C()
     {
         Foo();
     }
 
-    protected abstract Foo();
+    protected abstract void Foo();
 }
 ",
             GetCA2214CSharpResultAt(6, 9));
@@ -104,7 +104,7 @@ class C
         public void CA2214AbstractMethodBasic()
         {
             VerifyBasic(@"
-Class C
+MustInherit Class C
     Public Sub New()
         Foo()
     End Sub
@@ -118,7 +118,7 @@ End Class
         public void CA2214MultipleInstancesCSharp()
         {
             VerifyCSharp(@"
-class C
+abstract class C
 {
     C()
     {
@@ -126,8 +126,8 @@ class C
         Bar();
     }
 
-    protected abstract Foo();
-    protected virtual Bar() { }
+    protected abstract void Foo();
+    protected virtual void Bar() { }
 }
 ",
             GetCA2214CSharpResultAt(6, 9),
@@ -138,7 +138,7 @@ class C
         public void CA2214MultipleInstancesBasic()
         {
             VerifyBasic(@"
-Class C
+MustInherit Class C
     Public Sub New()
         Foo()
         Bar()
@@ -156,7 +156,7 @@ End Class
         public void CA2214NotTopLevelCSharp()
         {
             VerifyCSharp(@"
-class C
+abstract class C
 {
     C()
     {
@@ -171,7 +171,7 @@ class C
         }
     }
 
-    protected abstract Foo();
+    protected abstract void Foo();
 }
 ",
             GetCA2214CSharpResultAt(8, 13),
@@ -182,7 +182,7 @@ class C
         public void CA2214NotTopLevelBasic()
         {
             VerifyBasic(@"
-Class C
+MustInherit Class C
     Public Sub New()
         If True Then
             Foo()
@@ -203,9 +203,9 @@ End Class
         public void CA2214NoDiagnosticsOutsideConstructorCSharp()
         {
             VerifyCSharp(@"
-class C
+abstract class C
 {
-    protected abstract Foo();
+    protected abstract void Foo();
 
     void Method()
     {
@@ -219,7 +219,7 @@ class C
         public void CA2214NoDiagnosticsOutsideConstructorBasic()
         {
             VerifyBasic(@"
-Class C
+MustInherit Class C
     MustOverride Sub Foo()
 
     Sub Method()
@@ -233,7 +233,7 @@ End Class
         public void CA2214SpecialInheritanceCSharp()
         {
             var source = @"
-class C : System.Web.UI.Control
+abstract class C : System.Web.UI.Control
 {
     C()
     {
@@ -242,10 +242,10 @@ class C : System.Web.UI.Control
         OnLoad(null);
     }
 
-    protected abstract Foo();
+    protected abstract void Foo();
 }
 
-class D : System.Windows.Forms.Control
+abstract class D : System.Windows.Forms.Control
 {
     D()
     {
@@ -254,7 +254,7 @@ class D : System.Windows.Forms.Control
         OnPaint(null);
     }
 
-    protected abstract Foo();
+    protected abstract void Foo();
 }
 
 class ControlBase : System.Windows.Forms.Control
@@ -265,7 +265,7 @@ class E : ControlBase
 {
     E()
     {
-        OnLoad(null); // no diagnostics when we're not an immediate descendant of a special class
+        OnGotFocus(null); // no diagnostics when we're not an immediate descendant of a special class
     }
 }
 ";
@@ -280,24 +280,24 @@ class E : ControlBase
         public void CA2214SpecialInheritanceBasic()
         {
             var source = @"
-Class C
+MustInherit Class C
     Inherits System.Web.UI.Control
     Public Sub New()
         ' no diagnostics because we inherit from System.Web.UI.Control
         Foo()
         OnLoad(Nothing)
     End Sub
-    MustInherit Sub Foo()
+    MustOverride Sub Foo()
 End Class
 
-Class D
+MustInherit Class D
     Inherits System.Windows.Forms.Control
     Public Sub New()
         ' no diagnostics because we inherit from System.Web.UI.Control
         Foo()
         OnPaint(Nothing)
     End Sub
-    MustInherit Sub Foo()
+    MustOverride Sub Foo()
 End Class
 
 Class ControlBase
@@ -307,7 +307,7 @@ End Class
 Class E
     Inherits ControlBase
     Public Sub New()
-        OnLoad(Nothing) ' no diagnostics when we're not an immediate descendant of a special class
+        OnGotFocus(Nothing) ' no diagnostics when we're not an immediate descendant of a special class
     End Sub
 End Class
 ";

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/MarkMembersAsStaticTests.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/MarkMembersAsStaticTests.cs
@@ -57,7 +57,7 @@ public class MembersTests
     public int MyProperty
     {
         get { return 10; }
-        set { Console.WriteLine(value); }
+        set { System.Console.WriteLine(value); }
     }
 
     public event System.EventHandler<System.EventArgs> CustomEvent { add {} remove {} }
@@ -76,6 +76,8 @@ public class MembersTests
         public void BasicSimpleMembers()
         {
             VerifyBasic(@"
+Imports System
+
 Public Class MembersTests
     Shared s_field As Integer
     Public Const Zero As Integer = 0
@@ -126,14 +128,14 @@ Public Class MembersTests
     End Event
 End Class
 ",
-                GetBasicResultAt(6, 21, "Method1"),
-                GetBasicResultAt(10, 16, "Method2"),
-                GetBasicResultAt(13, 16, "Method3"),
-                GetBasicResultAt(17, 21, "Method4"),
-                GetBasicResultAt(21, 30, "Property1"),
-                GetBasicResultAt(27, 31, "Property2"),
-                GetBasicResultAt(33, 21, "MyProperty"),
-                GetBasicResultAt(42, 25, "CustomEvent"));
+                GetBasicResultAt(8, 21, "Method1"),
+                GetBasicResultAt(12, 16, "Method2"),
+                GetBasicResultAt(15, 16, "Method3"),
+                GetBasicResultAt(19, 21, "Method4"),
+                GetBasicResultAt(23, 30, "Property1"),
+                GetBasicResultAt(29, 31, "Property2"),
+                GetBasicResultAt(35, 21, "MyProperty"),
+                GetBasicResultAt(44, 25, "CustomEvent"));
         }
 
         [Fact]
@@ -144,7 +146,7 @@ public class MembersTests
 {
     public MembersTests() { }
 
-    public ~MembersTests() { }
+    ~MembersTests() { }
 
     public int x; 
 

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/PreferJaggedArraysOverMultidimensionalTests.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/PreferJaggedArraysOverMultidimensionalTests.cs
@@ -146,6 +146,7 @@ Public Class Class1
 
     Public Sub MethodWithJaggedArrayParameter(jaggedParameter As Integer()())
     End Sub
+End Class
 ");
         }
 

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/SealMethodsThatSatisfyPrivateInterfacesTests.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/SealMethodsThatSatisfyPrivateInterfacesTests.cs
@@ -295,7 +295,7 @@ Friend Interface IFace
     Sub M()
 End Interface
 
-Public MustOverride Class C
+Public MustInherit Class C
     Implements IFace
 
     Public MustOverride Sub M()

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/UseLiteralsWhereAppropriateTests.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/UseLiteralsWhereAppropriateTests.cs
@@ -82,7 +82,7 @@ End Class",
             VerifyBasic(@"
 Public Class Class1
     ' Not Private or Friend
-    Public Shared ReadOnly f1 As String = ""
+    Public Shared ReadOnly f1 As String = """"
     ' Not Readonly
     Shared f3 As String, f4 As String = ""Message is shown only for f4""
     ' Not Shared


### PR DESCRIPTION
Overview of typical issues in unittest code fragments:
* Missing namespace imports
* Missing `abstract`/`MustInherit` on class definition that contains abstract members
* Missing return type in method signatures
* Incorrectly escaped string values
* Missing VB end markers, such as `End Class`
