### PR TITLE
Fixed compiler errors in System.Runtime.Analyzers.UnitTests

### DIFF
--- a/src/System.Runtime.Analyzers/UnitTests/AvoidUnsealedAttributesTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/AvoidUnsealedAttributesTests.cs
@@ -51,8 +51,11 @@ using System;
 {
 }|]
 
-private class AttributeClass2: Attribute
+public class Outer
 {
+    private class AttributeClass2: Attribute
+    {
+    }
 }
 ",
             GetCA1813CSharpResultAt(4, 14));
@@ -83,12 +86,14 @@ Public Class AttributeClass
     Inherits Attribute
 End Class
 
-Private Class AttributeClass2
-    Inherits Attribute
+Public Class Outer
+    Private Class AttributeClass2
+        Inherits Attribute
+    End Class
 End Class
 ",
             GetCA1813BasicResultAt(4, 14),
-            GetCA1813BasicResultAt(8, 15));
+            GetCA1813BasicResultAt(9, 19));
         }
 
         [Fact]
@@ -101,11 +106,13 @@ Public Class AttributeClass
     Inherits Attribute
 End Class
 
-[|Private Class AttributeClass2
-    Inherits Attribute
-End Class|]
+Public Class Outer
+    [|Private Class AttributeClass2
+        Inherits Attribute
+    End Class|]
+End Class
 ",
-            GetCA1813BasicResultAt(8, 15));
+            GetCA1813BasicResultAt(9, 19));
         }
 
         [Fact]

--- a/src/System.Runtime.Analyzers/UnitTests/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/AvoidZeroLengthArrayAllocationsTests.cs
@@ -36,6 +36,9 @@ namespace System.Runtime.Analyzers.UnitTests
             const string badSource = @"
 using System.Collections.Generic;
 
+// This is a compile error but we want to ensure analyzer doesn't complain for it.
+[System.Runtime.CompilerServices.Dynamic(new bool[0])] // no
+
 class C
 {
     unsafe void M1()
@@ -59,6 +62,9 @@ class C
 
             const string fixedSource = @"
 using System.Collections.Generic;
+
+// This is a compile error but we want to ensure analyzer doesn't complain for it.
+[System.Runtime.CompilerServices.Dynamic(new bool[0])] // no
 
 class C
 {
@@ -84,12 +90,12 @@ class C
 
             VerifyCSharp(badSource + arrayEmptySource, new[]
             {
-                GetCSharpResultAt(8, 22, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(9, 23, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(10, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(14, 24, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(15, 28, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(17, 26, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor)
+                GetCSharpResultAt(11, 22, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(12, 23, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(13, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(17, 24, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(18, 28, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(20, 26, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor)
             });
             VerifyCSharpFix(
                 arrayEmptySource + badSource,

--- a/src/System.Runtime.Analyzers/UnitTests/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/AvoidZeroLengthArrayAllocationsTests.cs
@@ -34,7 +34,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 @"namespace System { public class Array { public static T[] Empty<T>() { return null; } } }";
 
             const string badSource = @"
-[System.Runtime.CompilerServices.Dynamic(new bool[0])] // no
+using System.Collections.Generic;
+
 class C
 {
     unsafe void M1()
@@ -52,12 +53,13 @@ class C
         int[][,] arr11 = new int[1][,];                // no
         int[,][] arr12 = new int[0,0][];               // no
         int*[] arr13 = new int*[0];                    // no
-        List<int> list1 = new List<int>() { }          // no
+        List<int> list1 = new List<int>() { };         // no
     }
 }";
 
             const string fixedSource = @"
-[System.Runtime.CompilerServices.Dynamic(new bool[0])] // no
+using System.Collections.Generic;
+
 class C
 {
     unsafe void M1()
@@ -75,19 +77,19 @@ class C
         int[][,] arr11 = new int[1][,];                // no
         int[,][] arr12 = new int[0,0][];               // no
         int*[] arr13 = new int*[0];                    // no
-        List<int> list1 = new List<int>() { }          // no
+        List<int> list1 = new List<int>() { };         // no
     }
 }";
             string arrayEmptySource = IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
 
             VerifyCSharp(badSource + arrayEmptySource, new[]
             {
-                GetCSharpResultAt(7, 22, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(8, 23, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(9, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(13, 24, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(14, 28, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(16, 26, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor)
+                GetCSharpResultAt(8, 22, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(9, 23, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(10, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(14, 24, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(15, 28, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(17, 26, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor)
             });
             VerifyCSharpFix(
                 arrayEmptySource + badSource,
@@ -112,6 +114,8 @@ Namespace System
 End Namespace
 ";
             const string badSource = @"
+Imports System.Collections.Generic
+
 <System.Runtime.CompilerServices.Dynamic(new Boolean(-1) {})> _
 Class C
     Sub M1()
@@ -133,6 +137,8 @@ Class C
 End Class";
 
             const string fixedSource = @"
+Imports System.Collections.Generic
+
 <System.Runtime.CompilerServices.Dynamic(new Boolean(-1) {})> _
 Class C
     Sub M1()
@@ -157,12 +163,12 @@ End Class";
 
             VerifyBasic(badSource + arrayEmptySource, new[]
             {
-                GetBasicResultAt(5, 33, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetBasicResultAt(6, 30, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetBasicResultAt(7, 27, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetBasicResultAt(11, 35, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetBasicResultAt(12, 39, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetBasicResultAt(14, 37, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor)
+                GetBasicResultAt(7, 33, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetBasicResultAt(8, 30, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetBasicResultAt(9, 27, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetBasicResultAt(13, 35, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetBasicResultAt(14, 39, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetBasicResultAt(16, 37, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor)
             });
             VerifyBasicFix(
                 arrayEmptySource + badSource,

--- a/src/System.Runtime.Analyzers/UnitTests/CallGCSuppressFinalizeCorrectlyTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/CallGCSuppressFinalizeCorrectlyTests.cs
@@ -887,6 +887,9 @@ Public Class DisposableComponent
 		Dispose(True)
 		' GC.SuppressFinalize(this);
 	End Sub
+
+    Protected Overridable Sub Dispose(disposing As Boolean)
+    End Sub
 End Class";
 
             var diagnosticResult = GetCA1816BasicResultAt(

--- a/src/System.Runtime.Analyzers/UnitTests/DisposableTypesShouldDeclareFinalizerTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/DisposableTypesShouldDeclareFinalizerTests.cs
@@ -153,7 +153,7 @@ public struct A : IDisposable // Although disposable structs are evil
 {
     private readonly IntPtr _pi;
 
-    public A()
+    public A(int i)
     {
         _pi = NativeMethods.AllocateResource();
     }
@@ -184,7 +184,7 @@ Public Structure A
 
     Private ReadOnly _pi As IntPtr
 
-    Public Sub New()
+    Public Sub New(i As Integer)
         _pi = NativeMethods.AllocateResource()
     End Sub
 
@@ -256,7 +256,7 @@ using System;
 
 internal static class ManagedMethods
 {
-    internal static IntPtr AllocateIntPtr()
+    internal static IntPtr AllocateResource()
     {
         return IntPtr.Zero;
     }
@@ -285,16 +285,16 @@ public class A : IDisposable
             var code = @"
 Imports System
 
-Friend Shared Class ManagedMethods
-    Friend Shared Function AllocateIntPtr() As IntPtr
-        Return IntPtr.Zero;
+Friend NotInheritable Class ManagedMethods
+    Friend Shared Function AllocateResource() As IntPtr
+        Return IntPtr.Zero
     End Function
 End Class
 
 Public Class A
     Implements IDisposable
 
-    Private ReadOnly I_pi As IntPtr
+    Private ReadOnly _pi As IntPtr
 
     Public Sub New()
         _pi = ManagedMethods.AllocateResource()

--- a/src/System.Runtime.Analyzers/UnitTests/DoNotLockOnObjectsWithWeakIdentityTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/DoNotLockOnObjectsWithWeakIdentityTests.cs
@@ -34,11 +34,11 @@ namespace System.Runtime.Analyzers.UnitTests
 ");
             VerifyBasic(@"
             Imports System
-            Public Class foo {
-                Public Sub Test() {
-                    Dim o As new Object();
+            Public Class foo
+                Public Sub Test()
+                    Dim o As new Object()
                     SyncLock o
-                        Console.WriteLine();
+                        Console.WriteLine()
                     End SyncLock
                 End Sub
             End Class
@@ -167,7 +167,7 @@ namespace System.Runtime.Analyzers.UnitTests
             {
                 public void Test()
                 {
-                    string s1 = "";
+                    string s1 = """";
                     lock (s1) { }
                     lock (""Hello"") { }
 
@@ -207,7 +207,7 @@ namespace System.Runtime.Analyzers.UnitTests
             Imports System
             Public Class foo
                 Public Sub Test()
-                    Dim s1 As String = """";
+                    Dim s1 As String = """"
                     SyncLock s1
                     End SyncLock
                     SyncLock (""Hello"")
@@ -226,7 +226,7 @@ namespace System.Runtime.Analyzers.UnitTests
                     SyncLock System.Threading.Thread.CurrentThread
                     End SyncLock
 
-                    SyncLock GetType foo
+                    SyncLock GetType (foo)
                     End SyncLock
 
                     Dim mi As System.Reflection.MemberInfo = Nothing

--- a/src/System.Runtime.Analyzers/UnitTests/InitializeStaticFieldsInlineTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/InitializeStaticFieldsInlineTests.cs
@@ -64,6 +64,8 @@ public class Class1
         Class1_Method();
         var field2 = 1;
     }
+
+    private static void Class1_Method() { throw new System.NotImplementedException(); }
 }
 ");
             VerifyBasic(@"
@@ -73,6 +75,10 @@ Public Class Class1
 		Class1_Method()
 		Dim field2 = 1
 	End Sub
+
+    Private Shared Sub Class1_Method()
+        Throw New System.NotImplementedException()
+    End Sub
 End Class
 ");
         }
@@ -83,7 +89,7 @@ End Class
             VerifyCSharp(@"
 public class Class1
 {
-    private static int Property { get { return 0; } }
+    private static int Property { get; set; }
 
     static Class1() // Static property initalization
     {
@@ -94,10 +100,12 @@ public class Class1
 
             VerifyBasic(@"
 Public Class Class1
-	Private Shared ReadOnly Property [Property]() As Integer
+	Private Shared Property [Property]() As Integer
 		Get
 			Return 0
 		End Get
+		Set
+		End Set
 	End Property
 
 	Shared Sub New()
@@ -114,7 +122,7 @@ End Class
             VerifyCSharp(@"
 public class Class1
 {
-    private readonly static int field = 1;
+    private static int field = 1;
     public Class1() // Non static constructor
     {
         field = 0;
@@ -128,7 +136,7 @@ public class Class1
 ");
             VerifyBasic(@"
 Public Class Class1
-	Private Shared ReadOnly field As Integer = 1
+	Private Shared field As Integer = 1
 	Public Sub New() ' Non static constructor
 		field = 0
 	End Sub

--- a/src/System.Runtime.Analyzers/UnitTests/InstantiateArgumentExceptionsCorrectlyTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/InstantiateArgumentExceptionsCorrectlyTests.cs
@@ -36,8 +36,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_noArguments, "ArgumentException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentException()
                     End Sub
                 End Class",
@@ -58,8 +58,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "", "paramName", "ArgumentNullException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentNullException("""")
                     End Sub
                 End Class",
@@ -80,8 +80,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", " ", "paramName", "ArgumentNullException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentNullException("" "")
                     End Sub
                 End Class",
@@ -103,8 +103,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(7, 31, s_incorrectParameterName, "Test", "foo", "paramName", "ArgumentNullException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Dim foo As New Object()
                         Throw New System.ArgumentNullException(NameOf(foo))
                     End Sub
@@ -126,8 +126,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectMessage, "Test", "first", "message", "ArgumentException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentException(""first"")
                     End Sub
                 End Class",
@@ -149,8 +149,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "first is incorrect", "paramName", "ArgumentException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentException(""first"", ""first is incorrect"")
                     End Sub
                 End Class",
@@ -172,8 +172,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_noArguments, "ArgumentNullException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentNullException()
                     End Sub
                 End Class",
@@ -209,8 +209,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectMessage, "Test", "first", "message", "ArgumentNullException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentNullException(""first is null"", ""first"")
                     End Sub
                 End Class",
@@ -232,8 +232,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_noArguments, "ArgumentOutOfRangeException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentOutOfRangeException()
                     End Sub
                 End Class",
@@ -254,8 +254,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "first is out of range", "paramName", "ArgumentOutOfRangeException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentOutOfRangeException(""first is out of range"")
                     End Sub
                 End Class",
@@ -277,8 +277,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectMessage, "Test", "first", "message", "ArgumentOutOfRangeException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentOutOfRangeException(""first is out of range"", ""first"")
                     End Sub
                 End Class",
@@ -300,8 +300,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_noArguments, "DuplicateWaitObjectException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.DuplicateWaitObjectException()
                     End Sub
                 End Class",
@@ -322,8 +322,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "first is duplicate", "parameterName", "DuplicateWaitObjectException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.DuplicateWaitObjectException(""first is duplicate"")
                     End Sub
                 End Class",
@@ -345,8 +345,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectMessage, "Test", "first", "message", "DuplicateWaitObjectException"));
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.DuplicateWaitObjectException(""first is duplicate"", ""first"")
                     End Sub
                 End Class",
@@ -368,8 +368,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 }");
 
             VerifyBasic(@"
-               Public Class MyClass
-                   Public Sub Test(Dim first As String)
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
                        Throw New System.ArgumentException(""first is incorrect"")
                    End Sub
                End Class");
@@ -388,8 +388,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 }");
 
             VerifyBasic(@"
-               Public Class MyClass
-                   Public Sub Test(Dim first As String)
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
                        Throw New System.ArgumentException(""first is incorrect"", ""first"")
                    End Sub
                End Class");
@@ -408,8 +408,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 }");
 
             VerifyBasic(@"
-               Public Class MyClass
-                   Public Sub Test(Dim first As String)
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
                        Throw New System.ArgumentNullException(""first"")
                    End Sub
                End Class");
@@ -430,8 +430,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 }");
 
             VerifyBasic(@"
-                Public Class MyClass
-                    Public Sub Test(Dim first As String)
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
                         Throw New System.ArgumentNullException(NameOf(first))
                     End Sub
                 End Class");
@@ -450,8 +450,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 }");
 
             VerifyBasic(@"
-               Public Class MyClass
-                   Public Sub Test(Dim first As String)
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
                        Throw New System.ArgumentNullException(""first"", ""first is null"")
                    End Sub
                End Class");
@@ -470,8 +470,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 }");
 
             VerifyBasic(@"
-               Public Class MyClass
-                   Public Sub Test(Dim first As String)
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
                        Throw New System.ArgumentOutOfRangeException(""first"")
                    End Sub
                End Class");
@@ -490,8 +490,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 }");
 
             VerifyBasic(@"
-               Public Class MyClass
-                   Public Sub Test(Dim first As String)
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
                        Throw New System.DuplicateWaitObjectException(""first"", ""first is out of range"")
                    End Sub
                End Class");
@@ -510,8 +510,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 }");
 
             VerifyBasic(@"
-               Public Class MyClass
-                   Public Sub Test(Dim first As String)
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
                        Throw New System.DuplicateWaitObjectException(""first"")
                    End Sub
                End Class");
@@ -530,8 +530,8 @@ namespace System.Runtime.Analyzers.UnitTests
                 }");
 
             VerifyBasic(@"
-               Public Class MyClass
-                   Public Sub Test(Dim first As String)
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
                        Throw New System.DuplicateWaitObjectException(""first"", ""first is duplicate"")
                    End Sub
                End Class");

--- a/src/System.Runtime.Analyzers/UnitTests/NormalizeStringsToUppercaseTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/NormalizeStringsToUppercaseTests.cs
@@ -112,7 +112,7 @@ Imports System
 Imports System.Globalization
 
 Public Class NormalizeStringsTesterClass
-    Public Sub TestMethodTwoB()
+    Public Sub TestMethodTwoA()
         Console.WriteLine(""FOO"".ToLower())
     End Sub
 

--- a/src/System.Runtime.Analyzers/UnitTests/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -30,16 +30,16 @@ public class C
 {
     void Method()
     {
-        var s = String.Format("""", 1);
-        var s = String.Format(""{0}"", 1, 2);
-        var s = String.Format(""{0} {1}"", 1, 2, 3);
-        var s = String.Format(""{0} {1} {2}"", 1, 2, 3, 4);
+        var a = String.Format("""", 1);
+        var b = String.Format(""{0}"", 1, 2);
+        var c = String.Format(""{0} {1}"", 1, 2, 3);
+        var d = String.Format(""{0} {1} {2}"", 1, 2, 3, 4);
 
         IFormatProvider p = null;
-        var s = String.Format(p, """", 1);
-        var s = String.Format(p, ""{0}"", 1, 2);
-        var s = String.Format(p, ""{0} {1}"", 1, 2, 3);
-        var s = String.Format(p, ""{0} {1} {2}"", 1, 2, 3, 4);
+        var e = String.Format(p, """", 1);
+        var f = String.Format(p, ""{0}"", 1, 2);
+        var g = String.Format(p, ""{0} {1}"", 1, 2, 3);
+        var h = String.Format(p, ""{0} {1} {2}"", 1, 2, 3, 4);
     }
 }
 ",
@@ -64,19 +64,19 @@ public class C
 {
     void Method()
     {
-        var s = Console.Write("""", 1);
-        var s = Console.Write(""{0}"", 1, 2);
-        var s = Console.Write(""{0} {1}"", 1, 2, 3);
-        var s = Console.Write(""{0} {1} {2}"", 1, 2, 3, 4);
-        var s = Console.Write(""{0} {1} {2} {3}"", 1, 2, 3, 4, 5);
+        Console.Write("""", 1);
+        Console.Write(""{0}"", 1, 2);
+        Console.Write(""{0} {1}"", 1, 2, 3);
+        Console.Write(""{0} {1} {2}"", 1, 2, 3, 4);
+        Console.Write(""{0} {1} {2} {3}"", 1, 2, 3, 4, 5);
     }
 }
 ",
-            GetCA2241CSharpResultAt(8, 17),
-            GetCA2241CSharpResultAt(9, 17),
-            GetCA2241CSharpResultAt(10, 17),
-            GetCA2241CSharpResultAt(11, 17),
-            GetCA2241CSharpResultAt(12, 17));
+            GetCA2241CSharpResultAt(8, 9),
+            GetCA2241CSharpResultAt(9, 9),
+            GetCA2241CSharpResultAt(10, 9),
+            GetCA2241CSharpResultAt(11, 9),
+            GetCA2241CSharpResultAt(12, 9));
         }
 
         [Fact]
@@ -89,19 +89,19 @@ public class C
 {
     void Method()
     {
-        var s = Console.WriteLine("""", 1);
-        var s = Console.WriteLine(""{0}"", 1, 2);
-        var s = Console.WriteLine(""{0} {1}"", 1, 2, 3);
-        var s = Console.WriteLine(""{0} {1} {2}"", 1, 2, 3, 4);
-        var s = Console.WriteLine(""{0} {1} {2} {3}"", 1, 2, 3, 4, 5);
+        Console.WriteLine("""", 1);
+        Console.WriteLine(""{0}"", 1, 2);
+        Console.WriteLine(""{0} {1}"", 1, 2, 3);
+        Console.WriteLine(""{0} {1} {2}"", 1, 2, 3, 4);
+        Console.WriteLine(""{0} {1} {2} {3}"", 1, 2, 3, 4, 5);
     }
 }
 ",
-            GetCA2241CSharpResultAt(8, 17),
-            GetCA2241CSharpResultAt(9, 17),
-            GetCA2241CSharpResultAt(10, 17),
-            GetCA2241CSharpResultAt(11, 17),
-            GetCA2241CSharpResultAt(12, 17));
+            GetCA2241CSharpResultAt(8, 9),
+            GetCA2241CSharpResultAt(9, 9),
+            GetCA2241CSharpResultAt(10, 9),
+            GetCA2241CSharpResultAt(11, 9),
+            GetCA2241CSharpResultAt(12, 9));
         }
 
         [Fact]
@@ -114,22 +114,22 @@ public class C
 {
     void Method()
     {
-        var s = String.Format(""{0}"", 1);
-        var s = String.Format(""{0} {1}"", 1, 2);
-        var s = String.Format(""{0} {1} {2}"", 1, 2, 3);
-        var s = String.Format(""{0} {1} {2} {3}"", 1, 2, 3, 4);
+        var a = String.Format(""{0}"", 1);
+        var b = String.Format(""{0} {1}"", 1, 2);
+        var c = String.Format(""{0} {1} {2}"", 1, 2, 3);
+        var d = String.Format(""{0} {1} {2} {3}"", 1, 2, 3, 4);
 
-        var s = Console.Write(""{0}"", 1);
-        var s = Console.Write(""{0} {1}"", 1, 2);
-        var s = Console.Write(""{0} {1} {2}"", 1, 2, 3);
-        var s = Console.Write(""{0} {1} {2} {3}"", 1, 2, 3, 4);
-        var s = Console.Write(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5);
+        Console.Write(""{0}"", 1);
+        Console.Write(""{0} {1}"", 1, 2);
+        Console.Write(""{0} {1} {2}"", 1, 2, 3);
+        Console.Write(""{0} {1} {2} {3}"", 1, 2, 3, 4);
+        Console.Write(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5);
 
-        var s = Console.WriteLine(""{0}"", 1);
-        var s = Console.WriteLine(""{0} {1}"", 1, 2);
-        var s = Console.WriteLine(""{0} {1} {2}"", 1, 2, 3);
-        var s = Console.WriteLine(""{0} {1} {2} {3}"", 1, 2, 3, 4);
-        var s = Console.WriteLine(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5);
+        Console.WriteLine(""{0}"", 1);
+        Console.WriteLine(""{0} {1}"", 1, 2);
+        Console.WriteLine(""{0} {1} {2}"", 1, 2, 3);
+        Console.WriteLine(""{0} {1} {2} {3}"", 1, 2, 3, 4);
+        Console.WriteLine(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5);
     }
 }
 ");
@@ -147,8 +147,8 @@ public class C
     void Method()
     {
         var s = String.Format(""{0} {1} {2} {3}"", new object[] {1, 2});
-        var s = Console.Write(""{0} {1} {2} {3}"", new object[] {1, 2, 3, 4, 5});
-        var s = Console.WriteLine(""{0} {1} {2} {3}"", new object[] {1, 2, 3, 4, 5});
+        Console.Write(""{0} {1} {2} {3}"", new object[] {1, 2, 3, 4, 5});
+        Console.WriteLine(""{0} {1} {2} {3}"", new object[] {1, 2, 3, 4, 5});
     }
 }
 ");
@@ -165,8 +165,8 @@ public class C
 {
     void Method()
     {
-        var s = Console.Write(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, _arglist(5));
-        var s = Console.WriteLine(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, _arglist(5));
+        Console.Write(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, __arglist(5));
+        Console.WriteLine(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, __arglist(5));
     }
 }
 ");
@@ -180,16 +180,16 @@ Imports System
 
 Public Class C
     Sub Method()
-        Dim s = String.Format("""", 1)
-        Dim s = String.Format(""{0}"", 1, 2)
-        Dim s = String.Format(""{0} {1}"", 1, 2, 3)
-        Dim s = String.Format(""{0} {1} {2}"", 1, 2, 3, 4)
+        Dim a = String.Format("""", 1)
+        Dim b = String.Format(""{0}"", 1, 2)
+        Dim c = String.Format(""{0} {1}"", 1, 2, 3)
+        Dim d = String.Format(""{0} {1} {2}"", 1, 2, 3, 4)
 
         Dim p as IFormatProvider = Nothing
-        Dim s = String.Format(p, """", 1)
-        Dim s = String.Format(p, ""{0}"", 1, 2)
-        Dim s = String.Format(p, ""{0} {1}"", 1, 2, 3)
-        Dim s = String.Format(p, ""{0} {1} {2}"", 1, 2, 3, 4)
+        Dim e = String.Format(p, """", 1)
+        Dim f = String.Format(p, ""{0}"", 1, 2)
+        Dim g = String.Format(p, ""{0} {1}"", 1, 2, 3)
+        Dim h = String.Format(p, ""{0} {1} {2}"", 1, 2, 3, 4)
     End Sub
 End Class
 ",
@@ -209,7 +209,7 @@ End Class
         {
             // this works in VB
             // Dim s = Console.WriteLine(""{0} {1} {2}"", 1, 2, 3, 4)
-            // since VB bind it to _arglist version where we skip analysis
+            // since VB bind it to __arglist version where we skip analysis
             // due to a bug - https://github.com/dotnet/roslyn/issues/7346
             // we might skip it only in C# since VB doesnt support __arglist
             VerifyBasic(@"
@@ -236,7 +236,7 @@ End Class
         {
             // this works in VB
             // Dim s = Console.WriteLine(""{0} {1} {2}"", 1, 2, 3, 4)
-            // since VB bind it to _arglist version where we skip analysis
+            // since VB bind it to __arglist version where we skip analysis
             // due to a bug - https://github.com/dotnet/roslyn/issues/7346
             // we might skip it only in C# since VB doesnt support __arglist
             VerifyBasic(@"
@@ -266,22 +266,22 @@ Imports System
 
 Public Class C
     Sub Method()
-        Dim s = String.Format(""{0}"", 1)
-        Dim s = String.Format(""{0} {1}"", 1, 2)
-        Dim s = String.Format(""{0} {1} {2}"", 1, 2, 3)
-        Dim s = String.Format(""{0} {1} {2} {3}"", 1, 2, 3, 4)
+        Dim a = String.Format(""{0}"", 1)
+        Dim b = String.Format(""{0} {1}"", 1, 2)
+        Dim c = String.Format(""{0} {1} {2}"", 1, 2, 3)
+        Dim d = String.Format(""{0} {1} {2} {3}"", 1, 2, 3, 4)
 
-        Dim s = Console.Write(""{0}"", 1)
-        Dim s = Console.Write(""{0} {1}"", 1, 2)
-        Dim s = Console.Write(""{0} {1} {2}"", 1, 2, 3)
-        Dim s = Console.Write(""{0} {1} {2} {3}"", 1, 2, 3, 4)
-        Dim s = Console.Write(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5)
+        Console.Write(""{0}"", 1)
+        Console.Write(""{0} {1}"", 1, 2)
+        Console.Write(""{0} {1} {2}"", 1, 2, 3)
+        Console.Write(""{0} {1} {2} {3}"", 1, 2, 3, 4)
+        Console.Write(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5)
 
-        Dim s = Console.WriteLine(""{0}"", 1)
-        Dim s = Console.WriteLine(""{0} {1}"", 1, 2)
-        Dim s = Console.WriteLine(""{0} {1} {2}"", 1, 2, 3)
-        Dim s = Console.WriteLine(""{0} {1} {2} {3}"", 1, 2, 3, 4)
-        Dim s = Console.WriteLine(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5)
+        Console.WriteLine(""{0}"", 1)
+        Console.WriteLine(""{0} {1}"", 1, 2)
+        Console.WriteLine(""{0} {1} {2}"", 1, 2, 3)
+        Console.WriteLine(""{0} {1} {2} {3}"", 1, 2, 3, 4)
+        Console.WriteLine(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5)
     End Sub
 End Class
 ");
@@ -295,9 +295,9 @@ Imports System
 
 Public Class C
     Sub Method()
-        Dim s = String.Format(""{0} {1} {2} {3}"", new object[] {1, 2})
-        Console.Write(""{0} {1} {2} {3}"", new object[] {1, 2, 3, 4, 5})
-        Console.WriteLine(""{0} {1} {2} {3}"", new object[] {1, 2, 3, 4, 5})
+        Dim s = String.Format(""{0} {1} {2} {3}"", New Object() {1, 2})
+        Console.Write(""{0} {1} {2} {3}"", New Object() {1, 2, 3, 4, 5})
+        Console.WriteLine(""{0} {1} {2} {3}"", New Object() {1, 2, 3, 4, 5})
     End Sub
 End Class
 ",
@@ -316,16 +316,16 @@ public class C
 {
     void Method()
     {
-        var s = String.Format(""{0,-4 :xd}"", 1);
-        var s = String.Format(""{0   ,    5 : d} {1}"", 1, 2);
-        var s = String.Format(""{0:d} {1} {2}"", 1, 2, 3);
-        var s = String.Format(""{0, 5} {1} {2} {3}"", 1, 2, 3, 4);
+        var a = String.Format(""{0,-4 :xd}"", 1);
+        var b = String.Format(""{0   ,    5 : d} {1}"", 1, 2);
+        var c = String.Format(""{0:d} {1} {2}"", 1, 2, 3);
+        var d = String.Format(""{0, 5} {1} {2} {3}"", 1, 2, 3, 4);
 
-        var s = Console.Write(""{0,1}"", 1);
-        var s = Console.Write(""{0:   x} {1}"", 1, 2);
-        var s = Console.Write(""{{escape}}{0} {1} {2}"", 1, 2, 3);
-        var s = Console.Write(""{0: {{escape}} x} {1} {2} {3}"", 1, 2, 3, 4);
-        var s = Console.Write(""{0 , -10  :   {{escape}}  y} {1} {2} {3} {4}"", 1, 2, 3, 4, 5);
+        Console.Write(""{0,1}"", 1);
+        Console.Write(""{0:   x} {1}"", 1, 2);
+        Console.Write(""{{escape}}{0} {1} {2}"", 1, 2, 3);
+        Console.Write(""{0: {{escape}} x} {1} {2} {3}"", 1, 2, 3, 4);
+        Console.Write(""{0 , -10  :   {{escape}}  y} {1} {2} {3} {4}"", 1, 2, 3, 4, 5);
     }
 }
 ");

--- a/src/System.Runtime.Analyzers/UnitTests/SpecifyIFormatProviderTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/SpecifyIFormatProviderTests.cs
@@ -45,7 +45,7 @@ public static class IFormatProviderStringTest
 
     public static string SpecifyIFormatProvider4()
     {
-        return string.Format(""Foo {0} {1} {2} {3}"", ""bar"", ""foo"", ""bar"", "");
+        return string.Format(""Foo {0} {1} {2} {3}"", ""bar"", ""foo"", ""bar"", """");
     }
 }",
 GetIFormatProviderAlternateStringRuleCSharpResultAt(10, 16, "string.Format(string, object)",
@@ -186,6 +186,7 @@ public class DerivedClass : IFormatProvider
         {
             VerifyCSharp(@"
 using System;
+using System.Globalization;
 
 public static class IFormatProviderStringTest
 {
@@ -220,16 +221,16 @@ internal static class IFormatProviderOverloads
         Console.WriteLine(string.Format(provider, format));
     }
 }",
-GetIFormatProviderAlternateRuleCSharpResultAt(8, 17, "Convert.ToInt32(string)",
+GetIFormatProviderAlternateRuleCSharpResultAt(9, 17, "Convert.ToInt32(string)",
                                                      "IFormatProviderStringTest.TestMethod()",
                                                      "Convert.ToInt32(string, IFormatProvider)"),
-GetIFormatProviderAlternateRuleCSharpResultAt(9, 18, "Convert.ToInt64(string)",
-                                                     "IFormatProviderStringTest.TestMethod()",
-                                                     "Convert.ToInt64(string, IFormatProvider)"),
-GetIFormatProviderAlternateRuleCSharpResultAt(10, 9, "IFormatProviderOverloads.LeadingIFormatProvider(string)",
+GetIFormatProviderAlternateRuleCSharpResultAt(10, 18, "Convert.ToInt64(string)",
+                                                      "IFormatProviderStringTest.TestMethod()",
+                                                      "Convert.ToInt64(string, IFormatProvider)"),
+GetIFormatProviderAlternateRuleCSharpResultAt(11, 9, "IFormatProviderOverloads.LeadingIFormatProvider(string)",
                                                      "IFormatProviderStringTest.TestMethod()",
                                                      "IFormatProviderOverloads.LeadingIFormatProvider(IFormatProvider, string)"),
-GetIFormatProviderAlternateRuleCSharpResultAt(11, 9, "IFormatProviderOverloads.TrailingIFormatProvider(string)",
+GetIFormatProviderAlternateRuleCSharpResultAt(12, 9, "IFormatProviderOverloads.TrailingIFormatProvider(string)",
                                                      "IFormatProviderStringTest.TestMethod()",
                                                      "IFormatProviderOverloads.TrailingIFormatProvider(string, IFormatProvider)"));
         }
@@ -553,7 +554,7 @@ End Class
 Public Class DerivedClass
     Implements IFormatProvider
 
-    Public Function GetFormat(formatType As Type) As Object
+    Public Function GetFormat(formatType As Type) As Object Implements IFormatProvider.GetFormat
         Throw New NotImplementedException()
     End Function
 End Class");

--- a/src/System.Runtime.Analyzers/UnitTests/TestForEmptyStringsUsingStringLengthTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/TestForEmptyStringsUsingStringLengthTests.cs
@@ -44,7 +44,7 @@ class C
 {
     void Method()
     {
-        string a;
+        string a = null;
 
         // equality with empty string
         string.Equals(a, """");
@@ -106,7 +106,7 @@ class C
 {
     void Method()
     {
-        string a;
+        string a = null;
 
         // equality with empty string
         a.Equals("""");
@@ -160,7 +160,7 @@ class C
 {
     void Method()
     {
-        string a;
+        string a = null;
         if (a == """") { }
         if ("""" != a) { }
         if (a == string.Empty) { }

--- a/src/System.Runtime.Analyzers/UnitTests/TestForNaNCorrectlyTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/TestForNaNCorrectlyTests.cs
@@ -394,7 +394,7 @@ End Class
             var code = @"
 public class A
 {
-    float _n = 42.0;
+    float _n = 42.0F;
 
     public void F()
     {
@@ -412,7 +412,7 @@ public class A
         {
             var code = @"
 Public Class A
-    Private _n As Single = 42.0;
+    Private _n As Single = 42.0F
 
     Public Sub F()
         G(_n = Single.NaN)
@@ -430,7 +430,7 @@ End Class
             var code = @"
 public class A
 {
-    float _n = 42.0;
+    float _n = 42.0F;
 
     public int F()
     {
@@ -447,7 +447,7 @@ public class A
             // VB doesn't have the ternary operator, but we add this test for symmetry.
             var code = @"
 Public Class A
-    Private _n As Single = 42.0;
+    Private _n As Single = 42.0F
 
     Public Function F() As Integer
         Return If(_n = Single.NaN, 1, 0)

--- a/src/System.Runtime.Analyzers/UnitTests/UseOrdinalStringComparisonTests.Fixer.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/UseOrdinalStringComparisonTests.Fixer.cs
@@ -209,8 +209,8 @@ class C
 {
     void M(string a, string b)
     {
-        System.Globalization.CultureInfo ci;
-        System.Globalization.CompareOptions co;
+        System.Globalization.CultureInfo ci = null;
+        System.Globalization.CompareOptions co = System.Globalization.CompareOptions.None;
 
         // add or correct StringComparison
         if (string.Compare(a, b) == 0) { }
@@ -233,8 +233,8 @@ class C
 {
     void M(string a, string b)
     {
-        System.Globalization.CultureInfo ci;
-        System.Globalization.CompareOptions co;
+        System.Globalization.CultureInfo ci = null;
+        System.Globalization.CompareOptions co = System.Globalization.CompareOptions.None;
 
         // add or correct StringComparison
         if (string.Compare(a, b, System.StringComparison.Ordinal) == 0) { }

--- a/src/System.Runtime.Analyzers/UnitTests/UseOrdinalStringComparisonTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/UseOrdinalStringComparisonTests.cs
@@ -45,7 +45,7 @@ class C
 {
     void Method()
     {
-        string a, b;
+        string a = null, b = null;
         // wrong overload
         string.Compare(a, b);
         string.Compare(a, b, true);
@@ -137,7 +137,7 @@ class C
 {
     void Method()
     {
-        string a, b;
+        string a = null, b = null;
         // wrong overload
         string.Equals(a, b); // (string, string) is bad
         // right overload, wrong value
@@ -187,7 +187,7 @@ class C
 {
     void Method()
     {
-        string a, b;
+        string a = null, b = null;
         // wrong overload
         a.Equals(b);
         // right overload, wrong value
@@ -237,7 +237,7 @@ class C
 {
     void Method()
     {
-        string a, b;
+        string a = null, b = null;
         // not allowed
         if (a == b) { }
         if (a != b) { }


### PR DESCRIPTION
Overview of issues in unittest code fragments:
* Copy/paste errors
* Private classes cannot exist in namespace scope
* Missing members that are referenced in tests
* Incorrectly escaped string values
* Struct parameterless constructor not allowed
* Unescaped indentifier names that are keywords (VB)
* Assignment of return value from void method to a local
* `_arglist` must be: `__arglist`
* Unassigned locals
* Missing type suffix in constant declaration of `float`/`Single` fields