### PR TITLE
Fixed compiler errors in Microsoft.ApiDesignGuidelines.Analyzers.Unit…

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/AbstractTypesShouldNotHaveConstructorsTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/AbstractTypesShouldNotHaveConstructorsTests.Fixer.cs
@@ -143,7 +143,7 @@ Public Structure C
         Public Sub New()
         End Sub
     End Class
-End Class
+End Structure
 ";
             var fix = @"
 Public Structure C
@@ -151,7 +151,7 @@ Public Structure C
         Protected Sub New()
         End Sub
     End Class
-End Class
+End Structure
 ";
             VerifyBasicFix(code, fix);
         }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/CollectionPropertiesShouldBeReadOnlyTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/CollectionPropertiesShouldBeReadOnlyTests.cs
@@ -67,9 +67,9 @@ class A
     internal System.Collections.ICollection Col { get; set; }
     protected System.Collections.ICollection Col2 { get; set; }
     private System.Collections.ICollection Col3 { get; set; }
-    public System.Collections.ICollection Col { get; }
-    public System.Collections.ICollection Col { get; protected set; }
-    public System.Collections.ICollection Col { get; private set; }
+    public System.Collections.ICollection Col4 { get; }
+    public System.Collections.ICollection Col5 { get; protected set; }
+    public System.Collections.ICollection Col6 { get; private set; }
 }
 ");
         }
@@ -95,7 +95,11 @@ using System;
 
 class A
 {
-    public System.Collections.ICollection Col[int i] { get; set; }
+    public System.Collections.ICollection this[int i]
+    {
+        get { throw new NotImplementedException(); }
+        set { }
+    }
 }
 ");
         }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/CollectionsShouldImplementGenericInterfaceTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/CollectionsShouldImplementGenericInterfaceTests.cs
@@ -22,259 +22,614 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         public void Test_WithCollectionBase()
         {
             VerifyCSharp(@"
-                        using System.Collections;
-                        public class TestClass :CollectionBase
-                        {
-                            public int Count => 0;
-                        }",
-                        GetCSharpResultAt(3, 38, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
+using System.Collections;
+
+public class TestClass : CollectionBase { }",
+                GetCSharpResultAt(4, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
 
             VerifyBasic(@"
-                        Imports System.Collections
-                        Public Class TestClass 
-                            Inherits CollectionBase
-	                        Public ReadOnly Property Count() As Integer
-		                        Get
-			                        Throw New NotImplementedException()
-		                        End Get
-	                        End Property
-                        End Class",
-                        GetBasicResultAt(3, 38, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
+Imports System.Collections
+
+Public Class TestClass 
+    Inherits CollectionBase
+End Class
+",
+                GetBasicResultAt(4, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
         }
 
         [Fact]
         public void Test_WithCollection()
         {
             VerifyCSharp(@"
-                        using System.Collections;
-                        public class TestClass :ICollection
-                        {
-                             public int Count => 0;
-                        }",
-                        GetCSharpResultAt(3, 38, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
+using System;
+using System.Collections;
+
+public class TestClass : ICollection
+{
+    public int Count => 0;
+    public object SyncRoot => null;
+    public bool IsSynchronized => false;
+
+    public IEnumerator GetEnumerator() { throw new NotImplementedException(); }
+    public void CopyTo(Array array, int index) { throw new NotImplementedException(); }
+}
+",
+                GetCSharpResultAt(5, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
 
             VerifyBasic(@"
-                        Imports System.Collections
-                        Public Class TestClass
-	                            Implements ICollection
-	                    Public ReadOnly Property Count() As Integer
-		                    Get
-			                    Throw New NotImplementedException()
-		                    End Get
-	                    End Property
-                        End Class",
-                        GetBasicResultAt(3, 38, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
+Imports System
+Imports System.Collections
+
+Public Class TestClass
+	Implements ICollection
+
+    Public ReadOnly Property Count As Integer Implements ICollection.Count
+    Public ReadOnly Property SyncRoot As Object Implements ICollection.SyncRoot
+    Public ReadOnly Property IsSynchronized As Boolean Implements ICollection.IsSynchronized
+
+    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub CopyTo(array As Array, index As Integer) Implements ICollection.CopyTo
+        Throw New NotImplementedException
+    End Sub
+End Class
+",
+                GetBasicResultAt(5, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
         }
 
         [Fact]
         public void Test_WithEnumerable()
         {
             VerifyCSharp(@"
-                        using System.Collections;
-                        public class TestClass :IEnumerable
-                        {
-                            public int Count => 0;
-                        }",
-                        GetCSharpResultAt(3, 38, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
+using System;
+using System.Collections;
+
+public class TestClass : IEnumerable
+{
+    public IEnumerator GetEnumerator() { throw new NotImplementedException(); }
+}
+",
+                GetCSharpResultAt(5, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
 
             VerifyBasic(@"
-                        Imports System.Collections
-                        Public Class TestClass
-	                            Implements IEnumerable
-	                    Public ReadOnly Property Count() As Integer
-		                    Get
-			                  Throw New NotImplementedException()
-		                    End Get
-	                    End Property
-                        End Class",
-                        GetBasicResultAt(3, 38, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
+Imports System
+Imports System.Collections
+
+Public Class TestClass
+    Implements IEnumerable
+
+    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException
+    End Function
+End Class
+",
+                GetBasicResultAt(5, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
         }
 
         [Fact]
         public void Test_WithList()
         {
             VerifyCSharp(@"
-                        using System.Collections;
-                        public class TestClass :IList
-                        {
-                           public int Count => 0;
-                        }",
-                        GetCSharpResultAt(3, 38, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
+using System;
+using System.Collections;
+
+public class TestClass : IList
+{
+    public int Count => 0;
+    public object SyncRoot => null;
+    public bool IsSynchronized => false;
+    public bool IsReadOnly => false;
+    public bool IsFixedSize => false;
+
+    public object this[int index]
+    {
+        get { throw new NotImplementedException(); }
+        set { throw new NotImplementedException(); }
+    }
+
+    public IEnumerator GetEnumerator() { throw new NotImplementedException(); }
+    public void CopyTo(Array array, int index) { throw new NotImplementedException(); }
+    public int Add(object value) { throw new NotImplementedException(); }
+    public bool Contains(object value) { throw new NotImplementedException(); }
+    public void Clear() { throw new NotImplementedException(); }
+    public int IndexOf(object value) { throw new NotImplementedException(); }
+    public void Insert(int index, object value) { throw new NotImplementedException(); }
+    public void Remove(object value) { throw new NotImplementedException(); }
+    public void RemoveAt(int index) { throw new NotImplementedException(); }
+}
+",
+                GetCSharpResultAt(5, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
 
             VerifyBasic(@"
-                        Imports System.Collections
-                        Public Class TestClass
-	                        Implements IList
-	                        Public ReadOnly Property Count() As Integer
-		                        Get
-			                        Throw New NotImplementedException()
-		                        End Get
-	                        End Property
-                        End Class",
-                        GetBasicResultAt(3, 38, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
+Imports System
+Imports System.Collections
+
+Public Class TestClass
+	Implements IList
+
+    Default Public Property Item(index As Integer) As Object Implements IList.Item
+        Get
+            Throw New NotImplementedException
+        End Get
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+
+    Public ReadOnly Property Count As Integer Implements ICollection.Count
+    Public ReadOnly Property SyncRoot As Object Implements ICollection.SyncRoot
+    Public ReadOnly Property IsSynchronized As Boolean Implements ICollection.IsSynchronized
+    Public ReadOnly Property IsReadOnly As Boolean Implements IList.IsReadOnly
+    Public ReadOnly Property IsFixedSize As Boolean Implements IList.IsFixedSize
+
+    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub CopyTo(array As Array, index As Integer) Implements ICollection.CopyTo
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function Add(value As Object) As Integer Implements IList.Add
+        Throw New NotImplementedException
+    End Function
+
+    Public Function Contains(value As Object) As Boolean Implements IList.Contains
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub Clear() Implements IList.Clear
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function IndexOf(value As Object) As Integer Implements IList.IndexOf
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub Insert(index As Integer, value As Object) Implements IList.Insert
+        Throw New NotImplementedException
+    End Sub
+
+    Public Sub Remove(value As Object) Implements IList.Remove
+        Throw New NotImplementedException
+    End Sub
+
+    Public Sub RemoveAt(index As Integer) Implements IList.RemoveAt
+        Throw New NotImplementedException
+    End Sub
+End Class
+",
+                GetBasicResultAt(5, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
         }
 
         [Fact]
         public void Test_WithGenericCollection()
         {
             VerifyCSharp(@"
-                    using System.Collections.Generic;
-                    public class TestClass :ICollection<int>
-                    {
-                        public int Count => 0;
-                    }");
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TestClass : ICollection<int>
+{
+    public int Count => 0;
+    public bool IsReadOnly => false;
+
+    public IEnumerator<int> GetEnumerator() { throw new NotImplementedException(); }
+    IEnumerator IEnumerable.GetEnumerator() { throw new NotImplementedException(); }
+    public void Add(int item) { throw new NotImplementedException(); }
+    public void Clear() { throw new NotImplementedException(); }
+    public bool Contains(int item) { throw new NotImplementedException(); }
+    public void CopyTo(int[] array, int arrayIndex) { throw new NotImplementedException(); }
+    public bool Remove(int item) { throw new NotImplementedException(); }
+}
+");
 
             VerifyBasic(@"
-                    Imports System.Collections.Generic
-                    Public Class TestClass
-	                    Implements ICollection(Of Integer)
-	                    Public ReadOnly Property Count() As Integer
-		                    Get
-			                    Throw New NotImplementedException()
-		                    End Get
-	                    End Property
-                    End Class");
+Imports System
+Imports System.Collections
+Imports System.Collections.Generic
+
+Public Class TestClass
+	Implements ICollection(Of Integer)
+
+    Public ReadOnly Property Count As Integer Implements ICollection(Of Integer).Count
+    Public ReadOnly Property IsReadOnly As Boolean Implements ICollection(Of Integer).IsReadOnly
+
+    Public Function IEnumerable_GetEnumerator() As IEnumerator(Of Integer) Implements IEnumerable(Of Integer).GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub Add(item As Integer) Implements ICollection(Of Integer).Add
+        Throw New NotImplementedException
+    End Sub
+
+    Public Sub Clear() Implements ICollection(Of Integer).Clear
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function Contains(item As Integer) As Boolean Implements ICollection(Of Integer).Contains
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub CopyTo(array As Integer(), arrayIndex As Integer) Implements ICollection(Of Integer).CopyTo
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function Remove(item As Integer) As Boolean Implements ICollection(Of Integer).Remove
+        Throw New NotImplementedException
+    End Function
+End Class
+");
         }
 
         [Fact]
         public void Test_WithGenericEnumerable()
         {
             VerifyCSharp(@"
-                    using System.Collections.Generic;
-                    public class TestClass :IEnumerable<int>
-                        {
-                            public int Count => 0;
-                        }");
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TestClass : IEnumerable<int>
+{
+    public IEnumerator<int> GetEnumerator() { throw new NotImplementedException(); }
+    IEnumerator IEnumerable.GetEnumerator() { throw new NotImplementedException(); }
+}
+");
 
             VerifyBasic(@"
-                    Imports System.Collections.Generic
-                    Public Class TestClass
-	                    Implements IEnumerable(Of Integer)
-	                    Public ReadOnly Property Count() As Integer
-		                    Get
-			                    Throw New NotImplementedException()
-		                    End Get
-	                    End Property
-                    End Class
-                    ");
+Imports System
+Imports System.Collections
+Imports System.Collections.Generic
+
+Public Class TestClass
+	Implements IEnumerable(Of Integer)
+
+    Public Function IEnumerable_GetEnumerator() As IEnumerator(Of Integer) Implements IEnumerable(Of Integer).GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException
+    End Function
+End Class
+");
         }
 
         [Fact]
         public void Test_WithGenericList()
         {
             VerifyCSharp(@"
-                    using System.Collections.Generic;
-                    public class TestClass :IList<int>
-                        {
-                            public int Count => 0;
-                        }");
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TestClass : IList<int>
+{
+    public int this[int index]
+    {
+        get { throw new NotImplementedException(); }
+        set { throw new NotImplementedException(); }
+    }
+
+    public int Count => 0;
+    public bool IsReadOnly => false;
+
+    public IEnumerator<int> GetEnumerator() { throw new NotImplementedException(); }
+    IEnumerator IEnumerable.GetEnumerator() { throw new NotImplementedException(); }
+    public void Add(int item) { throw new NotImplementedException(); }
+    public void Clear() { throw new NotImplementedException(); }
+    public bool Contains(int item) { throw new NotImplementedException(); }
+    public void CopyTo(int[] array, int arrayIndex) { throw new NotImplementedException(); }
+    public bool Remove(int item) { throw new NotImplementedException(); }
+    public int IndexOf(int item) { throw new NotImplementedException(); }
+    public void Insert(int index, int item) { throw new NotImplementedException(); }
+    public void RemoveAt(int index) { throw new NotImplementedException(); }
+}
+");
 
             VerifyBasic(@"
-                    Imports System.Collections.Generic
-                    Public Class TestClass
-	                    Implements IList(Of Integer)
-	                    Public ReadOnly Property Count() As Integer
-		                    Get
-			                    Throw New NotImplementedException()
-		                    End Get
-	                    End Property
-                    End Class
-                    ");
+Imports System
+Imports System.Collections
+Imports System.Collections.Generic
+
+Public Class TestClass
+	Implements IList(Of Integer)
+
+    Default Public Property Item(index As Integer) As Integer Implements IList(Of Integer).Item
+        Get
+            Throw New NotImplementedException
+        End Get
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+
+    Public ReadOnly Property Count As Integer Implements ICollection(Of Integer).Count
+    Public ReadOnly Property IsReadOnly As Boolean Implements ICollection(Of Integer).IsReadOnly
+
+    Public Function IEnumerable_GetEnumerator() As IEnumerator(Of Integer) Implements IEnumerable(Of Integer).GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub Add(item As Integer) Implements ICollection(Of Integer).Add
+        Throw New NotImplementedException
+    End Sub
+
+    Public Sub Clear() Implements ICollection(Of Integer).Clear
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function Contains(item As Integer) As Boolean Implements ICollection(Of Integer).Contains
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub CopyTo(array As Integer(), arrayIndex As Integer) Implements ICollection(Of Integer).CopyTo
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function Remove(item As Integer) As Boolean Implements ICollection(Of Integer).Remove
+        Throw New NotImplementedException
+    End Function
+
+    Public Function IndexOf(item As Integer) As Integer Implements IList(Of Integer).IndexOf
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub Insert(index As Integer, item As Integer) Implements IList(Of Integer).Insert
+        Throw New NotImplementedException
+    End Sub
+
+    Public Sub RemoveAt(index As Integer) Implements IList(Of Integer).RemoveAt
+        Throw New NotImplementedException
+    End Sub
+End Class
+");
         }
 
         [Fact]
         public void Test_WithCollectionBaseAndGenerics()
         {
             VerifyCSharp(@"
-                using System.Collections;
-                using System.Collections.Generic;
-                public class TestClass :CollectionBase, ICollection<int>, IEnumerable<int> , IList<int>
-                    {
-                        public int Count => 0;
-                    }");
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TestClass : CollectionBase, ICollection<int>, IEnumerable<int>, IList<int>
+{
+    public int this[int index]
+    {
+        get { throw new NotImplementedException(); }
+        set { throw new NotImplementedException(); }
+    }
+
+    public bool IsReadOnly => false;
+
+    public IEnumerator<int> GetEnumerator() { throw new NotImplementedException(); }
+
+    public void Add(int item) { throw new NotImplementedException(); }
+
+    public bool Contains(int item) { throw new NotImplementedException(); }
+
+    public void CopyTo(int[] array, int arrayIndex) { throw new NotImplementedException(); }
+
+    public bool Remove(int item) { throw new NotImplementedException(); }
+
+    public int IndexOf(int item) { throw new NotImplementedException(); }
+
+    public void Insert(int index, int item) { throw new NotImplementedException(); }
+}
+");
 
             VerifyBasic(@"
-                Imports System.Collections
-                Imports System.Collections.Generic
-                Public Class TestClass
-	                Inherits CollectionBase
-	                Implements ICollection(Of Integer)
-	                Implements IEnumerable(Of Integer)
-	                Implements IList(Of Integer)
-	                Public ReadOnly Property Count() As Integer
-		                Get
-			                Throw New NotImplementedException()
-		                End Get
-	                End Property
-                End Class
-                ");
+Imports System
+Imports System.Collections
+Imports System.Collections.Generic
+
+Public Class TestClass
+	Inherits CollectionBase
+    Implements ICollection(Of Integer)
+	Implements IEnumerable(Of Integer)
+	Implements IList(Of Integer)
+
+    Default Public Property Item(index As Integer) As Integer Implements IList(Of Integer).Item
+        Get
+            Throw New NotImplementedException
+        End Get
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+
+    Public ReadOnly Property Count As Integer Implements ICollection(Of Integer).Count
+    Public ReadOnly Property IsReadOnly As Boolean Implements ICollection(Of Integer).IsReadOnly
+
+    Public Function GetEnumerator() As IEnumerator(Of Integer) Implements IEnumerable(Of Integer).GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub Add(item As Integer) Implements ICollection(Of Integer).Add
+        Throw New NotImplementedException
+    End Sub
+
+    Public Sub Clear() Implements ICollection(Of Integer).Clear
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function Contains(item As Integer) As Boolean Implements ICollection(Of Integer).Contains
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub CopyTo(array As Integer(), arrayIndex As Integer) Implements ICollection(Of Integer).CopyTo
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function Remove(item As Integer) As Boolean Implements ICollection(Of Integer).Remove
+        Throw New NotImplementedException
+    End Function
+
+    Public Function IndexOf(item As Integer) As Integer Implements IList(Of Integer).IndexOf
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub Insert(index As Integer, item As Integer) Implements IList(Of Integer).Insert
+        Throw New NotImplementedException
+    End Sub
+
+    Public Sub RemoveAt(index As Integer) Implements IList(Of Integer).RemoveAt
+        Throw New NotImplementedException
+    End Sub
+End Class
+");
         }
 
         [Fact]
         public void Test_WithCollectionAndGenericCollection()
         {
             VerifyCSharp(@"
-                    using System.Collections;
-                    using System.Collections.Generic;
-                    public class TestClass :ICollection, ICollection<int>
-                        {
-                            public int Count => 0;
-                        }");
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TestClass : ICollection, ICollection<int>
+{
+    int ICollection<int>.Count
+    {
+        get { throw new NotImplementedException(); }
+    }
+
+    int ICollection.Count
+    {
+        get { throw new NotImplementedException(); }
+    }
+
+    public bool IsReadOnly => false;
+    public object SyncRoot => null;
+    public bool IsSynchronized => false;
+
+    public IEnumerator<int> GetEnumerator() { throw new NotImplementedException(); }
+    IEnumerator IEnumerable.GetEnumerator() { throw new NotImplementedException(); }
+    public void CopyTo(Array array, int index) { throw new NotImplementedException(); }
+    public void Add(int item) { throw new NotImplementedException(); }
+    public void Clear() { throw new NotImplementedException(); }
+    public bool Contains(int item) { throw new NotImplementedException(); }
+    public void CopyTo(int[] array, int arrayIndex) { throw new NotImplementedException(); }
+    public bool Remove(int item) { throw new NotImplementedException(); }
+}
+");
 
             VerifyBasic(@"
-                    Imports System.Collections
-                    Imports System.Collections.Generic
-                    Public Class TestClass
-	                    Implements ICollection
-	                    Implements ICollection(Of Integer)
-	                    Public ReadOnly Property Count() As Integer
-		                    Get
-			                    Throw New NotImplementedException()
-		                    End Get
-	                    End Property
-                    End Class");
+Imports System
+Imports System.Collections
+Imports System.Collections.Generic
+
+Public Class TestClass
+	Implements ICollection
+	Implements ICollection(Of Integer)
+
+    Public ReadOnly Property ICollection_Count As Integer Implements ICollection(Of Integer).Count
+
+    Public ReadOnly Property Count As Integer Implements ICollection.Count
+    Public ReadOnly Property IsReadOnly As Boolean Implements ICollection(Of Integer).IsReadOnly
+    Public ReadOnly Property SyncRoot As Object Implements ICollection.SyncRoot
+    Public ReadOnly Property IsSynchronized As Boolean Implements ICollection.IsSynchronized
+
+    Public Function IEnumerable_GetEnumerator() As IEnumerator(Of Integer) Implements IEnumerable(Of Integer).GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub CopyTo(array As Array, index As Integer) Implements ICollection.CopyTo
+        Throw New NotImplementedException
+    End Sub
+
+    Public Sub Add(item As Integer) Implements ICollection(Of Integer).Add
+        Throw New NotImplementedException
+    End Sub
+
+    Public Sub Clear() Implements ICollection(Of Integer).Clear
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function Contains(item As Integer) As Boolean Implements ICollection(Of Integer).Contains
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub CopyTo(array As Integer(), arrayIndex As Integer) Implements ICollection(Of Integer).CopyTo
+        Throw New NotImplementedException
+    End Sub
+
+    Public Function Remove(item As Integer) As Boolean Implements ICollection(Of Integer).Remove
+        Throw New NotImplementedException
+    End Function
+End Class
+");
         }
 
         [Fact]
         public void Test_WithBaseAndDerivedClassFailureCase()
         {
             VerifyCSharp(@"
-                    using System.Collections;
-                    using System.Collections.Generic;
-                    public class BaseClass :ICollection
-                        {
-                            public int Count => 0;
-                        }
-                    public class IntCollection :BaseClass
-                        {
-                            public int Count => 0;
-                        }",
-                        GetCSharpResultAt(4, 34, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()),
-                        GetCSharpResultAt(8, 34, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString())
-                        );
+using System;
+using System.Collections;
+
+public class BaseClass : ICollection
+{
+    public int Count => 0;
+    public object SyncRoot => null;
+    public bool IsSynchronized => false;
+
+    public IEnumerator GetEnumerator() { throw new NotImplementedException(); }
+    public void CopyTo(Array array, int index) { throw new NotImplementedException(); }
+}
+
+public class IntCollection : BaseClass
+{
+}
+",
+                GetCSharpResultAt(5, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()),
+                GetCSharpResultAt(15, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
 
             VerifyBasic(@"
-                    Imports System.Collections
-                    Imports System.Collections.Generic
-                    Public Class BaseClass
-	                    Implements ICollection
-	                    Public ReadOnly Property Count() As Integer
-		                    Get
-			                    Throw New NotImplementedException()
-		                    End Get
-	                    End Property
-                    End Class
-                    Public Class IntCollection
-	                    Inherits BaseClass
-	                    Public ReadOnly Property Count() As Integer
-		                    Get
-			                    Throw New NotImplementedException()
-		                    End Get
-	                    End Property
-                    End Class",
-                       GetBasicResultAt(4, 34, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()),
-                       GetBasicResultAt(12, 34, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString())
-                       );
+Imports System
+Imports System.Collections
+
+Public Class BaseClass
+	Implements ICollection
+
+    Public ReadOnly Property Count As Integer Implements ICollection.Count
+    Public ReadOnly Property SyncRoot As Object Implements ICollection.SyncRoot
+    Public ReadOnly Property IsSynchronized As Boolean Implements ICollection.IsSynchronized
+
+    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException
+    End Function
+
+    Public Sub CopyTo(array As Array, index As Integer) Implements ICollection.CopyTo
+        Throw New NotImplementedException
+    End Sub
+End Class
+
+Public Class IntCollection
+	Inherits BaseClass
+End Class
+",
+                GetBasicResultAt(5, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()),
+                GetBasicResultAt(21, 14, CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId, CollectionsShouldImplementGenericInterfaceAnalyzer.Rule.MessageFormat.ToString()));
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DefineAccessorsForAttributeArgumentsTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DefineAccessorsForAttributeArgumentsTests.Fixer.cs
@@ -50,7 +50,7 @@ public sealed class NoAccessorTestAttribute : Attribute
 }");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1007")]
         public void CSharp_CA1019_AddAccessor1()
         {
             VerifyCSharpFix(@"
@@ -108,10 +108,10 @@ public sealed class InternalGetterTestAttribute : Attribute
         m_name = name;
     }
 
-    public string Name
+    internal string Name
     {
-        internal get { return m_name; }
-        internal set { m_name = value; }
+        get { return m_name; }
+        set { m_name = value; }
     }
 }", @"
 using System;
@@ -129,6 +129,7 @@ public sealed class InternalGetterTestAttribute : Attribute
     public string Name
     {
         get { return m_name; }
+
         internal set { m_name = value; }
     }
 }");
@@ -308,8 +309,8 @@ Public NotInheritable Class SetterOnlyTestAttribute
         m_name = name
     End Sub
 
-    Public WriteOnly Property Name() As String
-        Friend Set
+    Friend WriteOnly Property Name() As String
+        Set
             m_name = value
         End Set
     End Property
@@ -442,7 +443,7 @@ Public NotInheritable Class InternalGetterTestAttribute
         m_name = name
     End Sub
 
-    Friend Property Name() As String
+    Friend ReadOnly Property Name() As String
         Get
             Return m_name
         End Get
@@ -459,7 +460,7 @@ Public NotInheritable Class InternalGetterTestAttribute
         m_name = name
     End Sub
 
-    Public Property Name() As String
+    Public ReadOnly Property Name() As String
         Get
             Return m_name
         End Get

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDeclareStaticMembersOnGenericTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDeclareStaticMembersOnGenericTypesTests.cs
@@ -196,6 +196,8 @@ public sealed class ClosedType : OpenType<String>
         public void Basic_CA1000_ShouldNotGenerate()
         {
             VerifyBasic(@"
+Imports System
+
 Public Class GenericType1(Of T)
     Private Sub New()
     End Sub

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDeclareVisibleInstanceFieldsTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDeclareVisibleInstanceFieldsTests.cs
@@ -71,7 +71,7 @@ class A
         public void PublicStaticVariableVB()
         {
             VerifyBasic(@"
-Class
+Class A
     Public Shared field as System.String
 End Class");
         }
@@ -101,7 +101,7 @@ End Class");
             VerifyCSharp(@"
 class A
 {
-    public const string field; 
+    public const string field = ""X""; 
 }");
         }
 
@@ -110,7 +110,7 @@ class A
         {
             VerifyBasic(@"
 Class A
-    Public Const field as System.String
+    Public Const field as System.String = ""X""
 End Class");
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDecreaseInheritedMemberVisibilityTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDecreaseInheritedMemberVisibilityTests.Fixer.cs
@@ -196,28 +196,30 @@ public class DerivedClass : BaseClass
 
             VerifyCSharpFix(
 // Original Code
-@"public class BaseClass
+@"using System;
+public class BaseClass
 {
-    protected internal event System.EventHandler MyEvent { add{} remove{} }
+    protected internal event EventHandler MyEvent { add{} remove{} }
     protected internal int MyProperty { get; set; }
 }
 
 public class DerivedClass : BaseClass
 {
-    internal new event System.EventHandler MyEvent { add{} remove{} }
+    internal new event EventHandler MyEvent { add{} remove{} }
     protected internal int MyProperty { internal get; set; }
 }",
 
 // Fixed Code
-@"public class BaseClass
+@"using System;
+public class BaseClass
 {
-    protected internal event System.EventHandler MyEvent { add{} remove{} }
+    protected internal event EventHandler MyEvent { add{} remove{} }
     protected internal int MyProperty { get; set; }
 }
 
 public class DerivedClass : BaseClass
 {
-    internal new event System.EventHandler MyEvent { add{} remove{} }
+    internal new event EventHandler MyEvent { add{} remove{} }
     protected internal int MyProperty { get; set; }
 }");
         }
@@ -307,12 +309,15 @@ End Class");
 
             VerifyBasicFix(
 // Original Code
-@"Public Class BaseClass
-	Protected Friend Custom Event MyEvent As System.EventHandler
-		AddHandler(ByVal value As System.EventHandler)
+@"Imports System
+Public Class BaseClass
+	Protected Friend Custom Event MyEvent As EventHandler
+		AddHandler(ByVal value As EventHandler)
 		End AddHandler
-		RemoveHandler(ByVal value As System.EventHandler)
+		RemoveHandler(ByVal value As EventHandler)
 		End RemoveHandler
+        RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+        End RaiseEvent
 	End Event
 	Protected Friend Property MyProperty() As Integer
 		Get
@@ -327,11 +332,13 @@ End Class
 
 Public Class DerivedClass
 	Inherits BaseClass
-	Friend Shadows Custom Event MyEvent As System.EventHandler
-		AddHandler(ByVal value As System.EventHandler)
+	Friend Shadows Custom Event MyEvent As EventHandler
+		AddHandler(ByVal value As EventHandler)
 		End AddHandler
-		RemoveHandler(ByVal value As System.EventHandler)
+		RemoveHandler(ByVal value As EventHandler)
 		End RemoveHandler
+        RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+        End RaiseEvent
 	End Event
 	Protected Friend Property MyProperty() As Integer
 		Friend Get
@@ -345,12 +352,15 @@ Public Class DerivedClass
 End Class",
 
 // Fixed Code
-@"Public Class BaseClass
-	Protected Friend Custom Event MyEvent As System.EventHandler
-		AddHandler(ByVal value As System.EventHandler)
+@"Imports System
+Public Class BaseClass
+	Protected Friend Custom Event MyEvent As EventHandler
+		AddHandler(ByVal value As EventHandler)
 		End AddHandler
-		RemoveHandler(ByVal value As System.EventHandler)
+		RemoveHandler(ByVal value As EventHandler)
 		End RemoveHandler
+        RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+        End RaiseEvent
 	End Event
 	Protected Friend Property MyProperty() As Integer
 		Get
@@ -365,11 +375,13 @@ End Class
 
 Public Class DerivedClass
 	Inherits BaseClass
-	Friend Shadows Custom Event MyEvent As System.EventHandler
-		AddHandler(ByVal value As System.EventHandler)
+	Friend Shadows Custom Event MyEvent As EventHandler
+		AddHandler(ByVal value As EventHandler)
 		End AddHandler
-		RemoveHandler(ByVal value As System.EventHandler)
+		RemoveHandler(ByVal value As EventHandler)
 		End RemoveHandler
+        RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+        End RaiseEvent
 	End Event
 	Protected Friend Property MyProperty() As Integer
 		Get

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDecreaseInheritedMemberVisibilityTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDecreaseInheritedMemberVisibilityTests.cs
@@ -63,8 +63,8 @@ public class DerivedClass : BaseClass
 
 public class DerivedClass : BaseClass
 {
-    inernal void MyMethod() {}
-}", GetCSharpCA2222RuleNameResultAt(8, 18));
+    internal void MyMethod() {}
+}", GetCSharpCA2222RuleNameResultAt(8, 19));
         }
 
         [Fact]
@@ -250,13 +250,13 @@ public class DerivedDerivedClass : DerivedClass
 @"public class BaseClass
 {
     public int MyProperty { get; set; }
-    public void MyMethod();
+    public void MyMethod() { }
 }
 
 public sealed class DerivedClass : BaseClass
 {
     private new int MyProperty { get; set; }
-    protected new void MyMethod();
+    protected new void MyMethod() { }
 }");
         }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDirectlyAwaitATaskTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDirectlyAwaitATaskTests.Fixer.cs
@@ -153,7 +153,7 @@ public class C
 {
     public async Task M()
     {
-        Task<Task> t;
+        Task<Task> t = null;
         await await t; // both have warnings.
         await await t.ConfigureAwait(false); // outer await is wrong.
         await (await t).ConfigureAwait(false); // inner await is wrong.
@@ -168,7 +168,7 @@ public class C
 {
     public async Task M()
     {
-        Task<Task> t;
+        Task<Task> t = null;
         await (await t.ConfigureAwait(false)).ConfigureAwait(false); // both have warnings.
         await (await t.ConfigureAwait(false)).ConfigureAwait(false); // outer await is wrong.
         await (await t.ConfigureAwait(false)).ConfigureAwait(false); // inner await is wrong.

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/EnumsShouldHaveZeroValueTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/EnumsShouldHaveZeroValueTests.Fixer.cs
@@ -31,15 +31,18 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [WorkItem(836193, "DevDiv")]
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1032")]
         public void CSharp_EnumsShouldZeroValueFlagsRename()
         {
             var code = @"
-[System.Flags]
-private enum E
+public class Outer
 {
-    A = 0,
-    B = 3
+    [System.Flags]
+    private enum E
+    {
+        A = 0,
+        B = 3
+    }
 }
 
 [System.Flags]
@@ -71,11 +74,14 @@ public enum NoZeroValuedField
 }";
 
             var expectedFixedCode = @"
-[System.Flags]
-private enum E
+public class Outer
 {
-    None = 0,
-    B = 3
+    [System.Flags]
+    private enum E
+    {
+        None = 0,
+        B = 3
+    }
 }
 
 [System.Flags]
@@ -212,11 +218,13 @@ internal enum E4
         public void VisualBasic_EnumsShouldZeroValueFlagsRename()
         {
             var code = @"
-<System.Flags>
-Private Enum E
-    A = 0
-    B = 1
-End Enum
+Class Outer
+    <System.Flags>
+    Private Enum E
+        A = 0
+        B = 1
+    End Enum
+End Class
 
 <System.Flags>
 Public Enum E2
@@ -238,11 +246,13 @@ End Enum
 ";
 
             var expectedFixedCode = @"
-<System.Flags>
-Private Enum E
-    None = 0
-    B = 1
-End Enum
+Class Outer
+    <System.Flags>
+    Private Enum E
+        None = 0
+        B = 1
+    End Enum
+End Class
 
 <System.Flags>
 Public Enum E2
@@ -270,11 +280,13 @@ End Enum
         public void VisualBasic_EnumsShouldZeroValueFlagsRename_AttributeListHasTrivia()
         {
             var code = @"
-<System.Flags> _
-Private Enum E
-    A = 0
-    B = 1
-End Enum
+Class Outer
+    <System.Flags> _
+    Private Enum E
+        A = 0
+        B = 1
+    End Enum
+End Class
 
 <System.Flags> _
 Public Enum E2
@@ -296,11 +308,13 @@ End Enum
 ";
 
             var expectedFixedCode = @"
-<System.Flags> _
-Private Enum E
-    None = 0
-    B = 1
-End Enum
+Class Outer
+    <System.Flags> _
+    Private Enum E
+        None = 0
+        B = 1
+    End Enum
+End Class
 
 <System.Flags> _
 Public Enum E2
@@ -327,11 +341,13 @@ End Enum
         public void VisualBasic_EnumsShouldZeroValueFlagsMultipleZero()
         {
             var code = @"
-<System.Flags>
-Private Enum E
-    None = 0
-    A = 0
-End Enum
+Class Outer
+    <System.Flags>
+    Private Enum E
+        None = 0
+        A = 0
+    End Enum
+End Class
 
 <System.Flags>
 Friend Enum E2
@@ -346,10 +362,12 @@ Public Enum E3
 End Enum";
 
             var expectedFixedCode = @"
-<System.Flags>
-Private Enum E
-    None = 0
-End Enum
+Class Outer
+    <System.Flags>
+    Private Enum E
+        None = 0
+    End Enum
+End Class
 
 <System.Flags>
 Friend Enum E2

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/EnumsShouldHaveZeroValueTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/EnumsShouldHaveZeroValueTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [WorkItem(836193, "DevDiv")]
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1032")]
         public void CSharp_EnumsShouldZeroValueFlagsRename()
         {
             // In enum '{0}', change the name of '{1}' to 'None'.
@@ -30,11 +30,14 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             string expectedMessage4 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsRename, "E4", "A4");
 
             var code = @"
-[System.Flags]
-private enum E
+class Outer
 {
-    A = 0,
-    B = 3
+    [System.Flags]
+    private enum E
+    {
+        A = 0,
+        B = 3
+    }
 }
 
 [System.Flags]
@@ -65,10 +68,10 @@ public enum NoZeroValuedField
     B5 = 2
 }";
             VerifyCSharp(code,
-                GetCSharpResultAt(5, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetCSharpResultAt(12, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
-                GetCSharpResultAt(19, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3),
-                GetCSharpResultAt(26, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage4));
+                GetCSharpResultAt(7, 9, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
+                GetCSharpResultAt(15, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
+                GetCSharpResultAt(22, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3),
+                GetCSharpResultAt(29, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage4));
         }
 
         [Fact]
@@ -79,12 +82,16 @@ public enum NoZeroValuedField
             string expectedMessage2 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsMultipleZeros, "E2");
 
             var code = @"// Some comment
-[System.Flags]
-private enum E
+class Outer
 {
-    None = 0,
-    A = 0
+    [System.Flags]
+    private enum E
+    {
+        None = 0,
+        A = 0
+    }
 }
+
 // Some comment
 [System.Flags]
 internal enum E2
@@ -93,8 +100,8 @@ internal enum E2
     A = None
 }";
             VerifyCSharp(code,
-                GetCSharpResultAt(3, 14, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetCSharpResultAt(10, 15, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
+                GetCSharpResultAt(5, 18, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
+                GetCSharpResultAt(14, 15, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
         }
 
         [Fact]
@@ -104,12 +111,16 @@ internal enum E2
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsMultipleZeros, "E2");
 
             var code = @"// Some comment
-[System.Flags]
-private enum E
+class Outer
 {
-    None = 0,
-    A = 0
+    [System.Flags]
+    private enum E
+    {
+        None = 0,
+        A = 0
+    }
 }
+
 [|// Some comment
 [System.Flags]
 internal enum E2
@@ -118,7 +129,7 @@ internal enum E2
     A = None
 }|]";
             VerifyCSharp(code,
-                GetCSharpResultAt(10, 15, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage));
+                GetCSharpResultAt(14, 15, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage));
         }
 
         [Fact]
@@ -129,15 +140,18 @@ internal enum E2
             string expectedMessage2 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue, "E2");
 
             var code = @"
-private enum E
+class Outer
 {
-    A = 1
-}
+    private enum E
+    {
+        A = 1
+    }
 
-private enum E2
-{
-    None = 1,
-    A = 2
+    private enum E2
+    {
+        None = 1,
+        A = 2
+    }
 }
 
 internal enum E3
@@ -153,8 +167,8 @@ internal enum E4
 }
 ";
             VerifyCSharp(code,
-                GetCSharpResultAt(2, 14, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetCSharpResultAt(7, 14, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
+                GetCSharpResultAt(4, 18, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
+                GetCSharpResultAt(9, 18, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
         }
 
         [Fact]
@@ -243,11 +257,13 @@ End Enum
             string expectedMessage2 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsRename, "E3", "A3");
 
             var code = @"
-<System.Flags>
-Private Enum E
-	A = 0
-	B = 1
-End Enum
+Class Outer
+    <System.Flags>
+    Private Enum E
+	    A = 0
+	    B = 1
+    End Enum
+End Class
 
 [|<System.Flags>
 Public Enum E2
@@ -268,8 +284,8 @@ Public Enum NoZeroValuedField
 End Enum
 ";
             VerifyBasic(code,
-                GetBasicResultAt(10, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetBasicResultAt(16, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
+                GetBasicResultAt(12, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
+                GetBasicResultAt(18, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
         }
 
         [WorkItem(836193, "DevDiv")]
@@ -282,11 +298,13 @@ End Enum
             string expectedMessage3 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsRename, "E3", "A3");
 
             var code = @"
-<System.Flags> _
-Private Enum E
-	A = 0
-	B = 1
-End Enum
+Class Outer
+    <System.Flags> _
+    Private Enum E
+	    A = 0
+	    B = 1
+    End Enum
+End Class
 
 <System.Flags> _
 Public Enum E2
@@ -307,9 +325,9 @@ Public Enum NoZeroValuedField
 End Enum
 ";
             VerifyBasic(code,
-                GetBasicResultAt(4, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetBasicResultAt(10, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
-                GetBasicResultAt(16, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3));
+                GetBasicResultAt(5, 6, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
+                GetBasicResultAt(12, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
+                GetBasicResultAt(18, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3));
         }
 
         [Fact]
@@ -321,11 +339,13 @@ End Enum
             string expectedMessage3 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsMultipleZeros, "E3");
 
             var code = @"
-<System.Flags>
-Private Enum E
-	None = 0
-	A = 0
-End Enum
+Class Outer
+    <System.Flags>
+    Private Enum E
+	    None = 0
+	    A = 0
+    End Enum
+End Class
 
 <System.Flags>
 Friend Enum E2
@@ -340,9 +360,9 @@ Public Enum E3
 End Enum";
 
             VerifyBasic(code,
-                GetBasicResultAt(3, 14, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetBasicResultAt(9, 13, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
-                GetBasicResultAt(15, 13, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3));
+                GetBasicResultAt(4, 18, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
+                GetBasicResultAt(11, 13, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
+                GetBasicResultAt(17, 13, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3));
         }
 
         [Fact]
@@ -353,14 +373,16 @@ End Enum";
             string expectedMessage2 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue, "E2");
 
             var code = @"
-Private Enum E
-	A = 1
-End Enum
+Class Outer
+    Private Enum E
+	    A = 1
+    End Enum
 
-Private Enum E2
-	None = 1
-	A = 2
-End Enum
+    Private Enum E2
+	    None = 1
+	    A = 2
+    End Enum
+End Class
 
 Friend Enum E3
     None = 0
@@ -374,8 +396,8 @@ End Enum
 ";
 
             VerifyBasic(code,
-                GetBasicResultAt(2, 14, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetBasicResultAt(6, 14, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
+                GetBasicResultAt(3, 18, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
+                GetBasicResultAt(7, 18, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
         }
 
         [Fact]
@@ -385,14 +407,16 @@ End Enum
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue, "E2");
 
             var code = @"
-Private Enum E
-	A = 1
-End Enum
+Class Outer
+    Private Enum E
+	    A = 1
+    End Enum
 
-[|Private Enum E2
-	None = 1
-	A = 2
-End Enum
+    [|Private Enum E2
+	    None = 1
+	    A = 2
+    End Enum
+End Class
 
 Friend Enum E3
     None = 0
@@ -406,7 +430,7 @@ End Enum
 ";
 
             VerifyBasic(code,
-                GetBasicResultAt(6, 14, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage));
+                GetBasicResultAt(7, 18, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage));
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/EquatableAnalyzerTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/EquatableAnalyzerTests.cs
@@ -206,7 +206,7 @@ class C : IEquatable<C>
 {
     public int Equals(C x)
     {
-        return true;
+        return 1;
     }
 }
 ";
@@ -275,7 +275,7 @@ using System;
 
 class C : IEquatable<C>
 {
-    public bool IEquatable<C>.Equals(object other)
+    bool IEquatable<C>.Equals(C other)
     {
         return true;
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ExceptionsShouldBePublicTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ExceptionsShouldBePublicTests.cs
@@ -79,10 +79,12 @@ End Class",
         {
             VerifyBasic(@"
 Imports System
-Private Class PrivateException
-   Inherits SystemException
+Public Class Outer
+    Private Class PrivateException
+        Inherits SystemException
+    End Class
 End Class",
-            GetCA1064VBasicResultAt(3, 15));
+            GetCA1064VBasicResultAt(4, 19));
         }
 
         [Fact]
@@ -99,7 +101,8 @@ End Class");
         public void TestVBasicNonExceptionType()
         {
             VerifyBasic(@"
-Imports System
+Imports System.IO
+Imports System.Text
 Public Class NonException
    Inherits StringWriter
 End Class");

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotContainUnderscoresTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotContainUnderscoresTests.cs
@@ -76,10 +76,11 @@ public class OuterType
     public class UnderScoreInName_
     {
     }
-}
 
-private class UnderScoreInNameButPrivate_
-{
+    private class UnderScoreInNameButPrivate_
+    {
+    }
+
 }",
             GetCA1707CSharpResultAt(line: 4, column: 18, symbolKind: SymbolKind.NamedType, identifierNames: "OuterType.UnderScoreInName_"));
         }
@@ -262,7 +263,7 @@ public class Der : Base
 {
     public override void M2(int int_)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public override void M1(int int_)
@@ -312,7 +313,7 @@ public class implementI : I
 {
     public void M<U_>()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }
 
@@ -329,12 +330,12 @@ public class Der : Base
 {
     public override void M2<U_>()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public override void M1<T_>()
     {
-        base.M1<T_>(int1);
+        base.M1<T_>();
     }
 }",
             GetCA1707CSharpResultAt(4, 26, SymbolKind.MethodTypeParameter, "DoesNotMatter22.PublicM1<T1_>()", "T1_"),
@@ -464,7 +465,7 @@ Public Interface I1
 End Interface
 
 Public Class ImplementI1
-    Inherits I1
+    Implements I1
     Public Sub M_() Implements I1.M_
     End Sub
     ' No diagnostic
@@ -566,29 +567,29 @@ End Class",
         {
             VerifyBasic(@"
 Public Class DoesNotMatter
-    Public Event PublicE1_ As EventHandler
-    Private Event PrivateE2_ As EventHandler
+    Public Event PublicE1_ As System.EventHandler
+    Private Event PrivateE2_ As System.EventHandler
     ' No diagnostic
-    Friend Event InternalE3_ As EventHandler
+    Friend Event InternalE3_ As System.EventHandler
     ' No diagnostic
-    Protected Event ProtectedE4_ As EventHandler
+    Protected Event ProtectedE4_ As System.EventHandler
 End Class
 
 Public Interface I1
-    Event E_ As EventHandler
+    Event E_ As System.EventHandler
 End Interface
 
 Public Class ImplementI1
     Implements I1
     ' No diagnostic
-    Public Event E_ As EventHandler Implements I1.E_
-    Public Event E2_ As EventHandler
+    Public Event E_ As System.EventHandler Implements I1.E_
+    Public Event E2_ As System.EventHandler
 End Class
 
 Public Class Derives
     Inherits ImplementI1
     ' No diagnostic
-    Public Shadows Event E2_ As EventHandler
+    Public Shadows Event E2_ As System.EventHandler
 End Class",
             GetCA1707BasicResultAt(line: 3, column: 18, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.PublicE1_"),
             GetCA1707BasicResultAt(line: 8, column: 21, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.ProtectedE4_"),
@@ -647,7 +648,7 @@ End Class
 Public Class Der
     Inherits Base
     Public Overrides Sub M2(int_ As Integer)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Overrides Sub M1(int_ As Integer)
@@ -695,7 +696,7 @@ End Interface
 Public Class implementI
     Implements I
     Public Sub M(Of U_)() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class
 
@@ -709,7 +710,7 @@ End Class
 Public Class Der
     Inherits Base
     Public Overrides Sub M2(Of U_)()
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Overrides Sub M1(Of T_)()

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
@@ -600,7 +600,8 @@ End Class");
         public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromDictionary()
         {
             VerifyBasic(
-@"Public Class MyBadDictionary {}",
+@"Public Class MyBadDictionary
+End Class",
                 GetBasicResultAt(
                     1, 14,
                     IdentifiersShouldNotHaveIncorrectSuffixAnalyzer.TypeNoAlternateRule,
@@ -612,7 +613,8 @@ End Class");
         public void CA1711_CSharp_NoDiagnostic_TypeImplementsIReadOnlyDictionary()
         {
             VerifyCSharp(
-@"using System.Collections.Generic;
+@"using System.Collections;
+using System.Collections.Generic;
 
 public class MyReadOnlyDictionary : IReadOnlyDictionary<string, int>
 {
@@ -637,10 +639,11 @@ public class MyReadOnlyDictionary : IReadOnlyDictionary<string, int>
         public void CA1711_BasicNoDiagnostic_TypeImplementsIReadOnlyDictionary()
         {
             VerifyBasic(
-@"Imports System.Collections.Generic
+@"Imports System.Collections
+Imports System.Collections.Generic
 
 Public Class MyReadOnlyDictionary
-            Implements IReadOnlyDictionary(Of String, Integer)
+    Implements IReadOnlyDictionary(Of String, Integer)
 
     Public ReadOnly Property Count As Integer Implements IReadOnlyCollection(Of KeyValuePair(Of String, Integer)).Count
         Get
@@ -736,14 +739,14 @@ public class MyNonGenericDictionary : IDictionary
         public void CA1711_Basic_NoDiagnostic_TypeImplementsNonGenericIDictionary()
         {
             VerifyBasic(
-@"Imports System.Collections
+@"Imports System
+Imports System.Collections
 Imports System.Runtime.Serialization
 
 Public Class MyNonGenericDictionary
     Implements IDictionary
 
     Protected Sub New(info As SerializationInfo, context As StreamingContext)
-        MyBase.New(info, context)
     End Sub
 
     Public ReadOnly Property Count As Integer Implements ICollection.Count
@@ -903,7 +906,7 @@ using System.Runtime.Serialization;
 [Serializable]
 public class MyStringToIntDictionary : Dictionary<string, int>
 {
-    protected MyStringDictionary(SerializationInfo info, StreamingContext context)
+    protected MyStringToIntDictionary(SerializationInfo info, StreamingContext context)
         : base(info, context)
     {
     }
@@ -963,7 +966,7 @@ public class MyNonGenericCollection : ICollection
     public int Count => 0;
     public bool IsSynchronized => true;
     public object SyncRoot => null;
-    public void CopyTo(Array array, int index) { }
+    public void CopyTo(System.Array array, int index) { }
 
     public IEnumerator GetEnumerator()
     {
@@ -999,7 +1002,7 @@ Public Class MyNonGenericCollection
         End Get
     End Property
 
-    Public Sub CopyTo(array As Array, index As Integer) Implements ICollection.CopyTo
+    Public Sub CopyTo(array As System.Array, index As Integer) Implements ICollection.CopyTo
     End Sub
 
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -1043,7 +1046,8 @@ End Class");
         public void CA1711_CSharp_NoDiagnostic_TypeImplementsInstantiatedGenericICollection()
         {
             VerifyCSharp(
-@"using System.Collections.Generic;
+@"using System.Collections;
+using System.Collections.Generic;
 
 public class MyIntCollection : ICollection<int>
 {
@@ -1081,7 +1085,8 @@ public class MyIntCollection : ICollection<int>
         public void CA1711_Basic_NoDiagnostic_TypeImplementsInstantiatedGenericICollection()
         {
             VerifyBasic(
-@"Imports System.Collections.Generic
+@"Imports System.Collections
+Imports System.Collections.Generic
 
 Public Class MyIntCollection
     Implements ICollection(Of Integer)

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
@@ -216,7 +216,7 @@ public interface I
             VerifyBasic(@"
 Public Interface I
     Sub F([int] As Integer)
-End Class",
+End Interface",
                 GetBasicResultAt(3, 11, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberParameterRule, "I.F(Integer)", "int", "int"));
         }
 
@@ -236,7 +236,7 @@ internal interface I
             VerifyBasic(@"
 Friend Interface I
     Sub F([int] As Integer)
-End Class");
+End Interface");
         }
 
         [Fact]
@@ -250,7 +250,7 @@ public class C
 
 public class D : C
 {
-    public override void F(int @int);
+    public override void F(int @int) {}
 }",
                 // Diagnostic for the virtual in C, but none for the override in D.
                 GetCSharpResultAt(4, 31, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberParameterRule, "C.F(int)", "int", "int"));
@@ -286,7 +286,7 @@ public class C
 
 public class D : C
 {
-    public new void F(int @int);
+    public new void F(int @int) {}
 }",
                 // Diagnostic for the virtual in C, but none for the override in D.
                 GetCSharpResultAt(4, 31, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberParameterRule, "C.F(int)", "int", "int"));
@@ -322,7 +322,7 @@ public class C
 
 public class D : C
 {
-    public virtual new void F(int @int);
+    public virtual new void F(int @int) {}
 }",
                 // Diagnostics for both the virtual in C, and the virtual new method in D.
                 GetCSharpResultAt(4, 31, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberParameterRule, "C.F(int)", "int", "int"),

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
@@ -71,7 +71,7 @@ public class C
             VerifyBasic(@"
 Public Class C
     ' Matches VB AddHandler keyword:
-    Public Overridable Sub aDdHaNdLeR()
+    Public Overridable Sub [aDdHaNdLeR]()
     End Sub
 End Class",
                 GetBasicResultAt(4, 28, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.aDdHaNdLeR()", "AddHandler"));
@@ -304,13 +304,13 @@ public class C
             VerifyBasic(@"
 Public Class C
     Private _for As Integer
-    Public Overridable Property [Sub] As Integer
+    Public Overridable ReadOnly Property [Sub] As Integer
         Get
             Return _for
         End Get
     End Property
 End Class",
-                GetBasicResultAt(4, 33, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.Sub", "Sub"));
+                GetBasicResultAt(4, 42, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.Sub", "Sub"));
         }
 
         [Fact]
@@ -337,13 +337,13 @@ public class C
             VerifyBasic(@"
 Public Class C
     Private _for As Integer
-    Public Overridable Property [Sub] As Integer
+    Public Overridable WriteOnly Property [Sub] As Integer
         Set(value As Integer)
             _for = value
         End Set
     End Property
 End Class",
-                GetBasicResultAt(4, 33, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.Sub", "Sub"));
+                GetBasicResultAt(4, 43, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.Sub", "Sub"));
         }
 
         [Fact]
@@ -404,7 +404,7 @@ public class C
 
 public class D : C
 {
-    public sealed override sealed void @internal() {}
+    public sealed override void @internal() {}
 }",
                 // Diagnostic for the virtual in C, but none for the sealed override in D.
                 GetCSharpResultAt(4, 25, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.internal()", "internal"));
@@ -415,17 +415,17 @@ public class D : C
         {
             VerifyBasic(@"
 Public Class C
-    Public Overridable Sub [internal]()
+    Public Overridable Sub [friend]()
     End Sub
 End Class
 
 Public Class D
     Inherits C
-    Public NotInheritable Overrides Sub [internal]()
+    Public NotOverridable Overrides Sub [friend]()
     End Sub
 End Class",
                 // Diagnostic for the virtual in C, but none for the sealed override in D.
-                GetBasicResultAt(3, 28, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.internal()", "internal"));
+                GetBasicResultAt(3, 28, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C.friend()", "friend"));
         }
 
         [Fact]
@@ -562,7 +562,7 @@ End Class",
             VerifyCSharp(@"
 public class C
 {
-    public delegate void Callback(object sender, EventArgs e);
+    public delegate void Callback(object sender, System.EventArgs e);
     public virtual event Callback @float;
 }",
                 // Diagnostics for both the virtual in C, and the virtual new method in D.

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
@@ -58,7 +58,7 @@ public struct aDdHaNdLeR {}
         public void BasicDiagnosticForCaseInsensitiveKeywordNamedPublicType()
         {
             VerifyBasic(@"
-Public Structure aDdHaNdLeR
+Public Structure [aDdHaNdLeR]
 End Structure",
                 GetBasicResultAt(2, 18, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "aDdHaNdLeR", "AddHandler"));
         }
@@ -115,7 +115,8 @@ namespace N
             VerifyBasic(@"
 Namespace N
     Public Enum [Enum]
-    End Class
+        X
+    End Enum
 End Namespace
 ",
                 GetBasicResultAt(3, 17, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "Enum", "Enum"));

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ImplementIDisposableCorrectlyTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ImplementIDisposableCorrectlyTests.cs
@@ -162,7 +162,7 @@ using System;
 
 public interface ITest : IDisposable
 {
-    void int Test { get; set; }
+    int Test { get; set; }
 }
 
 public class B : IDisposable
@@ -204,7 +204,7 @@ using System;
 
 public interface ITest : IDisposable
 {
-    void int Test { get; set; }
+    int Test { get; set; }
 }
 
 public class B : IDisposable
@@ -230,7 +230,7 @@ using System;
 
 public interface ITest : IDisposable
 {
-    void int Test { get; set; }
+    int Test { get; set; }
 }
 
 public class B : IDisposable

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
@@ -210,7 +210,7 @@ public class NestedExplicitInterfaceImplementation
             CSharpResult(50, 13, "ImplementsNestedGeneral", "NestedExplicitInterfaceImplementation.INestedGeneral.remove_TheEvent"));
         }
 
-        [Fact]
+        [Fact(Skip= "https://github.com/dotnet/roslyn-analyzers/issues/1008")]
         public void CA1033NoDiagnosticCasesCSharp()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/NestedTypesShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/NestedTypesShouldNotBeVisibleTests.cs
@@ -232,7 +232,7 @@ End Class
         {
             var code = @"
 Public Module Outer
-    Protected Class Inner
+    Friend Class Inner
     End Class
 End Module
 ";
@@ -250,7 +250,7 @@ public class Outer
     public class MyEnumerator: IEnumerator
     {
         public bool MoveNext() { return true; }
-        public object Current { get; } => null;
+        public object Current { get; } = null;
         public void Reset() {}
     }
 }
@@ -295,17 +295,17 @@ Public Class Outer
     Public Class MyEnumerator
         Implements IEnumerator
 
-        Public Function MoveNext() As Boolean
+        Public Function MoveNext() As Boolean Implements IEnumerator.MoveNext
             Return True
         End Function
 
-        Public Property Current As Object
+        Public ReadOnly Property Current As Object Implements IEnumerator.Current
             Get
                 Return Nothing
             End Get
         End Property
 
-        Public Sub Reset()
+        Public Sub Reset() Implements IEnumerator.Reset
         End Sub
     End Class
 End Class
@@ -327,6 +327,9 @@ public class MyDataSet : DataSet
 
     public class MyDataRow : DataRow
     {
+        public MyDataRow(DataRowBuilder builder) : base(builder)
+        {
+        }
     }
 }
 ";
@@ -348,6 +351,10 @@ Public Class MyDataSet
 
     Public Class MyDataRow
         Inherits DataRow
+
+        Public Sub New(builder As DataRowBuilder)
+            MyBase.New(builder)
+        End Sub
     End Class
 End Class
 ";
@@ -368,6 +375,9 @@ public class MyDataSet : DataSet
 
     public class MyDataRow : DataRow
     {
+        public MyDataRow(DataRowBuilder builder) : base(builder)
+        {
+        }
     }
 
     public class Inner
@@ -375,7 +385,7 @@ public class MyDataSet : DataSet
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpCA1034ResultAt(14, 18, "Inner"));
+            VerifyCSharp(code, GetCSharpCA1034ResultAt(17, 18, "Inner"));
         }
 
         [Fact]
@@ -393,13 +403,17 @@ Public Class MyDataSet
 
     Public Class MyDataRow
         Inherits DataRow
+
+        Public Sub New(builder As DataRowBuilder)
+            MyBase.New(builder)
+        End Sub
     End Class
 
     Public Class Inner
     End Class
 End Class
 ";
-            VerifyBasic(code, GetBasicCA1034ResultAt(15, 18, "Inner"));
+            VerifyBasic(code, GetBasicCA1034ResultAt(19, 18, "Inner"));
         }
 
         [Fact]
@@ -440,6 +454,10 @@ Public Class Outer
 
     Public Class MyDataRow
         Inherits DataRow
+
+        Public Sub New(builder As DataRowBuilder)
+            MyBase.New(builder)
+        End Sub
     End Class
 End Class
 ";

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/NonConstantFieldsShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/NonConstantFieldsShouldNotBeVisibleTests.cs
@@ -33,7 +33,7 @@ class A
         {
             VerifyBasic(@"
 Class A
-    field As System.String
+    Dim field As System.String
 End Class");
         }
         
@@ -70,7 +70,7 @@ class A
         public void PublicStaticVariableVB()
         {
             VerifyBasic(@"
-Class
+Class A
     Public Shared field as System.String
 End Class", GetBasicResultAt(3, 19, NonConstantFieldsShouldNotBeVisibleAnalyzer.RuleId, NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString()));
         }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -71,6 +71,7 @@ public struct EmptyStruct
         {
             VerifyCSharp(@"
 using System;
+using System.Collections;
 
 public struct MyEnumerator : System.Collections.IEnumerator
 {
@@ -192,7 +193,7 @@ public struct A
             VerifyCSharp(@"
 public struct A
 {
-    public new bool Equals(obj other)
+    public new bool Equals(object other)
     {
         return true;
     }
@@ -266,27 +267,29 @@ End Structure
         {
             VerifyBasic(@"
 Imports System
+Imports System.Collections
+Imports System.Collections.Generic
 
 Public Structure MyEnumerator
-	Implements System.Collections.IEnumerator
-	Public ReadOnly Property Current() As Object
+	Implements IEnumerator
+	Public ReadOnly Property Current As Object Implements IEnumerator.Current
 		Get
 			Throw New NotImplementedException()
 		End Get
 	End Property
 
-	Public Function MoveNext() As Boolean
+	Public Function MoveNext() As Boolean Implements IEnumerator.MoveNext
 		Throw New NotImplementedException()
 	End Function
 
-	Public Sub Reset()
+	Public Sub Reset() Implements IEnumerator.Reset
 		Throw New NotImplementedException()
 	End Sub
 End Structure
 
 Public Structure MyGenericEnumerator(Of T)
-	Implements System.Collections.Generic.IEnumerator(Of T)
-	Public ReadOnly Property Current() As T
+	Implements IEnumerator(Of T)
+	Public ReadOnly Property Current As T Implements IEnumerator(Of T).Current
 		Get
 			Throw New NotImplementedException()
 		End Get
@@ -298,15 +301,15 @@ Public Structure MyGenericEnumerator(Of T)
 		End Get
 	End Property
 
-	Public Sub Dispose()
+	Public Sub Dispose() Implements IEnumerator(Of T).Dispose
 		Throw New NotImplementedException()
 	End Sub
 
-	Public Function MoveNext() As Boolean
+	Public Function MoveNext() As Boolean Implements IEnumerator(Of T).MoveNext
 		Throw New NotImplementedException()
 	End Function
 
-	Public Sub Reset()
+	Public Sub Reset() Implements IEnumerator(Of T).Reset
 		Throw New NotImplementedException()
 	End Sub
 End Structure

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
@@ -147,7 +147,7 @@ Imports System
 
 Public Class A : Implements IComparable
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -156,7 +156,7 @@ Imports System
 
 Public Class A : Implements IComparable
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -202,7 +202,7 @@ Public Class A : Implements IComparable
         Return True
     End Operator
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -219,7 +219,7 @@ Public Class A : Implements IComparable
         Return True
     End Operator
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.cs
@@ -478,11 +478,11 @@ Imports System
 
 Public Class A : Implements IComparable
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -518,11 +518,11 @@ Imports System
 
 Public Structure A : Implements IComparable
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -557,11 +557,11 @@ Imports System
 
 [|Public Class A : Implements IComparable
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -589,11 +589,11 @@ End Class|]
 
 Public Structure B : Implements IComparable
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -627,11 +627,11 @@ Imports System
 
 Public Structure A : Implements IComparable
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -672,7 +672,7 @@ Public Class Class1
             Return 1234
         End Function
 
-        Public Function CompareTo(obj As Object) As Integer
+        Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
             Return 1
         End Function
 
@@ -701,11 +701,11 @@ Imports System
 
 Public Class A : Implements IComparable
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -738,11 +738,11 @@ Imports System
 
 Public Class A : Implements IComparable
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -771,11 +771,11 @@ Imports System
 
 Public Structure A : Implements IComparable
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
         Return 1
     End Function
 
@@ -804,11 +804,11 @@ Imports System
 
 Public Structure A : Implements IComparable(Of Integer)
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Integer) As Integer
+    Public Function CompareTo(other As Integer) As Integer Implements IComparable(Of Integer).CompareTo
         Return 1
     End Function
 
@@ -841,11 +841,11 @@ End Interface
 
 Public Structure A : Implements IDerived
 
-    Public Function Overrides GetHashCode() As Integer
+    Public Overrides Function GetHashCode() As Integer
         Return 1234
     End Function
 
-    Public Function CompareTo(obj As Object) As Integer
+    Public Function CompareTo(other As Integer) As Integer  Implements IComparable(Of Integer).CompareTo
         Return 1
     End Function
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ParameterNamesShouldMatchBaseDeclarationTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ParameterNamesShouldMatchBaseDeclarationTests.Fixer.cs
@@ -451,7 +451,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         {
             VerifyCSharpFix(@"public interface ITest1
                               {
-                                  public abstract void TestMethod(string arg1, string arg2, string arg3);
+                                  void TestMethod(string arg1, string arg2, string arg3);
                               }
 
                               public interface ITest2
@@ -461,11 +461,11 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                               public class TestClass : ITest1, ITest2
                               {
-                                  public override void TestMethod(string arg1, string arg2, string otherArg3) { }
+                                  public void TestMethod(string arg1, string arg2, string otherArg3) { }
                               }",
                             @"public interface ITest1
                               {
-                                  public abstract void TestMethod(string arg1, string arg2, string arg3);
+                                  void TestMethod(string arg1, string arg2, string arg3);
                               }
 
                               public interface ITest2
@@ -475,7 +475,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                               public class TestClass : ITest1, ITest2
                               {
-                                  public override void TestMethod(string arg1, string arg2, string arg3) { }
+                                  public void TestMethod(string arg1, string arg2, string arg3) { }
                               }");
 
             VerifyBasicFix(@"Public Interface ITest1

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ParameterNamesShouldMatchBaseDeclarationTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ParameterNamesShouldMatchBaseDeclarationTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                           End Class");
 
             VerifyBasic(@"Public Class TestClass
-                              Public Sub TestMethod(arg1 As String, arg2 As String) { }
+                              Public Sub TestMethod(arg1 As String, arg2 As String)
                               End Sub
                           End Class");
 
@@ -57,7 +57,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : BaseClass
                            {
-                               public override void TestMethod(string arg1, string arg2);
+                               public override void TestMethod(string arg1, string arg2) { }
                            }",
                          GetCSharpResultAt(8, 71, "void TestClass.TestMethod(string arg1, string arg2)", "arg1", "baseArg1", "void BaseClass.TestMethod(string baseArg1, string baseArg2)"),
                          GetCSharpResultAt(8, 84, "void TestClass.TestMethod(string arg1, string arg2)", "arg2", "baseArg2", "void BaseClass.TestMethod(string baseArg1, string baseArg2)"));
@@ -69,7 +69,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : BaseClass
                            {
-                               public override void TestMethod(string arg1, string arg2, __arglist);
+                               public override void TestMethod(string arg1, string arg2, __arglist) { }
                            }",
                          GetCSharpResultAt(8, 71, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg1", "baseArg1", "void BaseClass.TestMethod(string baseArg1, string baseArg2, __arglist)"),
                          GetCSharpResultAt(8, 84, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg2", "baseArg2", "void BaseClass.TestMethod(string baseArg1, string baseArg2, __arglist)"));
@@ -81,7 +81,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : BaseClass
                            {
-                               public override void TestMethod(string arg1, string arg2, params string[] arg3);
+                               public override void TestMethod(string arg1, string arg2, params string[] arg3) { }
                            }",
                          GetCSharpResultAt(8, 71, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg1", "baseArg1", "void BaseClass.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
                          GetCSharpResultAt(8, 84, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg2", "baseArg2", "void BaseClass.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
@@ -125,7 +125,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : IBase
                            {
-                               public void TestMethod(string arg1, string arg2);
+                               public void TestMethod(string arg1, string arg2) { }
                            }",
                          GetCSharpResultAt(8, 62, "void TestClass.TestMethod(string arg1, string arg2)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2)"),
                          GetCSharpResultAt(8, 75, "void TestClass.TestMethod(string arg1, string arg2)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2)"));
@@ -137,7 +137,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : IBase
                            {
-                               public void TestMethod(string arg1, string arg2, __arglist);
+                               public void TestMethod(string arg1, string arg2, __arglist) { }
                            }",
                          GetCSharpResultAt(8, 62, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2, __arglist)"),
                          GetCSharpResultAt(8, 75, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2, __arglist)"));
@@ -149,7 +149,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : IBase
                            {
-                               public void TestMethod(string arg1, string arg2, params string[] arg3);
+                               public void TestMethod(string arg1, string arg2, params string[] arg3) { }
                            }",
                          GetCSharpResultAt(8, 62, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
                          GetCSharpResultAt(8, 75, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
@@ -193,7 +193,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : IBase
                            {
-                               void IBase.TestMethod(string arg1, string arg2);
+                               void IBase.TestMethod(string arg1, string arg2) { }
                            }",
                          GetCSharpResultAt(8, 61, "void TestClass.TestMethod(string arg1, string arg2)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2)"),
                          GetCSharpResultAt(8, 74, "void TestClass.TestMethod(string arg1, string arg2)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2)"));
@@ -205,7 +205,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : IBase
                            {
-                               void IBase.TestMethod(string arg1, string arg2, __arglist);
+                               void IBase.TestMethod(string arg1, string arg2, __arglist) { }
                            }",
                          GetCSharpResultAt(8, 61, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2, __arglist)"),
                          GetCSharpResultAt(8, 74, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2, __arglist)"));
@@ -217,7 +217,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : IBase
                            {
-                               void IBase.TestMethod(string arg1, string arg2, params string[] arg3);
+                               void IBase.TestMethod(string arg1, string arg2, params string[] arg3) { }
                            }",
                          GetCSharpResultAt(8, 61, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
                          GetCSharpResultAt(8, 74, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
@@ -260,7 +260,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         {
             VerifyCSharp(@"public class TestClass
                            {
-                               public override void TestMethod(string arg1, string arg2);
+                               public override void TestMethod(string arg1, string arg2) { }
                            }");
 
             VerifyBasic(@"Public Class TestClass
@@ -323,7 +323,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                               Public Sub TestMethod(baseArg1 As String, baseArg2 As String)
                               End Sub
                           End Class
-                          }
 
                           Public Class TestClass
                               Inherits BaseClass
@@ -348,7 +347,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : BaseClass, ITest
                            {
-                               public override void TestMethod(string arg1, string arg2);
+                               public override void TestMethod(string arg1, string arg2) { }
                            }");
 
             VerifyCSharp(@"public abstract class BaseClass
@@ -363,7 +362,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : BaseClass, ITest
                            {
-                               public override void TestMethod(string interfaceArg1, string interfaceArg2);
+                               public override void TestMethod(string interfaceArg1, string interfaceArg2) { }
                            }",
                          GetCSharpResultAt(13, 71, "void TestClass.TestMethod(string interfaceArg1, string interfaceArg2)", "interfaceArg1", "arg1", "void BaseClass.TestMethod(string arg1, string arg2)"),
                          GetCSharpResultAt(13, 93, "void TestClass.TestMethod(string interfaceArg1, string interfaceArg2)", "interfaceArg2", "arg2", "void BaseClass.TestMethod(string arg1, string arg2)"));
@@ -373,7 +372,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                           End Class
 
                           Public Interface ITest
-                              Sub TestMethod(interfaceArg1 As String, interfaceArg2 As String);
+                              Sub TestMethod(interfaceArg1 As String, interfaceArg2 As String)
                           End Interface
 
                           Public Class TestClass
@@ -389,7 +388,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                           End Class
 
                           Public Interface ITest
-                              Sub TestMethod(interfaceArg1 As String, interfaceArg2 As String);
+                              Sub TestMethod(interfaceArg1 As String, interfaceArg2 As String)
                           End Interface
 
                           Public Class TestClass
@@ -418,7 +417,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : ITest1, ITest2
                            {
-                               public override void TestMethod(string arg1, string arg2);
+                               public void TestMethod(string arg1, string arg2) { }
                            }");
 
             VerifyBasic(@"Public Interface ITest1
@@ -442,7 +441,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         {
             VerifyCSharp(@"public interface ITest1
                            {
-                               public abstract void TestMethod(string arg1, string arg2, string arg3);
+                               void TestMethod(string arg1, string arg2, string arg3);
                            }
 
                            public interface ITest2
@@ -452,9 +451,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
                            public class TestClass : ITest1, ITest2
                            {
-                               public override void TestMethod(string arg1, string arg2, string otherArg3);
+                               public void TestMethod(string arg1, string arg2, string otherArg3) { }
                            }",
-                         GetCSharpResultAt(13, 97, "void TestClass.TestMethod(string arg1, string arg2, string otherArg3)", "otherArg3", "arg3", "void ITest1.TestMethod(string arg1, string arg2, string arg3)"));
+                         GetCSharpResultAt(13, 88, "void TestClass.TestMethod(string arg1, string arg2, string otherArg3)", "otherArg3", "arg3", "void ITest1.TestMethod(string arg1, string arg2, string arg3)"));
 
             VerifyBasic(@"Public Interface ITest1
                               Sub TestMethod(arg1 As String, arg2 As String, arg3 As String)

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/PropertiesShouldNotBeWriteOnlyTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/PropertiesShouldNotBeWriteOnlyTests.cs
@@ -90,8 +90,9 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests3
         protected string CS_field;
         protected string CS_AccessibleProperty3
         {
-        get { return CS_field; }
-        private set { CS_field = value; }
+            get { return CS_field; }
+            private set { CS_field = value; }
+        }
     }
 }";
             VerifyCSharp(code);
@@ -207,17 +208,18 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests8
 using System;
 namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests9
 {
-    public class IInterface
+    public interface IInterface
     {
         string InterfaceProperty
         {
-            set;
+            get; set;
         }
     }
     public class Class1 : IInterface
     {
         string IInterface.InterfaceProperty
         {
+            get { throw new NotImplementedException(); }
             set { }
         }
     }
@@ -236,7 +238,7 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests10
     {
         public virtual string BaseProperty
         {
-            get { }
+            get { throw new NotImplementedException(); }
             set { }
         }
     }
@@ -269,6 +271,7 @@ Namespace VB_DesignLibrary
             End Set
         End Property
     End Class
+End Namespace
 ";
             VerifyBasic(code);
         }
@@ -290,6 +293,7 @@ Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests1
             End Set
         End Property
     End Class
+End Namespace
 ";
             VerifyBasic(code);
         }
@@ -344,7 +348,7 @@ End NameSpace
             var code = @"
 Imports System
 Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests4
-    Public VB_class ClassWithReadableProperty
+    Public Class ClassWithReadableProperty
         Protected VB_field As String
         Friend Property VB_AccessibleProperty4() As String
             Get
@@ -456,13 +460,13 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests1
     public class CS_BadClassWithWriteOnlyProperty
     {
         protected string CS_someName;
-        protected public string CS_WriteOnlyProperty1
+        public string CS_WriteOnlyProperty1
         {
             set { CS_someName = value; }
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 33, CA1044MessageAddGetter, "CS_WriteOnlyProperty1"));
+            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 23, CA1044MessageAddGetter, "CS_WriteOnlyProperty1"));
         }
 
         [Fact]
@@ -475,13 +479,13 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests2
     public class CS_BadClassWithWriteOnlyProperty
     {
         string CS_someName;
-        protected public string CS_WriteOnlyProperty2
+        protected string CS_WriteOnlyProperty2
         {
             set { CS_someName = value; }
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 33, CA1044MessageAddGetter, "CS_WriteOnlyProperty2"));
+            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 26, CA1044MessageAddGetter, "CS_WriteOnlyProperty2"));
         }
 
         [Fact]
@@ -723,7 +727,7 @@ Imports System
 Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests5
     Public Class VB_BadClassWithWriteOnlyProperty
         Protected VB_someName As String
-        Protected Public WriteOnly Property VB_WriteOnlyProperty5() As String
+        Public WriteOnly Property VB_WriteOnlyProperty5() As String
             Set(ByVal value As String)
                 VB_someName = value
             End Set
@@ -731,7 +735,7 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests5
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 45, CA1044MessageAddGetter, "VB_WriteOnlyProperty5"));
+            VerifyBasic(code, GetCA1044BasicResultAt(6, 35, CA1044MessageAddGetter, "VB_WriteOnlyProperty5"));
         }
         [Fact]
         public void VB_CA1044Bad_Interface_Write()
@@ -761,13 +765,11 @@ End NameSpace
 Imports System
 Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests1
     Public Interface VB_IInterface
-        Protected WriteOnly Property VB_InterfaceProperty1() As String Implements VB_InterfaceProperty1
-            Set(ByVal value As String)
-            End Set
+        WriteOnly Property VB_InterfaceProperty1() As String
     End Interface
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(5, 38, CA1044MessageAddGetter, "VB_InterfaceProperty1"));
+            VerifyBasic(code, GetCA1044BasicResultAt(5, 28, CA1044MessageAddGetter, "VB_InterfaceProperty1"));
         }
 
         [Fact]
@@ -776,7 +778,7 @@ End NameSpace
             var code = @"
 Imports System
 Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests5
-    Public Interface IIterface
+    Public Interface IInterface
         WriteOnly Property InterfaceProperty As String
     End Interface
     Public Class Class1
@@ -815,18 +817,19 @@ End NameSpace
 Imports System
 Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests
     Public Class VB_BadClassWithWriteOnlyProperty
-         Public Property VB_InaccessibleProperty As String
+        Private field As String
+        Public Property VB_InaccessibleProperty As String
             Private Get
                 Return field
             End Get
             Set(ByVal value As String)
                 field = value
             End Set
-         End Property
+        End Property
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(5, 26, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty"));
+            VerifyBasic(code, GetCA1044BasicResultAt(6, 25, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty"));
         }
 
         [Fact]
@@ -858,6 +861,7 @@ End NameSpace
 Imports System
 Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests2
     Public Class VB_BadClassWithWriteOnlyProperty
+        Private field As String
         Protected Friend Property VB_InaccessibleProperty2() As String
             Friend Get
                 Return field
@@ -869,7 +873,7 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests2
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(5, 35, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty2"));
+            VerifyBasic(code, GetCA1044BasicResultAt(6, 35, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty2"));
         }
 
         [Fact]
@@ -879,6 +883,7 @@ End NameSpace
 Imports System
 Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests3
     Public Class VB_BadClassWithWriteOnlyProperty
+        Private field As String
         Public Property VB_InaccessibleProperty3() As String
             Friend Get
                 Return field
@@ -890,7 +895,7 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests3
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(5, 25, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty3"));
+            VerifyBasic(code, GetCA1044BasicResultAt(6, 25, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty3"));
         }
                 
         private static readonly string CA1044MessageAddGetter = MicrosoftApiDesignGuidelinesAnalyzersResources.PropertiesShouldNotBeWriteOnlyMessageAddGetter;

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/PropertiesShouldNotReturnArraysTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/PropertiesShouldNotReturnArraysTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
     {
         public override string[] Pages
         {
-            get { return _Pages; }
+            get { return null; }
         }
     }
 ", CreateCSharpResult(4, 33));
@@ -60,13 +60,16 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         {
             //No warning if property definition has no outside visibility
             VerifyCSharp(@"
+public class Outer
+{
     private class Book
     {
         public string[] Pages
         {
-            get { return _Pages; }
+            get { return null; }
         }
     }
+}
 ");
         }
 
@@ -79,7 +82,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
     {
         public string[] Pages 
         {
-            get { return _Pages; }
+            get { return null; }
         }
     }
 ");
@@ -128,6 +131,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         {
             //No warning if property has no outside visibility
             VerifyBasic(@"
+Public Class Outer
     Private Class Book
         Private _Pages As String()
         Public ReadOnly Property Pages() As String()
@@ -135,7 +139,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                 Return _Pages
             End Get
         End Property
-    End Class");
+    End Class
+End Class");
         }
 
         private static DiagnosticResult CreateCSharpResult(int line, int col)

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/StaticHolderTypeTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/StaticHolderTypeTests.cs
@@ -107,7 +107,7 @@ public class C4
 Public Class B4
     Public Shared Sub Foo()
     End Sub
-EndClass
+End Class
 ",
                 BasicResult(2, 14, "B4"));
         }
@@ -134,7 +134,7 @@ Public Class B5
 
     Public Shared Sub Foo()
     End Sub
-EndClass
+End Class
 ");
         }
 
@@ -338,7 +338,7 @@ End Class
             VerifyCSharp(@"
 public class C13
 {
-    public C13(int i = 0, string s = "") { }
+    public C13(int i = 0, string s = """") { }
 
     public static void Foo() { }
 }
@@ -350,7 +350,7 @@ public class C13
         {
             VerifyBasic(@"
 Public Class B13
-    Public Sub New(Optional i as Integer = 0, Optional s as String = "")
+    Public Sub New(Optional i as Integer = 0, Optional s as String = """")
     End Sub
 
     Public Shared Sub Foo()
@@ -535,6 +535,7 @@ public class C21
 Public Class B21
     Public Sub New()
     End Sub
+End Class
 ");
         }
 
@@ -640,10 +641,10 @@ public interface IC25Base
 {
     void Moo();
 }
-public class C25 : IC24Base
+public class C25 : IC25Base
 {
     public static void Foo() { }
-    void C25Base.Moo() { }
+    void IC25Base.Moo() { }
 }
 ");
         }
@@ -659,7 +660,7 @@ Public Class B25
 	Implements IB25Base
 	Public Shared Sub Foo()
 	End Sub
-	Private Sub B25Base_Moo() Implements B25Base.Moo
+	Private Sub B25Base_Moo() Implements IB25Base.Moo
 	End Sub
 End Class
 ");

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/UriReturnValuesShouldNotBeStringsTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/UriReturnValuesShouldNotBeStringsTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
     public class A
     {
-        public Uri GetUrl() { throw new NotImplmentedException(); }
+        public Uri GetUrl() { throw new NotImplementedException(); }
     }
 ");
         }
@@ -39,7 +39,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
     public class A
     {
-        public int GetUrl() { throw new NotImplmentedException(); }
+        public int GetUrl() { throw new NotImplementedException(); }
     }
 ");
         }
@@ -52,7 +52,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
     public class A
     {
-        public string GetUrl() { throw new NotImplmentedException(); }
+        public string GetUrl() { throw new NotImplementedException(); }
     }
 ", GetCA1055CSharpResultAt(6, 23, "A.GetUrl()"));
         }
@@ -65,7 +65,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
     public class A
     {
-        public string GetMethod() { throw new NotImplmentedException(); }
+        public string GetMethod() { throw new NotImplementedException(); }
     }
 ");
         }
@@ -91,7 +91,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
     public class A
     {
-        public string GetUrl(Uri in) { }
+        public string GetUrl(Uri u) { throw new NotImplementedException(); }
     }
 ");
         }
@@ -105,12 +105,12 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
     public class Base
     {
-        protected virtual string GetUrl() { }
+        protected virtual string GetUrl() { throw new NotImplementedException(); }
     }
 
     public class A : Base
     {
-        public override string GetUrl() { }
+        protected override string GetUrl() { throw new NotImplementedException(); }
     }
 ", GetCA1055CSharpResultAt(6, 34, "Base.GetUrl()"));
         }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/UseIntegralOrStringArgumentForIndexersTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/UseIntegralOrStringArgumentForIndexersTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 
     Public Class Months
         Private month() As String = {""Jan"", ""Feb"", ""...""}
-        Default ReadOnly Property Item(index As Float) As String
+        Default ReadOnly Property Item(index As Single) As String
             Get
                 Return month(index)
             End Get


### PR DESCRIPTION
…Tests (part 2)

Overview of issues in unittest code fragments:
* Copy/paste errors
* Property/method must return a value
* Interface implementations missing members
* Missing namespace imports
* Uninitialized constants
* Overriden methods without a body
* `RaiseEvent` missing in VB custom event
* Unassigned locals
* Private classes cannot exist in namespace scope
* VB `Inherits` instead of `Implements`
* Unescaped indentifier names that are keywords (VB)
* VB `WriteOnly`/`ReadOnly` missing in property declarations
* Enums cannot be empty
* Missing `Implements ...` in VB interface method implementations
* VB keywords swapped order
* Incorrectly escaped string values