### PR TITLE
Make unittests fail by default if their code has compile errors.

### DIFF
--- a/src/Desktop.Analyzers/UnitTests/DoNotCatchCorruptedStateExceptionsTests.cs
+++ b/src/Desktop.Analyzers/UnitTests/DoNotCatchCorruptedStateExceptionsTests.cs
@@ -1068,7 +1068,7 @@ namespace Desktop.Analyzers.UnitTests
         [Fact]
         public void CA2153TestSwallowAccessViolationExceptionInMethodHpcseAttribute()
         {
-            VerifyCSharp(@"
+            VerifyCSharpUnsafeCode(@"
             using System;
             using System.IO;
             using System.Security;
@@ -1103,7 +1103,7 @@ namespace Desktop.Analyzers.UnitTests
         [Fact]
         public void CA2153TestSwallowAccessViolationExceptionThenSwallowOtherExceptionInMethodHpcseAttribute()
         {
-            VerifyCSharp(@"
+            VerifyCSharpUnsafeCode(@"
             using System;
             using System.IO;
             using System.Security;

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DefineAccessorsForAttributeArgumentsTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DefineAccessorsForAttributeArgumentsTests.cs
@@ -2181,7 +2181,7 @@ Public NotInheritable Class PublicPropertyPrivateAccessorTestAttribute
 		End Get
 	End Property
 End Class
-",
+", TestValidationMode.AllowCompileErrors,
             GetCA1019BasicIncreaseVisibilityResultAt(14, 3, "Name", "name"),
             GetCA1019BasicIncreaseVisibilityResultAt(30, 3, "Name", "name"),
             GetCA1019BasicIncreaseVisibilityResultAt(54, 3, "Name", "name"),

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDecreaseInheritedMemberVisibilityTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDecreaseInheritedMemberVisibilityTests.cs
@@ -137,10 +137,11 @@ public class DerivedClass : BaseClass
 
 public class DerivedClass : BaseClass
 {
+    // error CS0507: cannot change access modifiers when overriding 'public' inherited member
     internal override void MyMethod() {}
 
     public override int MyProperty { private get; set; }
-}");
+}", TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDirectlyAwaitATaskTests.cs
@@ -129,7 +129,7 @@ public class SomeAwaiter : INotifyCompletion
     }
 }
 ";
-            VerifyCSharp(code);
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -173,7 +173,7 @@ Public Class SomeAwaiter
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            VerifyBasic(code, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/EquatableAnalyzerTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/EquatableAnalyzerTests.cs
@@ -116,7 +116,7 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
         }
 
@@ -135,7 +135,7 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
         }
 
@@ -154,7 +154,7 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
         }
 
@@ -173,7 +173,7 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
         }
 
@@ -192,7 +192,7 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
         }
 
@@ -211,7 +211,7 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
         }
 
@@ -227,7 +227,7 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
         }
 
@@ -246,7 +246,7 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
         }
 
@@ -264,7 +264,7 @@ class C
     }
 }
 ";
-            VerifyCSharp(code);
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -310,7 +310,7 @@ struct C : B
 ";
             string expectedMessage1 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsMessage, "B");
             string expectedMessage2 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsMessage, "C");
-            VerifyCSharp(code,
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
                 GetCSharpResultAt(4, 8, EquatableAnalyzer.ImplementIEquatableRuleId, expectedMessage1),
                 GetCSharpResultAt(12, 8, EquatableAnalyzer.ImplementIEquatableRuleId, expectedMessage2));
         }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldDifferByMoreThanCaseTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldDifferByMoreThanCaseTests.cs
@@ -26,9 +26,7 @@ namespace Microsoft.ApiDesignGuidelines.UnitTests
         [Fact]
         public void TestGlobalNamespaceNames()
         {
-            VerifyCSharp(new[]
-                {
-                @"
+            VerifyCSharp(@"
 namespace N
 {
     public class C { }
@@ -37,17 +35,14 @@ namespace n
 {
     public class C { }
 }
-"
-                },
+",
                 GetCA1708CSharpResult(Namespace, GetSymbolDisplayString("n", "N")));
         }
 
         [Fact]
         public void TestNestedNamespaceNames()
         {
-            VerifyCSharp(new[]
-                {
-                @"
+            VerifyCSharp(@"
 namespace N
 {
     class C { }
@@ -66,17 +61,14 @@ namespace n
         public class C { }
     }
 }
-"
-                },
+",
                 GetCA1708CSharpResult(Namespace, GetSymbolDisplayString("n", "N")));
         }
 
         [Fact]
         public void TestGlobalTypeNames()
         {
-            VerifyCSharp(new[]
-                {
-                    @"
+            VerifyCSharp(@"
 public class Ni
 {
 }
@@ -86,17 +78,14 @@ public struct ni
 public interface nI
 {
 }
-"
-                },
+",
                 GetCA1708CSharpResult(Type, GetSymbolDisplayString("nI", "ni", "Ni")));
         }
 
         [Fact]
         public void TestGenericClasses()
         {
-            VerifyCSharp(new[]
-                {
-                    @"
+            VerifyCSharp(@"
 public class C<T>
 {
 }
@@ -109,8 +98,7 @@ public class c
 public class C<T,X>
 {
 }
-"
-                },
+",
                 GetCA1708CSharpResult(Type, GetSymbolDisplayString("c<S>", "C<T>")));
         }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotContainUnderscoresTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/IdentifiersShouldNotContainUnderscoresTests.cs
@@ -777,7 +777,7 @@ End Structure
         private void Verify(string source, string language, DiagnosticAnalyzer analyzer, string testProjectName, DiagnosticResult[] expected)
         {
             var sources = new[] { source };
-            var diagnostics = GetSortedDiagnostics(sources.ToFileAndSource(), language, analyzer, true, testProjectName);
+            var diagnostics = GetSortedDiagnostics(sources.ToFileAndSource(), language, analyzer, addLanguageSpecificCodeAnalysisReference: true, projectName: testProjectName);
             diagnostics.Verify(analyzer, expected);
         }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OperatorOverloadsHaveNamedAlternatesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OperatorOverloadsHaveNamedAlternatesTests.Fixer.cs
@@ -134,20 +134,20 @@ class C
             VerifyCSharpFix(@"
 class C
 {
-    public static bool operator <(C left, C right) { return true; }
+    public static bool operator <(C left, C right) { return true; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 }
 ",
 @"
 class C
 {
-    public static bool operator <(C left, C right) { return true; }
+    public static bool operator <(C left, C right) { return true; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 
     public int CompareTo(C other)
     {
         throw new System.NotImplementedException();
     }
 }
-");
+", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -323,14 +323,14 @@ End Class
         {
             VerifyBasicFix(@"
 Class C
-    Public Shared Operator <(left As C, right As C) As Boolean
+    Public Shared Operator <(left As C, right As C) As Boolean   ' error BC33033: Matching '>' operator is required
         Return True
     End Operator
 End Class
 ",
 @"
 Class C
-    Public Shared Operator <(left As C, right As C) As Boolean
+    Public Shared Operator <(left As C, right As C) As Boolean   ' error BC33033: Matching '>' operator is required
         Return True
     End Operator
 
@@ -338,7 +338,7 @@ Class C
         Throw New System.NotImplementedException()
     End Function
 End Class
-");
+", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OperatorsShouldHaveSymmetricalOverloadsTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OperatorsShouldHaveSymmetricalOverloadsTests.Fixer.cs
@@ -36,17 +36,17 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                 @"
 class A
 {
-    public static bool operator==(A a1, A a2) { return false; }
+    public static bool operator==(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
 }", @"
 class A
 {
-    public static bool operator==(A a1, A a2) { return false; }
+    public static bool operator==(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
 
     public static bool operator !=(A a1, A a2)
     {
         return !(a1 == a2);
     }
-}");
+}", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -56,25 +56,25 @@ class A
                 @"
 class A
 {
-    public static bool operator==(A a1, A a2) { return false; }
-    public static bool operator==(A a1, bool a2) { return false; }
+    public static bool operator==(A a1, A a2) { return false; }      // error CS0216: The operator requires a matching operator '!=' to also be defined
+    public static bool operator==(A a1, bool a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
 }", @"
 class A
 {
-    public static bool operator==(A a1, A a2) { return false; }
+    public static bool operator==(A a1, A a2) { return false; }      // error CS0216: The operator requires a matching operator '!=' to also be defined
 
     public static bool operator !=(A a1, A a2)
     {
         return !(a1 == a2);
     }
 
-    public static bool operator==(A a1, bool a2) { return false; }
+    public static bool operator==(A a1, bool a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
 
     public static bool operator !=(A a1, bool a2)
     {
         return !(a1 == a2);
     }
-}");
+}", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -84,17 +84,17 @@ class A
                 @"
 class A
 {
-    public static bool operator!=(A a1, A a2) { return false; }
+    public static bool operator!=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '==' to also be defined
 }", @"
 class A
 {
-    public static bool operator!=(A a1, A a2) { return false; }
+    public static bool operator!=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '==' to also be defined
 
     public static bool operator ==(A a1, A a2)
     {
         return !(a1 != a2);
     }
-}");
+}", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -104,17 +104,17 @@ class A
                 @"
 class A
 {
-    public static bool operator<(A a1, A a2) { return false; }
+    public static bool operator<(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 }", @"
 class A
 {
-    public static bool operator<(A a1, A a2) { return false; }
+    public static bool operator<(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 
     public static bool operator >(A a1, A a2)
     {
         throw new System.NotImplementedException();
     }
-}");
+}", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -124,17 +124,17 @@ class A
                 @"
 class A
 {
-    public static bool operator<=(A a1, A a2) { return false; }
+    public static bool operator<=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>=' to also be defined
 }", @"
 class A
 {
-    public static bool operator<=(A a1, A a2) { return false; }
+    public static bool operator<=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>=' to also be defined
 
     public static bool operator >=(A a1, A a2)
     {
         throw new System.NotImplementedException();
     }
-}");
+}", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -144,17 +144,17 @@ class A
                 @"
 class A
 {
-    public static bool operator>(A a1, A a2) { return false; }
+    public static bool operator>(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '<' to also be defined
 }", @"
 class A
 {
-    public static bool operator>(A a1, A a2) { return false; }
+    public static bool operator>(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '<' to also be defined
 
     public static bool operator <(A a1, A a2)
     {
         throw new System.NotImplementedException();
     }
-}");
+}", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -164,17 +164,17 @@ class A
                 @"
 class A
 {
-    public static bool operator>=(A a1, A a2) { return false; }
+    public static bool operator>=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '<=' to also be defined
 }", @"
 class A
 {
-    public static bool operator>=(A a1, A a2) { return false; }
+    public static bool operator>=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '<=' to also be defined
 
     public static bool operator <=(A a1, A a2)
     {
         throw new System.NotImplementedException();
     }
-}");
+}", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -183,19 +183,19 @@ class A
             VerifyBasicFix(
                 @"
 class A
-    public shared operator =(a1 as A, a2 as A) as boolean
+    public shared operator =(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '<>' operator is required
         return false
     end operator
 end class", @"
 class A
-    public shared operator =(a1 as A, a2 as A) as boolean
+    public shared operator =(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '<>' operator is required
         return false
     end operator
 
     Public Shared Operator <>(a1 As A, a2 As A) As Boolean
         Return Not a1 = a2
     End Operator
-end class");
+end class", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -204,19 +204,19 @@ end class");
             VerifyBasicFix(
                 @"
 class A
-    public shared operator <>(a1 as A, a2 as A) as boolean
+    public shared operator <>(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '=' operator is required
         return false
     end operator
 end class", @"
 class A
-    public shared operator <>(a1 as A, a2 as A) as boolean
+    public shared operator <>(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '=' operator is required
         return false
     end operator
 
     Public Shared Operator =(a1 As A, a2 As A) As Boolean
         Return Not a1 <> a2
     End Operator
-end class");
+end class", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -225,19 +225,19 @@ end class");
             VerifyBasicFix(
                 @"
 class A
-    public shared operator <(a1 as A, a2 as A) as boolean
+    public shared operator <(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '>' operator is required
         return false
     end operator
 end class", @"
 class A
-    public shared operator <(a1 as A, a2 as A) as boolean
+    public shared operator <(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '>' operator is required
         return false
     end operator
 
     Public Shared Operator >(a1 As A, a2 As A) As Boolean
         Throw New System.NotImplementedException()
     End Operator
-end class");
+end class", validationMode: TestValidationMode.AllowCompileErrors);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OperatorsShouldHaveSymmetricalOverloadsTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OperatorsShouldHaveSymmetricalOverloadsTests.cs
@@ -21,105 +21,89 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         [Fact]
         public void CSharpTestMissingEquality()
         {
-            VerifyCSharp(new[] {
-                @"
+            VerifyCSharp(@"
 class A
 {
-    public static bool operator==(A a1, A a2) { return false; }
-}"
-},
+    public static bool operator==(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
+}", TestValidationMode.AllowCompileErrors,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="));
         }
 
         [Fact]
         public void CSharpTestMissingInequality()
         {
-            VerifyCSharp(new[] {
-                @"
+            VerifyCSharp(@"
 class A
 {
-    public static bool operator!=(A a1, A a2) { return false; }
-}"
-},
+    public static bool operator!=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '==' to also be defined
+}", TestValidationMode.AllowCompileErrors,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="));
         }
 
         [Fact]
         public void CSharpTestBothEqualityOperators()
         {
-            VerifyCSharp(new[] {
-                @"
+            VerifyCSharp(@"
 class A
 {
     public static bool operator==(A a1, A a2) { return false; }
     public static bool operator!=(A a1, A a2) { return false; }
-}"
-});
+}");
         }
 
         [Fact]
         public void CSharpTestMissingLessThan()
         {
-            VerifyCSharp(new[] {
-                @"
+            VerifyCSharp(@"
 class A
 {
-    public static bool operator<(A a1, A a2) { return false; }
-}"
-},
+    public static bool operator<(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>' to also be defined
+}", TestValidationMode.AllowCompileErrors,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<", ">"));
         }
 
         [Fact]
         public void CSharpTestNotMissingLessThan()
         {
-            VerifyCSharp(new[] {
-                @"
+            VerifyCSharp(@"
 class A
 {
     public static bool operator<(A a1, A a2) { return false; }
     public static bool operator>(A a1, A a2) { return false; }
-}"
-});
+}");
         }
 
         [Fact]
         public void CSharpTestMissingLessThanOrEqualTo()
         {
-            VerifyCSharp(new[] {
-                @"
+            VerifyCSharp(@"
 class A
 {
-    public static bool operator<=(A a1, A a2) { return false; }
-}"
-},
+    public static bool operator<=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>=' to also be defined
+}", TestValidationMode.AllowCompileErrors,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<=", ">="));
         }
 
         [Fact]
         public void CSharpTestNotMissingLessThanOrEqualTo()
         {
-            VerifyCSharp(new[] {
-                @"
+            VerifyCSharp(@"
 class A
 {
     public static bool operator<=(A a1, A a2) { return false; }
     public static bool operator>=(A a1, A a2) { return false; }
-}"
-});
+}");
         }
 
         [Fact]
         public void CSharpTestOperatorType()
         {
-            VerifyCSharp(new[] {
-                @"
+            VerifyCSharp(@"
 class A
 {
     public static bool operator==(A a1, int a2) { return false; }
     public static bool operator!=(A a1, string a2) { return false; }
-}"
-},
+}", TestValidationMode.AllowCompileErrors,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
 GetCSharpResultAt(5, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="));
         }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.Fixer.cs
@@ -107,7 +107,7 @@ public struct A
         throw new System.NotImplementedException();
     }
 
-    public static bool operator !=(A left, A right)
+    public static bool operator !=(A left, A right)   // error CS0216: The operator requires a matching operator '==' to also be defined
     {
         throw new System.NotImplementedException();
     }
@@ -127,7 +127,7 @@ public struct A
         throw new System.NotImplementedException();
     }
 
-    public static bool operator !=(A left, A right)
+    public static bool operator !=(A left, A right)   // error CS0216: The operator requires a matching operator '==' to also be defined
     {
         throw new System.NotImplementedException();
     }
@@ -137,7 +137,7 @@ public struct A
         throw new System.NotImplementedException();
     }
 }
-");
+", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -156,12 +156,7 @@ public struct A
         throw new System.NotImplementedException();
     }
 
-    public static bool operator ==(A left, A right)
-    {
-        throw new System.NotImplementedException();
-    }
-
-    public static bool operator !=(A left, A right)
+    public static bool operator ==(A left, A right)   // error CS0216: The operator requires a matching operator '!=' to also be defined
     {
         throw new System.NotImplementedException();
     }
@@ -181,7 +176,7 @@ public struct A
         throw new System.NotImplementedException();
     }
 
-    public static bool operator ==(A left, A right)
+    public static bool operator ==(A left, A right)   // error CS0216: The operator requires a matching operator '!=' to also be defined
     {
         throw new System.NotImplementedException();
     }
@@ -191,7 +186,7 @@ public struct A
         throw new System.NotImplementedException();
     }
 }
-");
+", validationMode: TestValidationMode.AllowCompileErrors);
         }
         [Fact]
         public void BasicCodeFixNoEqualsOverrideOrEqualityOperators()
@@ -274,7 +269,7 @@ Public Structure A
         Throw New System.NotImplementedException()
     End Function
 
-    Public Shared Operator <>(left As A, right As A) As Boolean
+    Public Shared Operator <>(left As A, right As A) As Boolean   ' error BC33033: Matching '=' operator is required
         Throw New System.NotImplementedException()
     End Operator
 End Structure
@@ -290,7 +285,7 @@ Public Structure A
         Throw New System.NotImplementedException()
     End Function
 
-    Public Shared Operator <>(left As A, right As A) As Boolean
+    Public Shared Operator <>(left As A, right As A) As Boolean   ' error BC33033: Matching '=' operator is required
         Throw New System.NotImplementedException()
     End Operator
 
@@ -298,7 +293,7 @@ Public Structure A
         Throw New System.NotImplementedException()
     End Operator
 End Structure
-");
+", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -314,7 +309,7 @@ Public Structure A
         Throw New System.NotImplementedException()
     End Function
 
-    Public Shared Operator =(left As A, right As A) As Boolean
+    Public Shared Operator =(left As A, right As A) As Boolean   ' error BC33033: Matching '<>' operator is required
         Throw New System.NotImplementedException()
     End Operator
 End Structure
@@ -330,7 +325,7 @@ Public Structure A
         Throw New System.NotImplementedException()
     End Function
 
-    Public Shared Operator =(left As A, right As A) As Boolean
+    Public Shared Operator =(left As A, right As A) As Boolean   ' error BC33033: Matching '<>' operator is required
         Throw New System.NotImplementedException()
     End Operator
 
@@ -338,7 +333,7 @@ Public Structure A
         Throw New System.NotImplementedException()
     End Operator
 End Structure
-");
+", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -362,7 +362,7 @@ Public Structure A
         Return False
     End Operator
 End Structure
-",
+", TestValidationMode.AllowCompileErrors,
             GetBasicOverrideEqualsDiagnostic(2, 18, "A"));
         }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.UnitTests;
 using Xunit;
 
 namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
@@ -91,7 +92,7 @@ public class A : IComparable
         return 1;
     }
 
-    public static bool operator !=(A objLeft, A objRight)
+    public static bool operator !=(A objLeft, A objRight)   // error CS0216: The operator requires a matching operator '==' to also be defined
     {
         return true;
     }
@@ -111,7 +112,7 @@ public class A : IComparable
         return 1;
     }
 
-    public static bool operator !=(A objLeft, A objRight)
+    public static bool operator !=(A objLeft, A objRight)   // error CS0216: The operator requires a matching operator '==' to also be defined
     {
         return true;
     }
@@ -136,7 +137,7 @@ public class A : IComparable
         throw new NotImplementedException();
     }
 }
-");
+", validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -198,7 +199,7 @@ Public Class A : Implements IComparable
         Return 1234
     End Function
 
-    Public Shared Operator <(objLeft As A, objRight As A) As Boolean
+    Public Shared Operator <(objLeft As A, objRight As A) As Boolean   ' error BC33033: Matching '>' operator is required
         Return True
     End Operator
 
@@ -215,7 +216,7 @@ Public Class A : Implements IComparable
         Return 1234
     End Function
 
-    Public Shared Operator <(objLeft As A, objRight As A) As Boolean
+    Public Shared Operator <(objLeft As A, objRight As A) As Boolean   ' error BC33033: Matching '>' operator is required
         Return True
     End Operator
 
@@ -238,7 +239,7 @@ Public Class A : Implements IComparable
     Public Shared Operator >(left As A, right As A) As Boolean
         Throw New NotImplementedException()
     End Operator
-End Class");
+End Class", validationMode: TestValidationMode.AllowCompileErrors);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ParameterNamesShouldMatchBaseDeclarationTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/ParameterNamesShouldMatchBaseDeclarationTests.cs
@@ -261,12 +261,12 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             VerifyCSharp(@"public class TestClass
                            {
                                public override void TestMethod(string arg1, string arg2) { }
-                           }");
+                           }", TestValidationMode.AllowCompileErrors);
 
             VerifyBasic(@"Public Class TestClass
                               Public Overrides Sub TestMethod(arg1 As String, arg2 As String)
                               End Sub
-                          End Class");
+                          End Class", TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/StaticHolderTypeTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/StaticHolderTypeTests.cs
@@ -674,7 +674,7 @@ public class C26 :
 {
     public static void Foo() { }
 }
-");
+", TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -686,7 +686,7 @@ Public Class B26
 	Public Shared Sub Foo()
 	End Sub
 End Class
-");
+", TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -696,7 +696,7 @@ End Class
 public class C27 :
 {
 }
-");
+", TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -706,7 +706,7 @@ public class C27 :
 Public Class B27
 	Inherits
 End Class
-");
+", TestValidationMode.AllowCompileErrors);
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/InternalImplementationOnlyTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/InternalImplementationOnlyTests.cs
@@ -79,13 +79,14 @@ class Boo : IBar { }";
         public void CSharp_VerifyISymbol()
         {
             var source = @"
+// Causes many compile errors, because not all members are implemented.
 class Foo : Microsoft.CodeAnalysis.ISymbol { }
 class Bar : Microsoft.CodeAnalysis.IAssemblySymbol { }
 ";
-            DiagnosticResult[] expected = new[] { GetCSharpExpectedDiagnostic(2, 7, "Foo", "ISymbol"), GetCSharpExpectedDiagnostic(3, 7, "Bar", "ISymbol") };
+            DiagnosticResult[] expected = new[] { GetCSharpExpectedDiagnostic(3, 7, "Foo", "ISymbol"), GetCSharpExpectedDiagnostic(4, 7, "Bar", "ISymbol") };
 
             // Verify that ISymbol is not implementable.
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true, expected: expected);
+            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
         }
 
         private const string AttributeStringBasic = @"
@@ -177,6 +178,7 @@ End Class
         public void Basic_VerifyISymbol()
         {
             var source = @"
+' Causes many compile errors, because not all members are implemented.
 Class Foo 
     Implements Microsoft.CodeAnalysis.ISymbol
 End Class
@@ -184,10 +186,10 @@ Class Bar
     Implements Microsoft.CodeAnalysis.IAssemblySymbol
 End Class
 ";
-            DiagnosticResult[] expected = new[] { GetBasicExpectedDiagnostic(2, 7, "Foo", "ISymbol"), GetBasicExpectedDiagnostic(5, 7, "Bar", "ISymbol") };
+            DiagnosticResult[] expected = new[] { GetBasicExpectedDiagnostic(3, 7, "Foo", "ISymbol"), GetBasicExpectedDiagnostic(6, 7, "Bar", "ISymbol") };
 
             // Verify that ISymbol is not implementable.
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true, expected: expected);
+            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
         }
 
         private void VerifyAcrossTwoAssemblies(string source1, string source2, string language, params DiagnosticResult[] expected)

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/DoNotStorePerCompilationDataOntoFieldsRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/DoNotStorePerCompilationDataOntoFieldsRuleTests.cs
@@ -27,8 +27,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Semantics;
 using MyNamedType = Microsoft.CodeAnalysis.INamedTypeSymbol;
 
-class MyCompilation : Compilation
+abstract class MyCompilation : Compilation
 {
+    // Compile error: no public constructor exists on Compilation.
 }
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -54,14 +55,14 @@ class MyAnalyzer : DiagnosticAnalyzer
 }";
             DiagnosticResult[] expected = new[]
             {
-                GetCSharpExpectedDiagnostic(18, 29, violatingTypeName: typeof(ITypeSymbol).FullName),
-                GetCSharpExpectedDiagnostic(19, 28, violatingTypeName: typeof(CSharpCompilation).FullName),
-                GetCSharpExpectedDiagnostic(20, 27, violatingTypeName: typeof(INamedTypeSymbol).FullName),
-                GetCSharpExpectedDiagnostic(21, 31, violatingTypeName: "MyCompilation"),
-                GetCSharpExpectedDiagnostic(22, 29, violatingTypeName: typeof(IBinaryOperatorExpression).FullName)
+                GetCSharpExpectedDiagnostic(19, 29, violatingTypeName: typeof(ITypeSymbol).FullName),
+                GetCSharpExpectedDiagnostic(20, 28, violatingTypeName: typeof(CSharpCompilation).FullName),
+                GetCSharpExpectedDiagnostic(21, 27, violatingTypeName: typeof(INamedTypeSymbol).FullName),
+                GetCSharpExpectedDiagnostic(22, 31, violatingTypeName: "MyCompilation"),
+                GetCSharpExpectedDiagnostic(23, 29, violatingTypeName: typeof(IBinaryOperatorExpression).FullName)
             };
 
-            VerifyCSharp(source, expected);
+            VerifyCSharp(source, TestValidationMode.AllowCompileErrors, expected);
         }
 
         [Fact]
@@ -69,6 +70,7 @@ class MyAnalyzer : DiagnosticAnalyzer
         {
             var source = @"
 Imports System
+Imports System.Collections.Generic
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -76,8 +78,8 @@ Imports Microsoft.CodeAnalysis.Semantics
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports MyNamedType = Microsoft.CodeAnalysis.INamedTypeSymbol
 
-Class MyCompilation
-    Inherits Compilation
+MustInherit Class MyCompilation
+    Inherits Compilation ' Compile error: no public constructor exists on Compilation.
 End Class
 
 <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
@@ -102,14 +104,14 @@ End Class
 ";
             DiagnosticResult[] expected = new[]
             {
-                GetBasicExpectedDiagnostic(18, 35, violatingTypeName: typeof(ITypeSymbol).FullName),
-                GetBasicExpectedDiagnostic(19, 34, violatingTypeName: typeof(VisualBasicCompilation).FullName),
-                GetBasicExpectedDiagnostic(20, 36, violatingTypeName: typeof(INamedTypeSymbol).FullName),
-                GetBasicExpectedDiagnostic(21, 40, violatingTypeName: "MyCompilation"),
-                GetBasicExpectedDiagnostic(22, 35, violatingTypeName: typeof(IBinaryOperatorExpression).FullName)
+                GetBasicExpectedDiagnostic(19, 35, violatingTypeName: typeof(ITypeSymbol).FullName),
+                GetBasicExpectedDiagnostic(20, 34, violatingTypeName: typeof(VisualBasicCompilation).FullName),
+                GetBasicExpectedDiagnostic(21, 36, violatingTypeName: typeof(INamedTypeSymbol).FullName),
+                GetBasicExpectedDiagnostic(22, 40, violatingTypeName: "MyCompilation"),
+                GetBasicExpectedDiagnostic(23, 35, violatingTypeName: typeof(IBinaryOperatorExpression).FullName)
             };
 
-            VerifyBasic(source, expected);
+            VerifyBasic(source, TestValidationMode.AllowCompileErrors, expected);
         }
 
         [Fact]
@@ -124,8 +126,9 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using MyNamedType = Microsoft.CodeAnalysis.INamedTypeSymbol;
 
-class MyCompilation : Compilation
+abstract class MyCompilation : Compilation
 {
+    // Compile error: no public constructor exists on Compilation.
 }
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -178,7 +181,7 @@ class MyAnalyzerWithoutAttribute : DiagnosticAnalyzer
     }
 }";
 
-            VerifyCSharp(source);
+            VerifyCSharp(source, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -186,14 +189,15 @@ class MyAnalyzerWithoutAttribute : DiagnosticAnalyzer
         {
             var source = @"
 Imports System
+Imports System.Collections.Generic
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports MyNamedType = Microsoft.CodeAnalysis.INamedTypeSymbol
 
-Class MyCompilation
-    Inherits Compilation
+MustInherit Class MyCompilation
+    Inherits Compilation ' Compile error: no public constructor exists on Compilation.
 End Class
 
 <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
@@ -241,7 +245,7 @@ Class MyAnalyzerWithoutAttribute
 End Class
 ";
 
-            VerifyBasic(source);
+            VerifyBasic(source, TestValidationMode.AllowCompileErrors);
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/InvalidReportDiagnosticRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/InvalidReportDiagnosticRuleTests.cs
@@ -23,14 +23,14 @@ using Microsoft.CodeAnalysis.Diagnostics;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 class MyAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor descriptor = new TriggerDiagnosticDescriptor(""MyDiagnosticId"");
-    private static readonly DiagnosticDescriptor descriptor2 = new TriggerDiagnosticDescriptor(""MyDiagnosticId2"");
+    private static readonly DiagnosticDescriptor descriptor1 = new DiagnosticDescriptor(""MyDiagnosticId1"", null, null, null, DiagnosticSeverity.Warning, false);
+    private static readonly DiagnosticDescriptor descriptor2 = new DiagnosticDescriptor(""MyDiagnosticId2"", null, null, null, DiagnosticSeverity.Warning, false);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {
         get
         {
-            return ImmutableArray.Create(descriptor);
+            return ImmutableArray.Create(descriptor1);
         }
     }
 
@@ -88,8 +88,8 @@ Imports Microsoft.CodeAnalysis.Diagnostics
 Class MyAnalyzer
     Inherits DiagnosticAnalyzer
 
-    Private Shared ReadOnly descriptor1 As DiagnosticDescriptor = New TriggerDiagnosticDescriptor(""MyDiagnosticId"")
-    Private Shared ReadOnly descriptor2 As DiagnosticDescriptor = New TriggerDiagnosticDescriptor(""MyDiagnosticId2"")
+    Private Shared ReadOnly descriptor1 As DiagnosticDescriptor = New DiagnosticDescriptor(""MyDiagnosticId1"", Nothing, Nothing, Nothing, DiagnosticSeverity.Warning, False)
+    Private Shared ReadOnly descriptor2 As DiagnosticDescriptor = New DiagnosticDescriptor(""MyDiagnosticId2"", Nothing, Nothing, Nothing, DiagnosticSeverity.Warning, False)
 
     Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
         Get
@@ -147,14 +147,14 @@ using Microsoft.CodeAnalysis.Diagnostics;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 class MyAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor descriptor = new TriggerDiagnosticDescriptor(""MyDiagnosticId"");
-    private static readonly DiagnosticDescriptor descriptor2 = new TriggerDiagnosticDescriptor(""MyDiagnosticId2"");
+    private static readonly DiagnosticDescriptor descriptor1 = new DiagnosticDescriptor(""MyDiagnosticId1"", null, null, null, DiagnosticSeverity.Warning, false);
+    private static readonly DiagnosticDescriptor descriptor2 = new DiagnosticDescriptor(""MyDiagnosticId2"", null, null, null, DiagnosticSeverity.Warning, false);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {
         get
         {
-            return ImmutableArray.Create(descriptor);
+            return ImmutableArray.Create(descriptor1);
         }
     }
 
@@ -176,7 +176,7 @@ class MyAnalyzer : DiagnosticAnalyzer
     }
 }";
 
-            VerifyCSharp(source);
+            VerifyCSharp(source, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -184,6 +184,7 @@ class MyAnalyzer : DiagnosticAnalyzer
         {
             var source = @"
 Imports System
+Imports System.Collections.Generic
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -192,8 +193,8 @@ Imports Microsoft.CodeAnalysis.Diagnostics
 Class MyAnalyzer
     Inherits DiagnosticAnalyzer
 
-    Private Shared ReadOnly descriptor1 As DiagnosticDescriptor = New TriggerDiagnosticDescriptor(""MyDiagnosticId"")
-    Private Shared ReadOnly descriptor2 As DiagnosticDescriptor = New TriggerDiagnosticDescriptor(""MyDiagnosticId2"")
+    Private Shared ReadOnly descriptor1 As DiagnosticDescriptor = New DiagnosticDescriptor(""MyDiagnosticId1"", Nothing, Nothing, Nothing, DiagnosticSeverity.Warning, False)
+    Private Shared ReadOnly descriptor2 As DiagnosticDescriptor = New DiagnosticDescriptor(""MyDiagnosticId2"", Nothing, Nothing, Nothing, DiagnosticSeverity.Warning, False)
 
     Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
         Get
@@ -218,7 +219,7 @@ Class MyAnalyzer
 End Class
 ";
 
-            VerifyBasic(source);
+            VerifyBasic(source, TestValidationMode.AllowCompileErrors);
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/InvalidSyntaxKindTypeArgumentRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/InvalidSyntaxKindTypeArgumentRuleTests.cs
@@ -142,7 +142,7 @@ abstract class MyAnalyzer<T> : DiagnosticAnalyzer
     }
 }";
 
-            VerifyCSharp(source);
+            VerifyCSharp(source, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -181,7 +181,7 @@ Class MyAnalyzer(Of T As Structure)
 End Class
 ";
 
-            VerifyBasic(source);
+            VerifyBasic(source, TestValidationMode.AllowCompileErrors);
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/MissingKindArgumentToRegisterActionRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/MissingKindArgumentToRegisterActionRuleTests.cs
@@ -124,6 +124,7 @@ class MyAnalyzer : DiagnosticAnalyzer
         public void VisualBasic_VerifyRegisterSyntaxActionDiagnostic()
         {
             var source = @"
+Imports System
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -149,7 +150,7 @@ Class MyAnalyzer
     End Sub
 End Class
 ";
-            DiagnosticResult expected = GetBasicExpectedDiagnostic(17, 9, MissingKindArgument.SyntaxKind);
+            DiagnosticResult expected = GetBasicExpectedDiagnostic(18, 9, MissingKindArgument.SyntaxKind);
             VerifyBasic(source, expected);
         }
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
@@ -41,7 +41,7 @@ class MyAnalyzer : DiagnosticAnalyzer
 
         context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.InvocationExpression);
         context.RegisterCodeBlockStartAction<SyntaxKind>(AnalyzeCodeBlockStart);
-        context.RegisterOperationBlockStartAction<SyntaxKind>(AnalyzeOperationBlockStart);
+        context.RegisterOperationBlockStartAction(AnalyzeOperationBlockStart);
     }
 
     private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
@@ -93,7 +93,7 @@ Class MyAnalyzer
 
         context.RegisterSyntaxNodeAction(AddressOf AnalyzeSyntax, SyntaxKind.InvocationExpression)
         context.RegisterCodeBlockStartAction(Of SyntaxKind)(AddressOf AnalyzeCodeBlockStart)
-        context.RegisterOperationBlockStartAction(Of SyntaxKind)(AddressOf AnalyzeOperationBlockStart)
+        context.RegisterOperationBlockStartAction(AddressOf AnalyzeOperationBlockStart)
     End Sub
 
     Private Shared Sub AnalyzeSyntax(context As SyntaxNodeAnalysisContext)
@@ -227,7 +227,7 @@ class MyAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        compilationContext.RegisterOperationAction(AnalyzeOperation, OperationKind.InvocationExpression);
+        context.RegisterOperationAction(AnalyzeOperation, OperationKind.InvocationExpression);
     }
 
     private static void AnalyzeOperation(OperationAnalysisContext context)
@@ -248,7 +248,7 @@ class MyAnalyzer2 : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        compilationContext.RegisterOperationBlockAction(AnalyzeOperationBlock);
+        context.RegisterOperationBlockAction(AnalyzeOperationBlock);
     }
 
     private static void AnalyzeOperationBlock(OperationBlockAnalysisContext context)
@@ -419,7 +419,7 @@ Class MyAnalyzer
 	End Property
 
 	Public Overrides Sub Initialize(context As AnalysisContext)
-		compilationContext.RegisterOperationAction(AddressOf AnalyzeOperation, OperationKind.InvocationExpression)
+		context.RegisterOperationAction(AddressOf AnalyzeOperation, OperationKind.InvocationExpression)
 	End Sub
 
 	Private Shared Sub AnalyzeOperation(context As OperationAnalysisContext)
@@ -436,7 +436,7 @@ Class MyAnalyzer2
 	End Property
 
 	Public Overrides Sub Initialize(context As AnalysisContext)
-		compilationContext.RegisterOperationBlockAction(AddressOf AnalyzeOperationBlock)
+		context.RegisterOperationBlockAction(AddressOf AnalyzeOperationBlock)
 	End Sub
 
 	Private Shared Sub AnalyzeOperationBlock(context As OperationBlockAnalysisContext)

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/UnsupportedSymbolKindArgumentRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/UnsupportedSymbolKindArgumentRuleTests.cs
@@ -189,7 +189,7 @@ class MyAnalyzer : DiagnosticAnalyzer
     }
 }";
 
-            VerifyCSharp(source);
+            VerifyCSharp(source, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -234,7 +234,7 @@ Class MyAnalyzer
 End Class
 ";
 
-            VerifyBasic(source);
+            VerifyBasic(source, TestValidationMode.AllowCompileErrors);
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/UseLocalizableStringsInDescriptorTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Test/MetaAnalyzers/UseLocalizableStringsInDescriptorTests.cs
@@ -71,7 +71,7 @@ End Class
             VerifyBasic(source, expected);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1039")]
         public void CSharp_NoDiagnosticCases()
         {
             var source = @"
@@ -104,7 +104,7 @@ class MyAnalyzer : DiagnosticAnalyzer
             VerifyCSharp(source);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1039")]
         public void VisualBasic_NoDiagnosticCases()
         {
             var source = @"

--- a/src/Microsoft.Composition.Analyzers/UnitTests/DoNotMixAttributesFromDifferentVersionsOfMEFTests.cs
+++ b/src/Microsoft.Composition.Analyzers/UnitTests/DoNotMixAttributesFromDifferentVersionsOfMEFTests.cs
@@ -28,7 +28,7 @@ namespace System.Composition
 
     public class ImportingConstructorAttribute : System.Attribute
     {
-        public ImportManyAttribute() { }
+        public ImportingConstructorAttribute() { }
     }
 }
 
@@ -52,7 +52,7 @@ public class SystemCompositionMetadataAttribute : System.Attribute
 
     public class ImportingConstructorAttribute : System.Attribute
     {
-        public ImportManyAttribute() { }
+        public ImportingConstructorAttribute() { }
     }
 }
 
@@ -75,7 +75,7 @@ namespace System.ComponentModel.Composition
 
     public class ImportingConstructorAttribute : System.Attribute
     {
-        public ImportManyAttribute() { }
+        public ImportingConstructorAttribute() { }
     }
 }
 
@@ -292,7 +292,7 @@ public class C
 public class C2
 {
     [System.ComponentModel.Composition.ImportingConstructor]
-    public C([System.ComponentModel.Composition.Import]B b) { }
+    public C2([System.ComponentModel.Composition.Import]B b) { }
 
     [System.ComponentModel.Composition.Import]
     public B PropertyB { get; }
@@ -339,7 +339,7 @@ public class C
     [System.ComponentModel.Composition.Import]
     public B PropertyB { get; }
 }
-");
+", TestValidationMode.AllowCompileErrors);
 
             VerifyBasic(@"
 Public Class B
@@ -350,7 +350,7 @@ Public Class C
 	<System.ComponentModel.Composition.Import> _
 	Public ReadOnly Property PropertyB() As B
 End Class
-");
+", TestValidationMode.AllowCompileErrors);
         }
 
         #endregion
@@ -421,7 +421,7 @@ public class C
 public class C2
 {
     [System.Composition.ImportingConstructor]
-    public C([System.ComponentModel.Composition.Import]B b) { }
+    public C2([System.ComponentModel.Composition.Import]B b) { }
 
     [System.Composition.Import]
     public B PropertyB { get; }

--- a/src/Microsoft.Composition.Analyzers/UnitTests/PartsExportedWithMEFv2MustBeMarkedAsSharedTests.cs
+++ b/src/Microsoft.Composition.Analyzers/UnitTests/PartsExportedWithMEFv2MustBeMarkedAsSharedTests.cs
@@ -82,7 +82,7 @@ using System.Composition;
 public class C
 {
 }
-");
+", TestValidationMode.AllowCompileErrors);
 
             VerifyBasic(@"
 Imports System
@@ -91,7 +91,7 @@ Imports System.Composition
 <Export(GetType(C)), [Shared]> _
 Public Class C
 End Class
-");
+", TestValidationMode.AllowCompileErrors);
         }
 
         #endregion
@@ -146,7 +146,7 @@ public class SharedAttribute: Attribute
             VerifyBasic(@"
 Imports System
 
-<System.Composition.Export(GetType(C)), Shared> _
+<System.Composition.Export(GetType(C)), [Shared]> _
 Public Class C
 End Class
 

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/DoNotIgnoreMethodResultsTests.cs
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/DoNotIgnoreMethodResultsTests.cs
@@ -134,10 +134,10 @@ Imports System.Globalization
 
 Class C
     Public Sub DoesNotAssignObjectToVariable()
-        New C()
+        New C() ' error BC30035: Syntax error
     End Sub
 End Class
-");
+", TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]

--- a/src/Microsoft.Maintainability.Analyzers/UnitTests/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.Maintainability.Analyzers/UnitTests/ReviewUnusedParametersTests.cs
@@ -462,11 +462,11 @@ class C
     {
     }
 
-    public void UnusedErrorTypeParamMethod(UndefinedType param1)
+    public void UnusedErrorTypeParamMethod(UndefinedType param1) // error CS0246: The type or namespace name 'UndefinedType' could not be found.
     {
     }
 }
-",
+", TestValidationMode.AllowCompileErrors,
       // Test0.cs(6,18): warning CA1801: Parameter param of method .ctor is never used. Remove the parameter or use it in the method body.
       GetCSharpUnusedParameterResultAt(6, 18, "param", ".ctor"),
       // Test0.cs(10,39): warning CA1801: Parameter param of method UnusedParamMethod is never used. Remove the parameter or use it in the method body.
@@ -509,10 +509,10 @@ Class C
     Private Sub UnusedRefParamMethod(ByRef param1 As Integer)
     End Sub
 
-    Public Sub UnusedErrorTypeParamMethod(param1 As UndefinedType)
+    Public Sub UnusedErrorTypeParamMethod(param1 As UndefinedType) ' error BC30002: Type 'UndefinedType' is not defined.
     End Sub
 End Class
-",
+", TestValidationMode.AllowCompileErrors,
       // Test0.vb(3,20): warning CA1801: Parameter param of method .ctor is never used. Remove the parameter or use it in the method body.
       GetBasicUnusedParameterResultAt(3, 20, "param", ".ctor"),
       // Test0.vb(6,34): warning CA1801: Parameter param of method UnusedParamMethod is never used. Remove the parameter or use it in the method body.

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/RethrowToPreserveStackDetailsTests.cs
@@ -65,7 +65,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1016")]
         public void CA2200CSharpTestWithLegalExceptionThrowNested()
         {
             VerifyCSharp(@"
@@ -256,7 +256,7 @@ Class Program
 End Class");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1016")]
         public void CA2200VisualBasicTestWithLegalExceptionThrowNested()
         {
             VerifyBasic(@"

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/SealMethodsThatSatisfyPrivateInterfacesTests.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/SealMethodsThatSatisfyPrivateInterfacesTests.cs
@@ -299,6 +299,9 @@ Public MustInherit Class C
     Implements IFace
 
     Public MustOverride Sub M()
+
+    Public Sub IFace_M() Implements IFace.M
+    End Sub
 End Class
 ");
         }

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
@@ -82,11 +82,6 @@ namespace Roslyn.Diagnostics.Analyzers.UnitTests
             VerifyAdditionalFileFix(LanguageNames.CSharp, source, shippedApiText, oldUnshippedApiText, newUnshippedApiText, onlyFixFirstFixableDiagnostic);
         }
 
-        private void VerifyBasicAdditionalFileFix(string source, string shippedApiText, string oldUnshippedApiText, string newUnshippedApiText, bool onlyFixFirstFixableDiagnostic = false)
-        {
-            VerifyAdditionalFileFix(LanguageNames.VisualBasic, source, shippedApiText, oldUnshippedApiText, newUnshippedApiText, onlyFixFirstFixableDiagnostic);
-        }
-
         private void VerifyAdditionalFileFix(string language, string source, string shippedApiText, string oldUnshippedApiText, string newUnshippedApiText, bool onlyFixFirstFixableDiagnostic)
         {
             var analyzer = language == LanguageNames.CSharp ? GetCSharpDiagnosticAnalyzer() : GetBasicDiagnosticAnalyzer();

--- a/src/System.Runtime.Analyzers/UnitTests/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/AvoidZeroLengthArrayAllocationsTests.cs
@@ -36,9 +36,6 @@ namespace System.Runtime.Analyzers.UnitTests
             const string badSource = @"
 using System.Collections.Generic;
 
-// This is a compile error but we want to ensure analyzer doesn't complain for it.
-[System.Runtime.CompilerServices.Dynamic(new bool[0])] // no
-
 class C
 {
     unsafe void M1()
@@ -63,9 +60,6 @@ class C
             const string fixedSource = @"
 using System.Collections.Generic;
 
-// This is a compile error but we want to ensure analyzer doesn't complain for it.
-[System.Runtime.CompilerServices.Dynamic(new bool[0])] // no
-
 class C
 {
     unsafe void M1()
@@ -88,23 +82,34 @@ class C
 }";
             string arrayEmptySource = IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
 
-            VerifyCSharp(badSource + arrayEmptySource, new[]
+            VerifyCSharpUnsafeCode(badSource + arrayEmptySource, new[]
             {
-                GetCSharpResultAt(11, 22, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(12, 23, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(13, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(17, 24, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(18, 28, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
-                GetCSharpResultAt(20, 26, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor)
+                GetCSharpResultAt(8, 22, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(9, 23, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(10, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(14, 24, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(15, 28, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor),
+                GetCSharpResultAt(17, 26, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor)
             });
-            VerifyCSharpFix(
+            VerifyCSharpUnsafeCodeFix(
                 arrayEmptySource + badSource,
                 arrayEmptySource + fixedSource,
                 allowNewCompilerDiagnostics: true);
-            VerifyCSharpFix(
+            VerifyCSharpUnsafeCodeFix(
                 "using System;\r\n" + arrayEmptySource + badSource,
                 "using System;\r\n" + arrayEmptySource + fixedSource.Replace("System.Array.Empty", "Array.Empty"),
                 allowNewCompilerDiagnostics: true);
+        }
+
+        [Fact]
+        public void EmptyArrayCSharpError()
+        {
+            const string badSource = @"
+// This is a compile error but we want to ensure analyzer doesn't complain for it.
+[System.Runtime.CompilerServices.Dynamic(new bool[0])]
+";
+
+            VerifyCSharp(badSource, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]

--- a/src/System.Runtime.Analyzers/UnitTests/TestForNaNCorrectlyTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/TestForNaNCorrectlyTests.cs
@@ -244,7 +244,7 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code);
+            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
@@ -257,7 +257,7 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code);
+            VerifyBasic(code, TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]

--- a/src/Test/Utilities/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/DiagnosticExtensions.cs
@@ -3,12 +3,13 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Roslyn.Test.Utilities;
+using Microsoft.CodeAnalysis.UnitTests;
 using Roslyn.Utilities;
 using Xunit;
 
@@ -18,128 +19,13 @@ namespace Microsoft.CodeAnalysis
     {
         public static readonly Action<Exception, DiagnosticAnalyzer, Diagnostic> FailFastOnAnalyzerException = (e, a, d) => FailFast.OnFatalException(e);
 
-        /// <summary>
-        /// This is obsolete. Use Verify instead.
-        /// </summary>
-        public static void VerifyErrorCodes(this IEnumerable<Diagnostic> actual, params DiagnosticDescription[] expected)
-        {
-            Verify(actual, expected, errorCodeOnly: true);
-        }
-
-        public static void VerifyErrorCodes(this ImmutableArray<Diagnostic> actual, params DiagnosticDescription[] expected)
-        {
-            VerifyErrorCodes((IEnumerable<Diagnostic>)actual, expected);
-        }
-
-        internal static void Verify(this DiagnosticBag actual, params DiagnosticDescription[] expected)
-        {
-            Verify(actual.AsEnumerable(), expected, errorCodeOnly: false);
-        }
-
-        public static void Verify(this IEnumerable<Diagnostic> actual, params DiagnosticDescription[] expected)
-        {
-            Verify(actual, expected, errorCodeOnly: false);
-        }
-
-        public static void Verify(this IEnumerable<Diagnostic> actual, bool fallbackToErrorCodeOnlyForNonEnglish, params DiagnosticDescription[] expected)
-        {
-            Verify(actual, expected, errorCodeOnly: fallbackToErrorCodeOnlyForNonEnglish && EnsureEnglishUICulture.PreferredOrNull != null);
-        }
-
-        public static void VerifyWithFallbackToErrorCodeOnlyForNonEnglish(this IEnumerable<Diagnostic> actual, params DiagnosticDescription[] expected)
-        {
-            Verify(actual, true, expected);
-        }
-
-        public static void Verify(this ImmutableArray<Diagnostic> actual, params DiagnosticDescription[] expected)
-        {
-            Verify((IEnumerable<Diagnostic>)actual, expected);
-        }
-
-        private static void Verify(IEnumerable<Diagnostic> actual, DiagnosticDescription[] expected, bool errorCodeOnly)
-        {
-            if (expected == null)
-            {
-                throw new ArgumentException("Must specify expected errors.", "expected");
-            }
-
-            List<DiagnosticDescription> unmatched = actual.Select(d => new DiagnosticDescription(d, errorCodeOnly)).ToList();
-
-            // Try to match each of the 'expected' errors to one of the 'actual' ones.
-            // If any of the expected errors don't appear, fail test.
-            foreach (DiagnosticDescription d in expected)
-            {
-                int index = unmatched.IndexOf(d);
-                if (index > -1)
-                {
-                    unmatched.RemoveAt(index);
-                }
-                else
-                {
-                    Assert.True(false, DiagnosticDescription.GetAssertText(expected, actual));
-                }
-            }
-
-            // If any 'extra' errors appear that were not in the 'expected' list, fail test.
-            if (unmatched.Count > 0)
-            {
-                Assert.True(false, DiagnosticDescription.GetAssertText(expected, actual));
-            }
-        }
-
-        public static TCompilation VerifyDiagnostics<TCompilation>(this TCompilation c, params DiagnosticDescription[] expected)
-            where TCompilation : Compilation
-        {
-            ImmutableArray<Diagnostic> diagnostics = c.GetDiagnostics();
-            diagnostics.Verify(expected);
-            return c;
-        }
-
-        public static void VerifyAnalyzerOccurrenceCount<TCompilation>(
-            this TCompilation c,
-            DiagnosticAnalyzer[] analyzers,
-            int expectedCount,
-            Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
-            where TCompilation : Compilation
-        {
-            Assert.Equal(expectedCount, c.GetAnalyzerDiagnostics(analyzers, null, onAnalyzerException).Length);
-        }
-
-        public static TCompilation VerifyAnalyzerDiagnostics<TCompilation>(
-                this TCompilation c,
-                DiagnosticAnalyzer[] analyzers,
-                AnalyzerOptions options = null,
-                Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null,
-                bool logAnalyzerExceptionAsDiagnostics = true,
-                params DiagnosticDescription[] expected)
-            where TCompilation : Compilation
-        {
-            ImmutableArray<Diagnostic> diagnostics;
-            c = c.GetAnalyzerDiagnostics(analyzers, options, onAnalyzerException, logAnalyzerExceptionAsDiagnostics, diagnostics: out diagnostics);
-            diagnostics.Verify(expected);
-            return c; // note this is a new compilation
-        }
-
         public static ImmutableArray<Diagnostic> GetAnalyzerDiagnostics<TCompilation>(
             this TCompilation c,
             DiagnosticAnalyzer[] analyzers,
+            TestValidationMode validationMode,
             AnalyzerOptions options = null,
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null,
             bool logAnalyzerExceptionAsDiagnostics = true)
-            where TCompilation : Compilation
-        {
-            ImmutableArray<Diagnostic> diagnostics;
-            GetAnalyzerDiagnostics(c, analyzers, options, onAnalyzerException, logAnalyzerExceptionAsDiagnostics, out diagnostics);
-            return diagnostics;
-        }
-
-        private static TCompilation GetAnalyzerDiagnostics<TCompilation>(
-                this TCompilation c,
-                DiagnosticAnalyzer[] analyzers,
-                AnalyzerOptions options,
-                Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException,
-                bool logAnalyzerExceptionAsDiagnostics,
-                out ImmutableArray<Diagnostic> diagnostics)
             where TCompilation : Compilation
         {
             ImmutableArray<DiagnosticAnalyzer> analyzersArray = analyzers.ToImmutableArray();
@@ -164,111 +50,29 @@ namespace Microsoft.CodeAnalysis
 
             Compilation newCompilation;
             AnalyzerDriver driver = AnalyzerDriver.CreateAndAttachToCompilation(c, analyzersArray, options, AnalyzerManager.Instance, onAnalyzerException, null, false, out newCompilation, CancellationToken.None);
-            ImmutableArray<Diagnostic> discarded = newCompilation.GetDiagnostics();
-            diagnostics = driver.GetDiagnosticsAsync(newCompilation).Result.AddRange(exceptionDiagnostics);
 
-            return (TCompilation)newCompilation; // note this is a new compilation
+            ImmutableArray<Diagnostic> diagnostics = newCompilation.GetDiagnostics();
+            if (validationMode != TestValidationMode.AllowCompileErrors)
+            {
+                ValidateNoCompileErrors(diagnostics);
+            }
+
+            return driver.GetDiagnosticsAsync(newCompilation).Result.AddRange(exceptionDiagnostics);
         }
 
-        /// <summary>
-        /// Given a set of compiler or <see cref="IDiagnosticAnalyzer"/> generated <paramref name="diagnostics"/>, returns the effective diagnostics after applying the below filters:
-        /// 1) <see cref="CompilationOptions.SpecificDiagnosticOptions"/> specified for the given <paramref name="compilation"/>.
-        /// 2) <see cref="CompilationOptions.GeneralDiagnosticOption"/> specified for the given <paramref name="compilation"/>.
-        /// 3) Diagnostic suppression through applied <see cref="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute"/>.
-        /// 4) Pragma directives for the given <paramref name="compilation"/>.
-        /// </summary>
-        public static IEnumerable<Diagnostic> GetEffectiveDiagnostics(this Compilation compilation, IEnumerable<Diagnostic> diagnostics)
+        private static void ValidateNoCompileErrors(ImmutableArray<Diagnostic> compilerDiagnostics)
         {
-            return CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, compilation);
+            var compileErrors = compilerDiagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+
+            if (compileErrors.Any())
+            {
+                var builder = new StringBuilder();
+                builder.Append($"Test contains compilation error(s). Pass {nameof(TestValidationMode)}.{nameof(TestValidationMode.AllowCompileErrors)} if these are intended:");
+                builder.Append(string.Concat(compileErrors.Select(x => "\n" + x.ToString())));
+
+                string message = builder.ToString();
+                Assert.True(false, message);
+            }
         }
-
-        /// <summary>
-        /// Returns true if all the diagnostics that can be produced by this analyzer are suppressed through options.
-        /// <paramref name="continueOnError"/> says whether the caller would like the exception thrown by the analyzers to be handled or not. If true - Handles ; False - Not handled.
-        /// </summary>
-        public static bool IsDiagnosticAnalyzerSuppressed(this DiagnosticAnalyzer analyzer, CompilationOptions options)
-        {
-            return CompilationWithAnalyzers.IsDiagnosticAnalyzerSuppressed(analyzer, options);
-        }
-
-        // TODO (tomescht): Determine if this method is actually needed.
-        //public static TCompilation VerifyEmitDiagnostics<TCompilation>(this TCompilation c, EmitOptions options, params DiagnosticDescription[] expected)
-        //    where TCompilation : Compilation
-        //{
-        //    var pdbStream = CLRHelpers.IsRunningOnMono() ? null : new MemoryStream();
-        //    c.Emit(new MemoryStream(), pdbStream: pdbStream, options: options).Diagnostics.Verify(expected);
-        //    return c;
-        //}
-
-        // TODO (tomescht): Determine if this method is actually needed.
-        //public static TCompilation VerifyEmitDiagnostics<TCompilation>(this TCompilation c, params DiagnosticDescription[] expected)
-        //    where TCompilation : Compilation
-        //{
-        //    return VerifyEmitDiagnostics(c, EmitOptions.Default, expected);
-        //}
-
-        // TODO (tomescht): Determine if this method is actually needed.
-        //public static TCompilation VerifyEmitDiagnostics<TCompilation>(this TCompilation c, IEnumerable<ResourceDescription> manifestResources, params DiagnosticDescription[] expected)
-        //    where TCompilation : Compilation
-        //{
-        //    var pdbStream = CLRHelpers.IsRunningOnMono() ? null : new MemoryStream();
-        //    c.Emit(new MemoryStream(), pdbStream: pdbStream, manifestResources: manifestResources).Diagnostics.Verify(expected);
-        //    return c;
-        //}
-
-        public static string Concat(this string[] str)
-        {
-            return str.Aggregate(new StringBuilder(), (sb, s) => sb.AppendLine(s), sb => sb.ToString());
-        }
-
-        // TODO (tomescht): Determine if this method is actually needed.
-        //public static DiagnosticAnalyzer GetCompilerDiagnosticAnalyzer(string languageName)
-        //{
-        //    return languageName == LanguageNames.CSharp ?
-        //        (DiagnosticAnalyzer)new Diagnostics.CSharp.CSharpCompilerDiagnosticAnalyzer() :
-        //        new Diagnostics.VisualBasic.VisualBasicCompilerDiagnosticAnalyzer();
-        //}
-
-        // TODO (tomescht): Determine if this method is actually needed.
-        //public static ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>> GetCompilerDiagnosticAnalyzersMap()
-        //{
-        //    var builder = ImmutableDictionary.CreateBuilder<string, ImmutableArray<DiagnosticAnalyzer>>();
-        //    builder.Add(LanguageNames.CSharp, ImmutableArray.Create(GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp)));
-        //    builder.Add(LanguageNames.VisualBasic, ImmutableArray.Create(GetCompilerDiagnosticAnalyzer(LanguageNames.VisualBasic)));
-        //    return builder.ToImmutable();
-        //}
-
-        // TODO (tomescht): Determine if this method is actually needed.
-        //public static AnalyzerReference GetCompilerDiagnosticAnalyzerReference(string languageName)
-        //{
-        //    var analyzer = GetCompilerDiagnosticAnalyzer(languageName);
-        //    return new AnalyzerImageReference(ImmutableArray.Create(analyzer), display: analyzer.GetType().FullName);
-        //}
-
-        // TODO (tomescht): Determine if this method is actually needed.
-        //public static ImmutableDictionary<string, ImmutableArray<AnalyzerReference>> GetCompilerDiagnosticAnalyzerReferencesMap()
-        //{
-        //    var builder = ImmutableDictionary.CreateBuilder<string, ImmutableArray<AnalyzerReference>>();
-        //    builder.Add(LanguageNames.CSharp, ImmutableArray.Create(GetCompilerDiagnosticAnalyzerReference(LanguageNames.CSharp)));
-        //    builder.Add(LanguageNames.VisualBasic, ImmutableArray.Create(GetCompilerDiagnosticAnalyzerReference(LanguageNames.VisualBasic)));
-        //    return builder.ToImmutable();
-        //}
-
-        // TODO (tomescht): Determine if this method is actually needed.
-        //      internal static string GetExpectedErrorLogHeader(string actualOutput, CommonCompiler compiler)
-        //      {
-        //          var expectedToolName = compiler.GetToolName();
-        //          var expectedProductVersion = compiler.GetAssemblyVersion().ToString(fieldCount: 3);
-        //          var fileVersion = compiler.GetAssemblyFileVersion();
-        //          var expectedFileVersion = fileVersion.Substring(0, fileVersion.LastIndexOf('.'));
-
-        //          return string.Format(@"{{
-        //""version"": ""{0}"",
-        //""toolInfo"": {{
-        //  ""toolName"": ""{1}"",
-        //  ""productVersion"": ""{2}"",
-        //  ""fileVersion"": ""{3}""
-        //}},", ErrorLogger.OutputFormatVersion, expectedToolName, expectedProductVersion, expectedFileVersion);
-        //      }
     }
 }

--- a/src/Test/Utilities/DiagnosticsTestUtilities.csproj
+++ b/src/Test/Utilities/DiagnosticsTestUtilities.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <Compile Include="CodeFixTestBase.cs" />
     <Compile Include="CodeFixTests.Extensions.cs" />
+    <Compile Include="TestValidationMode.cs" />
     <Compile Include="DiagnosticAnalyzerTestBase.cs" />
     <Compile Include="DiagnosticAnalyzerTests.Extensions.cs" />
     <Compile Include="DiagnosticDescription.cs" />

--- a/src/Test/Utilities/TestValidationMode.cs
+++ b/src/Test/Utilities/TestValidationMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public enum TestValidationMode
+    {
+        AllowCompileWarnings,
+        AllowCompileErrors
+    }
+}


### PR DESCRIPTION
- Added an optional `TestValidationMode` flag to `VerifyXXX` methods for exceptional cases.
- Updated tests with intentional compile errors to pass this flag.
- Fixed a small set of remaining tests that contained unintentional compile errors.
- Added `VerifyCSharpUnsafeCode` for code that requires the `/unsafe` compiler switch.
- Reduced the number of overloads of `VerifyXXX` to those actually used; removed other dead code.
- Some tests unneededly used the `VerifyXXX` overload that accepts an array of sources instead of one.