### PR TITLE
Fix a few small analyzer bugs

### DIFF
--- a/src/AggregateNugetPackages/FxCop/NuGet/FxCopAnalyzers.nuspec
+++ b/src/AggregateNugetPackages/FxCop/NuGet/FxCopAnalyzers.nuspec
@@ -30,6 +30,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="ThirdPartyNotices.rtf" target="" />

--- a/src/AggregateNugetPackages/Microsoft.Net.RoslynDiagnostics/NuGet/Microsoft.Net.RoslynDiagnostics.nuspec
+++ b/src/AggregateNugetPackages/Microsoft.Net.RoslynDiagnostics/NuGet/Microsoft.Net.RoslynDiagnostics.nuspec
@@ -29,6 +29,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="Microsoft.Net.RoslynDiagnostics.props" target="build" />

--- a/src/ApiReview.Analyzers/Core/ApiReview.Analyzers.nuspec
+++ b/src/ApiReview.Analyzers/Core/ApiReview.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$ApiReview.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/ApiReview.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/ApiReview.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="ApiReview.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="ApiReview.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="ApiReview.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ApiReview.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ApiReview.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ApiReview.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/Desktop.Analyzers/Core/Desktop.Analyzers.nuspec
+++ b/src/Desktop.Analyzers/Core/Desktop.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$Desktop.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/Desktop.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Desktop.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Desktop.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Desktop.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Desktop.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Desktop.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Desktop.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Desktop.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/FxCop/NuGet/FxCopAnalyzers.nuspec
+++ b/src/FxCop/NuGet/FxCopAnalyzers.nuspec
@@ -30,6 +30,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="ThirdPartyNotices.rtf" target="" />

--- a/src/MetaCompilation/MetaCompilation/MetaCompilation/Diagnostic.nuspec
+++ b/src/MetaCompilation/MetaCompilation/MetaCompilation/Diagnostic.nuspec
@@ -16,6 +16,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$MetaCompilation.dll" target="tools\analyzers\" />

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.nuspec
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/Microsoft.ApiDesignGuidelines.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$Microsoft.ApiDesignGuidelines.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.cs
@@ -71,7 +71,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             {
                 if (!(namedTypeSymbol.OverridesEquals() && namedTypeSymbol.ImplementsComparisonOperators()))
                 {
-                    addDiagnostic(namedTypeSymbol.CreateDiagnostic(Rule));
+                    // CA1036: {0} should override Equals since it implements IComparable.
+                    addDiagnostic(namedTypeSymbol.CreateDiagnostic(Rule, namedTypeSymbol.Name));
                 }
             }
         }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.ApiDesignGuidelines.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.ApiDesignGuidelines.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.ApiDesignGuidelines.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.ApiDesignGuidelines.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
     }
 
-", GetCA1036CSharpResultAt(4, 18));
+", GetCA1036CSharpResultAt(4, 18, "A"));
         }
 
         [Fact]
@@ -317,7 +317,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
     }
 ",
-            GetCA1036CSharpResultAt(4, 18));
+            GetCA1036CSharpResultAt(4, 18, "A"));
         }
 
         [Fact]
@@ -354,7 +354,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
     }
 ",
-            GetCA1036CSharpResultAt(4, 18));
+            GetCA1036CSharpResultAt(4, 18, "A"));
         }
 
         [Fact]
@@ -391,7 +391,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
     }
 ",
-            GetCA1036CSharpResultAt(4, 19));
+            GetCA1036CSharpResultAt(4, 19, "A"));
         }
 
         [Fact]
@@ -428,7 +428,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
     }
 ",
-            GetCA1036CSharpResultAt(4, 18));
+            GetCA1036CSharpResultAt(4, 18, "A"));
         }
 
         [Fact]
@@ -467,7 +467,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
     }
 ",
-            GetCA1036CSharpResultAt(6, 18));
+            GetCA1036CSharpResultAt(6, 18, "A"));
         }
 
         [Fact]
@@ -546,7 +546,7 @@ Public Structure A : Implements IComparable
 
 End Structure
 ",
-            GetCA1036BasicResultAt(4, 18));
+            GetCA1036BasicResultAt(4, 18, "A"));
         }
 
         [Fact]
@@ -727,7 +727,7 @@ Public Class A : Implements IComparable
 
 End Class
 ",
-            GetCA1036BasicResultAt(4, 14));
+            GetCA1036BasicResultAt(4, 14, "A"));
         }
 
         [Fact]
@@ -760,7 +760,7 @@ Public Class A : Implements IComparable
 
 End Class
 ",
-            GetCA1036BasicResultAt(4, 14));
+            GetCA1036BasicResultAt(4, 14, "A"));
         }
 
         [Fact]
@@ -793,7 +793,7 @@ Public Structure A : Implements IComparable
 
 End Structure
 ",
-            GetCA1036BasicResultAt(4, 18));
+            GetCA1036BasicResultAt(4, 18, "A"));
         }
 
         [Fact]
@@ -826,7 +826,7 @@ Public Structure A : Implements IComparable(Of Integer)
 
 End Structure
 ",
-            GetCA1036BasicResultAt(4, 18));
+            GetCA1036BasicResultAt(4, 18, "A"));
         }
 
         [Fact]
@@ -863,7 +863,7 @@ Public Structure A : Implements IDerived
 
 End Structure
 ",
-            GetCA1036BasicResultAt(8, 18));
+            GetCA1036BasicResultAt(8, 18, "A"));
         }
 
         [Fact]
@@ -882,14 +882,16 @@ Enum MyEnum
 End Enum");
         }
 
-        private static DiagnosticResult GetCA1036CSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCA1036CSharpResultAt(int line, int column, string typeName)
         {
-            return GetCSharpResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideMethodsOnComparableTypesMessageEquals);
+            var message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideMethodsOnComparableTypesMessageEquals, typeName);
+            return GetCSharpResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, message);
         }
 
-        private static DiagnosticResult GetCA1036BasicResultAt(int line, int column)
+        private static DiagnosticResult GetCA1036BasicResultAt(int line, int column, string typeName)
         {
-            return GetBasicResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideMethodsOnComparableTypesMessageEquals);
+            var message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideMethodsOnComparableTypesMessageEquals, typeName);
+            return GetBasicResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, message);
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/Diagnostic.nuspec
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/Diagnostic.nuspec
@@ -19,6 +19,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$Microsoft.CodeAnalysis.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/Microsoft.CodeAnalysis.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="|CodeAnalysisDiagnosticAnalyzers|" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="|BasicCodeAnalysisDiagnosticAnalyzers|" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="|CSharpCodeAnalysisDiagnosticAnalyzers|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|CodeAnalysisDiagnosticAnalyzers|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|BasicCodeAnalysisDiagnosticAnalyzers|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|CSharpCodeAnalysisDiagnosticAnalyzers|" />
   </Assets>
 </PackageManifest>

--- a/src/Microsoft.Composition.Analyzers/Core/Microsoft.Composition.Analyzers.nuspec
+++ b/src/Microsoft.Composition.Analyzers/Core/Microsoft.Composition.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$Microsoft.Composition.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/Microsoft.Composition.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.Composition.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.Composition.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.Composition.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.Composition.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.Composition.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.Composition.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.Composition.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/Microsoft.Maintainability.Analyzers/Core/Microsoft.Maintainability.Analyzers.nuspec
+++ b/src/Microsoft.Maintainability.Analyzers/Core/Microsoft.Maintainability.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$Microsoft.Maintainability.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/Microsoft.Maintainability.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.Maintainability.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.Maintainability.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.Maintainability.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.Maintainability.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.Maintainability.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.Maintainability.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.Maintainability.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/Microsoft.QualityGuidelines.Analyzers.nuspec
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/Microsoft.QualityGuidelines.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$Microsoft.QualityGuidelines.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/Microsoft.QualityGuidelines.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.QualityGuidelines.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.QualityGuidelines.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.QualityGuidelines.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.QualityGuidelines.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.QualityGuidelines.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.QualityGuidelines.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.nuspec
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$Roslyn.Diagnostics.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/Roslyn.Diagnostics.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Roslyn.Diagnostics.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Roslyn.Diagnostics.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Roslyn.Diagnostics.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Roslyn.Diagnostics.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Roslyn.Diagnostics.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Roslyn.Diagnostics.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Roslyn.Diagnostics.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/System.Collections.Immutable.Analyzers/Core/System.Collections.Immutable.Analyzers.nuspec
+++ b/src/System.Collections.Immutable.Analyzers/Core/System.Collections.Immutable.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$System.Collections.Immutable.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/System.Collections.Immutable.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/System.Collections.Immutable.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Collections.Immutable.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Collections.Immutable.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Collections.Immutable.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Collections.Immutable.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Collections.Immutable.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Collections.Immutable.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/System.Resources.Analyzers/Core/System.Resources.Analyzers.nuspec
+++ b/src/System.Resources.Analyzers/Core/System.Resources.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$System.Resources.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/System.Resources.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/System.Resources.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Resources.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Resources.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Resources.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Resources.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Resources.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Resources.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/System.Runtime.Analyzers/Core/CallGCSuppressFinalizeCorrectly.cs
+++ b/src/System.Runtime.Analyzers/Core/CallGCSuppressFinalizeCorrectly.cs
@@ -75,7 +75,7 @@ namespace System.Runtime.Analyzers
             {
                 var gcSuppressFinalizeMethodSymbol = compilationContext.Compilation
                                                         .GetTypeByMetadataName("System.GC")
-                                                        .GetMembers("SuppressFinalize")
+                                                        ?.GetMembers("SuppressFinalize")
                                                         .OfType<IMethodSymbol>()
                                                         .SingleOrDefault();
 

--- a/src/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.nuspec
+++ b/src/System.Runtime.Analyzers/Core/System.Runtime.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$System.Runtime.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/System.Runtime.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/System.Runtime.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Runtime.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Runtime.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Runtime.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Runtime.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Runtime.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Runtime.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/System.Runtime.InteropServices.Analyzers/Core/System.Runtime.InteropServices.Analyzers.nuspec
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/System.Runtime.InteropServices.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$System.Runtime.InteropServices.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/System.Runtime.InteropServices.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/System.Runtime.InteropServices.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Runtime.InteropServices.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Runtime.InteropServices.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Runtime.InteropServices.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Runtime.InteropServices.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Runtime.InteropServices.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Runtime.InteropServices.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/SystemSecurityCryptographyHashingAlgorithmsAnalyzers.nuspec
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Core/SystemSecurityCryptographyHashingAlgorithmsAnalyzers.nuspec
@@ -19,6 +19,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$System.Security.Cryptography.Hashing.Algorithms.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/System.Security.Cryptography.Hashing.Algorithms.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Security.Cryptography.Hashing.Algorithms.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Security.Cryptography.Hashing.Algorithms.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Security.Cryptography.Hashing.Algorithms.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Security.Cryptography.Hashing.Algorithms.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Security.Cryptography.Hashing.Algorithms.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Security.Cryptography.Hashing.Algorithms.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/System.Threading.Tasks.Analyzers/Core/System.Threading.Tasks.Analyzers.nuspec
+++ b/src/System.Threading.Tasks.Analyzers/Core/System.Threading.Tasks.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$System.Threading.Tasks.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/System.Threading.Tasks.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/System.Threading.Tasks.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Threading.Tasks.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Threading.Tasks.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="System.Threading.Tasks.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Threading.Tasks.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Threading.Tasks.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="System.Threading.Tasks.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/Text.Analyzers/Core/Text.Analyzers.nuspec
+++ b/src/Text.Analyzers/Core/Text.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$Text.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/Text.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Text.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Text.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Text.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Text.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Text.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Text.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Text.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/Tools/AnalyzerCodeGenerator/template/src/REPLACE.ME/Core/REPLACE.ME.Analyzers.nuspec
+++ b/src/Tools/AnalyzerCodeGenerator/template/src/REPLACE.ME/Core/REPLACE.ME.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$REPLACE.ME.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/Tools/AnalyzerCodeGenerator/template/src/REPLACE.ME/Setup/source.extension.vsixmanifest
+++ b/src/Tools/AnalyzerCodeGenerator/template/src/REPLACE.ME/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="REPLACE.ME.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="REPLACE.ME.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="REPLACE.ME.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="REPLACE.ME.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="REPLACE.ME.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="REPLACE.ME.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>

--- a/src/Unfactored/AsyncPackage/AsyncPackage/Diagnostic.nuspec
+++ b/src/Unfactored/AsyncPackage/AsyncPackage/Diagnostic.nuspec
@@ -14,6 +14,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="*.dll" target="tools\analyzers\" exclude="**\Microsoft.CodeAnalysis.*;**\System.Collections.Immutable.*;**\System.Reflection.Metadata.*" />

--- a/src/Unfactored/Roslyn/Setup/source.extension.vsixmanifest
+++ b/src/Unfactored/Roslyn/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="|RoslynDiagnosticAnalyzers|" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="|BasicRoslynDiagnosticAnalyzers|" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="|CSharpRoslynDiagnosticAnalyzers|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|RoslynDiagnosticAnalyzers|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|BasicRoslynDiagnosticAnalyzers|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|CSharpRoslynDiagnosticAnalyzers|" />
   </Assets>
 </PackageManifest>

--- a/src/XmlDocumentationComments.Analyzers/Core/XmlDocumentationComments.Analyzers.nuspec
+++ b/src/XmlDocumentationComments.Analyzers/Core/XmlDocumentationComments.Analyzers.nuspec
@@ -20,6 +20,7 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="$binaries$XmlDocumentationComments.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/src/XmlDocumentationComments.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/XmlDocumentationComments.Analyzers/Setup/source.extension.vsixmanifest
@@ -16,5 +16,8 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="XmlDocumentationComments.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="XmlDocumentationComments.CSharp.Analyzers.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="XmlDocumentationComments.VisualBasic.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="XmlDocumentationComments.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="XmlDocumentationComments.CSharp.Analyzers.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="XmlDocumentationComments.VisualBasic.Analyzers.dll" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
1. Fix NRE in CallGCSuppressFinalizeCorrectlyAnalyzer - handle missing well known type.
Fixes #1050 

2. Fix VSIX manifest files to specify analyzer assemblies also as MEF components.
Fixes #1042 

3. Fix message for CA1036 to substitute the type name
Fixes #1051 

4. Mark all analyzer nuget packages as developmentDependency 
Fixes #1048 