### PR TITLE
Makes fixers add null checks in method bodies for Equals, CompareTo and comparison operators

### DIFF
--- a/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
@@ -69,7 +69,7 @@ namespace Analyzer.Utilities.Extensions
         public static bool ImplementsOperator(this INamedTypeSymbol symbol, string op)
         {
             // TODO: should this filter on the right-hand-side operator type?
-            return symbol.GetMembers(op).OfType<IMethodSymbol>().Where(m => m.MethodKind == MethodKind.UserDefinedOperator).Any();
+            return symbol.GetMembers(op).OfType<IMethodSymbol>().Any(m => m.MethodKind == MethodKind.UserDefinedOperator);
         }
 
         /// <summary>
@@ -104,19 +104,21 @@ namespace Analyzer.Utilities.Extensions
         {
             return symbol.ImplementsEqualityOperators() &&
                    symbol.ImplementsOperator(WellKnownMemberNames.LessThanOperatorName) &&
-                   symbol.ImplementsOperator(WellKnownMemberNames.GreaterThanOperatorName);
+                   symbol.ImplementsOperator(WellKnownMemberNames.LessThanOrEqualOperatorName) &&
+                   symbol.ImplementsOperator(WellKnownMemberNames.GreaterThanOperatorName) &&
+                   symbol.ImplementsOperator(WellKnownMemberNames.GreaterThanOrEqualOperatorName);
         }
 
         public static bool OverridesEquals(this INamedTypeSymbol symbol)
         {
             // Does the symbol override Object.Equals?
-            return symbol.GetMembers(WellKnownMemberNames.ObjectEquals).OfType<IMethodSymbol>().Where(m => m.IsEqualsOverride()).Any();
+            return symbol.GetMembers(WellKnownMemberNames.ObjectEquals).OfType<IMethodSymbol>().Any(m => m.IsEqualsOverride());
         }
 
         public static bool OverridesGetHashCode(this INamedTypeSymbol symbol)
         {
             // Does the symbol override Object.GetHashCode?
-            return symbol.GetMembers(WellKnownMemberNames.ObjectGetHashCode).OfType<IMethodSymbol>().Where(m => m.IsGetHashCodeOverride()).Any();
+            return symbol.GetMembers(WellKnownMemberNames.ObjectGetHashCode).OfType<IMethodSymbol>().Any(m => m.IsGetHashCodeOverride());
         }
 
         public static bool HasFinalizer(this INamedTypeSymbol symbol)

--- a/src/Analyzer.Utilities/SyntaxGeneratorExtensions.cs
+++ b/src/Analyzer.Utilities/SyntaxGeneratorExtensions.cs
@@ -16,7 +16,7 @@ namespace Analyzer.Utilities
         private const string SystemNotImplementedExceptionTypeName = "System.NotImplementedException";
 
         /// <summary>
-        /// Creates a declaration for an operator equality overload.
+        /// Creates a default declaration for an operator equality overload.
         /// </summary>
         /// <param name="generator">
         /// The <see cref="SyntaxGenerator"/> used to create the declaration.
@@ -27,7 +27,7 @@ namespace Analyzer.Utilities
         /// <returns>
         /// A <see cref="SyntaxNode"/> representing the declaration.
         /// </returns>
-        public static SyntaxNode OperatorEqualityDeclaration(this SyntaxGenerator generator,
+        public static SyntaxNode DefaultOperatorEqualityDeclaration(this SyntaxGenerator generator,
             INamedTypeSymbol containingType)
         {
             var leftArgument = generator.IdentifierName(LeftIdentifierName);
@@ -71,7 +71,7 @@ namespace Analyzer.Utilities
         }
 
         /// <summary>
-        /// Creates a declaration for an operator inequality overload.
+        /// Creates a default declaration for an operator inequality overload.
         /// </summary>
         /// <param name="generator">
         /// The <see cref="SyntaxGenerator"/> used to create the declaration.
@@ -82,7 +82,7 @@ namespace Analyzer.Utilities
         /// <returns>
         /// A <see cref="SyntaxNode"/> representing the declaration.
         /// </returns>
-        public static SyntaxNode OperatorInequalityDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
+        public static SyntaxNode DefaultOperatorInequalityDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
             var leftArgument = generator.IdentifierName(LeftIdentifierName);
             var rightArgument = generator.IdentifierName(RightIdentifierName);
@@ -97,7 +97,7 @@ namespace Analyzer.Utilities
         }
 
         /// <summary>
-        /// Creates a declaration for an operator less than overload.
+        /// Creates a default declaration for an operator less than overload.
         /// </summary>
         /// <param name="generator">
         /// The <see cref="SyntaxGenerator"/> used to create the declaration.
@@ -108,7 +108,7 @@ namespace Analyzer.Utilities
         /// <returns>
         /// A <see cref="SyntaxNode"/> representing the declaration.
         /// </returns>
-        public static SyntaxNode OperatorLessThanDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
+        public static SyntaxNode DefaultOperatorLessThanDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
             var leftArgument = generator.IdentifierName(LeftIdentifierName);
             var rightArgument = generator.IdentifierName(RightIdentifierName);
@@ -149,7 +149,7 @@ namespace Analyzer.Utilities
         }
 
         /// <summary>
-        /// Creates a declaration for an operator less than or equal overload.
+        /// Creates a default declaration for an operator less than or equal overload.
         /// </summary>
         /// <param name="generator">
         /// The <see cref="SyntaxGenerator"/> used to create the declaration.
@@ -160,7 +160,7 @@ namespace Analyzer.Utilities
         /// <returns>
         /// A <see cref="SyntaxNode"/> representing the declaration.
         /// </returns>
-        public static SyntaxNode OperatorLessThanOrEqualDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
+        public static SyntaxNode DefaultOperatorLessThanOrEqualDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
             var leftArgument = generator.IdentifierName(LeftIdentifierName);
             var rightArgument = generator.IdentifierName(RightIdentifierName);
@@ -196,7 +196,7 @@ namespace Analyzer.Utilities
         }
 
         /// <summary>
-        /// Creates a declaration for an operator greater than overload.
+        /// Creates a default declaration for an operator greater than overload.
         /// </summary>
         /// <param name="generator">
         /// The <see cref="SyntaxGenerator"/> used to create the declaration.
@@ -207,7 +207,7 @@ namespace Analyzer.Utilities
         /// <returns>
         /// A <see cref="SyntaxNode"/> representing the declaration.
         /// </returns>
-        public static SyntaxNode OperatorGreaterThanDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
+        public static SyntaxNode DefaultOperatorGreaterThanDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
             var leftArgument = generator.IdentifierName(LeftIdentifierName);
             var rightArgument = generator.IdentifierName(RightIdentifierName);
@@ -244,7 +244,7 @@ namespace Analyzer.Utilities
         }
 
         /// <summary>
-        /// Creates a declaration for an operator greater than or equal overload.
+        /// Creates a default declaration for an operator greater than or equal overload.
         /// </summary>
         /// <param name="generator">
         /// The <see cref="SyntaxGenerator"/> used to create the declaration.
@@ -255,7 +255,7 @@ namespace Analyzer.Utilities
         /// <returns>
         /// A <see cref="SyntaxNode"/> representing the declaration.
         /// </returns>
-        public static SyntaxNode OperatorGreaterThanOrEqualDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
+        public static SyntaxNode DefaultOperatorGreaterThanOrEqualDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
             var leftArgument = generator.IdentifierName(LeftIdentifierName);
             var rightArgument = generator.IdentifierName(RightIdentifierName);
@@ -310,7 +310,7 @@ namespace Analyzer.Utilities
         }
 
         /// <summary>
-        /// Creates a declaration for an override of <see cref="object.Equals(object)"/>.
+        /// Creates a default declaration for an override of <see cref="object.Equals(object)"/>.
         /// </summary>
         /// <param name="generator">
         /// The <see cref="SyntaxGenerator"/> used to create the declaration.
@@ -322,7 +322,7 @@ namespace Analyzer.Utilities
         /// <returns>
         /// A <see cref="SyntaxNode"/> representing the declaration.
         /// </returns>
-        public static SyntaxNode EqualsOverrideDeclaration(this SyntaxGenerator generator, Compilation compilation, INamedTypeSymbol containingType)
+        public static SyntaxNode DefaultEqualsOverrideDeclaration(this SyntaxGenerator generator, Compilation compilation, INamedTypeSymbol containingType)
         {
             var argumentName = generator.IdentifierName("obj");
 
@@ -357,7 +357,7 @@ namespace Analyzer.Utilities
         }
 
         /// <summary>
-        /// Creates a declaration for an override of <see cref="object.GetHashCode()"/>.
+        /// Creates a default declaration for an override of <see cref="object.GetHashCode()"/>.
         /// </summary>
         /// <param name="generator">
         /// The <see cref="SyntaxGenerator"/> used to create the declaration.
@@ -366,7 +366,7 @@ namespace Analyzer.Utilities
         /// <returns>
         /// A <see cref="SyntaxNode"/> representing the declaration.
         /// </returns>
-        public static SyntaxNode GetHashCodeOverrideDeclaration(
+        public static SyntaxNode DefaultGetHashCodeOverrideDeclaration(
             this SyntaxGenerator generator, Compilation compilation)
         {
             return generator.MethodDeclaration(

--- a/src/Analyzer.Utilities/SyntaxGeneratorExtensions.cs
+++ b/src/Analyzer.Utilities/SyntaxGeneratorExtensions.cs
@@ -37,17 +37,7 @@ namespace Analyzer.Utilities
 
             if (containingType.TypeKind == TypeKind.Class)
             {
-                statements.AddRange(new[]
-                {
-                    generator.IfStatement(
-                        generator.InvocationExpression(
-                            generator.IdentifierName(ReferenceEqualsMethodName),
-                            leftArgument,
-                            rightArgument),
-                        new[]
-                        {
-                            generator.ReturnStatement(generator.TrueLiteralExpression())
-                        }),
+                statements.Add(
                     generator.IfStatement(
                         generator.InvocationExpression(
                             generator.IdentifierName(ReferenceEqualsMethodName),
@@ -56,8 +46,7 @@ namespace Analyzer.Utilities
                         new[]
                         {
                             generator.ReturnStatement(generator.FalseLiteralExpression())
-                        })
-                });
+                        }));
             }
 
             statements.Add(
@@ -330,7 +319,17 @@ namespace Analyzer.Utilities
 
             if (containingType.TypeKind == TypeKind.Class)
             {
-                statements.Add(
+                statements.AddRange(new[]
+                {
+                    generator.IfStatement(
+                        generator.InvocationExpression(
+                            generator.IdentifierName(ReferenceEqualsMethodName),
+                            generator.ThisExpression(),
+                            argumentName),
+                        new[]
+                        {
+                            generator.ReturnStatement(generator.TrueLiteralExpression())
+                        }),
                     generator.IfStatement(
                         generator.InvocationExpression(
                             generator.IdentifierName(ReferenceEqualsMethodName),
@@ -339,7 +338,8 @@ namespace Analyzer.Utilities
                         new[]
                         {
                             generator.ReturnStatement(generator.FalseLiteralExpression())
-                        }));
+                        })
+                });
             }
 
             statements.AddRange(generator.DefaultMethodBody(compilation));

--- a/src/Analyzer.Utilities/SyntaxGeneratorExtensions.cs
+++ b/src/Analyzer.Utilities/SyntaxGeneratorExtensions.cs
@@ -8,6 +8,13 @@ namespace Analyzer.Utilities
 {
     public static class SyntaxGeneratorExtensions
     {
+        private const string LeftIdentifierName = "left";
+        private const string RightIdentifierName = "right";
+        private const string ReferenceEqualsMethodName = "ReferenceEquals";
+        private const string EqualsMethodName = "Equals";
+        private const string CompareToMethodName = "CompareTo";
+        private const string SystemNotImplementedExceptionTypeName = "System.NotImplementedException";
+
         /// <summary>
         /// Creates a declaration for an operator equality overload.
         /// </summary>
@@ -23,8 +30,8 @@ namespace Analyzer.Utilities
         public static SyntaxNode OperatorEqualityDeclaration(this SyntaxGenerator generator,
             INamedTypeSymbol containingType)
         {
-            var leftArgument = generator.IdentifierName("left");
-            var rightArgument = generator.IdentifierName("right");
+            var leftArgument = generator.IdentifierName(LeftIdentifierName);
+            var rightArgument = generator.IdentifierName(RightIdentifierName);
 
             List<SyntaxNode> statements = new List<SyntaxNode>();
 
@@ -34,7 +41,7 @@ namespace Analyzer.Utilities
                 {
                     generator.IfStatement(
                         generator.InvocationExpression(
-                            generator.IdentifierName("ReferenceEquals"),
+                            generator.IdentifierName(ReferenceEqualsMethodName),
                             leftArgument,
                             rightArgument),
                         new[]
@@ -43,7 +50,7 @@ namespace Analyzer.Utilities
                         }),
                     generator.IfStatement(
                         generator.InvocationExpression(
-                            generator.IdentifierName("ReferenceEquals"),
+                            generator.IdentifierName(ReferenceEqualsMethodName),
                             leftArgument,
                             generator.NullLiteralExpression()),
                         new[]
@@ -57,7 +64,7 @@ namespace Analyzer.Utilities
                 generator.ReturnStatement(
                     generator.InvocationExpression(
                         generator.MemberAccessExpression(
-                            leftArgument, "Equals"),
+                            leftArgument, EqualsMethodName),
                         rightArgument)));
 
             return generator.ComparisonOperatorDeclaration(OperatorKind.Equality, containingType, statements.ToArray());
@@ -77,8 +84,8 @@ namespace Analyzer.Utilities
         /// </returns>
         public static SyntaxNode OperatorInequalityDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
-            var leftArgument = generator.IdentifierName("left");
-            var rightArgument = generator.IdentifierName("right");
+            var leftArgument = generator.IdentifierName(LeftIdentifierName);
+            var rightArgument = generator.IdentifierName(RightIdentifierName);
 
             var returnStatement = generator.ReturnStatement(
                     generator.LogicalNotExpression(
@@ -103,8 +110,8 @@ namespace Analyzer.Utilities
         /// </returns>
         public static SyntaxNode OperatorLessThanDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
-            var leftArgument = generator.IdentifierName("left");
-            var rightArgument = generator.IdentifierName("right");
+            var leftArgument = generator.IdentifierName(LeftIdentifierName);
+            var rightArgument = generator.IdentifierName(RightIdentifierName);
 
             SyntaxNode expression;
 
@@ -113,17 +120,17 @@ namespace Analyzer.Utilities
                 expression =
                     generator.ConditionalExpression(
                         generator.InvocationExpression(
-                            generator.IdentifierName("ReferenceEquals"),
+                            generator.IdentifierName(ReferenceEqualsMethodName),
                             leftArgument,
                             generator.NullLiteralExpression()),
                         generator.LogicalNotExpression(
                             generator.InvocationExpression(
-                                generator.IdentifierName("ReferenceEquals"),
+                                generator.IdentifierName(ReferenceEqualsMethodName),
                                 rightArgument,
                                 generator.NullLiteralExpression())),
                         generator.LessThanExpression(
                             generator.InvocationExpression(
-                                generator.MemberAccessExpression(leftArgument, generator.IdentifierName("CompareTo")),
+                                generator.MemberAccessExpression(leftArgument, generator.IdentifierName(CompareToMethodName)),
                                 rightArgument),
                             generator.LiteralExpression(0)));
             }
@@ -132,7 +139,7 @@ namespace Analyzer.Utilities
                 expression =
                     generator.LessThanExpression(
                         generator.InvocationExpression(
-                            generator.MemberAccessExpression(leftArgument, generator.IdentifierName("CompareTo")),
+                            generator.MemberAccessExpression(leftArgument, generator.IdentifierName(CompareToMethodName)),
                             rightArgument),
                         generator.LiteralExpression(0));
             }
@@ -155,8 +162,8 @@ namespace Analyzer.Utilities
         /// </returns>
         public static SyntaxNode OperatorLessThanOrEqualDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
-            var leftArgument = generator.IdentifierName("left");
-            var rightArgument = generator.IdentifierName("right");
+            var leftArgument = generator.IdentifierName(LeftIdentifierName);
+            var rightArgument = generator.IdentifierName(RightIdentifierName);
 
             SyntaxNode expression;
 
@@ -165,12 +172,12 @@ namespace Analyzer.Utilities
                 expression =
                     generator.LogicalOrExpression(
                         generator.InvocationExpression(
-                            generator.IdentifierName("ReferenceEquals"),
+                            generator.IdentifierName(ReferenceEqualsMethodName),
                             leftArgument,
                             generator.NullLiteralExpression()),
                         generator.LessThanOrEqualExpression(
                             generator.InvocationExpression(
-                                generator.MemberAccessExpression(leftArgument, generator.IdentifierName("CompareTo")),
+                                generator.MemberAccessExpression(leftArgument, generator.IdentifierName(CompareToMethodName)),
                                 rightArgument),
                             generator.LiteralExpression(0)));
             }
@@ -179,7 +186,7 @@ namespace Analyzer.Utilities
                 expression =
                     generator.LessThanOrEqualExpression(
                         generator.InvocationExpression(
-                            generator.MemberAccessExpression(leftArgument, generator.IdentifierName("CompareTo")),
+                            generator.MemberAccessExpression(leftArgument, generator.IdentifierName(CompareToMethodName)),
                             rightArgument),
                         generator.LiteralExpression(0));
             }
@@ -202,8 +209,8 @@ namespace Analyzer.Utilities
         /// </returns>
         public static SyntaxNode OperatorGreaterThanDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
-            var leftArgument = generator.IdentifierName("left");
-            var rightArgument = generator.IdentifierName("right");
+            var leftArgument = generator.IdentifierName(LeftIdentifierName);
+            var rightArgument = generator.IdentifierName(RightIdentifierName);
 
             SyntaxNode expression;
 
@@ -213,12 +220,12 @@ namespace Analyzer.Utilities
                     generator.LogicalAndExpression(
                         generator.LogicalNotExpression(
                             generator.InvocationExpression(
-                                generator.IdentifierName("ReferenceEquals"),
+                                generator.IdentifierName(ReferenceEqualsMethodName),
                                 leftArgument,
                                 generator.NullLiteralExpression())),
                         generator.GreaterThanExpression(
                             generator.InvocationExpression(
-                                generator.MemberAccessExpression(leftArgument, generator.IdentifierName("CompareTo")),
+                                generator.MemberAccessExpression(leftArgument, generator.IdentifierName(CompareToMethodName)),
                                 rightArgument),
                             generator.LiteralExpression(0)));
             }
@@ -227,7 +234,7 @@ namespace Analyzer.Utilities
                 expression =
                     generator.GreaterThanExpression(
                         generator.InvocationExpression(
-                            generator.MemberAccessExpression(leftArgument, generator.IdentifierName("CompareTo")),
+                            generator.MemberAccessExpression(leftArgument, generator.IdentifierName(CompareToMethodName)),
                             rightArgument),
                         generator.LiteralExpression(0));
             }
@@ -250,8 +257,8 @@ namespace Analyzer.Utilities
         /// </returns>
         public static SyntaxNode OperatorGreaterThanOrEqualDeclaration(this SyntaxGenerator generator, INamedTypeSymbol containingType)
         {
-            var leftArgument = generator.IdentifierName("left");
-            var rightArgument = generator.IdentifierName("right");
+            var leftArgument = generator.IdentifierName(LeftIdentifierName);
+            var rightArgument = generator.IdentifierName(RightIdentifierName);
 
             SyntaxNode expression;
 
@@ -260,16 +267,16 @@ namespace Analyzer.Utilities
                 expression =
                     generator.ConditionalExpression(
                             generator.InvocationExpression(
-                                generator.IdentifierName("ReferenceEquals"),
+                                generator.IdentifierName(ReferenceEqualsMethodName),
                                 leftArgument,
                                 generator.NullLiteralExpression()),
                             generator.InvocationExpression(
-                                generator.IdentifierName("ReferenceEquals"),
+                                generator.IdentifierName(ReferenceEqualsMethodName),
                                 rightArgument,
                                 generator.NullLiteralExpression()),
                         generator.GreaterThanOrEqualExpression(
                             generator.InvocationExpression(
-                                generator.MemberAccessExpression(leftArgument, generator.IdentifierName("CompareTo")),
+                                generator.MemberAccessExpression(leftArgument, generator.IdentifierName(CompareToMethodName)),
                                 rightArgument),
                             generator.LiteralExpression(0)));
             }
@@ -278,7 +285,7 @@ namespace Analyzer.Utilities
                 expression =
                     generator.GreaterThanOrEqualExpression(
                         generator.InvocationExpression(
-                            generator.MemberAccessExpression(leftArgument, generator.IdentifierName("CompareTo")),
+                            generator.MemberAccessExpression(leftArgument, generator.IdentifierName(CompareToMethodName)),
                             rightArgument),
                         generator.LiteralExpression(0));
             }
@@ -293,8 +300,8 @@ namespace Analyzer.Utilities
                 operatorKind,
                 new[]
                 {
-                    generator.ParameterDeclaration("left", generator.TypeExpression(containingType)),
-                    generator.ParameterDeclaration("right", generator.TypeExpression(containingType))
+                    generator.ParameterDeclaration(LeftIdentifierName, generator.TypeExpression(containingType)),
+                    generator.ParameterDeclaration(RightIdentifierName, generator.TypeExpression(containingType))
                 },
                 generator.TypeExpression(SpecialType.System_Boolean),
                 Accessibility.Public,
@@ -326,7 +333,7 @@ namespace Analyzer.Utilities
                 statements.Add(
                     generator.IfStatement(
                         generator.InvocationExpression(
-                            generator.IdentifierName("ReferenceEquals"),
+                            generator.IdentifierName(ReferenceEqualsMethodName),
                             argumentName,
                             generator.NullLiteralExpression()),
                         new[]
@@ -390,7 +397,7 @@ namespace Analyzer.Utilities
         {
             return generator.ThrowStatement(generator.ObjectCreationExpression(
                 generator.TypeExpression(
-                    compilation.GetTypeByMetadataName("System.NotImplementedException"))));
+                    compilation.GetTypeByMetadataName(SystemNotImplementedExceptionTypeName))));
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
@@ -1954,7 +1954,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, or greater than..
+        ///   Looks up a localized string similar to A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal..
         /// </summary>
         internal static string OverrideMethodsOnComparableTypesDescription {
             get {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -307,7 +307,7 @@
     <value>Override methods on comparable types</value>
   </data>
   <data name="OverrideMethodsOnComparableTypesDescription" xml:space="preserve">
-    <value>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, or greater than.</value>
+    <value>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</value>
   </data>
   <data name="OverrideMethodsOnComparableTypesMessageEquals" xml:space="preserve">
     <value>{0} should override Equals since it implements IComparable.</value>

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
@@ -56,14 +56,14 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.EqualityOperatorName))
             {
-                var equalityOperator = generator.OperatorEqualityDeclaration(typeSymbol);
+                var equalityOperator = generator.DefaultOperatorEqualityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, equalityOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.InequalityOperatorName))
             {
-                var inequalityOperator = generator.OperatorInequalityDeclaration(typeSymbol);
+                var inequalityOperator = generator.DefaultOperatorInequalityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, inequalityOperator);
             }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
@@ -44,9 +44,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             // We cannot have multiple overlapping diagnostics of this id.
             Diagnostic diagnostic = context.Diagnostics.Single();
 
-            context.RegisterCodeFix(new MyCodeAction(MicrosoftApiDesignGuidelinesAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEqualsTitle,
-                                                     async ct => await ImplementOperatorEquals(context.Document, declaration, typeSymbol, ct).ConfigureAwait(false)),
-                                    diagnostic);
+            context.RegisterCodeFix(
+                new MyCodeAction(MicrosoftApiDesignGuidelinesAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEqualsTitle,
+                    async ct => await ImplementOperatorEquals(context.Document, declaration, typeSymbol, ct).ConfigureAwait(false)), diagnostic);
         }
 
         private async Task<Document> ImplementOperatorEquals(Document document, SyntaxNode declaration, INamedTypeSymbol typeSymbol, CancellationToken cancellationToken)
@@ -56,16 +56,14 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.EqualityOperatorName))
             {
-                var equalityOperator = generator.ComparisonOperatorDeclaration(
-                    OperatorKind.Equality, typeSymbol, editor.SemanticModel.Compilation);
+                var equalityOperator = generator.OperatorEqualityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, equalityOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.InequalityOperatorName))
             {
-                var inequalityOperator = generator.ComparisonOperatorDeclaration(
-                    OperatorKind.Inequality, typeSymbol, editor.SemanticModel.Compilation);
+                var inequalityOperator = generator.OperatorInequalityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, inequalityOperator);
             }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
@@ -62,7 +62,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             var editor = await DocumentEditor.CreateAsync(document, ct).ConfigureAwait(false);
             var generator = editor.Generator;
-            var language = document.Project.Language;
 
             if (!typeSymbol.OverridesEquals())
             {
@@ -82,16 +81,14 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.EqualityOperatorName))
             {
-                var equalityOperator = generator.ComparisonOperatorDeclaration(
-                    OperatorKind.Equality, typeSymbol, editor.SemanticModel.Compilation);
+                var equalityOperator = generator.OperatorEqualityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, equalityOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.InequalityOperatorName))
             {
-                var inequalityOperator = generator.ComparisonOperatorDeclaration(
-                    OperatorKind.Inequality, typeSymbol, editor.SemanticModel.Compilation);
+                var inequalityOperator = generator.OperatorInequalityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, inequalityOperator);
             }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             if (!typeSymbol.OverridesEquals())
             {
-                var equalsMethod = generator.EqualsOverrideDeclaration(
+                var equalsMethod = generator.DefaultEqualsOverrideDeclaration(
                     editor.SemanticModel.Compilation, typeSymbol);
 
                 editor.AddMember(declaration, equalsMethod);
@@ -73,7 +73,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             if (!typeSymbol.OverridesGetHashCode())
             {
-                var getHashCodeMethod = generator.GetHashCodeOverrideDeclaration(
+                var getHashCodeMethod = generator.DefaultGetHashCodeOverrideDeclaration(
                     editor.SemanticModel.Compilation);
 
                 editor.AddMember(declaration, getHashCodeMethod);
@@ -81,14 +81,14 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.EqualityOperatorName))
             {
-                var equalityOperator = generator.OperatorEqualityDeclaration(typeSymbol);
+                var equalityOperator = generator.DefaultOperatorEqualityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, equalityOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.InequalityOperatorName))
             {
-                var inequalityOperator = generator.OperatorInequalityDeclaration(typeSymbol);
+                var inequalityOperator = generator.DefaultOperatorInequalityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, inequalityOperator);
             }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             if (!typeSymbol.OverridesEquals())
             {
                 var equalsMethod = generator.EqualsOverrideDeclaration(
-                    editor.SemanticModel.Compilation);
+                    editor.SemanticModel.Compilation, typeSymbol);
 
                 editor.AddMember(declaration, equalsMethod);
             }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsOnOverloadingOperatorEquals.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideEqualsOnOverloadingOperatorEquals.Fixer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             var generator = editor.Generator;
 
-            var methodDeclaration = generator.EqualsOverrideDeclaration(editor.SemanticModel.Compilation, typeSymbol);
+            var methodDeclaration = generator.DefaultEqualsOverrideDeclaration(editor.SemanticModel.Compilation, typeSymbol);
 
             editor.AddMember(typeDeclaration, methodDeclaration);
             return editor.GetChangedDocument();

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideGetHashCodeOnOverridingEquals.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideGetHashCodeOnOverridingEquals.Fixer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             var generator = editor.Generator;
 
-            var methodDeclaration = generator.GetHashCodeOverrideDeclaration(editor.SemanticModel.Compilation);
+            var methodDeclaration = generator.DefaultGetHashCodeOverrideDeclaration(editor.SemanticModel.Compilation);
 
             editor.AddMember(typeDeclaration, methodDeclaration);
             return editor.GetChangedDocument();

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.Fixer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             if (!typeSymbol.OverridesEquals())
             {
-                var equalsMethod = generator.EqualsOverrideDeclaration(editor.SemanticModel.Compilation);
+                var equalsMethod = generator.EqualsOverrideDeclaration(editor.SemanticModel.Compilation, typeSymbol);
 
                 editor.AddMember(declaration, equalsMethod);
             }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.Fixer.cs
@@ -54,56 +54,56 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             if (!typeSymbol.OverridesEquals())
             {
-                var equalsMethod = generator.EqualsOverrideDeclaration(editor.SemanticModel.Compilation, typeSymbol);
+                var equalsMethod = generator.DefaultEqualsOverrideDeclaration(editor.SemanticModel.Compilation, typeSymbol);
 
                 editor.AddMember(declaration, equalsMethod);
             }
 
             if (!typeSymbol.OverridesGetHashCode())
             {
-                var getHashCodeMethod = generator.GetHashCodeOverrideDeclaration(editor.SemanticModel.Compilation);
+                var getHashCodeMethod = generator.DefaultGetHashCodeOverrideDeclaration(editor.SemanticModel.Compilation);
 
                 editor.AddMember(declaration, getHashCodeMethod);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.EqualityOperatorName))
             {
-                var equalityOperator = generator.OperatorEqualityDeclaration(typeSymbol);
+                var equalityOperator = generator.DefaultOperatorEqualityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, equalityOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.InequalityOperatorName))
             {
-                var inequalityOperator = generator.OperatorInequalityDeclaration(typeSymbol);
+                var inequalityOperator = generator.DefaultOperatorInequalityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, inequalityOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.LessThanOperatorName))
             {
-                var lessThanOperator = generator.OperatorLessThanDeclaration(typeSymbol);
+                var lessThanOperator = generator.DefaultOperatorLessThanDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, lessThanOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.LessThanOrEqualOperatorName))
             {
-                var lessThanOrEqualOperator = generator.OperatorLessThanOrEqualDeclaration(typeSymbol);
+                var lessThanOrEqualOperator = generator.DefaultOperatorLessThanOrEqualDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, lessThanOrEqualOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.GreaterThanOperatorName))
             {
-                var greaterThanOperator = generator.OperatorGreaterThanDeclaration(typeSymbol);
+                var greaterThanOperator = generator.DefaultOperatorGreaterThanDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, greaterThanOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.GreaterThanOrEqualOperatorName))
             {
-                var greaterThanOrEqualOperator = generator.OperatorGreaterThanOrEqualDeclaration(typeSymbol);
+                var greaterThanOrEqualOperator = generator.DefaultOperatorGreaterThanOrEqualDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, greaterThanOrEqualOperator);
             }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.Fixer.cs
@@ -42,12 +42,12 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             // We cannot have multiple overlapping diagnostics of this id.
             Diagnostic diagnostic = context.Diagnostics.Single();
 
-            context.RegisterCodeFix(new MyCodeAction(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementComparable,
-                                                     async ct => await ImplementComparable(context.Document, declaration, typeSymbol, ct).ConfigureAwait(false)),
-                                    diagnostic);
+            context.RegisterCodeFix(
+                new MyCodeAction(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementComparable,
+                    async ct => await ImplementComparableAsync(context.Document, declaration, typeSymbol, ct).ConfigureAwait(false)), diagnostic);
         }
 
-        private async Task<Document> ImplementComparable(Document document, SyntaxNode declaration, INamedTypeSymbol typeSymbol, CancellationToken cancellationToken)
+        private async Task<Document> ImplementComparableAsync(Document document, SyntaxNode declaration, INamedTypeSymbol typeSymbol, CancellationToken cancellationToken)
         {
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             var generator = editor.Generator;
@@ -68,30 +68,44 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.EqualityOperatorName))
             {
-                var equalityOperator = generator.ComparisonOperatorDeclaration(OperatorKind.Equality, typeSymbol, editor.SemanticModel.Compilation);
+                var equalityOperator = generator.OperatorEqualityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, equalityOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.InequalityOperatorName))
             {
-                var inequalityOperator = generator.ComparisonOperatorDeclaration(OperatorKind.Inequality, typeSymbol, editor.SemanticModel.Compilation);
+                var inequalityOperator = generator.OperatorInequalityDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, inequalityOperator);
             }
 
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.LessThanOperatorName))
             {
-                var lessThanOperator = generator.ComparisonOperatorDeclaration(OperatorKind.LessThan, typeSymbol, editor.SemanticModel.Compilation);
+                var lessThanOperator = generator.OperatorLessThanDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, lessThanOperator);
             }
 
+            if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.LessThanOrEqualOperatorName))
+            {
+                var lessThanOrEqualOperator = generator.OperatorLessThanOrEqualDeclaration(typeSymbol);
+
+                editor.AddMember(declaration, lessThanOrEqualOperator);
+            }
+
             if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.GreaterThanOperatorName))
             {
-                var greaterThanOperator = generator.ComparisonOperatorDeclaration(OperatorKind.GreaterThan, typeSymbol, editor.SemanticModel.Compilation);
+                var greaterThanOperator = generator.OperatorGreaterThanDeclaration(typeSymbol);
 
                 editor.AddMember(declaration, greaterThanOperator);
+            }
+
+            if (!typeSymbol.ImplementsOperator(WellKnownMemberNames.GreaterThanOrEqualOperatorName))
+            {
+                var greaterThanOrEqualOperator = generator.OperatorGreaterThanOrEqualDeclaration(typeSymbol);
+
+                editor.AddMember(declaration, greaterThanOrEqualOperator);
             }
 
             return editor.GetChangedDocument();

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OverrideMethodsOnComparableTypes.cs
@@ -13,8 +13,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
     /// <summary>
     /// CA1036: A public or protected type implements the System.IComparable interface and 
     /// does not override Object.Equals or does not overload the language-specific operator
-    /// for equality, inequality, less than, or greater than. The rule does not report a
-    /// violation if the type inherits only an implementation of the interface.
+    /// for equality, inequality, less than, less than or equal, greater than or 
+    /// greater than or equal. The rule does not report a violation if the type inherits 
+    /// only an implementation of the interface.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class OverrideMethodsOnComparableTypesAnalyzer : DiagnosticAnalyzer

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OperatorOverloadsHaveNamedAlternatesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OperatorOverloadsHaveNamedAlternatesTests.Fixer.cs
@@ -144,6 +144,33 @@ class C
 
     public int CompareTo(C other)
     {
+        if (ReferenceEquals(other, null))
+        {
+            return 1;
+        }
+
+        throw new System.NotImplementedException();
+    }
+}
+", validationMode: TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void AddAlternateForStructCompare_CSharp()
+        {
+            VerifyCSharpFix(@"
+struct C
+{
+    public static bool operator <(C left, C right) { return true; }   // error CS0216: The operator requires a matching operator '>' to also be defined
+}
+",
+@"
+struct C
+{
+    public static bool operator <(C left, C right) { return true; }   // error CS0216: The operator requires a matching operator '>' to also be defined
+
+    public int CompareTo(C other)
+    {
         throw new System.NotImplementedException();
     }
 }
@@ -335,9 +362,36 @@ Class C
     End Operator
 
     Public Function CompareTo(other As C) As Integer
+        If ReferenceEquals(other, Nothing) Then
+            Return 1
+        End If
+
         Throw New System.NotImplementedException()
     End Function
 End Class
+", validationMode: TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void AddAlternateForStructCompare_Basic()
+        {
+            VerifyBasicFix(@"
+Structure C
+    Public Shared Operator <(left As C, right As C) As Boolean   ' error BC33033: Matching '>' operator is required
+        Return True
+    End Operator
+End Structure
+",
+@"
+Structure C
+    Public Shared Operator <(left As C, right As C) As Boolean   ' error BC33033: Matching '>' operator is required
+        Return True
+    End Operator
+
+    Public Function CompareTo(other As C) As Integer
+        Throw New System.NotImplementedException()
+    End Function
+End Structure
 ", validationMode: TestValidationMode.AllowCompileErrors);
         }
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.Fixer.cs
@@ -46,12 +46,12 @@ public struct A
 
     public static bool operator ==(A left, A right)
     {
-        throw new NotImplementedException();
+        return left.Equals(right);
     }
 
     public static bool operator !=(A left, A right)
     {
-        throw new NotImplementedException();
+        return !(left == right);
     }
 }
 ",
@@ -82,11 +82,11 @@ Public Structure A
     End Function
 
     Public Shared Operator =(left As A, right As A) As Boolean
-        Throw New NotImplementedException()
+        Return left.Equals(right)
     End Operator
 
     Public Shared Operator <>(left As A, right As A) As Boolean
-        Throw New NotImplementedException()
+        Return Not left = right
     End Operator
 End Structure
 ");

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsAndOperatorEqualsOnValueTypesTests.Fixer.cs
@@ -38,12 +38,12 @@ public struct A
 
     public static bool operator ==(A left, A right)
     {
-        throw new System.NotImplementedException();
+        return left.Equals(right);
     }
 
     public static bool operator !=(A left, A right)
     {
-        throw new System.NotImplementedException();
+        return !(left == right);
     }
 }
 ");
@@ -136,7 +136,7 @@ public struct A
 
     public static bool operator ==(A left, A right)
     {
-        throw new System.NotImplementedException();
+        return left.Equals(right);
     }
 }
 ", validationMode: TestValidationMode.AllowCompileErrors);
@@ -185,7 +185,7 @@ public struct A
 
     public static bool operator !=(A left, A right)
     {
-        throw new System.NotImplementedException();
+        return !(left == right);
     }
 }
 ", validationMode: TestValidationMode.AllowCompileErrors);
@@ -212,11 +212,11 @@ Public Structure A
     End Function
 
     Public Shared Operator =(left As A, right As A) As Boolean
-        Throw New System.NotImplementedException()
+        Return left.Equals(right)
     End Operator
 
     Public Shared Operator <>(left As A, right As A) As Boolean
-        Throw New System.NotImplementedException()
+        Return Not left = right
     End Operator
 End Structure
 ");
@@ -292,7 +292,7 @@ Public Structure A
     End Operator
 
     Public Shared Operator =(left As A, right As A) As Boolean
-        Throw New System.NotImplementedException()
+        Return left.Equals(right)
     End Operator
 End Structure
 ", validationMode: TestValidationMode.AllowCompileErrors);
@@ -332,7 +332,7 @@ Public Structure A
     End Operator
 
     Public Shared Operator <>(left As A, right As A) As Boolean
-        Throw New System.NotImplementedException()
+        Return Not left = right
     End Operator
 End Structure
 ", validationMode: TestValidationMode.AllowCompileErrors);

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsOnOverloadingOperatorEqualsTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsOnOverloadingOperatorEqualsTests.Fixer.cs
@@ -50,6 +50,11 @@ class C
 
     public override bool Equals(object obj)
     {
+        if (ReferenceEquals(obj, null))
+        {
+            return false;
+        }
+
         throw new System.NotImplementedException();
     }
 }
@@ -80,6 +85,11 @@ class C
 
     public override bool Equals(object obj)
     {
+        if (ReferenceEquals(obj, null))
+        {
+            return false;
+        }
+
         throw new NotImplementedException();
     }
 }
@@ -113,6 +123,10 @@ Class C
     End Operator
 
     Public Overrides Function Equals(obj As Object) As Boolean
+        If ReferenceEquals(obj, Nothing) Then
+            Return False
+        End If
+
         Throw New System.NotImplementedException()
     End Function
 End Class
@@ -148,6 +162,10 @@ Class C
     End Operator
 
     Public Overrides Function Equals(obj As Object) As Boolean
+        If ReferenceEquals(obj, Nothing) Then
+            Return False
+        End If
+
         Throw New NotImplementedException()
     End Function
 End Class

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsOnOverloadingOperatorEqualsTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideEqualsOnOverloadingOperatorEqualsTests.Fixer.cs
@@ -50,6 +50,11 @@ class C
 
     public override bool Equals(object obj)
     {
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
         if (ReferenceEquals(obj, null))
         {
             return false;
@@ -85,6 +90,11 @@ class C
 
     public override bool Equals(object obj)
     {
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
         if (ReferenceEquals(obj, null))
         {
             return false;
@@ -123,6 +133,10 @@ Class C
     End Operator
 
     Public Overrides Function Equals(obj As Object) As Boolean
+        If ReferenceEquals(Me, obj) Then
+            Return True
+        End If
+
         If ReferenceEquals(obj, Nothing) Then
             Return False
         End If
@@ -162,6 +176,10 @@ Class C
     End Operator
 
     Public Overrides Function Equals(obj As Object) As Boolean
+        If ReferenceEquals(Me, obj) Then
+            Return True
+        End If
+
         If ReferenceEquals(obj, Nothing) Then
             Return False
         End If

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CA1036GenerateAllCSharp()
+        public void CA1036ClassGenerateAllCSharp()
         {
             VerifyCSharpFix(@"
 using System;
@@ -53,29 +53,115 @@ public class A : IComparable
 
     public static bool operator ==(A left, A right)
     {
-        throw new NotImplementedException();
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (ReferenceEquals(left, null))
+        {
+            return false;
+        }
+
+        return left.Equals(right);
     }
 
     public static bool operator !=(A left, A right)
     {
-        throw new NotImplementedException();
+        return !(left == right);
     }
 
     public static bool operator <(A left, A right)
     {
-        throw new NotImplementedException();
+        return ReferenceEquals(left, null) ? !ReferenceEquals(right, null) : left.CompareTo(right) < 0;
+    }
+
+    public static bool operator <=(A left, A right)
+    {
+        return ReferenceEquals(left, null) || left.CompareTo(right) <= 0;
     }
 
     public static bool operator >(A left, A right)
     {
-        throw new NotImplementedException();
+        return !ReferenceEquals(left, null) && left.CompareTo(right) > 0;
+    }
+
+    public static bool operator >=(A left, A right)
+    {
+        return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
     }
 }
 ");
         }
 
         [Fact]
-        public void CA1036GenerateSomeCSharp()
+        public void CA1036StructGenerateAllCSharp()
+        {
+            VerifyCSharpFix(@"
+using System;
+
+public struct A : IComparable
+{    
+    public int CompareTo(object obj)
+    {
+        return 1;
+    }
+}
+", @"
+using System;
+
+public struct A : IComparable
+{    
+    public int CompareTo(object obj)
+    {
+        return 1;
+    }
+
+    public override bool Equals(object obj)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool operator ==(A left, A right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(A left, A right)
+    {
+        return !(left == right);
+    }
+
+    public static bool operator <(A left, A right)
+    {
+        return left.CompareTo(right) < 0;
+    }
+
+    public static bool operator <=(A left, A right)
+    {
+        return left.CompareTo(right) <= 0;
+    }
+
+    public static bool operator >(A left, A right)
+    {
+        return left.CompareTo(right) > 0;
+    }
+
+    public static bool operator >=(A left, A right)
+    {
+        return left.CompareTo(right) >= 0;
+    }
+}
+");
+        }
+
+        [Fact]
+        public void CA1036ClassGenerateSomeCSharp()
         {
             VerifyCSharpFix(@"
 using System;
@@ -124,24 +210,122 @@ public class A : IComparable
 
     public static bool operator ==(A left, A right)
     {
-        throw new NotImplementedException();
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (ReferenceEquals(left, null))
+        {
+            return false;
+        }
+
+        return left.Equals(right);
     }
 
     public static bool operator <(A left, A right)
     {
-        throw new NotImplementedException();
+        return ReferenceEquals(left, null) ? !ReferenceEquals(right, null) : left.CompareTo(right) < 0;
+    }
+
+    public static bool operator <=(A left, A right)
+    {
+        return ReferenceEquals(left, null) || left.CompareTo(right) <= 0;
     }
 
     public static bool operator >(A left, A right)
     {
-        throw new NotImplementedException();
+        return !ReferenceEquals(left, null) && left.CompareTo(right) > 0;
+    }
+
+    public static bool operator >=(A left, A right)
+    {
+        return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
     }
 }
-", validationMode: TestValidationMode.AllowCompileErrors);
+", 
+            validationMode: TestValidationMode.AllowCompileErrors);
         }
 
         [Fact]
-        public void CA1036GenerateAllVisualBasic()
+        public void CA1036StructGenerateSomeCSharp()
+        {
+            VerifyCSharpFix(@"
+using System;
+
+public struct A : IComparable
+{    
+    public override int GetHashCode()
+    {
+        return 1234;
+    }
+
+    public int CompareTo(object obj)
+    {
+        return 1;
+    }
+
+    public static bool operator !=(A objLeft, A objRight)   // error CS0216: The operator requires a matching operator '==' to also be defined
+    {
+        return true;
+    }
+}
+", @"
+using System;
+
+public struct A : IComparable
+{    
+    public override int GetHashCode()
+    {
+        return 1234;
+    }
+
+    public int CompareTo(object obj)
+    {
+        return 1;
+    }
+
+    public static bool operator !=(A objLeft, A objRight)   // error CS0216: The operator requires a matching operator '==' to also be defined
+    {
+        return true;
+    }
+
+    public override bool Equals(object obj)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool operator ==(A left, A right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator <(A left, A right)
+    {
+        return left.CompareTo(right) < 0;
+    }
+
+    public static bool operator <=(A left, A right)
+    {
+        return left.CompareTo(right) <= 0;
+    }
+
+    public static bool operator >(A left, A right)
+    {
+        return left.CompareTo(right) > 0;
+    }
+
+    public static bool operator >=(A left, A right)
+    {
+        return left.CompareTo(right) >= 0;
+    }
+}
+", 
+            validationMode: TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void CA1036ClassGenerateAllVisualBasic()
         {
             VerifyBasicFix(@"
 Imports System
@@ -152,7 +336,8 @@ Public Class A : Implements IComparable
         Return 1
     End Function
 
-End Class", @"
+End Class
+", @"
 Imports System
 
 Public Class A : Implements IComparable
@@ -170,25 +355,99 @@ Public Class A : Implements IComparable
     End Function
 
     Public Shared Operator =(left As A, right As A) As Boolean
-        Throw New NotImplementedException()
+        If ReferenceEquals(left, right) Then
+            Return True
+        End If
+
+        If ReferenceEquals(left, Nothing) Then
+            Return False
+        End If
+
+        Return left.Equals(right)
     End Operator
 
     Public Shared Operator <>(left As A, right As A) As Boolean
-        Throw New NotImplementedException()
+        Return Not left = right
     End Operator
 
     Public Shared Operator <(left As A, right As A) As Boolean
-        Throw New NotImplementedException()
+        Return If(ReferenceEquals(left, Nothing), Not ReferenceEquals(right, Nothing), left.CompareTo(right) < 0)
+    End Operator
+
+    Public Shared Operator <=(left As A, right As A) As Boolean
+        Return ReferenceEquals(left, Nothing) OrElse left.CompareTo(right) <= 0
     End Operator
 
     Public Shared Operator >(left As A, right As A) As Boolean
-        Throw New NotImplementedException()
+        Return Not ReferenceEquals(left, Nothing) AndAlso left.CompareTo(right) > 0
     End Operator
-End Class");
+
+    Public Shared Operator >=(left As A, right As A) As Boolean
+        Return If(ReferenceEquals(left, Nothing), ReferenceEquals(right, Nothing), left.CompareTo(right) >= 0)
+    End Operator
+End Class
+");
         }
 
         [Fact]
-        public void CA1036GenerateSomeVisualBasic()
+        public void CA1036StructGenerateAllVisualBasic()
+        {
+            VerifyBasicFix(@"
+Imports System
+
+Public Structure A : Implements IComparable
+
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
+        Return 1
+    End Function
+
+End Structure
+", @"
+Imports System
+
+Public Structure A : Implements IComparable
+
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
+        Return 1
+    End Function
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+        Throw New NotImplementedException()
+    End Function
+
+    Public Overrides Function GetHashCode() As Integer
+        Throw New NotImplementedException()
+    End Function
+
+    Public Shared Operator =(left As A, right As A) As Boolean
+        Return left.Equals(right)
+    End Operator
+
+    Public Shared Operator <>(left As A, right As A) As Boolean
+        Return Not left = right
+    End Operator
+
+    Public Shared Operator <(left As A, right As A) As Boolean
+        Return left.CompareTo(right) < 0
+    End Operator
+
+    Public Shared Operator <=(left As A, right As A) As Boolean
+        Return left.CompareTo(right) <= 0
+    End Operator
+
+    Public Shared Operator >(left As A, right As A) As Boolean
+        Return left.CompareTo(right) > 0
+    End Operator
+
+    Public Shared Operator >=(left As A, right As A) As Boolean
+        Return left.CompareTo(right) >= 0
+    End Operator
+End Structure
+");
+        }
+
+        [Fact]
+        public void CA1036ClassGenerateSomeVisualBasic()
         {
             VerifyBasicFix(@"
 Imports System
@@ -207,7 +466,8 @@ Public Class A : Implements IComparable
         Return 1
     End Function
 
-End Class", @"
+End Class
+", @"
 Imports System
 
 Public Class A : Implements IComparable
@@ -229,17 +489,101 @@ Public Class A : Implements IComparable
     End Function
 
     Public Shared Operator =(left As A, right As A) As Boolean
-        Throw New NotImplementedException()
+        If ReferenceEquals(left, right) Then
+            Return True
+        End If
+
+        If ReferenceEquals(left, Nothing) Then
+            Return False
+        End If
+
+        Return left.Equals(right)
     End Operator
 
     Public Shared Operator <>(left As A, right As A) As Boolean
-        Throw New NotImplementedException()
+        Return Not left = right
+    End Operator
+
+    Public Shared Operator <=(left As A, right As A) As Boolean
+        Return ReferenceEquals(left, Nothing) OrElse left.CompareTo(right) <= 0
     End Operator
 
     Public Shared Operator >(left As A, right As A) As Boolean
-        Throw New NotImplementedException()
+        Return Not ReferenceEquals(left, Nothing) AndAlso left.CompareTo(right) > 0
     End Operator
-End Class", validationMode: TestValidationMode.AllowCompileErrors);
+
+    Public Shared Operator >=(left As A, right As A) As Boolean
+        Return If(ReferenceEquals(left, Nothing), ReferenceEquals(right, Nothing), left.CompareTo(right) >= 0)
+    End Operator
+End Class
+", 
+            validationMode: TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void CA1036StructGenerateSomeVisualBasic()
+        {
+            VerifyBasicFix(@"
+Imports System
+
+Public Structure A : Implements IComparable
+
+    Public Overrides Function GetHashCode() As Integer
+        Return 1234
+    End Function
+
+    Public Shared Operator <(objLeft As A, objRight As A) As Boolean   ' error BC33033: Matching '>' operator is required
+        Return True
+    End Operator
+
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
+        Return 1
+    End Function
+
+End Structure
+", @"
+Imports System
+
+Public Structure A : Implements IComparable
+
+    Public Overrides Function GetHashCode() As Integer
+        Return 1234
+    End Function
+
+    Public Shared Operator <(objLeft As A, objRight As A) As Boolean   ' error BC33033: Matching '>' operator is required
+        Return True
+    End Operator
+
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
+        Return 1
+    End Function
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+        Throw New NotImplementedException()
+    End Function
+
+    Public Shared Operator =(left As A, right As A) As Boolean
+        Return left.Equals(right)
+    End Operator
+
+    Public Shared Operator <>(left As A, right As A) As Boolean
+        Return Not left = right
+    End Operator
+
+    Public Shared Operator <=(left As A, right As A) As Boolean
+        Return left.CompareTo(right) <= 0
+    End Operator
+
+    Public Shared Operator >(left As A, right As A) As Boolean
+        Return left.CompareTo(right) > 0
+    End Operator
+
+    Public Shared Operator >=(left As A, right As A) As Boolean
+        Return left.CompareTo(right) >= 0
+    End Operator
+End Structure
+", 
+            validationMode: TestValidationMode.AllowCompileErrors);
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
@@ -43,6 +43,11 @@ public class A : IComparable
 
     public override bool Equals(object obj)
     {
+        if (ReferenceEquals(obj, null))
+        {
+            return false;
+        }
+
         throw new NotImplementedException();
     }
 
@@ -205,6 +210,11 @@ public class A : IComparable
 
     public override bool Equals(object obj)
     {
+        if (ReferenceEquals(obj, null))
+        {
+            return false;
+        }
+
         throw new NotImplementedException();
     }
 
@@ -347,6 +357,10 @@ Public Class A : Implements IComparable
     End Function
 
     Public Overrides Function Equals(obj As Object) As Boolean
+        If ReferenceEquals(obj, Nothing) Then
+            Return False
+        End If
+
         Throw New NotImplementedException()
     End Function
 
@@ -485,6 +499,10 @@ Public Class A : Implements IComparable
     End Function
 
     Public Overrides Function Equals(obj As Object) As Boolean
+        If ReferenceEquals(obj, Nothing) Then
+            Return False
+        End If
+
         Throw New NotImplementedException()
     End Function
 

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.Fixer.cs
@@ -43,6 +43,11 @@ public class A : IComparable
 
     public override bool Equals(object obj)
     {
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
         if (ReferenceEquals(obj, null))
         {
             return false;
@@ -58,11 +63,6 @@ public class A : IComparable
 
     public static bool operator ==(A left, A right)
     {
-        if (ReferenceEquals(left, right))
-        {
-            return true;
-        }
-
         if (ReferenceEquals(left, null))
         {
             return false;
@@ -210,6 +210,11 @@ public class A : IComparable
 
     public override bool Equals(object obj)
     {
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
         if (ReferenceEquals(obj, null))
         {
             return false;
@@ -220,11 +225,6 @@ public class A : IComparable
 
     public static bool operator ==(A left, A right)
     {
-        if (ReferenceEquals(left, right))
-        {
-            return true;
-        }
-
         if (ReferenceEquals(left, null))
         {
             return false;
@@ -357,6 +357,10 @@ Public Class A : Implements IComparable
     End Function
 
     Public Overrides Function Equals(obj As Object) As Boolean
+        If ReferenceEquals(Me, obj) Then
+            Return True
+        End If
+
         If ReferenceEquals(obj, Nothing) Then
             Return False
         End If
@@ -369,10 +373,6 @@ Public Class A : Implements IComparable
     End Function
 
     Public Shared Operator =(left As A, right As A) As Boolean
-        If ReferenceEquals(left, right) Then
-            Return True
-        End If
-
         If ReferenceEquals(left, Nothing) Then
             Return False
         End If
@@ -499,6 +499,10 @@ Public Class A : Implements IComparable
     End Function
 
     Public Overrides Function Equals(obj As Object) As Boolean
+        If ReferenceEquals(Me, obj) Then
+            Return True
+        End If
+
         If ReferenceEquals(obj, Nothing) Then
             Return False
         End If
@@ -507,10 +511,6 @@ Public Class A : Implements IComparable
     End Function
 
     Public Shared Operator =(left As A, right As A) As Boolean
-        If ReferenceEquals(left, right) Then
-            Return True
-        End If
-
         If ReferenceEquals(left, Nothing) Then
             Return False
         End If

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/OverrideMethodsOnComparableTypesTests.cs
@@ -56,12 +56,21 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             return true;
         }
 
+        public static bool operator <=(A objLeft, A objRight)
+        {
+            return true;
+        }
+
         public static bool operator >(A objLeft, A objRight)
         {
             return true;
         }
-    }
 
+        public static bool operator >=(A objLeft, A objRight)
+        {
+            return true;
+        }
+    }
 ");
         }
 
@@ -105,7 +114,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             return true;
         }
     }
-
 ", GetCA1036CSharpResultAt(4, 18, "A"));
         }
 
@@ -147,7 +155,17 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             return true;
         }
 
+        public static bool operator <=(A objLeft, A objRight)
+        {
+            return true;
+        }
+
         public static bool operator >(A objLeft, A objRight)
+        {
+            return true;
+        }
+
+        public static bool operator >=(A objLeft, A objRight)
         {
             return true;
         }
@@ -182,12 +200,21 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             return true;
         }
 
+        public static bool operator <=(B objLeft, B objRight)
+        {
+            return true;
+        }
+
         public static bool operator >(B objLeft, B objRight)
         {
             return true;
         }
-    }
 
+        public static bool operator >=(B objLeft, B objRight)
+        {
+            return true;
+        }
+    }
 ");
         }
 
@@ -229,12 +256,21 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             return true;
         }
 
+        public static bool operator <=(A objLeft, A objRight)
+        {
+            return true;
+        }
+
         public static bool operator >(A objLeft, A objRight)
         {
             return true;
         }
-    }
 
+        public static bool operator >=(A objLeft, A objRight)
+        {
+            return true;
+        }
+    }
 ");
         }
 
@@ -274,7 +310,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             }
         }
     }
-
 ");
         }
 
@@ -502,7 +537,15 @@ Public Class A : Implements IComparable
         Return True
     End Operator
 
+    Public Shared Operator <=(objLeft As A, objRight As A) As Boolean
+        Return True
+    End Operator
+
     Public Shared Operator >(objLeft As A, objRight As A) As Boolean
+        Return True
+    End Operator
+
+    Public Shared Operator >=(objLeft As A, objRight As A) As Boolean
         Return True
     End Operator
 
@@ -581,7 +624,15 @@ Imports System
         Return True
     End Operator
 
+    Public Shared Operator <=(objLeft As A, objRight As A) As Boolean
+        Return True
+    End Operator
+
     Public Shared Operator >(objLeft As A, objRight As A) As Boolean
+        Return True
+    End Operator
+
+    Public Shared Operator >=(objLeft As A, objRight As A) As Boolean
         Return True
     End Operator
 
@@ -651,7 +702,15 @@ Public Structure A : Implements IComparable
         Return True
     End Operator
 
+    Public Shared Operator <=(objLeft As A, objRight As A) As Boolean
+        Return True
+    End Operator
+
     Public Shared Operator >(objLeft As A, objRight As A) As Boolean
+        Return True
+    End Operator
+
+    Public Shared Operator >=(objLeft As A, objRight As A) As Boolean
         Return True
     End Operator
 


### PR DESCRIPTION
This fixes most of #791.

Because a fixer for EquatableAnalyzer (CA1066/CA1067) does not yet exist, generating method bodies for ``System.IEquatable`1`` members is not in this PR.