### PR TITLE
Fix #1074 CA2214 complains about InitializeComponent methods in components

### DIFF
--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/DoNotCallOverridableMethodsInConstructors.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/DoNotCallOverridableMethodsInConstructors.cs
@@ -45,11 +45,11 @@ namespace Microsoft.QualityGuidelines.Analyzers
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
                 INamedTypeSymbol webUiControlType = compilationContext.Compilation.GetTypeByMetadataName("System.Web.UI.Control");
-                INamedTypeSymbol windowsFormsControlType = compilationContext.Compilation.GetTypeByMetadataName("System.Windows.Forms.Control");
+                INamedTypeSymbol componentModelComponentType = compilationContext.Compilation.GetTypeByMetadataName("System.ComponentModel.Component");
 
                 compilationContext.RegisterOperationBlockStartAction(context =>
                 {
-                    if (ShouldOmitThisDiagnostic(context.OwningSymbol, webUiControlType, windowsFormsControlType))
+                    if (ShouldOmitThisDiagnostic(context.OwningSymbol, webUiControlType, componentModelComponentType))
                     {
                         return;
                     }
@@ -71,7 +71,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
             }
         }
 
-        private static bool ShouldOmitThisDiagnostic(ISymbol symbol, INamedTypeSymbol webUiControlType, INamedTypeSymbol windowsFormsControlType)
+        private static bool ShouldOmitThisDiagnostic(ISymbol symbol, INamedTypeSymbol webUiControlType, INamedTypeSymbol componentModelComponentType)
         {
             // This diagnostic is only relevant in constructors.
             // TODO: should this apply to instance field initializers for VB?
@@ -87,13 +87,13 @@ namespace Microsoft.QualityGuidelines.Analyzers
                 return true;
             }
 
-            // special case ASP.NET and WinForms constructors
+            // special case ASP.NET and Components constructors
             if (containingType.Inherits(webUiControlType))
             {
                 return true;
             }
 
-            if (containingType.Inherits(windowsFormsControlType))
+            if (containingType.Inherits(componentModelComponentType))
             {
                 return true;
             }

--- a/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/DoNotCallOverridableMethodsInConstructorsTests.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/UnitTests/DoNotCallOverridableMethodsInConstructorsTests.cs
@@ -248,7 +248,7 @@ abstract class D : System.Windows.Forms.Control
 {
     D()
     {
-        // no diagnostics because we inherit from System.Web.UI.Control
+        // no diagnostics because we inherit from System.Windows.Forms.Control
         Foo();
         OnPaint(null);
     }
@@ -266,6 +266,17 @@ class E : ControlBase
     {
         OnGotFocus(null); // no diagnostics when we're not an immediate descendant of a special class
     }
+}
+
+abstract class F : System.ComponentModel.Component
+{
+    F()
+    {
+        // no diagnostics because we inherit from System.ComponentModel.Component
+        Foo();
+    }
+
+    protected abstract void Foo();
 }
 ";
             Document document = CreateDocument(source, LanguageNames.CSharp);
@@ -292,7 +303,7 @@ End Class
 MustInherit Class D
     Inherits System.Windows.Forms.Control
     Public Sub New()
-        ' no diagnostics because we inherit from System.Web.UI.Control
+        ' no diagnostics because we inherit from System.Windows.Forms.Control
         Foo()
         OnPaint(Nothing)
     End Sub
@@ -308,6 +319,15 @@ Class E
     Public Sub New()
         OnGotFocus(Nothing) ' no diagnostics when we're not an immediate descendant of a special class
     End Sub
+End Class
+
+MustInherit Class F
+    Inherits System.ComponentModel.Component
+    Public Sub New()
+        ' no diagnostics because we inherit from System.ComponentModel.Component
+        Foo()
+    End Sub
+    MustOverride Sub Foo()
 End Class
 ";
             Document document = CreateDocument(source, LanguageNames.VisualBasic);


### PR DESCRIPTION
- Change CA2214 DoNotCallOverridableMethodsInConstructors to ignore all descendant of System.ComponentModel.Component instead of System.Windows.Forms.Control
- Modified unit tests to check for both Component and Control.