### PR TITLE
Add CA1061: Do not hide base class methods

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/ApiDesignGuidelines/CSharpDoNotHideBaseClassMethods.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/ApiDesignGuidelines/CSharpDoNotHideBaseClassMethods.Fixer.cs
@@ -1,0 +1,15 @@
+﻿using System.Composition;
+using Microsoft.ApiDesignGuidelines.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.ApiDesignGuidelines.CSharp.Analyzers
+{
+    /// <summary>
+    /// CA1061: Do not hide base class methods
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    public sealed class CSharpDoNotHideBaseClassMethodsFixer : DoNotHideBaseClassMethodsFixer
+    {
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.Fixer.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.ApiDesignGuidelines.Analyzers
+{
+    /// <summary>
+    /// CA1061: Do not hide base class methods
+    /// </summary>
+    public abstract class DoNotHideBaseClassMethodsFixer : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DoNotHideBaseClassMethodsAnalyzer.RuleId);
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            // This is to get rid of warning CS1998, please remove when implementing this analyzer
+            await Task.Run(() => { }).ConfigureAwait(false);
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.ApiDesignGuidelines.Analyzers
+{
+    /// <summary>
+    /// CA1061: Do not hide base class methods
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class DoNotHideBaseClassMethodsAnalyzer : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA1061";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.DoNotHideBaseClassMethodsTitle), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.DoNotHideBaseClassMethodsMessage), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.DoNotHideBaseClassMethodsDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+
+        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            RuleId,
+            s_localizableTitle,
+            s_localizableMessage,
+            DiagnosticCategory.Design,
+            DiagnosticSeverity.Warning, 
+            isEnabledByDefault: true,
+            description: s_localizableDescription,
+            helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182143.aspx",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext analysisContext)
+        {
+            //analysisContext.EnableConcurrentExecution();
+            analysisContext.RegisterSymbolAction(SymbolAnalyzer, SymbolKind.Method);
+        }
+
+        private void SymbolAnalyzer(SymbolAnalysisContext context)
+        {
+            var method = (IMethodSymbol)context.Symbol;
+
+            // Bail out if this method overrides another (parameter types cannot be changed) 
+            // or doesn't have any parameters
+            if (method.IsOverride || !method.Parameters.Any())
+            {
+                return;
+            }
+
+            foreach (var hiddenMethod in GetMethodsHiddenByMethod(method, method.ContainingType.BaseType))
+            {
+                var diagnostic = Diagnostic.Create(Rule, context.Symbol.Locations[0], method.ToDisplayString(), hiddenMethod.ToDisplayString());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        private IEnumerable<IMethodSymbol> GetMethodsHiddenByMethod(IMethodSymbol method, INamedTypeSymbol baseType)
+        {
+            while (true)
+            {
+                if (baseType?.BaseType == null)
+                {
+                    // There are no other base types to check - we're at the top of the hierarchy
+                    yield break;
+                }
+
+                var baseTypeMethods = baseType.GetMembers(method.Name)
+                    .Where(x => !x.IsStatic && !x.IsVirtual && x.DeclaredAccessibility != Accessibility.Private)
+                    .OfType<IMethodSymbol>();
+
+                foreach (var baseTypeMethod in baseTypeMethods)
+                {
+                    if (method.Parameters.Length != baseTypeMethod.Parameters.Length)
+                    {
+                        continue;
+                    }
+
+                    var zippedParams = method.Parameters.Zip(
+                        baseTypeMethod.Parameters, 
+                        (x, y) => new {DerivedParm = x, BaseParam = y}).ToList();
+
+                    // Does the matching base type method also have the same return type, the same parameter names, 
+                    // and at least one parameter with a type that is more derived than the derived type's corresponding parameter? 
+                    if (method.ReturnType.Equals(baseTypeMethod.ReturnType) 
+                        && zippedParams.All(x => x.DerivedParm.Name == x.BaseParam.Name) 
+                        && zippedParams.Any(x => !x.BaseParam.Type.Equals(x.DerivedParm.Type) 
+                                            && x.BaseParam.Type.DerivesFrom(x.DerivedParm.Type)))
+                    {
+                        // Yes - the derived type method is "hiding" the base type method (we can't call it)
+                        yield return baseTypeMethod;
+                    }
+                }
+
+                // Repeat the same checks with the base type of this base type
+                baseType = baseType.BaseType;
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             s_localizableTitle,
             s_localizableMessage,
             DiagnosticCategory.Design,
-            DiagnosticSeverity.Warning, 
+            DiagnosticHelpers.DefaultDiagnosticSeverity, 
             isEnabledByDefault: true,
             description: s_localizableDescription,
             helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182143.aspx",
@@ -38,6 +38,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         public override void Initialize(AnalysisContext analysisContext)
         {
             analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             analysisContext.RegisterSymbolAction(SymbolAnalyzer, SymbolKind.Method);
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
@@ -93,14 +93,18 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                             break;
                         }
 
-                        if (baseMethodParameter.Type.Equals(derivedMethodParameter.Type))
+                        // All parameter types must match except for those that are subtypes of the
+                        // derived method's parameter type - there must be at least one.
+                        if (!baseMethodParameter.Type.Equals(derivedMethodParameter.Type))
                         {
-                            continue;
-                        }
+                            if (!baseMethodParameter.Type.DerivesFrom(derivedMethodParameter.Type))
+                            {
+                                isMethodHidden = false;
+                                break;
+                            }
 
-                        // If all parameter names and types match, the only thing that determines if this method is hidden
-                        // is whether the derived method parameter is a base type of our base method parameter.
-                        isMethodHidden = baseMethodParameter.Type.DerivesFrom(derivedMethodParameter.Type);
+                            isMethodHidden = true;
+                        }
                     }
 
                     if (isMethodHidden)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
@@ -540,6 +540,33 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A method in a base type is hidden by an identically named method in a derived type when the parameter signature of the derived method differs only by types that are more weakly derived than the corresponding types in the parameter signature of the base method..
+        /// </summary>
+        internal static string DoNotHideBaseClassMethodsDescription {
+            get {
+                return ResourceManager.GetString("DoNotHideBaseClassMethodsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change or remove &apos;{0}&apos; because it hides a more specific base class method: &apos;{1}&apos;..
+        /// </summary>
+        internal static string DoNotHideBaseClassMethodsMessage {
+            get {
+                return ResourceManager.GetString("DoNotHideBaseClassMethodsMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not hide base class methods.
+        /// </summary>
+        internal static string DoNotHideBaseClassMethodsTitle {
+            get {
+                return ResourceManager.GetString("DoNotHideBaseClassMethodsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove FlagsAttribute from enum..
         /// </summary>
         internal static string DoNotMarkEnumsWithFlagsCodeFix {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -991,4 +991,13 @@ Names of parameters and members are better used to communicate their meaning tha
   <data name="RenameToTitle" xml:space="preserve">
     <value>Rename to '{0}'</value>
   </data>
+  <data name="DoNotHideBaseClassMethodsDescription" xml:space="preserve">
+    <value>A method in a base type is hidden by an identically named method in a derived type when the parameter signature of the derived method differs only by types that are more weakly derived than the corresponding types in the parameter signature of the base method.</value>
+  </data>
+  <data name="DoNotHideBaseClassMethodsMessage" xml:space="preserve">
+    <value>Change or remove '{0}' because it hides a more specific base class method: '{1}'.</value>
+  </data>
+  <data name="DoNotHideBaseClassMethodsTitle" xml:space="preserve">
+    <value>Do not hide base class methods</value>
+  </data>
 </root>

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.Fixer.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.ApiDesignGuidelines.CSharp.Analyzers;
+using Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Test.Utilities;
+
+namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
+{
+    public class DoNotHideBaseClassMethodsFixerTests : CodeFixTestBase
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DoNotHideBaseClassMethodsAnalyzer();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new DoNotHideBaseClassMethodsAnalyzer();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new CSharpDoNotHideBaseClassMethodsFixer();
+        }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            return new BasicDoNotHideBaseClassMethodsFixer();
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -400,7 +400,40 @@ End Class
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_ParameterTypeMismatch_NoDiagnostic()
+        public void CA1061_DerivedMethodHasLessDerivedParameter_ParameterTypeMismatchAtStart_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Base
+{
+    public void Method(int input, string input2)
+    {
+    }
+}
+
+class Derived : Base
+{
+    public void Method(char input, object input2)
+    {
+    }
+}");
+
+            VerifyBasic(@"
+Class Base
+    Private Sub Method(input As Integer, input2 As String)
+    End Sub
+End Class
+
+Class Derived
+    Inherits Base
+
+    Public Sub Method(input As Char, input2 As Object)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1061_DerivedMethodHasLessDerivedParameter_ParameterTypeMismatchAtEnd_NoDiagnostic()
         {
             VerifyCSharp(@"
 class Base
@@ -419,14 +452,14 @@ class Derived : Base
 
             VerifyBasic(@"
 Class Base
-    Private Sub Method(input As String, input2 as Integer)
+    Private Sub Method(input As String, input2 As Integer)
     End Sub
 End Class
 
 Class Derived
     Inherits Base
 
-    Public Sub Method(input As Object, input2 as Char)
+    Public Sub Method(input As Object, input2 As Char)
     End Sub
 End Class
 ");

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -1,0 +1,262 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
+{
+    public class DoNotHideBaseClassMethodsTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new DoNotHideBaseClassMethodsAnalyzer();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DoNotHideBaseClassMethodsAnalyzer();
+        }
+
+        [Fact]
+        public void CA1061_DerivedMethodMatchesBaseMethod_NoDiagnostic()
+        {
+            const string Test = @"
+using System;
+
+class BaseType
+{
+    public void Method(string input)
+    {
+    }
+}
+
+class DerivedType : BaseType
+{
+    public void Method(string input)
+    {
+    }
+}";
+
+            VerifyCSharp(Test);
+        }
+
+        [Fact]
+        public void CA1061_BaseMethodHasLessDerivedParameter_NoDiagnostic()
+        {
+            const string Test = @"
+using System;
+
+class BaseType
+{
+    public void Method(object input)
+    {
+    }
+}
+
+class DerivedType : BaseType
+{
+    public void Method(string input)
+    {
+    }
+}";
+
+            VerifyCSharp(Test);
+        }
+
+        [Fact]
+        public void CA1061_DerivedMethodHasLessDerivedParameter_Diagnostic()
+        {
+            const string Test = @"
+using System;
+
+class BaseType
+{
+    public void Method(string input1, string input2)
+    {
+    }
+}
+
+class DerivedType : BaseType
+{
+    public void Method(object input1, string input2)
+    {
+    }
+}";
+
+            VerifyCSharp(Test, GetCA1061ResultAt(13, 17, "DerivedType.Method(object, string)", "BaseType.Method(string, string)"));
+        }
+
+        [Fact]
+        public void CA1061_DerivedMethodHasLessDerivedParameter_BaseMethodPrivate_NoDiagnostic()
+        {
+            const string Test = @"
+using System;
+
+class BaseType
+{
+    private void Method(string input)
+    {
+    }
+}
+
+class DerivedType : BaseType
+{
+    public void Method(object input)
+    {
+    }
+}";
+
+            // Note: This behavior differs from FxCop's CA1061, but I think it makes sense
+            VerifyCSharp(Test);
+        }
+
+        [Fact]
+        public void CA1061_DerivedMethodHasLessDerivedParameter_DerivedMethodPrivate_Diagnostic()
+        {
+            const string Test = @"
+using System;
+
+class BaseType
+{
+    public void Method(string input)
+    {
+    }
+}
+
+class DerivedType : BaseType
+{
+    private void Method(object input)
+    {
+    }
+}";
+
+            VerifyCSharp(Test, GetCA1061ResultAt(13, 18, "DerivedType.Method(object)", "BaseType.Method(string)"));
+        }
+
+        [Fact]
+        public void CA1061_DerivedMethodHasLessDerivedParameter_MatchingMethodInBasesBase_Diagnostic()
+        {
+            const string Test = @"
+using System;
+
+class BaseBaseType
+{
+    public void Method(string input)
+    {
+    }
+}
+
+class BaseType : BaseBaseType
+{
+}
+
+class DerivedType : BaseType
+{
+    public void Method(object input)
+    {
+    }
+}";
+
+            VerifyCSharp(Test, GetCA1061ResultAt(17, 17, "DerivedType.Method(object)", "BaseBaseType.Method(string)"));
+        }
+
+        [Fact]
+        public void CA1601_DerivedMethodOverridesAbstractBaseMethod_NoDiagnostic()
+        {
+            const string Test = @"
+using System;
+
+abstract class BaseType
+{
+    public abstract void Method(string input);
+}
+
+class DerivedType : BaseType
+{
+    public override void Method(string input)
+    {
+    }
+}";
+
+            VerifyCSharp(Test);
+        }
+
+        [Fact]
+        public void CA1061_DerivedMethodOverridesBaseMethod_NoDiagnostic()
+        {
+            const string Test = @"
+using System;
+
+class BaseType
+{
+    public virtual void Method(string input)
+    {
+    }
+}
+
+class DerivedType : BaseType
+{
+    public override void Method(string input)
+    {
+    }
+}";
+
+            VerifyCSharp(Test);
+        }
+
+        [Fact]
+        public void CA1061_DerivedMethodImplementsInterfaceMethod_NoDiagnostic()
+        {
+            const string Test = @"
+using System;
+
+interface IFace
+{
+    void Method(string input);
+}
+
+class DerivedType : IFace
+{
+    public void Method(string input)
+    {
+    }
+}";
+
+            VerifyCSharp(Test);
+        }
+
+        [Fact]
+        public void CA1061_DerivedMethodDoesNotMatchBaseMethod_NoDiagnostic()
+        {
+            const string Test = @"
+using System;
+
+class BaseType
+{
+    public void Method(string input, string input2)
+    {
+    }
+}
+
+class DerivedType : BaseType
+{
+    public void Method(object input)
+    {
+    }
+}";
+
+            VerifyCSharp(Test);
+        }
+
+        private DiagnosticResult GetCA1061ResultAt(int line, int column, string derivedMethod, string baseMethod)
+        {
+            var message = string.Format(
+                MicrosoftApiDesignGuidelinesAnalyzersResources.DoNotHideBaseClassMethodsMessage, 
+                derivedMethod, 
+                baseMethod);
+
+            return GetCSharpResultAt(line, column, DoNotHideBaseClassMethodsAnalyzer.RuleId, message);
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/ApiDesignGuidelines/BasicDoNotHideBaseClassMethods.Fixer.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/ApiDesignGuidelines/BasicDoNotHideBaseClassMethods.Fixer.vb
@@ -1,0 +1,17 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports Microsoft.ApiDesignGuidelines.Analyzers
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeFixes
+
+Namespace Microsoft.ApiDesignGuidelines.VisualBasic.Analyzers
+    ''' <summary>
+    ''' CA1061: Do not hide base class methods
+    ''' </summary>
+    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
+    Public NotInheritable Class BasicDoNotHideBaseClassMethodsFixer
+        Inherits DoNotHideBaseClassMethodsFixer
+
+    End Class
+End Namespace


### PR DESCRIPTION
This code should duplicate the FxCop rule CA1061 exactly except when the
base type method is private. In this circumstance, my implementation does
not report a diagnostic while FxCop does.

The fixer is only boilerplate at this time.