### PR TITLE
Fix #1085 CA2222 reports less visible constructors

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDecreaseInheritedMemberVisibility.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotDecreaseInheritedMemberVisibility.cs
@@ -54,8 +54,8 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 return;
             }
 
-            // Bail out if the method is publicly accessible or is sealed.
-            if (method.GetResultantVisibility() == SymbolVisibility.Public || method.IsSealed)
+            // Bail out if the method is publicly accessible, sealed, or a constructor.
+            if (method.GetResultantVisibility() == SymbolVisibility.Public || method.IsSealed || method.MethodKind == MethodKind.Constructor)
             {
                 return;
             }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDecreaseInheritedMemberVisibilityTests.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/UnitTests/DoNotDecreaseInheritedMemberVisibilityTests.cs
@@ -368,6 +368,36 @@ public sealed class DerivedClass : BaseClass
 End Class");
         }
 
+        [Fact]
+        public void DecreaseCSharpConstructorVisibility()
+        {
+            VerifyCSharp(
+@"public class BaseClass
+{
+}
+
+public class DerivedClass : BaseClass
+{
+    private DerivedClass()
+    {
+    }
+}");
+        }
+
+        [Fact]
+        public void DecreaseBasicConstructorVisibility()
+        {
+            VerifyBasic(
+@"Public Class BaseClass
+End Class
+
+Public Class DerivedClass
+    Inherits BaseClass
+    Private Sub New()
+    End Sub
+End Class");
+        }
+
         private DiagnosticResult GetCSharpCA2222RuleNameResultAt(int line, int column)
         {
             return GetCSharpResultAt(line, column, DoNotDecreaseInheritedMemberVisibilityAnalyzer.RuleId, MicrosoftApiDesignGuidelinesAnalyzersResources.DoNotDecreaseInheritedMemberVisibilityMessage);


### PR DESCRIPTION
CA2222 shouldn't apply to constructors because "when you use a
constructor, you know you are dealing with a subtype." Having different
constructors (or none at all) does not violate the Liskov substitution
principle, as elaborated on here:
http://stackoverflow.com/questions/5490824/should-constructors-comply-with-the-liskov-substitution-principle

Thus, CA2222 has been changed to ignore all methods that are constructors,
and tests for each language have been added.