### PR TITLE
Fix crashes in CA1725

### DIFF
--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ParameterNamesShouldMatchBaseDeclaration.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ParameterNamesShouldMatchBaseDeclaration.cs
@@ -136,11 +136,14 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
 
             var typeSymbol = methodSymbol.ContainingType;
+            var methodSymbolName = methodSymbol.Name;
 
             originalDefinitionsBuilder.AddRange(typeSymbol.AllInterfaces
-                .SelectMany(m => m.GetMembers(methodSymbol.Name))
-                .Where(m => typeSymbol.FindImplementationForInterfaceMember(m) != null)
-                .Cast<IMethodSymbol>());
+                .SelectMany(m => m.GetMembers(methodSymbolName))
+                .OfType<IMethodSymbol>()
+                .Where(m => methodSymbol.Parameters.Length == m.Parameters.Length
+                            && methodSymbol.Arity == m.Arity
+                            && typeSymbol.FindImplementationForInterfaceMember(m) != null));
 
             return originalDefinitionsBuilder.ToImmutable();
         }


### PR DESCRIPTION
Two issues are fixed with this change:

1) `System.IndexOutOfRangeException` if the base type has method overloads with varying number of parameters.

```C#
public interface ITest
{
    void TestMethod(string arg1);
    void TestMethod(string arg1, string arg2);
}

public class TestClass : ITest
{
    public void TestMethod(string arg1) { }
    public void TestMethod(string arg1, string arg2) { }
}
```

2) `System.InvalidCastException` if the type implements a property with the same name as a method being checked.

```C#
public interface ITest1
{
    void TestMethod(string arg1, string arg2);
}

public interface ITest2
{
    int TestMethod { get; set; }
}

public class TestClass : ITest1, ITest2
{
    public void TestMethod(string arg1, string arg2) { }
    int ITest2.TestMethod { get; set; }
}
```

Without the fix, the tests fail with these messages:

1) `warning AD0001: Analyzer 'Microsoft.ApiDesignGuidelines.Analyzers.ParameterNamesShouldMatchBaseDeclarationAnalyzer' threw an exception of type 'System.IndexOutOfRangeException' with message 'Index was outside the bounds of the array.'.`

2) `warning AD0001: Analyzer 'Microsoft.ApiDesignGuidelines.Analyzers.ParameterNamesShouldMatchBaseDeclarationAnalyzer' threw an exception of type 'System.InvalidCastException' with message 'Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertySymbol' to type 'Microsoft.CodeAnalysis.IMethodSymbol'.'.`
