### PR TITLE
Fix System.NullReferenceException in CA1305

### DIFF
--- a/src/System.Runtime.Analyzers/Core/SpecifyIFormatProvider.cs
+++ b/src/System.Runtime.Analyzers/Core/SpecifyIFormatProvider.cs
@@ -195,7 +195,7 @@ namespace System.Runtime.Analyzers
                             var semanticModel = oaContext.Compilation.GetSemanticModel(argument.Syntax.SyntaxTree);
                             var symbol = semanticModel.GetSymbolInfo(argument.Syntax).Symbol;
 
-                            if (symbol != null &
+                            if (symbol != null &&
                                 (symbol.Equals(currentUICultureProperty) ||
                                  symbol.Equals(installedUICultureProperty) ||
                                  symbol.Equals(currentThreadCurrentUICultureProperty) ||

--- a/src/System.Runtime.Analyzers/UnitTests/SpecifyIFormatProviderTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/SpecifyIFormatProviderTests.cs
@@ -385,6 +385,32 @@ GetIFormatProviderUICultureRuleCSharpResultAt(13, 9, "UICultureAsIFormatProvider
                                                      "IFormatProviderOverloads.IFormatProviderReturningNonString(string, IFormatProvider, IFormatProvider)"));
         }
 
+
+        [Fact]
+        public void CA1305_AcceptNullForIFormatProvider_CSharp()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Globalization;
+using System.Threading;
+
+public static class UICultureAsIFormatProviderReturningStringTest
+{
+    public static void TestMethod()
+    {
+        IFormatProviderOverloads.IFormatProviderReturningString(""1"", null);
+    }
+}
+
+internal static class IFormatProviderOverloads
+{
+    public static string IFormatProviderReturningString(string format, IFormatProvider provider)
+    {
+        return null;
+    }
+}");
+        }
+
         [Fact]
         public void CA1305_RuleException_NoDiagnostics_CSharp()
         {


### PR DESCRIPTION
A typo in the source code causes `CA1305` to crash. The code used a binary AND (`&`) to check if a local was null, before incorrectly assuming it would shortcircuit a later access. The code now correctly uses a logical AND (`&&`).