### PR TITLE
Fix to CA1304/CA1305 to not recommend obsolete overloads

### DIFF
--- a/src/Analyzer.Utilities/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
@@ -7,6 +7,19 @@ namespace Analyzer.Utilities.Extensions
     public static class IEnumerableOfIMethodSymbolExtensions
     {
         /// <summary>
+        /// Excludes <paramref name="methods"/> that have an attribute that precisely matches <paramref name="attributeType"/>.
+        /// </summary>
+        /// <param name="methods">List of <see cref="IMethodSymbol"/> to filter.</param>
+        /// <param name="attributeType">The <see cref="INamedTypeSymbol"/> of the attribute class to search.</param>
+        /// <returns>A filtered list of methods.</returns>
+        public static IEnumerable<IMethodSymbol> WhereMethodDoesNotContainAttribute(
+            this IEnumerable<IMethodSymbol> methods,
+            INamedTypeSymbol attributeType)
+        {
+            return methods.Where(m => !m.GetAttributes().Any(a => a.AttributeClass.Equals(attributeType)));
+        }
+
+        /// <summary>
         /// Returns a list of method symbols from a given list of the method symbols, which has its parameter type as
         /// expectedParameterType as its first parameter or the last parameter in addition to matching all the other 
         /// parameter types of the selectedOverload method symbol

--- a/src/Analyzer.Utilities/WellKnownTypes.cs
+++ b/src/Analyzer.Utilities/WellKnownTypes.cs
@@ -335,5 +335,10 @@ namespace Analyzer.Utilities
         {
             return compilation.GetTypeByMetadataName("System.Runtime.Serialization.DataMemberAttribute");
         }
+
+        public static INamedTypeSymbol ObsoleteAttribute(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.ObsoleteAttribute");
+        }
     }
 }

--- a/src/System.Runtime.Analyzers/UnitTests/SpecifyCultureInfoTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/SpecifyCultureInfoTests.cs
@@ -165,6 +165,33 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
+        public void CA1304_DoesNotRecommendObsoleteOverload_CSharp()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Globalization;
+
+public class CultureInfoTestClass2
+{
+    public static void Method()
+    {
+        MethodOverloadHasJustCultureInfo();
+    }
+
+    public static void MethodOverloadHasJustCultureInfo()
+    {
+        MethodOverloadHasJustCultureInfo(CultureInfo.CurrentCulture);
+    }
+
+    [Obsolete]
+    public static void MethodOverloadHasJustCultureInfo(CultureInfo provider)
+    {
+        Console.WriteLine(string.Format(provider, """"));
+    }
+}");
+        }
+
+        [Fact]
         public void CA1304_TargetMethodIsGenericsAndNonGenerics_CSharp()
         {
             VerifyCSharp(@"

--- a/src/System.Runtime.Analyzers/UnitTests/SpecifyIFormatProviderTests.cs
+++ b/src/System.Runtime.Analyzers/UnitTests/SpecifyIFormatProviderTests.cs
@@ -386,6 +386,37 @@ GetIFormatProviderUICultureRuleCSharpResultAt(13, 9, "UICultureAsIFormatProvider
         }
 
         [Fact]
+        public void CA1305_DoesNotRecommendObsoleteOverload_CSharp()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Globalization;
+using System.Threading;
+
+public static class TestClass
+{
+    public static void TestMethod()
+    {
+        IFormatProviderOverloads.TrailingObsoleteIFormatProvider(""1"");
+    }
+}
+
+internal static class IFormatProviderOverloads
+{
+    public static string TrailingObsoleteIFormatProvider(string format)
+    {
+        return null;
+    }
+
+    [Obsolete]
+    public static string TrailingObsoleteIFormatProvider(string format, IFormatProvider provider)
+    {
+        return null;
+    }
+}");
+        }
+
+        [Fact]
         public void CA1305_RuleException_NoDiagnostics_CSharp()
         {
             VerifyCSharp(@"


### PR DESCRIPTION
CA1304 recommends overloads that take CultureInfo arguments; similarly CA1305 recommends overloads that take IFormatProvider arguments. This change prevents the rules from recommending overloads that are marked with [System.ObsoleteAttribute]. Otherwise, the developer will find themselves in a loop where there cannot satisfy this rule without breaking CA1041 that prevents usage of obsolete members. CA1041 supercedes CA1304/CA1305 since the rules should never recommend obsolete functionality.