### PR TITLE
Support type forwarding in PublicAPI checker

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
@@ -204,7 +204,7 @@ namespace Roslyn.Diagnostics.Analyzers
                                 {
                                     var overloadPublicApiName = GetPublicApiName(overload);
                                     var isOverloadUnshipped = !_publicApiMap.TryGetValue(overloadPublicApiName, out ApiLine overloadPublicApiLine) ||
-    !overloadPublicApiLine.IsShippedApi;
+                                        !overloadPublicApiLine.IsShippedApi;
                                     if (isOverloadUnshipped)
                                     {
                                         string errorMessageName = GetErrorMessageName(method, isImplicitlyDeclaredConstructor);
@@ -386,8 +386,7 @@ namespace Roslyn.Diagnostics.Analyzers
 
             private bool IsPublicAPI(ISymbol symbol)
             {
-                if (symbol is IMethodSymbol methodSymbol &&
-    s_ignorableMethodKinds.Contains(methodSymbol.MethodKind))
+                if (symbol is IMethodSymbol methodSymbol && s_ignorableMethodKinds.Contains(methodSymbol.MethodKind))
                 {
                     return false;
                 }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.cs
@@ -162,7 +162,7 @@ namespace Roslyn.Diagnostics.Analyzers
                 return;
             }
 
-            var impl = new Impl(shippedData, unshippedData);
+            var impl = new Impl(compilationContext.Compilation, shippedData, unshippedData);
             compilationContext.RegisterSymbolAction(
                 impl.OnSymbolAction,
                 SymbolKind.NamedType,
@@ -170,41 +170,6 @@ namespace Roslyn.Diagnostics.Analyzers
                 SymbolKind.Field,
                 SymbolKind.Method);
             compilationContext.RegisterCompilationEndAction(impl.OnCompilationEnd);
-        }
-
-        internal static string GetPublicApiName(ISymbol symbol)
-        {
-            string publicApiName = symbol.ToDisplayString(s_publicApiFormat);
-
-            ITypeSymbol memberType = null;
-            if (symbol is IMethodSymbol)
-            {
-                memberType = ((IMethodSymbol)symbol).ReturnType;
-            }
-            else if (symbol is IPropertySymbol)
-            {
-                memberType = ((IPropertySymbol)symbol).Type;
-            }
-            else if (symbol is IEventSymbol)
-            {
-                memberType = ((IEventSymbol)symbol).Type;
-            }
-            else if (symbol is IFieldSymbol)
-            {
-                memberType = ((IFieldSymbol)symbol).Type;
-            }
-
-            if (memberType != null)
-            {
-                publicApiName = publicApiName + " -> " + memberType.ToDisplayString(s_publicApiFormat);
-            }
-
-            if (((symbol as INamespaceSymbol)?.IsGlobalNamespace).GetValueOrDefault())
-            {
-                return string.Empty;
-            }
-
-            return publicApiName;
         }
 
         private static ApiData ReadApiData(string path, SourceText sourceText, bool isShippedApi)

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
@@ -532,6 +532,28 @@ C.Method() -> void
                 GetAdditionalFileResultAt(7, 1, shippedFilePath, DeclarePublicAPIAnalyzer.RemoveDeletedApiRule, "C.Method() -> void"));
         }
 
+
+        [Fact]
+        public void TypeForwardsAreProcessed()
+        {
+            var source = @"
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.StringComparison))]
+";
+
+            string shippedText = $@"
+System.StringComparison
+System.StringComparison.CurrentCulture = 0 -> System.StringComparison
+System.StringComparison.CurrentCultureIgnoreCase = 1 -> System.StringComparison
+System.StringComparison.InvariantCulture = 2 -> System.StringComparison
+System.StringComparison.InvariantCultureIgnoreCase = 3 -> System.StringComparison
+System.StringComparison.Ordinal = 4 -> System.StringComparison
+System.StringComparison.OrdinalIgnoreCase = 5 -> System.StringComparison
+";
+            string unshippedText = $@"";
+
+            VerifyCSharp(source, shippedText, unshippedText);
+        }
+
         [Fact, WorkItem(851, "https://github.com/dotnet/roslyn-analyzers/issues/851")]
         public void TestAvoidMultipleOverloadsWithOptionalParameters()
         {

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
@@ -541,13 +541,13 @@ C.Method() -> void
 ";
 
             string shippedText = $@"
-System.StringComparison
-System.StringComparison.CurrentCulture = 0 -> System.StringComparison
-System.StringComparison.CurrentCultureIgnoreCase = 1 -> System.StringComparison
-System.StringComparison.InvariantCulture = 2 -> System.StringComparison
-System.StringComparison.InvariantCultureIgnoreCase = 3 -> System.StringComparison
-System.StringComparison.Ordinal = 4 -> System.StringComparison
-System.StringComparison.OrdinalIgnoreCase = 5 -> System.StringComparison
+System.StringComparison (forwarded, contained in mscorlib)
+System.StringComparison.CurrentCulture = 0 -> System.StringComparison (forwarded, contained in mscorlib)
+System.StringComparison.CurrentCultureIgnoreCase = 1 -> System.StringComparison (forwarded, contained in mscorlib)
+System.StringComparison.InvariantCulture = 2 -> System.StringComparison (forwarded, contained in mscorlib)
+System.StringComparison.InvariantCultureIgnoreCase = 3 -> System.StringComparison (forwarded, contained in mscorlib)
+System.StringComparison.Ordinal = 4 -> System.StringComparison (forwarded, contained in mscorlib)
+System.StringComparison.OrdinalIgnoreCase = 5 -> System.StringComparison (forwarded, contained in mscorlib)
 ";
             string unshippedText = $@"";
 


### PR DESCRIPTION
If our assembly forwards types and the forwarded types are also public, then they are effectively a public API of our assembly.

*Review:* @dotnet/roslyn-analysis, @dotnet/roslyn-compiler