### PR TITLE
Disable problematic analyzer CA1801

### DIFF
--- a/build/Rulesets/Analyzers.ruleset
+++ b/build/Rulesets/Analyzers.ruleset
@@ -23,4 +23,10 @@
     <!-- SpecifyIFormatProvider -->
     <Rule Id="CA1305" Action="None" />
   </Rules>
+
+  <!-- TODO: Remove the below suppression once https://github.com/dotnet/roslyn/issues/8884 has been fixed. -->
+  <Rules AnalyzerId="Microsoft.Maintainability.Analyzers" RuleNamespace="Microsoft.Maintainability.Analyzers">
+    <!-- ReviewUnusedParameters -->
+    <Rule Id="CA1801" Action="None" />
+  </Rules>
 </RuleSet>

--- a/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
@@ -344,13 +344,10 @@ namespace Analyzer.Utilities.Extensions
             return interfaceMember != null && symbol.Equals(symbol.ContainingType.FindImplementationForInterfaceMember(interfaceMember));
         }
 
-        // TODO: Remove the below suppression once the following Roslyn bug is fixed: https://github.com/dotnet/roslyn/issues/8884
-#pragma warning disable CA1801
         /// <summary>
         /// Checks if a given symbol implements an interface member explicitly
         /// </summary>
         public static bool IsImplementationOfAnyExplicitInterfaceMember(this ISymbol symbol)
-#pragma warning restore CA1801
         {
             if (symbol is IMethodSymbol methodSymbol && methodSymbol.ExplicitInterfaceImplementations.Any())
             {

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotRaiseExceptionsInUnexpectedLocations.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotRaiseExceptionsInUnexpectedLocations.cs
@@ -161,10 +161,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
         }
 
-        // TODO: Remove the below suppression once the following Roslyn bug is fixed: https://github.com/dotnet/roslyn/issues/8884
-#pragma warning disable CA1801
         private static List<MethodCategory> GetMethodCategories(Compilation compilation)
-#pragma warning disable CA1801
         {
             var methodCategories = new List<MethodCategory> {
                 new MethodCategory(IsPropertyGetter, true,

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ImplementIDisposableCorrectly.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ImplementIDisposableCorrectly.cs
@@ -299,14 +299,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 }
             }
 
-            // CA1801: Remove unused parameters.
-            // TODO: Remove the below suppression once Roslyn bug https://github.com/dotnet/roslyn/issues/8884 is fixed.
-#pragma warning disable CA1801
             /// <summary>
             /// Checks rule: Ensure that {0} is declared as public and sealed.
             /// </summary>
             private static void CheckDisposeSignatureRule(IMethodSymbol method, INamedTypeSymbol type, SymbolAnalysisContext context)
-#pragma warning restore CA1801
             {
                 if (!method.IsPublic() ||
                     method.IsAbstract || method.IsVirtual || (method.IsOverride && !method.IsSealed))
@@ -315,14 +311,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 }
             }
 
-            // CA1801: Remove unused parameters.
-            // TODO: Remove the below suppression once Roslyn bug https://github.com/dotnet/roslyn/issues/8884 is fixed.
-#pragma warning disable CA1801
             /// <summary>
             /// Checks rule: Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.
             /// </summary>
             private static void CheckRenameDisposeRule(IMethodSymbol method, INamedTypeSymbol type, SymbolAnalysisContext context)
-#pragma warning restore CA1801
             {
                 if (method.Name != DisposeMethodName)
                 {
@@ -330,14 +322,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 }
             }
 
-            // CA1801: Remove unused parameters.
-            // TODO: Remove the below suppression once Roslyn bug https://github.com/dotnet/roslyn/issues/8884 is fixed.
-#pragma warning disable CA1801
             /// <summary>
             /// Checks rule: Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.
             /// </summary>
             private void CheckDisposeOverrideRule(IMethodSymbol method, INamedTypeSymbol type, SymbolAnalysisContext context)
-#pragma warning restore CA1801
             {
                 if (method.MethodKind == MethodKind.Ordinary && method.IsOverride && method.ReturnsVoid && method.Parameters.Length == 0)
                 {
@@ -377,14 +365,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 context.ReportDiagnostic(type.CreateDiagnostic(ProvideDisposeBoolRule, type.Name));
             }
 
-            // CA1801: Remove unused parameters.
-            // TODO: Remove the below suppression once Roslyn bug https://github.com/dotnet/roslyn/issues/8884 is fixed.
-#pragma warning disable CA1801
             /// <summary>
             /// Checks rule: Ensure that {0} is declared as protected, virtual, and unsealed.
             /// </summary>
             private static void CheckDisposeBoolSignatureRule(IMethodSymbol method, INamedTypeSymbol type, SymbolAnalysisContext context)
-#pragma warning restore CA1801
             {
                 if (method.DeclaredAccessibility != Accessibility.Protected ||
                     !(method.IsVirtual || method.IsAbstract || method.IsOverride) || method.IsSealed)
@@ -405,13 +389,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
                 }
             }
 
-            // CA1801: Remove unused parameters.
-#pragma warning disable CA1801
             /// <summary>
             /// Checks rule: Modify {0} so that it calls Dispose(false) and then returns.
             /// </summary>
             private static void CheckFinalizeImplementationRule(IMethodSymbol method, INamedTypeSymbol type, ImmutableArray<IOperation> operationBlocks, OperationBlockAnalysisContext context)
-#pragma warning restore CA1801
             {
                 // TODO: Implement check of Finalize
             }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OperatorOverloadsHaveNamedAlternates.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/OperatorOverloadsHaveNamedAlternates.cs
@@ -183,11 +183,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
         }
 
-        // CA1801: Remove unused parameters.
-        // TODO: Remove the below suppression once Roslyn bug https://github.com/dotnet/roslyn/issues/8884 is fixed.
-#pragma warning disable CA1801
         internal static ExpectedAlternateMethodGroup GetExpectedAlternateMethodGroup(string operatorName, ITypeSymbol returnType)
-#pragma warning restore CA1801
         {
             // list of operator alternate names: https://msdn.microsoft.com/en-us/library/ms182355.aspx
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
@@ -428,10 +428,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 }
             }
 
-            // TODO: Remove the below suppression once the following Roslyn bug is fixed: https://github.com/dotnet/roslyn/issues/8884
-#pragma warning disable CA1801
             private void AnalyzerParameterSyntax(SyntaxNodeAnalysisContext context)
-#pragma warning restore CA1801
             {
                 if (context.SemanticModel.GetDeclaredSymbol(context.Node, context.CancellationToken) is IParameterSymbol parameter)
                 {

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
@@ -239,10 +239,7 @@ namespace Roslyn.Diagnostics.Analyzers
                 }
             }
 
-            // TODO: Remove the below suppression once the following Roslyn bug is fixed: https://github.com/dotnet/roslyn/issues/8884
-#pragma warning disable CA1801
             private string GetSiblingNamesToRemoveFromUnshippedTextCore(ISymbol symbol)
-#pragma warning restore CA1801
             {
                 // Compute all sibling names that must be removed from unshipped text, as they are no longer public or have been changed.
                 if (symbol.ContainingSymbol is INamespaceOrTypeSymbol containingSymbol)

--- a/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
@@ -137,10 +137,7 @@ namespace Roslyn.Diagnostics.Analyzers
                     arrayType.Rank == 1;
             }
 
-            // TODO: Remove the below suppression once the following Roslyn bug is fixed: https://github.com/dotnet/roslyn/issues/8884
-#pragma warning disable CA1801
             protected void AnalyzeMemberAccessName(SyntaxNode name, SemanticModel semanticModel, Action<Diagnostic> addDiagnostic)
-#pragma warning restore CA1801
             {
                 if (semanticModel.GetSymbolInfo(name).Symbol is IMethodSymbol methodSymbol &&
                     methodSymbol.OriginalDefinition == _genericEmptyEnumerableSymbol)

--- a/src/System.Runtime.Analyzers/Core/TestForNaNCorrectly.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/TestForNaNCorrectly.Fixer.cs
@@ -82,10 +82,7 @@ namespace System.Runtime.Analyzers
             return null;
         }
 
-        // TODO: Remove the below suppression once the following Roslyn bug is fixed: https://github.com/dotnet/roslyn/issues/8884
-#pragma warning disable CA1801
         private ITypeSymbol TryGetSystemTypeForNanConstantExpression(SyntaxNode expressionSyntax, SemanticModel model, INamedTypeSymbol systemSingleType, INamedTypeSymbol systemDoubleType)
-#pragma warning restore CA1801
         {
             if (model.GetSymbolInfo(expressionSyntax).Symbol is IFieldSymbol fieldSymbol)
             {


### PR DESCRIPTION
CA1801 is causing false positives, and ~the code fix renders~ the light bulb is unusable when this occurs. This pull request disables the analyzer until the known problems can be corrected.

Edit: I'm not certain the code fix is the cause of the light bulb usability problem, but its implementation is suspect.