### PR TITLE
Fix cibuild.cmd: assuming VS150COMNTOOLS exists

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -13,7 +13,23 @@ if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArgu
 call :Usage && exit /b 1
 :DoneParsing
 
-call "%VS150COMNTOOLS%VsDevCmd.bat"
+if exist "%VS150COMNTOOLS%VsDevCmd.bat" (
+    call "%VS150COMNTOOLS%VsDevCmd.bat"
+)
+
+REM load Visual Studio 2017 developer command prompt if VS150COMNTOOLS is not set
+if "%VS150COMNTOOLS%" EQU "" if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
+    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+)
+if "%VS150COMNTOOLS%" EQU "" if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat" (
+    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat"
+)
+if "%VS150COMNTOOLS%" EQU "" if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
+    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+)
+if "%VS150COMNTOOLS%" EQU "" if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" (
+    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat"
+)
 
 msbuild /v:m /m %AnalyzersRoot%\BuildAndTest.proj /p:CIBuild=true /p:Configuration=%BuildConfiguration%
 


### PR DESCRIPTION
"VS2017 does not add VS150COMNTOOLS as a system environment variable." [1] Therefore, cibuild.cmd only currently works from a VS 2017 developer prompt. This is unideal, as cibuild.cmd should load the appropriate environment, as it did in VS 2015. "This makes it easier for people to simply clone this repo and build." [2]

This is a port of Microsoft/visualfsharp@bf52776167fe6a9f2354ea96094a025191dbd3e7 [2].

[1] https://github.com/Microsoft/visualfsharp/issues/1761
[2] https://github.com/Microsoft/visualfsharp/pull/2690