### PR TITLE
Do not throw NotImplementedException from NYI fixers. This causes…

### DIFF
--- a/src/ApiReview.Analyzers/Core/AvoidCallingProblematicMethods.Fixer.cs
+++ b/src/ApiReview.Analyzers/Core/AvoidCallingProblematicMethods.Fixer.cs
@@ -20,10 +20,10 @@ namespace ApiReview.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/ApiReview.Analyzers/Core/AvoidCallingProblematicMethods.Fixer.cs
+++ b/src/ApiReview.Analyzers/Core/AvoidCallingProblematicMethods.Fixer.cs
@@ -24,7 +24,7 @@ namespace ApiReview.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/AvoidDuplicateAccelerators.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/AvoidDuplicateAccelerators.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/AvoidDuplicateAccelerators.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/AvoidDuplicateAccelerators.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/ImplementISerializableCorrectly.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/ImplementISerializableCorrectly.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/ImplementISerializableCorrectly.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/ImplementISerializableCorrectly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/ImplementSerializationMethodsCorrectly.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/ImplementSerializationMethodsCorrectly.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/ImplementSerializationMethodsCorrectly.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/ImplementSerializationMethodsCorrectly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/SetLocaleForDataTypes.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/SetLocaleForDataTypes.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/SetLocaleForDataTypes.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/SetLocaleForDataTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/SpecifyMessageBoxOptions.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/SpecifyMessageBoxOptions.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/SpecifyMessageBoxOptions.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/SpecifyMessageBoxOptions.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Desktop.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.Fixer.cs
@@ -20,10 +20,10 @@ namespace Desktop.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Desktop.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.Fixer.cs
+++ b/src/Desktop.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Desktop.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AsyncMethodNamesShouldEndInAsync.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AsyncMethodNamesShouldEndInAsync.Fixer.cs
@@ -24,7 +24,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AsyncMethodNamesShouldEndInAsync.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AsyncMethodNamesShouldEndInAsync.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidAsyncVoid.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidAsyncVoid.Fixer.cs
@@ -24,7 +24,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidAsyncVoid.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidAsyncVoid.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidEmptyInterfaces.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidEmptyInterfaces.Fixer.cs
@@ -24,7 +24,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidEmptyInterfaces.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/AvoidEmptyInterfaces.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CollectionsShouldImplementGenericInterface.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CollectionsShouldImplementGenericInterface.Fixer.cs
@@ -24,7 +24,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CollectionsShouldImplementGenericInterface.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/CollectionsShouldImplementGenericInterface.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DeclareTypesInNamespaces.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DeclareTypesInNamespaces.Fixer.cs
@@ -24,7 +24,6 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DeclareTypesInNamespaces.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DeclareTypesInNamespaces.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotMixBlockingAndAsync.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotMixBlockingAndAsync.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotMixBlockingAndAsync.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotMixBlockingAndAsync.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotPassAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotPassAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotPassAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotPassAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotStoreAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotStoreAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotStoreAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/DoNotStoreAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumsShouldHavePluralNames.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumsShouldHavePluralNames.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumsShouldHavePluralNames.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/EnumsShouldHavePluralNames.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectPrefix.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectPrefix.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectPrefix.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectPrefix.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectSuffix.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectSuffix.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectSuffix.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldHaveCorrectSuffix.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainUnderscores.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainUnderscores.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainUnderscores.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotContainUnderscores.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotHaveIncorrectSuffix.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotHaveIncorrectSuffix.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotHaveIncorrectSuffix.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotHaveIncorrectSuffix.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/IdentifiersShouldNotMatchKeywords.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ImplementIDisposableCorrectly.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ImplementIDisposableCorrectly.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ImplementIDisposableCorrectly.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/ImplementIDisposableCorrectly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithAssemblyVersion.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithAssemblyVersion.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithAssemblyVersion.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithAssemblyVersion.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithClsCompliant.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithClsCompliant.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithClsCompliant.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithClsCompliant.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithComVisible.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithComVisible.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithComVisible.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MarkAssembliesWithComVisible.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MovePInvokesToNativeMethodsClass.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MovePInvokesToNativeMethodsClass.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MovePInvokesToNativeMethodsClass.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/MovePInvokesToNativeMethodsClass.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NonConstantFieldsShouldNotBeVisible.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NonConstantFieldsShouldNotBeVisible.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NonConstantFieldsShouldNotBeVisible.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/NonConstantFieldsShouldNotBeVisible.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropagateCancellationTokensWhenPossible.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropagateCancellationTokensWhenPossible.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropagateCancellationTokensWhenPossible.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropagateCancellationTokensWhenPossible.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertiesShouldNotBeWriteOnly.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertiesShouldNotBeWriteOnly.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertiesShouldNotBeWriteOnly.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertiesShouldNotBeWriteOnly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertyNamesShouldNotMatchGetMethods.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertyNamesShouldNotMatchGetMethods.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertyNamesShouldNotMatchGetMethods.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/PropertyNamesShouldNotMatchGetMethods.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypeNamesShouldNotMatchNamespaces.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypeNamesShouldNotMatchNamespaces.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypeNamesShouldNotMatchNamespaces.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/TypeNamesShouldNotMatchNamespaces.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseEventsWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseEventsWhereAppropriate.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseEventsWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseEventsWhereAppropriate.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseGenericEventHandlerInstances.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseGenericEventHandlerInstances.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseGenericEventHandlerInstances.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UseGenericEventHandlerInstances.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePreferredTerms.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePreferredTerms.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePreferredTerms.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePreferredTerms.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePropertiesWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePropertiesWhereAppropriate.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePropertiesWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.ApiDesignGuidelines.Analyzers/Core/UsePropertiesWhereAppropriate.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.Composition.Analyzers/Core/DoNotMixAttributesFromDifferentVersionsOfMEF.Fixer.cs
+++ b/src/Microsoft.Composition.Analyzers/Core/DoNotMixAttributesFromDifferentVersionsOfMEF.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Composition.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.Composition.Analyzers/Core/DoNotMixAttributesFromDifferentVersionsOfMEF.Fixer.cs
+++ b/src/Microsoft.Composition.Analyzers/Core/DoNotMixAttributesFromDifferentVersionsOfMEF.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Composition.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.Composition.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.Fixer.cs
+++ b/src/Microsoft.Composition.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Composition.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.Composition.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.Fixer.cs
+++ b/src/Microsoft.Composition.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Composition.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.Maintainability.Analyzers/Core/AvoidUninstantiatedInternalClasses.Fixer.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/AvoidUninstantiatedInternalClasses.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Maintainability.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.Maintainability.Analyzers/Core/AvoidUninstantiatedInternalClasses.Fixer.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/AvoidUninstantiatedInternalClasses.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maintainability.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.Maintainability.Analyzers/Core/RemoveUnusedLocals.Fixer.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/RemoveUnusedLocals.Fixer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maintainability.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.Maintainability.Analyzers/Core/RemoveUnusedLocals.Fixer.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/RemoveUnusedLocals.Fixer.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Maintainability.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.Maintainability.Analyzers/Core/ReviewUnusedParameters.Fixer.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/ReviewUnusedParameters.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Maintainability.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.Maintainability.Analyzers/Core/ReviewUnusedParameters.Fixer.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/ReviewUnusedParameters.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maintainability.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.Maintainability.Analyzers/Core/VariableNamesShouldNotMatchFieldNames.Fixer.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/VariableNamesShouldNotMatchFieldNames.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Maintainability.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.Maintainability.Analyzers/Core/VariableNamesShouldNotMatchFieldNames.Fixer.cs
+++ b/src/Microsoft.Maintainability.Analyzers/Core/VariableNamesShouldNotMatchFieldNames.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maintainability.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/DisposeObjectsBeforeLosingScope.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/DisposeObjectsBeforeLosingScope.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/DisposeObjectsBeforeLosingScope.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/DisposeObjectsBeforeLosingScope.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.QualityGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/MarkMembersAsStatic.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/MarkMembersAsStatic.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/MarkMembersAsStatic.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/MarkMembersAsStatic.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.QualityGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/PreferJaggedArraysOverMultidimensional.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/PreferJaggedArraysOverMultidimensional.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/PreferJaggedArraysOverMultidimensional.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/PreferJaggedArraysOverMultidimensional.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.QualityGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/ReviewVisibleEventHandlers.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/ReviewVisibleEventHandlers.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/ReviewVisibleEventHandlers.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/ReviewVisibleEventHandlers.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.QualityGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/UseLiteralsWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/UseLiteralsWhereAppropriate.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.QualityGuidelines.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Microsoft.QualityGuidelines.Analyzers/Core/UseLiteralsWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.QualityGuidelines.Analyzers/Core/UseLiteralsWhereAppropriate.Fixer.cs
@@ -20,10 +20,10 @@ namespace Microsoft.QualityGuidelines.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Collections.Immutable.Analyzers/Core/DoNotCallToImmutableArrayOnAnImmutableArrayValue.Fixer.cs
+++ b/src/System.Collections.Immutable.Analyzers/Core/DoNotCallToImmutableArrayOnAnImmutableArrayValue.Fixer.cs
@@ -18,11 +18,10 @@ namespace System.Collections.Immutable.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
-            
+            // Fixer not yet implemented.
+            return Task.CompletedTask;           
         }
     }
 }

--- a/src/System.Collections.Immutable.Analyzers/Core/DoNotCallToImmutableArrayOnAnImmutableArrayValue.Fixer.cs
+++ b/src/System.Collections.Immutable.Analyzers/Core/DoNotCallToImmutableArrayOnAnImmutableArrayValue.Fixer.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Immutable.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/CallGCSuppressFinalizeCorrectly.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/CallGCSuppressFinalizeCorrectly.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/CallGCSuppressFinalizeCorrectly.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/CallGCSuppressFinalizeCorrectly.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/DisposableTypesShouldDeclareFinalizer.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DisposableTypesShouldDeclareFinalizer.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/DisposableTypesShouldDeclareFinalizer.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DisposableTypesShouldDeclareFinalizer.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/DisposeMethodsShouldCallBaseClassDispose.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DisposeMethodsShouldCallBaseClassDispose.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/DisposeMethodsShouldCallBaseClassDispose.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DisposeMethodsShouldCallBaseClassDispose.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/DoNotLockOnObjectsWithWeakIdentity.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotLockOnObjectsWithWeakIdentity.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/DoNotLockOnObjectsWithWeakIdentity.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotLockOnObjectsWithWeakIdentity.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/DoNotUseTimersThatPreventPowerStateChanges.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotUseTimersThatPreventPowerStateChanges.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/DoNotUseTimersThatPreventPowerStateChanges.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/DoNotUseTimersThatPreventPowerStateChanges.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/InitializeStaticFieldsInline.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/InitializeStaticFieldsInline.Fixer.cs
@@ -21,11 +21,11 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             // TODO: Implement the fixer.
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/InstantiateArgumentExceptionsCorrectly.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/InstantiateArgumentExceptionsCorrectly.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/InstantiateArgumentExceptionsCorrectly.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/InstantiateArgumentExceptionsCorrectly.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/NormalizeStringsToUppercase.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/NormalizeStringsToUppercase.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/NormalizeStringsToUppercase.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/NormalizeStringsToUppercase.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/SpecifyCultureInfo.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/SpecifyCultureInfo.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/SpecifyCultureInfo.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/SpecifyCultureInfo.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/SpecifyIFormatProvider.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/SpecifyIFormatProvider.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/SpecifyIFormatProvider.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/SpecifyIFormatProvider.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/SpecifyStringComparison.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/SpecifyStringComparison.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/SpecifyStringComparison.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/SpecifyStringComparison.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.Analyzers/Core/TestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/TestForEmptyStringsUsingStringLength.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.Analyzers/Core/TestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/System.Runtime.Analyzers/Core/TestForEmptyStringsUsingStringLength.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.InteropServices.Analyzers/Core/MarkBooleanPInvokeArgumentsWithMarshalAs.Fixer.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/MarkBooleanPInvokeArgumentsWithMarshalAs.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.InteropServices.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.InteropServices.Analyzers/Core/MarkBooleanPInvokeArgumentsWithMarshalAs.Fixer.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/MarkBooleanPInvokeArgumentsWithMarshalAs.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.InteropServices.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Runtime.InteropServices.Analyzers/Core/UseManagedEquivalentsOfWin32Api.Fixer.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/UseManagedEquivalentsOfWin32Api.Fixer.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.InteropServices.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/System.Runtime.InteropServices.Analyzers/Core/UseManagedEquivalentsOfWin32Api.Fixer.cs
+++ b/src/System.Runtime.InteropServices.Analyzers/Core/UseManagedEquivalentsOfWin32Api.Fixer.cs
@@ -19,10 +19,10 @@ namespace System.Runtime.InteropServices.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Threading.Tasks.Analyzers/Core/DoNotCreateTasksWithoutPassingATaskScheduler.Fixer.cs
+++ b/src/System.Threading.Tasks.Analyzers/Core/DoNotCreateTasksWithoutPassingATaskScheduler.Fixer.cs
@@ -18,10 +18,10 @@ namespace System.Threading.Tasks.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/System.Threading.Tasks.Analyzers/Core/DoNotCreateTasksWithoutPassingATaskScheduler.Fixer.cs
+++ b/src/System.Threading.Tasks.Analyzers/Core/DoNotCreateTasksWithoutPassingATaskScheduler.Fixer.cs
@@ -22,7 +22,7 @@ namespace System.Threading.Tasks.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.Fixer.cs
+++ b/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Text.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.Fixer.cs
+++ b/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.Fixer.cs
@@ -20,10 +20,10 @@ namespace Text.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }

--- a/src/XmlDocumentationComments.Analyzers/Core/AvoidUsingCrefTagsWithAPrefix.Fixer.cs
+++ b/src/XmlDocumentationComments.Analyzers/Core/AvoidUsingCrefTagsWithAPrefix.Fixer.cs
@@ -24,7 +24,7 @@ namespace XmlDocumentationComments.Analyzers
         {
             // This is to get rid of warning CS1998, please remove when implementing this analyzer
             await Task.Run(() => { }).ConfigureAwait(false);
-            throw new NotImplementedException();
+            
         }
     }
 }

--- a/src/XmlDocumentationComments.Analyzers/Core/AvoidUsingCrefTagsWithAPrefix.Fixer.cs
+++ b/src/XmlDocumentationComments.Analyzers/Core/AvoidUsingCrefTagsWithAPrefix.Fixer.cs
@@ -20,10 +20,10 @@ namespace XmlDocumentationComments.Analyzers
             return WellKnownFixAllProviders.BatchFixer;
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // This is to get rid of warning CS1998, please remove when implementing this analyzer
-            await Task.Run(() => { }).ConfigureAwait(false);
+            // Fixer not yet implemented.
+            return Task.CompletedTask;
             
         }
     }


### PR DESCRIPTION
… lightbulb to show the info bar with fixer crash when attempting to invoke these fixes.