### PR TITLE
Fix for CA1063: Implement IDisposable correctly

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
@@ -281,13 +281,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers
             }
 
             /// <summary>
-            /// Check rule: Remove IDisposable from the list of interfaces implemented by {0}. It is redundant.
+            /// Check rule: Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.
             /// </summary>
             private static void CheckIDisposableReimplementationRule(INamedTypeSymbol type, SymbolAnalysisContext context, bool implementsDisposableInBaseType)
             {
                 if (implementsDisposableInBaseType)
                 {
-                    context.ReportDiagnostic(type.CreateDiagnostic(IDisposableReimplementationRule, type.Name));
+                    context.ReportDiagnostic(type.CreateDiagnostic(IDisposableReimplementationRule, type.Name, type.BaseType.Name));
                 }
             }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
@@ -1261,7 +1261,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove IDisposable from the list of interfaces implemented by {0} and override the base class Dispose implementation instead..
+        ///   Looks up a localized string similar to Remove IDisposable from the list of interfaces implemented by {0}. It is redundant..
         /// </summary>
         internal static string ImplementIDisposableCorrectlyMessageIDisposableReimplementation {
             get {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.Designer.cs
@@ -1261,7 +1261,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove IDisposable from the list of interfaces implemented by {0}. It is redundant..
+        ///   Looks up a localized string similar to Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}..
         /// </summary>
         internal static string ImplementIDisposableCorrectlyMessageIDisposableReimplementation {
             get {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -638,7 +638,7 @@ Names of parameters and members are better used to communicate their meaning tha
     <value>All IDisposable types should implement the Dispose pattern correctly.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageIDisposableReimplementation" xml:space="preserve">
-    <value>Remove IDisposable from the list of interfaces implemented by {0}. It is redundant.</value>
+    <value>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageFinalizeOverride" xml:space="preserve">
     <value>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</value>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -638,7 +638,7 @@ Names of parameters and members are better used to communicate their meaning tha
     <value>All IDisposable types should implement the Dispose pattern correctly.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageIDisposableReimplementation" xml:space="preserve">
-    <value>Remove IDisposable from the list of interfaces implemented by {0} and override the base class Dispose implementation instead.</value>
+    <value>Remove IDisposable from the list of interfaces implemented by {0}. It is redundant.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageFinalizeOverride" xml:space="preserve">
     <value>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</value>

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
@@ -108,9 +108,7 @@ public class B : IDisposable
 }|]
 ",
             GetCA1063CSharpIDisposableReimplementationResultAt(11, 14, "C"),
-            GetCA1063CSharpFinalizeOverrideResultAt(11, 14, "C"),
-            GetCA1063CSharpDisposeSignatureResultAt(13, 26, "C", "Dispose"),
-            GetCA1063CSharpDisposeOverrideResultAt(13, 26, "C", "Dispose"));
+            GetCA1063CSharpDisposeSignatureResultAt(13, 26, "C", "Dispose"));
         }
 
         [Fact]
@@ -149,13 +147,11 @@ public class B : A
 }|]
 ",
             GetCA1063CSharpIDisposableReimplementationResultAt(15, 14, "C"),
-            GetCA1063CSharpFinalizeOverrideResultAt(15, 14, "C"),
-            GetCA1063CSharpDisposeSignatureResultAt(17, 26, "C", "Dispose"),
-            GetCA1063CSharpDisposeOverrideResultAt(17, 26, "C", "Dispose"));
+            GetCA1063CSharpDisposeSignatureResultAt(17, 26, "C", "Dispose"));
         }
 
         [Fact]
-        public void CSharp_CA1063_IDisposableReimplementation_Diagnostic_ImplementingInterfaceInheritedFromIDisposable()
+        public void CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInterfaceInheritedFromIDisposable()
         {
             VerifyCSharp(@"
 using System;
@@ -191,13 +187,11 @@ public class B : IDisposable
     {
     }
 }|]
-",
-            GetCA1063CSharpIDisposableReimplementationResultAt(16, 14, "C"),
-            GetCA1063CSharpFinalizeOverrideResultAt(16, 14, "C"));
+");
         }
 
         [Fact]
-        public void CSharp_CA1063_IDisposableReimplementation_Diagnostic_ReImplementingIDisposableWithNoDisposeMethod()
+        public void CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ReImplementingIDisposableWithNoDisposeMethod()
         {
             VerifyCSharp(@"
 using System;
@@ -455,10 +449,10 @@ public class B : A
 
         #endregion
 
-        #region CSharp FinilizeOverride Unit Tests
+        #region CSharp FinalizeOverride Unit Tests
 
         [Fact]
-        public void CSharp_CA1063_FinilizeOverride_Diagnostic_SimpleFinalizeOverride()
+        public void CSharp_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride()
         {
             VerifyCSharp(@"
 using System;
@@ -492,7 +486,7 @@ public class B : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_FinilizeOverride_Diagnostic_DoubleFinalizeOverride()
+        public void CSharp_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride()
         {
             VerifyCSharp(@"
 using System;
@@ -533,7 +527,7 @@ public class B : A
         }
 
         [Fact]
-        public void CSharp_CA1063_FinilizeOverride_Diagnostic_FinalizeNotInBaseType()
+        public void CSharp_CA1063_FinalizeOverride_NoDiagnostic_FinalizeNotInBaseType()
         {
             VerifyCSharp(@"
 using System;
@@ -551,8 +545,7 @@ public class B : IDisposable
     {
     }
 }|]
-",
-            GetCA1063CSharpFinalizeOverrideResultAt(11, 14, "C"));
+");
         }
 
         #endregion
@@ -1219,9 +1212,7 @@ End Class
 End Class|]
 ",
             GetCA1063BasicIDisposableReimplementationResultAt(11, 14, "C"),
-            GetCA1063BasicFinalizeOverrideResultAt(11, 14, "C"),
-            GetCA1063BasicDisposeSignatureResultAt(15, 26, "C", "Dispose"),
-            GetCA1063BasicDisposeOverrideResultAt(15, 26, "C", "Dispose"));
+            GetCA1063BasicDisposeSignatureResultAt(15, 26, "C", "Dispose"));
         }
 
         [Fact]
@@ -1261,13 +1252,11 @@ End Class
 End Class|]
 ",
             GetCA1063BasicIDisposableReimplementationResultAt(15, 14, "C"),
-            GetCA1063BasicFinalizeOverrideResultAt(15, 14, "C"),
-            GetCA1063BasicDisposeSignatureResultAt(19, 26, "C", "Dispose"),
-            GetCA1063BasicDisposeOverrideResultAt(19, 26, "C", "Dispose"));
+            GetCA1063BasicDisposeSignatureResultAt(19, 26, "C", "Dispose"));
         }
 
         [Fact]
-        public void Basic_CA1063_IDisposableReimplementation_Diagnostic_ImplementingInterfaceInheritedFromIDisposable()
+        public void Basic_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInterfaceInheritedFromIDisposable()
         {
             VerifyBasic(@"
 Imports System
@@ -1305,9 +1294,7 @@ End Class
     End Sub
 
 End Class|]
-",
-            GetCA1063BasicIDisposableReimplementationResultAt(17, 14, "C"),
-            GetCA1063BasicFinalizeOverrideResultAt(17, 14, "C"));
+");
         }
 
         [Fact]
@@ -1681,10 +1668,10 @@ End Class|]
 
         #endregion
 
-        #region VB FinilizeOverride Unit Tests
+        #region VB FinalizeOverride Unit Tests
 
         [Fact]
-        public void Basic_CA1063_FinilizeOverride_Diagnostic_SimpleFinalizeOverride()
+        public void Basic_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride()
         {
             VerifyBasic(@"
 Imports System
@@ -1719,7 +1706,7 @@ End Class|]
         }
 
         [Fact]
-        public void Basic_CA1063_FinilizeOverride_Diagnostic_DoubleFinalizeOverride()
+        public void Basic_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride()
         {
             VerifyBasic(@"
 Imports System
@@ -1762,7 +1749,7 @@ End Class|]
         }
 
         [Fact]
-        public void Basic_CA1063_FinilizeOverride_Diagnostic_FinalizeNotInBaseType()
+        public void Basic_CA1063_FinalizeOverride_NoDiagnostic_FinalizeNotInBaseType()
         {
             VerifyBasic(@"
 Imports System
@@ -1781,8 +1768,7 @@ End Class
         MyBase.Finalize()
     End Sub
 End Class|]
-",
-            GetCA1063BasicFinalizeOverrideResultAt(11, 14, "C"));
+");
         }
 
         #endregion

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
@@ -107,7 +107,7 @@ public class B : IDisposable
     }
 }|]
 ",
-            GetCA1063CSharpIDisposableReimplementationResultAt(11, 14, "C"),
+            GetCA1063CSharpIDisposableReimplementationResultAt(11, 14, "C", "B"),
             GetCA1063CSharpDisposeSignatureResultAt(13, 26, "C", "Dispose"));
         }
 
@@ -146,7 +146,7 @@ public class B : A
     }
 }|]
 ",
-            GetCA1063CSharpIDisposableReimplementationResultAt(15, 14, "C"),
+            GetCA1063CSharpIDisposableReimplementationResultAt(15, 14, "C", "B"),
             GetCA1063CSharpDisposeSignatureResultAt(17, 26, "C", "Dispose"));
         }
 
@@ -213,7 +213,7 @@ public class B : IDisposable
     public int Test { get; set; }
 }|]
 ",
-            GetCA1063CSharpIDisposableReimplementationResultAt(16, 14, "C"));
+            GetCA1063CSharpIDisposableReimplementationResultAt(16, 14, "C", "B"));
         }
 
         [Fact]
@@ -1211,7 +1211,7 @@ End Class
 
 End Class|]
 ",
-            GetCA1063BasicIDisposableReimplementationResultAt(11, 14, "C"),
+            GetCA1063BasicIDisposableReimplementationResultAt(11, 14, "C", "B"),
             GetCA1063BasicDisposeSignatureResultAt(15, 26, "C", "Dispose"));
         }
 
@@ -1251,7 +1251,7 @@ End Class
 
 End Class|]
 ",
-            GetCA1063BasicIDisposableReimplementationResultAt(15, 14, "C"),
+            GetCA1063BasicIDisposableReimplementationResultAt(15, 14, "C", "B"),
             GetCA1063BasicDisposeSignatureResultAt(19, 26, "C", "Dispose"));
         }
 
@@ -1325,7 +1325,7 @@ End Class
 
 End Class|]
 ",
-            GetCA1063BasicIDisposableReimplementationResultAt(17, 29, "C"));
+            GetCA1063BasicIDisposableReimplementationResultAt(17, 29, "C", "B"));
         }
 
         [Fact]
@@ -2344,15 +2344,15 @@ End Class
 
         #region Helpers
 
-        private static DiagnosticResult GetCA1063CSharpIDisposableReimplementationResultAt(int line, int column, string typeName)
+        private static DiagnosticResult GetCA1063CSharpIDisposableReimplementationResultAt(int line, int column, string typeName, string baseTypeName)
         {
-            string message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementIDisposableCorrectlyMessageIDisposableReimplementation, typeName);
+            string message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementIDisposableCorrectlyMessageIDisposableReimplementation, typeName, baseTypeName);
             return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
         }
 
-        private static DiagnosticResult GetCA1063BasicIDisposableReimplementationResultAt(int line, int column, string typeName)
+        private static DiagnosticResult GetCA1063BasicIDisposableReimplementationResultAt(int line, int column, string typeName, string baseTypeName)
         {
-            string message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementIDisposableCorrectlyMessageIDisposableReimplementation, typeName);
+            string message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.ImplementIDisposableCorrectlyMessageIDisposableReimplementation, typeName, baseTypeName);
             return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
         }
 


### PR DESCRIPTION
- Changed the two diagnostics that direct a user to remove a finalizer or a Dispose override in favor of overriding Dispose(bool) so they are only emitted if there is an overridable Dispose(bool) definition in an ancestor class.
- Changed the "IDisposable reimplemented" rule's message and updated emission logic accordingly. Previously the message included "...override the base class Dispose implementation instead." This only makes sense if both the derived class and the base/ancestor class have Dispose implementations, in which case the derived class is either (1) already overriding properly, or (2) already getting a more general error about a method hiding the implementation from a base class.
The new message simply warns to remove a redundant "IDisposable" declaration when it is already being inherited from a base type or other interface.