### PR TITLE
Fix CA1308 throwing InvalidCastException

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/System.Runtime.Analyzers/NormalizeStringsToUppercase.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/System.Runtime.Analyzers/NormalizeStringsToUppercase.cs
@@ -88,7 +88,7 @@ namespace System.Runtime.Analyzers
                     var method = invocation.TargetMethod;
                     if (method.Equals(toLowerInvariant) ||
                         (method.Equals(toLowerWithCultureInfo) &&
-                         ((IMemberReferenceExpression)invocation.ArgumentsInParameterOrder.FirstOrDefault()?.Value)?.Member == invariantCulture))
+                         ((invocation.ArgumentsInParameterOrder.FirstOrDefault()?.Value as IMemberReferenceExpression)?.Member.Equals(invariantCulture) ?? false)))
                     {
                         var suggestedMethod = toUpperInvariant ?? toUpperWithCultureInfo;
 

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/System.Runtime.Analyzers/NormalizeStringsToUppercaseTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/System.Runtime.Analyzers/NormalizeStringsToUppercaseTests.cs
@@ -49,6 +49,12 @@ public class NormalizeStringsTesterClass
     {
         Console.WriteLine(""FOO"".ToUpper(CultureInfo.InstalledUICulture));
     }
+
+    public void TestMethodOneE()
+    {
+        var dynamicCulture = CultureInfo.CurrentCulture;
+        Console.WriteLine(""FOO"".ToUpper(dynamicCulture));
+    }
 }
 ");
 
@@ -71,6 +77,11 @@ Public Class NormalizeStringsTesterClass
 
     Public Sub TestMethodOneD()
         Console.WriteLine(""FOO"".ToUpper(CultureInfo.InstalledUICulture))
+    End Sub
+
+    Public Sub TestMethodOneE()
+        Dim dynamicCulture = CultureInfo.CurrentCulture
+        Console.WriteLine(""FOO"".ToUpper(dynamicCulture))
     End Sub
 End Class
 ");
@@ -104,6 +115,12 @@ public class NormalizeStringsTesterClass
     {
         Console.WriteLine(""FOO"".ToLower(CultureInfo.InstalledUICulture));
     }
+
+    public void TestMethodTwoE()
+    {
+        var dynamicCulture = CultureInfo.CurrentCulture;
+        Console.WriteLine(""FOO"".ToLower(dynamicCulture));
+    }
 }
 ");
 
@@ -126,6 +143,11 @@ Public Class NormalizeStringsTesterClass
 
     Public Sub TestMethodTwoD()
         Console.WriteLine(""FOO"".ToLower(CultureInfo.InstalledUICulture))
+    End Sub
+
+    Public Sub TestMethodTwoE()
+        Dim dynamicCulture = CultureInfo.CurrentCulture
+        Console.WriteLine(""FOO"".ToLower(dynamicCulture))
     End Sub
 End Class
 ");


### PR DESCRIPTION
When ToLower() is passed its culture as a local variable, the invocation's first argument is of type BoundLocal, which derives from ILocalReferenceExpression. ILocalReferenceExpression does not derive from IMemberReferenceExpression, so the cast throws an exception. Thus, the code has been updated to gracefully handle any failing cast.