### PR TITLE
Miscellaneous  Clean up 

### DIFF
--- a/.coby.yml
+++ b/.coby.yml
@@ -1,2 +1,0 @@
-solution-file-path:  src\Analyzers.sln 
-nuget-path: src\.nuget\NuGet.exe 

--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -13,7 +13,6 @@
     <RunTestArgs>-noshadow -parallel all</RunTestArgs>
     <RunTestArgs Condition="'$(CIBuild)' == 'true'">$(RunTestArgs) -xml TestResults.xml</RunTestArgs>
 
-    <NuGetExe>$(MSBuildThisFileDirectory)\Src\.nuget\Nuget.exe</NuGetExe>
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot>
     <!-- Respect environment variable if set -->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and

--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ Getting Started
 ===============
 
 1. Clone the repository
-2. Install NuGet packages: `powershell -executionpolicy bypass src\.nuget\NuGetRestore.ps1`
+2. Install NuGet packages: `msbuild /t:restore src\Analyzers.sln`
 3. Build: `msbuild src\Analyzers.sln`
+
+Execute `cibuild.cmd` to clean, restore, build and runs tests
 
 **NOTE** The current build of System.Reflection.Metadata (from NuGet package System.Reflection.Metadata.1.2.0-rc2-23629) is unsigned. This causes unit tests to fail. To work around this problem until a new, signed version is available, give the command
 ```

--- a/src/.nuget/NuGetRestore.ps1
+++ b/src/.nuget/NuGetRestore.ps1
@@ -1,5 +1,0 @@
-$NuGetExe = "$PSScriptRoot\NuGet.exe"
-$NuGetConfig = "$PSScriptRoot\NuGet.config"
-
-& $NuGetExe restore "$PSScriptRoot\..\Analyzers.sln" -configfile "$NuGetConfig"
-


### PR DESCRIPTION
- Now that msbuild support restore we don't need separate restore script 
- No need of Coby.yml file 
- Updated readme to reflect the same.
@mavasani  for review 
