### PR TITLE
Some infrastructure fixes for the repo

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -9,9 +9,8 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <IncludePattern Condition="'$(IncludePattern)' == ''">*.Test*.dll</IncludePattern>
 
-    <!-- Emit XML in a CIBuild in order to get structured test results -->
-    <RunTestArgs>-noshadow -parallel all</RunTestArgs>
-    <RunTestArgs Condition="'$(CIBuild)' == 'true'">$(RunTestArgs) -xml TestResults.xml</RunTestArgs>
+    <!-- Emit XML in order to get structured test results -->
+    <RunTestArgs>-noshadow -parallel all -xml Binaries\$(Configuration)\TestResults.xml</RunTestArgs>
 
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot>
     <!-- Respect environment variable if set -->
@@ -31,7 +30,7 @@
   <Target Name="Build" DependsOnTargets="RestorePackages">
     <MSBuild BuildInParallel="true"
              Projects="$(SolutionFile)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=false"
+             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=true"
              Targets="Build"/>
   </Target>
 
@@ -47,7 +46,7 @@
   <Target Name="Rebuild">
     <MSBuild BuildInParallel="true"
              Projects="$(SolutionFile)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=false"
+             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=true"
              Targets="Rebuild"/>
   </Target>
 

--- a/build/Targets/Analyzers.Imports.targets
+++ b/build/Targets/Analyzers.Imports.targets
@@ -213,7 +213,7 @@
        
        ==================================================================================== -->
 
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != '' AND '$(ImportVSSDKTargets)' == 'true' AND '$(CIBuild)' == ''" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets') AND '$(ImportVSSDKTargets)' == 'true'" />
 
   <!-- The VSSDK immplements some targets which are run during design time builds per convention. 
        If the Project is not a VSIX project and sets $CreateVSIXContainer=false these targets should be 

--- a/build/Targets/Analyzers.Imports.targets
+++ b/build/Targets/Analyzers.Imports.targets
@@ -5,29 +5,60 @@
 
   <!-- Compute/set the assembly, file, and NuGet versions -->
   <PropertyGroup>
-      <Version Condition="'$(Version)' == ''">2.0.0</Version>     
-      <SemanticVersion Condition="'$(SemanticVersion)' == ''">$(Version)</SemanticVersion>
-      <PreReleaseVersion Condition="'$(PreReleaseVersion)' == ''">beta1</PreReleaseVersion>      
-      <ToolsSemanticVersion>0.0.0</ToolsSemanticVersion>
-      <ToolsPreReleaseVersion>beta1</ToolsPreReleaseVersion>
-      <AssemblyVersion>$(SemanticVersion).0</AssemblyVersion>
+    <Version>2.0.0</Version>
+    <RoslynSemanticVersion>$(Version)</RoslynSemanticVersion>
+    <PreReleaseVersion Condition="'$(PreReleaseVersion)' == ''">beta1</PreReleaseVersion>
+    <ToolsSemanticVersion>0.0.0</ToolsSemanticVersion>
+    <ToolsPreReleaseVersion>beta1</ToolsPreReleaseVersion>
+
+    <BuildNumber Condition="'$(BuildNumber)' == ''AND ('$(BUILD_BUILDNUMBER)' != '')">$(BUILD_BUILDNUMBER)</BuildNumber>
+    <BuildNumber Condition="'$(BuildNumber)' == '' AND ('$(TF_BUILD_BUILDNUMBER)' != '')
+                     AND ($(TF_BUILD_BUILDNUMBER.Split('_').Length) == 2)">$(TF_BUILD_BUILDNUMBER.Split('_')[1])</BuildNumber>
+    <!-- When a build number is not specified, then we should default back to '00065535.0', which is a build number in the
+         same format as provided by MicroBuild v2, but greater than any that MicroBuild v2 will produce, and is still compatible
+         with the Win32 file version limitations. This is required so that builds done locally, where '$(OfficialBuild)' == 'true',
+         can still be deployed to VS and override the version that is globally installed. -->
+    <BuildNumber Condition="'$(BuildNumber)' == ''">00065535.0</BuildNumber>
+
+    <!-- Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
+         where BuildNumberFiveDigitDateStamp is mmmdd (such as 60615) and BuildNumberBuildOfTheDay is nn (which represents the nth build
+         started that day). So the first build of the day, 20160615.1, will produce something similar to BuildNumberFiveDigitDateStamp: 60615,
+         BuildNumberBuildOfTheDayPadded: 01;and the 12th build of the day, 20160615.12, will produce BuildNumberFiveDigitDateStamp: 60615, BuildNumberBuildOfTheDay: 12
+
+         Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
+         in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Unfortunately for releases in 2017 we can't go any higher, so
+         we will continue the month counting instead: the build after 61231 is 61301. -->
+    <BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(BuildNumber.Split('.')[0].Substring(3).Trim()), 8800))</BuildNumberFiveDigitDateStamp>
+    <BuildNumberBuildOfTheDayPadded Condition="$(BuildNumber.Split('.').Length) == 2">$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberBuildOfTheDayPadded>
+  </PropertyGroup>
+
+  <!-- NuGet version -->
+  <PropertyGroup>
+    <NuGetReleaseVersion>$(RoslynSemanticVersion)</NuGetReleaseVersion>
+    <NuGetPreReleaseVersion>$(NuGetReleaseVersion)-$(PreReleaseVersion)</NuGetPreReleaseVersion>
+    <NuGetPerBuildPreReleaseVersion>$(NuGetPreReleaseVersion)-$(BuildNumberFiveDigitDateStamp.Trim())</NuGetPerBuildPreReleaseVersion>
+    <NuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberBuildOfTheDayPadded)' != ''">$(NuGetPerBuildPreReleaseVersion)-$(BuildNumberBuildOfTheDayPadded.Trim())</NuGetPerBuildPreReleaseVersion>
   </PropertyGroup>
 
   <Choose>
-    <When Condition="('$(BuildNumber)' != '') and ($(BuildNumber.Split('.').Length) == 2)">
-      <!-- The user specified a build number, so we should use that. -->
+    <When Condition="'$(OfficialBuild)' == 'true' OR '$(UseShippingAssemblyVersion)' == 'true'">
       <PropertyGroup>
-        <BuildVersion>$(SemanticVersion).$(BuildNumber.Split('.')[0])</BuildVersion>
+        <AssemblyVersion>$(RoslynSemanticVersion).0</AssemblyVersion>
+        <BuildVersion>$(RoslynSemanticVersion).$(BuildNumberFiveDigitDateStamp)</BuildVersion>
+        <VsixVersion>$(RoslynSemanticVersion).$(BuildNumberFiveDigitDateStamp)$(BuildNumberBuildOfTheDayPadded)</VsixVersion>
       </PropertyGroup>
     </When>
 
     <Otherwise>
       <!-- No build version was supplied.  We'll use a special version, higher than anything
-           installed, so that the assembly identity is different.  This will allows us to 
-           have a build with an actual number installed, but then build and F5 a build with 
-           this number.  -->
+           installed, so that the assembly identity is different.  This will allows us to
+           have a build with an actual number installed, but then build and F5 a build with
+           this number. We will make AssemblyVersion and BuildVersion different, to catch
+           any bugs where people might assume they are the same. -->
       <PropertyGroup>
-        <BuildVersion>$(SemanticVersion).0</BuildVersion>
+        <AssemblyVersion>42.42.42.42</AssemblyVersion>
+        <BuildVersion>42.42.42.42424</BuildVersion>
+        <VsixVersion>42.42.42.42424</VsixVersion>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -42,22 +73,6 @@
     <FileVersion Condition="'$(FileVersion)' == ''">$(BuildVersion)</FileVersion>
     <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(BuildVersion)</InformationalVersion>
     <NeutralLanguage Condition="'$(NeutralLanguage)' == ''">en-US</NeutralLanguage>
-  </PropertyGroup>
-
-  <!-- NuGet version -->
-  <PropertyGroup>
-    <BuildNumberSuffix Condition="('$(TF_BUILD_BUILDNUMBER)' != '')
-                     and ($(TF_BUILD_BUILDNUMBER.Split('_').Length) == 2)">$(TF_BUILD_BUILDNUMBER.Split('_')[1])</BuildNumberSuffix>
-    <BuildNumberPart1 Condition="'$(BuildNumberSuffix)' != ''">
-      $(BuildNumberSuffix.Split('.')[0])
-    </BuildNumberPart1>
-    <BuildNumberPart2 Condition="'$(BuildNumberSuffix)' != ''">
-      $(BuildNumberSuffix.Split('.')[1].PadLeft(2,'0'))
-    </BuildNumberPart2>
-
-    <NuGetReleaseVersion>$(SemanticVersion)</NuGetReleaseVersion>
-    <NuGetPreReleaseVersion>$(NuGetReleaseVersion)-$(PreReleaseVersion)</NuGetPreReleaseVersion>
-    <NuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberSuffix)' != ''">$(NuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</NuGetPerBuildPreReleaseVersion>
   </PropertyGroup>
 
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->
@@ -96,7 +111,7 @@
   <PropertyGroup Condition="'$(USE_INTERNAL_IOPERATION_APIS)' == 'true'">
     <DefineConstants>$(DefineConstants),USE_INTERNAL_IOPERATION_APIS,DEFAULT_SEVERITY_SUGGESTION</DefineConstants>
   </PropertyGroup>
-  
+
   <!-- Settings for strong name signing -->
   <Choose>
     <When Condition="'$(SignAssembly)' == 'true'">

--- a/build/Targets/Analyzers.Imports.targets
+++ b/build/Targets/Analyzers.Imports.targets
@@ -5,11 +5,11 @@
 
   <!-- Compute/set the assembly, file, and NuGet versions -->
   <PropertyGroup>
-      <Version Condition="'$(Version)' == ''">1.2.0</Version>     
+      <Version Condition="'$(Version)' == ''">2.0.0</Version>     
       <SemanticVersion Condition="'$(SemanticVersion)' == ''">$(Version)</SemanticVersion>
-      <PreReleaseVersion Condition="'$(PreReleaseVersion)' == ''">beta3</PreReleaseVersion>      
+      <PreReleaseVersion Condition="'$(PreReleaseVersion)' == ''">beta1</PreReleaseVersion>      
       <ToolsSemanticVersion>0.0.0</ToolsSemanticVersion>
-      <ToolsPreReleaseVersion>beta3</ToolsPreReleaseVersion>
+      <ToolsPreReleaseVersion>beta1</ToolsPreReleaseVersion>
       <AssemblyVersion>$(SemanticVersion).0</AssemblyVersion>
   </PropertyGroup>
 

--- a/build/Targets/References.Targets
+++ b/build/Targets/References.Targets
@@ -7,8 +7,9 @@
         <IncludeAnalyzerReferences>true</IncludeAnalyzerReferences>
         <IncludeToolsetCompilerReference>true</IncludeToolsetCompilerReference>
         <IncludeFakeSignReference>true</IncludeFakeSignReference>
-        <IncludeTestReferences>false</IncludeTestReferences>    
-    </PropertyGroup>
+        <IncludeTestReferences>false</IncludeTestReferences>
+        <IncludeVSSDKReferences>false</IncludeVSSDKReferences>
+      </PropertyGroup>
     </When>
     <When Condition="'$(TestProject)' == 'true'">
       <PropertyGroup>
@@ -17,8 +18,20 @@
         <IncludeAnalyzerReferences>false</IncludeAnalyzerReferences>
         <IncludeToolsetCompilerReference>true</IncludeToolsetCompilerReference>
         <IncludeFakeSignReference>true</IncludeFakeSignReference>
-        <IncludeTestReferences>true</IncludeTestReferences>      
-    </PropertyGroup>
+        <IncludeTestReferences>true</IncludeTestReferences>
+        <IncludeVSSDKReferences>false</IncludeVSSDKReferences>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(SetupProject)' == 'true'">
+      <PropertyGroup>
+        <IncludeCoreFrameworkReferences>false</IncludeCoreFrameworkReferences>
+        <IncludeCodeAnalysisReference>false</IncludeCodeAnalysisReference>
+        <IncludeAnalyzerReferences>false</IncludeAnalyzerReferences>
+        <IncludeToolsetCompilerReference>true</IncludeToolsetCompilerReference>
+        <IncludeFakeSignReference>true</IncludeFakeSignReference>
+        <IncludeTestReferences>false</IncludeTestReferences>
+        <IncludeVSSDKReferences>true</IncludeVSSDKReferences>
+      </PropertyGroup>
     </When>
   </Choose>
 
@@ -77,7 +90,15 @@
         <PackageReference Include="xunit" Version="$(XUnitVersion)" />
         <PackageReference Include="xunit.runner.console" Version="$(XUnitVersion)" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
-      </ItemGroup>      
+      </ItemGroup>
+    </When>
+  </Choose>
+
+  <Choose>
+    <When Condition="'$(IncludeVSSDKReferences)' == 'true'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26201" />
+      </ItemGroup>
     </When>
   </Choose>
 

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -5,11 +5,13 @@ REM Parse Arguments.
 
 set AnalyzersRoot=%~dp0
 set BuildConfiguration=Debug
+set OfficialBuild=false
 :ParseArguments
 if "%1" == "" goto :DoneParsing
 if /I "%1" == "/?" call :Usage && exit /b 1
 if /I "%1" == "/debug" set BuildConfiguration=Debug&&shift&& goto :ParseArguments
 if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArguments
+if /I "%1" == "/officialbuild" set OfficialBuild=true&&shift&& goto :ParseArguments
 call :Usage && exit /b 1
 :DoneParsing
 
@@ -31,7 +33,7 @@ if "%VS150COMNTOOLS%" EQU "" if exist "%ProgramFiles(x86)%\Microsoft Visual Stud
     call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat"
 )
 
-msbuild /v:m /m %AnalyzersRoot%\BuildAndTest.proj /p:CIBuild=true /p:Configuration=%BuildConfiguration%
+msbuild /v:m /m %AnalyzersRoot%\BuildAndTest.proj /p:CIBuild=true /p:Configuration=%BuildConfiguration% /p:OfficialBuild=%OfficialBuild%
 
 if ERRORLEVEL 1 (
     taskkill /F /IM vbcscompiler.exe

--- a/src/Microsoft.CodeAnalysis.Analyzers/Setup/Microsoft.CodeAnalysis.Analyzers.Setup.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Setup/Microsoft.CodeAnalysis.Analyzers.Setup.csproj
@@ -5,7 +5,7 @@
   </ImportGroup>
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
-    <TestProject>true</TestProject>
+    <SetupProject>true</SetupProject>
     <AssemblyName>Microsoft.CodeAnalysis.Analyzers.Setup</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>

--- a/src/Microsoft.CodeQuality.Analyzers/Setup/Microsoft.CodeQuality.Analyzers.Setup.csproj
+++ b/src/Microsoft.CodeQuality.Analyzers/Setup/Microsoft.CodeQuality.Analyzers.Setup.csproj
@@ -5,7 +5,7 @@
   </ImportGroup>
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
-    <TestProject>true</TestProject>
+    <SetupProject>true</SetupProject>
     <AssemblyName>Microsoft.CodeQuality.Analyzers.Setup</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>

--- a/src/Microsoft.NetCore.Analyzers/Setup/Microsoft.NetCore.Analyzers.Setup.csproj
+++ b/src/Microsoft.NetCore.Analyzers/Setup/Microsoft.NetCore.Analyzers.Setup.csproj
@@ -5,7 +5,7 @@
   </ImportGroup>
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
-    <TestProject>true</TestProject>
+    <SetupProject>true</SetupProject>
     <AssemblyName>Microsoft.NetCore.Analyzers.Setup</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>

--- a/src/Roslyn.Diagnostics.Analyzers/Setup/Roslyn.Diagnostics.Analyzers.Setup.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/Setup/Roslyn.Diagnostics.Analyzers.Setup.csproj
@@ -5,7 +5,7 @@
   </ImportGroup>
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
-    <TestProject>true</TestProject>
+    <SetupProject>true</SetupProject>
     <AssemblyName>Roslyn.Diagnostics.Analyzers.Setup</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>

--- a/src/Text.Analyzers/Setup/Text.Analyzers.Setup.csproj
+++ b/src/Text.Analyzers/Setup/Text.Analyzers.Setup.csproj
@@ -5,7 +5,7 @@
   </ImportGroup>
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
-    <TestProject>true</TestProject>
+    <SetupProject>true</SetupProject>
     <AssemblyName>Text.Analyzers.Setup</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>


### PR DESCRIPTION
1. Always build and deploy VSIXes with cibuild.cmd
2. Always generate TestResults.xml after running unit tests with BuildAndTest.proj
3. Use Microsoft.VSSDK.BuildTools NuGet package instead of relying on the VSSDK installation on the box.
4. Bump the package and assembly version for analyzer packages to 2.0.0 and beta1.
5. Fix BuildNumber/Version computation and add switch to cibuild to trigger official builds.