### PR TITLE
Added a few exceptions to the definition of Static Holder types

### DIFF
--- a/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
@@ -215,6 +215,21 @@ namespace Analyzer.Utilities.Extensions
                 return false;
             }
 
+            // A static constructor does not qualify or disqualify a class from being a
+            // static holder, because it isn't accessible to any consumers of the class.
+            if (member.IsConstructor())
+            {
+                return false;
+            }
+
+            // Private or protected members do not qualify or disqualify a class from
+            // being a static holder class, because they are not accessible to any
+            // consumers of the class.
+            if (member.IsProtected() || member.IsPrivate())
+            {
+                return false;
+            }
+
             return member.IsStatic;
         }
 
@@ -236,6 +251,15 @@ namespace Analyzer.Utilities.Extensions
             // parameters, so presumably the author of the class intended for it to be
             // instantiated.
             if (member.IsUserDefinedOperator())
+            {
+                return true;
+            }
+
+            // Like user-defined operators, explicit conversion operators disqualify a class
+            // from being considered a static holder, because it converts from an instance of
+            // another class to this class, so presumably the author intended for it to be
+            // instantiated
+            if (member.IsExplicitConversion())
             {
                 return true;
             }

--- a/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
@@ -255,11 +255,11 @@ namespace Analyzer.Utilities.Extensions
                 return true;
             }
 
-            // Like user-defined operators, explicit conversion operators disqualify a class
+            // Like user-defined operators, conversion operators disqualify a class
             // from being considered a static holder, because it converts from an instance of
             // another class to this class, so presumably the author intended for it to be
             // instantiated
-            if (member.IsExplicitConversion())
+            if (member.IsConversionOperator())
             {
                 return true;
             }

--- a/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
@@ -71,7 +71,7 @@ namespace Analyzer.Utilities.Extensions
             return (symbol as IMethodSymbol)?.MethodKind == MethodKind.UserDefinedOperator;
         }
 
-        public static bool IsExplicitConversion(this ISymbol symbol)
+        public static bool IsConversionOperator(this ISymbol symbol)
         {
             return (symbol as IMethodSymbol)?.MethodKind == MethodKind.Conversion;
         }

--- a/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
@@ -39,6 +39,11 @@ namespace Analyzer.Utilities.Extensions
             return symbol.DeclaredAccessibility == Accessibility.Protected;
         }
 
+        public static bool IsPrivate(this ISymbol symbol)
+        {
+            return symbol.DeclaredAccessibility == Accessibility.Private;
+        }
+
         public static bool IsErrorType(this ISymbol symbol)
         {
             return
@@ -64,6 +69,11 @@ namespace Analyzer.Utilities.Extensions
         public static bool IsUserDefinedOperator(this ISymbol symbol)
         {
             return (symbol as IMethodSymbol)?.MethodKind == MethodKind.UserDefinedOperator;
+        }
+
+        public static bool IsExplicitConversion(this ISymbol symbol)
+        {
+            return (symbol as IMethodSymbol)?.MethodKind == MethodKind.Conversion;
         }
 
         public static ImmutableArray<IParameterSymbol> GetParameters(this ISymbol symbol)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.Fixer.cs
@@ -166,46 +166,6 @@ public class C
         }
 
         [Fact]
-        public void CA1052FixesNonStaticClassWithStaticConstructorCSharp()
-        {
-            const string Code = @"
-public class C
-{
-    static C() { }
-}
-";
-
-            const string FixedCode = @"
-public static class C
-{
-    static C() { }
-}
-";
-
-            VerifyCSharpFix(Code, FixedCode);
-        }
-
-        [Fact]
-        public void CA1052FixesNonStaticClassWithStaticConstructorAndInstanceConstructorCSharp()
-        {
-            const string Code = @"
-public class C
-{
-    public C() { }
-    static C() { }
-}
-";
-            const string FixedCode = @"
-public static class C
-{
-    static C() { }
-}
-";
-
-            VerifyCSharpFix(Code, FixedCode);
-        }
-
-        [Fact]
         public void CA1052FixesNestedPublicClassInOtherwiseEmptyNonStaticClassCSharp()
         {
             const string Code = @"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -741,6 +741,17 @@ public class C29
         }
 
         [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyImplicitConversionOperatorsCSharp()
+        {
+            VerifyCSharp(@"
+public class C29
+{
+    public static implicit operator C29(int foo) => new C29();
+}
+");
+        }
+
+        [Fact]
         public void CA1052NoDiagnosticForNonStaticClassWithOnlyExplicitConversionOperatorsBasic()
         {
             VerifyBasic(@"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -407,27 +407,25 @@ public static class C15
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithStaticConstructorCSharp()
+        public void CA1052NoDiagnosticForNonStaticClassWithStaticConstructorCSharp()
         {
             VerifyCSharp(@"
 public class C16
 {
     static C16() { }
 }
-",
-                CSharpResult(2, 14, "C16"));
+");
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithStaticConstructorBasic()
+        public void CA1052NoDiagnosticForNonStaticClassWithStaticConstructorBasic()
         {
             VerifyBasic(@"
 Public Class B16
     Shared Sub New()
     End Sub
 End Class
-",
-                BasicResult(2, 14, "B16"));
+");
         }
 
         [Fact]
@@ -442,7 +440,7 @@ public static class C17
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithStaticConstructorAndInstanceConstructorCSharp()
+        public void CA1052NoDiagnosticForNonStaticClassWithStaticConstructorAndInstanceConstructorCSharp()
         {
             VerifyCSharp(@"
 public class C18
@@ -450,12 +448,11 @@ public class C18
     public C18() { }
     static C18() { }
 }
-",
-                CSharpResult(2, 14, "C18"));
+");
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithStaticConstructorAndInstanceConstructorBasic()
+        public void CA1052NoDiagnosticForNonStaticClassWithStaticConstructorAndInstanceConstructorBasic()
         {
             VerifyBasic(@"
 Public Class B18
@@ -465,8 +462,7 @@ Public Class B18
     Shared Sub New()
     End Sub
 End Class
-",
-                BasicResult(2, 14, "B18"));
+");
         }
 
         [Fact]
@@ -706,6 +702,54 @@ Public Class B27
 	Inherits
 End Class
 ", TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyPrivateAndProtectedStaticMethodsCSharp()
+        {
+            VerifyCSharp(@"
+public class C28
+{
+    private static void Foo() {}
+    protected static void Bar() {}
+}
+");
+        }
+
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyPrivateAndProtectedStaticMethodsBasic()
+        {
+            VerifyBasic(@"
+Public Class B28
+	Private Shared Sub Foo()
+	End Sub
+	Protected Shared Sub Bar()
+	End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyExplicitConversionOperatorsCSharp()
+        {
+            VerifyCSharp(@"
+public class C29
+{
+    public static explicit operator C29(int foo) => new C29();
+}
+");
+        }
+
+        [Fact]
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyExplicitConversionOperatorsBasic()
+        {
+            VerifyBasic(@"
+Public Class B29
+    Public Shared Widening Operator CType(ByVal foo As Integer) As B29
+        Return New B29()
+    End Operator
+End Class
+");
         }
     }
 }


### PR DESCRIPTION
Static methods that are not externally accessible should not be considered when determining if a method is a static holder type. We also now consider explicit conversion operators to be disqualifying from marking a class as a static holder type, much like user-defined operators also disqualify a class from being a static holder type.

Tagging @dotnet/analyzer-ioperation @sharwell for review. Fixes https://github.com/dotnet/roslyn-analyzers/issues/1162.