### PR TITLE
Consider pure functions as part of CA1806.

### DIFF
--- a/src/Analyzer.Utilities/WellKnownTypes.cs
+++ b/src/Analyzer.Utilities/WellKnownTypes.cs
@@ -340,5 +340,10 @@ namespace Analyzer.Utilities
         {
             return compilation.GetTypeByMetadataName("System.ObsoleteAttribute");
         }
+
+        public static INamedTypeSymbol PureAttribute(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Diagnostics.Contracts.PureAttribute");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/DoNotIgnoreMethodResults.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/DoNotIgnoreMethodResults.cs
@@ -2,12 +2,12 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Semantics;
-using System.Diagnostics.Contracts;
-using System.Linq;
 
 namespace Microsoft.Maintainability.Analyzers
 {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.Designer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.Designer.cs
@@ -162,6 +162,15 @@ namespace Microsoft.Maintainability.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method..
+        /// </summary>
+        internal static string DoNotIgnoreMethodResultsMessagePureMethod {
+            get {
+                return ResourceManager.GetString("DoNotIgnoreMethodResultsMessagePureMethod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary..
         /// </summary>
         internal static string DoNotIgnoreMethodResultsMessageStringCreation {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.resx
@@ -189,4 +189,7 @@
   <data name="CategoryPerformance" xml:space="preserve">
     <value>Performance</value>
   </data>
+  <data name="DoNotIgnoreMethodResultsMessagePureMethod" xml:space="preserve">
+    <value>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</value>
+  </data>
 </root>

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
@@ -251,6 +251,43 @@ End Interface
     GetBasicHResultOrErrorCodeResultAt(6, 9, "M", "NativeMethod"));
         }
 
+        [Fact]
+        [WorkItem(1164, "https://github.com/dotnet/roslyn-analyzers/issues/1164")]
+        public void UnusedPureMethodTriggersError()
+        {
+            VerifyCSharp(@"
+using System.Diagnostics.Contracts;
+
+class C
+{
+    [Pure]
+    public int Returns1() => 1;
+
+    public void DoesNotUseResult()
+    {
+        Returns1();
+    }
+}",
+    GetCSharpPureMethodResultAt(11, 9, "DoesNotUseResult", "Returns1"));
+
+            VerifyBasic(@"
+Imports System.Diagnostics.Contracts
+
+Module Module1
+    <Pure>
+    Function Returns1() As Integer
+        Return 1
+    End Function
+
+    Sub DoesNotUseResult()
+        Returns1()
+    End Sub
+
+End Module
+",
+    GetBasicPureMethodResultAt(11, 9, "DoesNotUseResult", "Returns1"));
+        }
+
         #endregion
 
         #region Helpers
@@ -305,6 +342,18 @@ End Interface
         private static DiagnosticResult GetBasicHResultOrErrorCodeResultAt(int line, int column, string containingMethodName, string invokedMethodName)
         {
             string message = string.Format(MicrosoftMaintainabilityAnalyzersResources.DoNotIgnoreMethodResultsMessageHResultOrErrorCode, containingMethodName, invokedMethodName);
+            return GetBasicResultAt(line, column, DoNotIgnoreMethodResultsAnalyzer.RuleId, message);
+        }
+
+        private static DiagnosticResult GetCSharpPureMethodResultAt(int line, int column, string containingMethodName, string invokedMethodName)
+        {
+            string message = string.Format(MicrosoftMaintainabilityAnalyzersResources.DoNotIgnoreMethodResultsMessagePureMethod, containingMethodName, invokedMethodName);
+            return GetCSharpResultAt(line, column, DoNotIgnoreMethodResultsAnalyzer.RuleId, message);
+        }
+
+        private static DiagnosticResult GetBasicPureMethodResultAt(int line, int column, string containingMethodName, string invokedMethodName)
+        {
+            string message = string.Format(MicrosoftMaintainabilityAnalyzersResources.DoNotIgnoreMethodResultsMessagePureMethod, containingMethodName, invokedMethodName);
             return GetBasicResultAt(line, column, DoNotIgnoreMethodResultsAnalyzer.RuleId, message);
         }
 


### PR DESCRIPTION
Functions that are marked `Pure` have no side effects, and should be considered when we check to see if function results are discarded without use. Fixes #1164. Tagging @dotnet/analyzer-ioperation @sharwell for review.