### PR TITLE
Add SignTool functionality to sign our analyzer assemblies and VSIXes.

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -9,12 +9,12 @@
     <BinariesPath>$(MSBuildThisFileDirectory)Binaries\$(Configuration)</BinariesPath>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <IncludePattern Condition="'$(IncludePattern)' == ''">*.Test*.dll</IncludePattern>
-    
+
     <!-- Emit XML in order to get structured test results -->
     <RunTestArgs>-noshadow -parallel all -xml Binaries\$(Configuration)\TestResults.xml</RunTestArgs>
 
     <!-- Arguments to the SignTool -->
-    <SignRoslynArgs>-msbuildPath "$(MSBuildBinPath)\msbuild.exe"</SignRoslynArgs>
+    <SignRoslynArgs>-msbuildPath "$(MSBuildBinPath)\msbuild.exe" -config "$(MSBuildThisFileDirectory)build\Config\SignToolData.json"</SignRoslynArgs>
     <RoslynToolsMicrosoftSignToolVersion>0.3.0-beta</RoslynToolsMicrosoftSignToolVersion>
     
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot>

--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -5,13 +5,18 @@
   
   <PropertyGroup>
     <SolutionFile>$(MSBuildThisFileDirectory)RoslynAnalyzers.sln</SolutionFile>
-    <PackagingProject>$(MSBuildThisFileDirectory)\src\Packaging\Packaging.proj</PackagingProject>
+    <PackagingProject>$(MSBuildThisFileDirectory)src\Packaging\Packaging.proj</PackagingProject>
+    <BinariesPath>$(MSBuildThisFileDirectory)Binaries\$(Configuration)</BinariesPath>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <IncludePattern Condition="'$(IncludePattern)' == ''">*.Test*.dll</IncludePattern>
-
+    
     <!-- Emit XML in order to get structured test results -->
     <RunTestArgs>-noshadow -parallel all -xml Binaries\$(Configuration)\TestResults.xml</RunTestArgs>
 
+    <!-- Arguments to the SignTool -->
+    <SignRoslynArgs>-msbuildPath "$(MSBuildBinPath)\msbuild.exe"</SignRoslynArgs>
+    <RoslynToolsMicrosoftSignToolVersion>0.3.0-beta</RoslynToolsMicrosoftSignToolVersion>
+    
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot>
     <!-- Respect environment variable if set -->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and
@@ -50,6 +55,10 @@
              Targets="Rebuild"/>
   </Target>
 
+  <Target Name="Sign" Condition="'$(OfficialBuild)' == 'true'">
+    <Exec Command="$(NuGetPackageRoot)\RoslynTools.Microsoft.SignTool\$(RoslynToolsMicrosoftSignToolVersion)\tools\SignTool.exe $(SignRoslynArgs) &quot;$(BinariesPath)&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+  </Target>
+
   <Target Name="Package" DependsOnTargets="Build">
     <MSBuild Projects="$(PackagingProject)" Targets="Build" />
   </Target>
@@ -69,6 +78,6 @@
 
   </Target>
 
-  <Target Name="BuildAndTest"
-          DependsOnTargets="Build;Package;Test" />
+ <Target Name="BuildAndTest"
+          DependsOnTargets="Build;Sign;Package;Test" />
 </Project>

--- a/build/Config/SignToolData.json
+++ b/build/Config/SignToolData.json
@@ -1,0 +1,41 @@
+﻿{
+  "sign": [
+    {
+      "certificate": "Microsoft402",
+      "strongName": "MsSharedLib72",
+      "values": [
+        "Analyzer.Utilities.dll",
+        "Microsoft.CodeAnalysis.Analyzers.dll",
+        "Microsoft.CodeAnalysis.CSharp.Analyzers.dll",
+        "Microsoft.CodeAnalysis.VisualBasic.Analyzers.dll",
+        "Microsoft.CodeQuality.Analyzers.dll",
+        "Microsoft.CodeQuality.CSharp.Analyzers.dll",
+        "Microsoft.CodeQuality.VisualBasic.Analyzers.dll",
+        "Microsoft.NetCore.Analyzers.dll",
+        "Microsoft.NetCore.CSharp.Analyzers.dll",
+        "Microsoft.NetCore.VisualBasic.Analyzers.dll",
+        "Microsoft.NetFramework.Analyzers.dll",
+        "Microsoft.NetFramework.CSharp.Analyzers.dll",
+        "Microsoft.NetFramework.VisualBasic.Analyzers.dll",
+        "Roslyn.Diagnostics.Analyzers.dll",
+        "Roslyn.Diagnostics.CSharp.Analyzers.dll",
+        "Roslyn.Diagnostics.VisualBasic.Analyzers.dll",
+        "Text.Analyzers.dll",
+        "Text.CSharp.Analyzers.dll",
+        "Text.VisualBasic.Analyzers.dll"
+      ]
+    },
+    {
+      "certificate": "VsixSHA2",
+      "strongName": null,
+      "values": [
+        "Microsoft.CodeAnalysis.Analyzers.Setup.vsix",
+        "Microsoft.CodeQuality.Analyzers.Setup.vsix",
+        "Microsoft.NetCore.Analyzers.Setup.vsix",
+        "Microsoft.NetFramework.Analyzers.Setup.vsix",
+        "Roslyn.Diagnostics.Analyzers.Setup.vsix",
+        "Text.Analyzers.Setup.vsix"
+      ]
+    }
+  ]
+}

--- a/build/Targets/References.Targets
+++ b/build/Targets/References.Targets
@@ -102,4 +102,8 @@
     </When>
   </Choose>
 
+  <!-- TODO: Create a separate Toolset package project and only reference this package from that project -->
+  <ItemGroup>
+    <PackageReference Include="RoslynTools.Microsoft.SignTool" Version="0.3.0-beta" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Eventually we want to move away from the hard coded list of binaries to sign and our custom signtool, but this should unblock the signing for now.