### PR TITLE
Don't warn on marker interfaces

### DIFF
--- a/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
@@ -175,7 +175,10 @@ namespace Analyzer.Utilities.Extensions
                 return false;
             }
 
-            if (symbol.BaseType == null || symbol.BaseType.SpecialType != SpecialType.System_Object)
+            // If the class inherits from another object, or implements some interface, presumably the user meant for the class to be instanciated. This
+            // will also bail out if the user inherits from an empty interface, typically used as a marker of some kind. We assume that if _any_ interface
+            // is inherited, the user meant to instanciate the type.
+            if (symbol.BaseType == null || symbol.BaseType.SpecialType != SpecialType.System_Object || !symbol.AllInterfaces.IsDefaultOrEmpty)
             {
                 return false;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -599,7 +599,7 @@ End Class
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceCSharp()
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceCSharp()
         {
             VerifyCSharp(@"
 public interface IC24Base
@@ -609,12 +609,11 @@ public class C24 : IC24Base
 {
     public static void Foo() { }
 }
-",
-                CSharpResult(5, 14, "C24"));
+");
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceBasic()
+        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceBasic()
         {
             VerifyBasic(@"
 Public Interface IB24Base
@@ -624,8 +623,7 @@ Public Class B24
 	Public Shared Sub Foo()
 	End Sub
 End Class
-",
-                BasicResult(4, 14, "B24"));
+");
         }
 
         [Fact]


### PR DESCRIPTION
Updates CA1052 to ignore classes that have any inherited interface. Fixes #1163. Tagging @sharwell @dotnet/roslyn-analysis for review.