### PR TITLE
Verify IOperation API version in analyzer packages

### DIFF
--- a/src/Analyzer.Utilities/AbstractVersionCheckAnalyzer.cs
+++ b/src/Analyzer.Utilities/AbstractVersionCheckAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Analyzer.Utilities
     public abstract class AbstractVersionCheckAnalyzer : DiagnosticAnalyzer
     {
         private const string RuleId = "CA9999";
-        private const string AnalyzerPackageVersion = "2.3.*";
+        private const string AnalyzerPackageVersion = "2.0.*";
 
         private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(AnalyzerUtilitiesResources.VersionCheckTitle), AnalyzerUtilitiesResources.ResourceManager, typeof(AnalyzerUtilitiesResources));
         private static readonly LocalizableString s_localizableMessageFormat = new LocalizableResourceString(nameof(AnalyzerUtilitiesResources.VersionCheckMessage), AnalyzerUtilitiesResources.ResourceManager, typeof(AnalyzerUtilitiesResources));

--- a/src/Analyzer.Utilities/AbstractVersionCheckAnalyzer.cs
+++ b/src/Analyzer.Utilities/AbstractVersionCheckAnalyzer.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Analyzer.Utilities
+{
+    public abstract class AbstractVersionCheckAnalyzer : DiagnosticAnalyzer
+    {
+        private const string RuleId = "CA9999";
+        private const string AnalyzerPackageVersion = "2.3.*";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(AnalyzerUtilitiesResources.VersionCheckTitle), AnalyzerUtilitiesResources.ResourceManager, typeof(AnalyzerUtilitiesResources));
+        private static readonly LocalizableString s_localizableMessageFormat = new LocalizableResourceString(nameof(AnalyzerUtilitiesResources.VersionCheckMessage), AnalyzerUtilitiesResources.ResourceManager, typeof(AnalyzerUtilitiesResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(AnalyzerUtilitiesResources.VersionCheckDescription), AnalyzerUtilitiesResources.ResourceManager, typeof(AnalyzerUtilitiesResources));
+
+        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+                                                        RuleId,
+                                                        s_localizableTitle,
+                                                        s_localizableMessageFormat,
+                                                        DiagnosticCategory.Reliability,
+                                                        DiagnosticSeverity.Warning,
+                                                        isEnabledByDefault: true,
+                                                        description: s_localizableDescription);
+
+        protected abstract string AnalyzerPackageName { get; }
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            // Suppress RS1013 as CompilationAction is only executed with FSA on and we want the analyzer to run even with FSA off.
+#pragma warning disable RS1013 // Start action has no registered non-end actions.
+            context.RegisterCompilationStartAction(compilationStartContext =>
+#pragma warning restore RS1013 // Start action has no registered non-end actions.
+            {
+                compilationStartContext.RegisterCompilationEndAction(compilationContext =>
+                {
+                    if (!AnalysisContextExtensions.ShouldExecuteOperationAnalyzers)
+                    {
+                        // Version mismatch between the analyzer package '{0}' and Microsoft.CodeAnalysis '{1}'. Certain analyzers in this package will not run until the version mismatch is fixed.
+                        var arg1 = AnalyzerPackageName + "-" + AnalyzerPackageVersion;
+                        var arg2 = AnalysisContextExtensions.s_MicrosoftCodeAnalysisVersion;
+                        var diagnostic = Diagnostic.Create(Rule, Location.None, arg1, arg2);
+                        compilationContext.ReportDiagnostic(diagnostic);
+                    }
+                });
+            });
+        }
+    }
+}

--- a/src/Analyzer.Utilities/AnalyzerUtilitiesResources.Designer.cs
+++ b/src/Analyzer.Utilities/AnalyzerUtilitiesResources.Designer.cs
@@ -159,5 +159,32 @@ namespace Analyzer.Utilities {
                 return ResourceManager.GetString("CategoryUsage", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mistatch between the analyzer and Microsoft.CodeAnalysis version and should either switch your analyzer NuGet package/VSIX to a matching version of the analyzer package or move to a  different version of Visual Studio..
+        /// </summary>
+        internal static string VersionCheckDescription {
+            get {
+                return ResourceManager.GetString("VersionCheckDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Version mismatch between the analyzer package &apos;{0}&apos; and Microsoft.CodeAnalysis &apos;{1}&apos;. Certain analyzers in this package will not run until the version mismatch is fixed..
+        /// </summary>
+        internal static string VersionCheckMessage {
+            get {
+                return ResourceManager.GetString("VersionCheckMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Analyzer version mismatch.
+        /// </summary>
+        internal static string VersionCheckTitle {
+            get {
+                return ResourceManager.GetString("VersionCheckTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Analyzer.Utilities/AnalyzerUtilitiesResources.resx
+++ b/src/Analyzer.Utilities/AnalyzerUtilitiesResources.resx
@@ -150,4 +150,13 @@
   <data name="CategorySecurity" xml:space="preserve">
     <value>Security</value>
   </data>
+  <data name="VersionCheckDescription" xml:space="preserve">
+    <value>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mistatch between the analyzer and Microsoft.CodeAnalysis version and should either switch your analyzer NuGet package/VSIX to a matching version of the analyzer package or move to a  different version of Visual Studio.</value>
+  </data>
+  <data name="VersionCheckMessage" xml:space="preserve">
+    <value>Version mismatch between the analyzer package '{0}' and Microsoft.CodeAnalysis '{1}'. Certain analyzers in this package will not run until the version mismatch is fixed.</value>
+  </data>
+  <data name="VersionCheckTitle" xml:space="preserve">
+    <value>Analyzer version mismatch</value>
+  </data>
 </root>

--- a/src/Analyzer.Utilities/Extensions/AnalysisContextExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/AnalysisContextExtensions.cs
@@ -11,8 +11,8 @@ namespace Analyzer.Utilities
 {
     public static class AnalysisContextExtensions
     {
-        private static Version s_MicrosoftCodeAnalysisMinVersion = new Version("2.3");
-        private static Version s_MicrosoftCodeAnalysisMaxVersion = new Version("2.6");
+        private static Version s_MicrosoftCodeAnalysisMinVersion = new Version("2.0");
+        private static Version s_MicrosoftCodeAnalysisMaxVersion = new Version("2.3");
         private static Version s_MicrosoftCodeAnalysisDogfoodVersion = new Version("42.42");
         internal static readonly Version s_MicrosoftCodeAnalysisVersion = typeof(AnalysisContext).GetTypeInfo().Assembly.GetName().Version;
 

--- a/src/Analyzer.Utilities/Extensions/AnalysisContextExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/AnalysisContextExtensions.cs
@@ -11,6 +11,16 @@ namespace Analyzer.Utilities
 {
     public static class AnalysisContextExtensions
     {
+        private static Version s_MicrosoftCodeAnalysisMinVersion = new Version("2.3");
+        private static Version s_MicrosoftCodeAnalysisMaxVersion = new Version("2.6");
+        private static Version s_MicrosoftCodeAnalysisDogfoodVersion = new Version("42.42");
+        internal static readonly Version s_MicrosoftCodeAnalysisVersion = typeof(AnalysisContext).GetTypeInfo().Assembly.GetName().Version;
+
+        // Execute IOperation analyzers if we are either using dogfood bits of Microsoft.CodeAnalysis or its version is in the [min, max) version range.
+        internal static bool ShouldExecuteOperationAnalyzers =>
+            s_MicrosoftCodeAnalysisVersion >= s_MicrosoftCodeAnalysisDogfoodVersion ||
+            (s_MicrosoftCodeAnalysisVersion >= s_MicrosoftCodeAnalysisMinVersion && s_MicrosoftCodeAnalysisVersion < s_MicrosoftCodeAnalysisMaxVersion);
+
 #if USE_INTERNAL_IOPERATION_APIS
         // By pass the IOperation feature flag check if building analyzers VSIX.
         private const string RegisterOperationActionMethodName = "RegisterOperationActionImmutableArrayInternal";
@@ -49,15 +59,25 @@ namespace Analyzer.Utilities
 
         public static void RegisterOperationActionInternal(this AnalysisContext context, Action<OperationAnalysisContext> analyzerOperationCallback, params OperationKind[] operationKinds)
         {
+            if (!ShouldExecuteOperationAnalyzers)
+            {
+                return;
+            }
+
 #if USE_INTERNAL_IOPERATION_APIS
             s_registerOperationActionOnAnalysisContext.Invoke(context, new object[] { analyzerOperationCallback, ImmutableArray.Create(operationKinds) });
 #else
-            context.RegisterOperationAction(analyzerOperationCallback, operationKinds);
+                context.RegisterOperationAction(analyzerOperationCallback, operationKinds);
 #endif
         }
 
         public static void RegisterOperationBlockActionInternal(this AnalysisContext context, Action<OperationBlockAnalysisContext> analyzerOperationCallback)
         {
+            if (!ShouldExecuteOperationAnalyzers)
+            {
+                return;
+            }
+
 #if USE_INTERNAL_IOPERATION_APIS
             s_registerOperationBlockActionOnAnalysisContext.Invoke(context, new object[] { analyzerOperationCallback });
 #else
@@ -67,6 +87,11 @@ namespace Analyzer.Utilities
 
         public static void RegisterOperationBlockStartActionInternal(this AnalysisContext context, Action<OperationBlockStartAnalysisContext> analyzerOperationCallback)
         {
+            if (!ShouldExecuteOperationAnalyzers)
+            {
+                return;
+            }
+
 #if USE_INTERNAL_IOPERATION_APIS
             s_registerOperationBlockStartActionOnAnalysisContext.Invoke(context, new object[] { analyzerOperationCallback });
 #else
@@ -76,6 +101,11 @@ namespace Analyzer.Utilities
 
         public static void RegisterOperationActionInternal(this CompilationStartAnalysisContext context, Action<OperationAnalysisContext> analyzerOperationCallback, params OperationKind[] operationKinds)
         {
+            if (!ShouldExecuteOperationAnalyzers)
+            {
+                return;
+            }
+
 #if USE_INTERNAL_IOPERATION_APIS
             s_registerOperationActionOnCompilationStartAnalysisContext.Invoke(context, new object[] { analyzerOperationCallback, ImmutableArray.Create(operationKinds) });
 #else
@@ -85,6 +115,11 @@ namespace Analyzer.Utilities
 
         public static void RegisterOperationBlockActionInternal(this CompilationStartAnalysisContext context, Action<OperationBlockAnalysisContext> analyzerOperationCallback)
         {
+            if (!ShouldExecuteOperationAnalyzers)
+            {
+                return;
+            }
+
 #if USE_INTERNAL_IOPERATION_APIS
             s_registerOperationBlockActionOnCompilationStartAnalysisContext.Invoke(context, new object[] { analyzerOperationCallback });
 #else
@@ -94,6 +129,11 @@ namespace Analyzer.Utilities
 
         public static void RegisterOperationBlockStartActionInternal(this CompilationStartAnalysisContext context, Action<OperationBlockStartAnalysisContext> analyzerOperationCallback)
         {
+            if (!ShouldExecuteOperationAnalyzers)
+            {
+                return;
+            }
+
 #if USE_INTERNAL_IOPERATION_APIS
             s_registerOperationBlockStartActionOnCompilationStartAnalysisContext.Invoke(context, new object[] { analyzerOperationCallback });
 #else
@@ -103,12 +143,22 @@ namespace Analyzer.Utilities
 
         public static void RegisterOperationActionInternal(this OperationBlockStartAnalysisContext context, Action<OperationAnalysisContext> analyzerOperationCallback, params OperationKind[] operationKinds)
         {
+            if (!ShouldExecuteOperationAnalyzers)
+            {
+                return;
+            }
+
             // No feature flag check on OperationBlockStartAnalysisContext.RegisterOperationAction, so we call it directly.
             context.RegisterOperationAction(analyzerOperationCallback, operationKinds);
         }
 
         public static IOperation GetOperationInternal(this SemanticModel model, SyntaxNode node, CancellationToken cancellationToken)
         {
+            if (!ShouldExecuteOperationAnalyzers)
+            {
+                return null;
+            }
+
 #if USE_INTERNAL_IOPERATION_APIS
             return (IOperation)s_getOperationOnSemanticModel.Invoke(model, new object[] { node, cancellationToken });
 #else

--- a/src/Microsoft.CodeQuality.Analyzers/Core/VersionCheckAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/VersionCheckAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeQuality.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class VersionCheckAnalyzer : AbstractVersionCheckAnalyzer
+    {
+        protected override string AnalyzerPackageName => "Microsoft.CodeQuality.Analyzers";
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/Core/VersionCheckAnalyzer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/VersionCheckAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.NetCore.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class VersionCheckAnalyzer : AbstractVersionCheckAnalyzer
+    {
+        protected override string AnalyzerPackageName => "Microsoft.NetCore.Analyzers";
+    }
+}

--- a/src/Microsoft.NetFramework.Analyzers/Core/VersionCheckAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/VersionCheckAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.NetFramework.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class VersionCheckAnalyzer : AbstractVersionCheckAnalyzer
+    {
+        protected override string AnalyzerPackageName => "Microsoft.NetFramework.Analyzers";
+    }
+}

--- a/src/Roslyn.Diagnostics.Analyzers/Core/VersionCheckAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/VersionCheckAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Roslyn.Diagnostics.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class VersionCheckAnalyzer : AbstractVersionCheckAnalyzer
+    {
+        protected override string AnalyzerPackageName => "Roslyn.Diagnostics.Analyzers";
+    }
+}


### PR DESCRIPTION
We now do couple of things:

1. All the RegisterOperationXXXAction invocations in our analyzer packages verify that the loaded version of Microsoft.CodeAnalysis is in the range against which the analyzer package was built. If not, then they silently bail out, preventing crashes downstream.
2. Each of the analyzer packages get a new VersionCheckAnalyzer that detects this version mismatch and reports a version mismatch warning between analyzer package and Microsoft.CodeAnalysis package.