### PR TITLE
Format our source

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,78 @@
+# EditorConfig is awesome:http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# CSharp code style settings:
+[*.cs]
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true

--- a/RoslynAnalyzers.sln
+++ b/RoslynAnalyzers.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.0
+VisualStudioVersion = 15.0.26424.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.NetFramework.Analyzers", "Microsoft.NetFramework.Analyzers", "{AB503AAC-EE72-4DD4-A339-C7DD545494DB}"
 EndProject
@@ -87,6 +87,12 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NetFramework.Analyzers.UnitTests", "src\Microsoft.NetFramework.Analyzers\UnitTests\Microsoft.NetFramework.Analyzers.UnitTests.csproj", "{FC381B07-C102-472D-A73A-6EB71F9D67B0}"
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.NetFramework.VisualBasic.Analyzers", "src\Microsoft.NetFramework.Analyzers\VisualBasic\Microsoft.NetFramework.VisualBasic.Analyzers.vbproj", "{A5CDB779-6B8B-4DEF-A87E-F892355C9A96}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{77D6EC8A-02B7-4EC9-B14A-E8C3A1543AAE}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Analyzer.Utilities/Extensions/AnalysisContextExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/AnalysisContextExtensions.cs
@@ -67,7 +67,7 @@ namespace Analyzer.Utilities
 #if USE_INTERNAL_IOPERATION_APIS
             s_registerOperationActionOnAnalysisContext.Invoke(context, new object[] { analyzerOperationCallback, ImmutableArray.Create(operationKinds) });
 #else
-                context.RegisterOperationAction(analyzerOperationCallback, operationKinds);
+            context.RegisterOperationAction(analyzerOperationCallback, operationKinds);
 #endif
         }
 
@@ -167,5 +167,5 @@ namespace Analyzer.Utilities
         }
 
 
-        }
     }
+}

--- a/src/Analyzer.Utilities/Extensions/IDictionaryExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/IDictionaryExtensions.cs
@@ -4,7 +4,7 @@ namespace Analyzer.Utilities.Extensions
 {
     public static class IDictionaryExtensions
     {
-        public static void AddKeyValueIfNotNull<TKey, TValue>( 
+        public static void AddKeyValueIfNotNull<TKey, TValue>(
             this IDictionary<TKey, TValue> dictionary,
             TKey key,
             TValue value)

--- a/src/Analyzer.Utilities/WordParser.cs
+++ b/src/Analyzer.Utilities/WordParser.cs
@@ -106,10 +106,10 @@ namespace Analyzer.Utilities
             _prefix = prefix;
         }
 
-        private bool SkipMnemonics => 
+        private bool SkipMnemonics =>
             (_options & WordParserOptions.IgnoreMnemonicsIndicators) == WordParserOptions.IgnoreMnemonicsIndicators;
 
-        private bool SplitCompoundWords => 
+        private bool SplitCompoundWords =>
             (_options & WordParserOptions.SplitCompoundWords) == WordParserOptions.SplitCompoundWords;
 
         /// <summary>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => 
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(CreateCodeActionEquivalenceKeyRule, OverrideCodeActionEquivalenceKeyRule);
 
         public override void Initialize(AnalysisContext context)

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
@@ -316,7 +316,7 @@ class MyAnalyzer : DiagnosticAnalyzer
 
             VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: false);
         }
-    
+
         [Fact]
         public void VisualBasic_NoDiagnosticCases()
         {
@@ -528,7 +528,7 @@ End Class
 
         private static DiagnosticResult GetExpectedDiagnostic(string language, int line, int column, string parameterName, StartActionKind kind)
         {
-            string arg2;            
+            string arg2;
             switch (kind)
             {
                 case StartActionKind.CompilationStartAction:

--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/ApiDesignGuidelines/CSharpEnumStorageShouldBeInt32.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/ApiDesignGuidelines/CSharpEnumStorageShouldBeInt32.Fixer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines
         {
             var enumDecl = (EnumDeclarationSyntax)node;
             var baseTypeNode = (enumDecl.BaseList.Types.FirstOrDefault() as SimpleBaseTypeSyntax)?.Type;
-            return baseTypeNode; 
+            return baseTypeNode;
         }
     }
-} 
+}

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             s_localizableTitle,
             s_localizableMessage,
             DiagnosticCategory.Design,
-            DiagnosticHelpers.DefaultDiagnosticSeverity, 
+            DiagnosticHelpers.DefaultDiagnosticSeverity,
             isEnabledByDefault: true,
             description: s_localizableDescription,
             helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182143.aspx",

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotMixBlockingAndAsync.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotMixBlockingAndAsync.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotPassAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotPassAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotStoreAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotStoreAsyncLambdasAsVoidReturningDelegateTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumStorageShouldBeInt32.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumStorageShouldBeInt32.Fixer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
     /// </summary>
     public abstract class EnumStorageShouldBeInt32Fixer : CodeFixProvider
     {
-        protected abstract SyntaxNode GetTargetNode (SyntaxNode node);
+        protected abstract SyntaxNode GetTargetNode(SyntaxNode node);
 
         public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(EnumStorageShouldBeInt32Analyzer.RuleId);
 
@@ -59,7 +59,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             editor.RemoveNode(targetNode, SyntaxRemoveOptions.KeepLeadingTrivia | SyntaxRemoveOptions.KeepTrailingTrivia | SyntaxRemoveOptions.KeepExteriorTrivia | SyntaxRemoveOptions.KeepEndOfLine);
 
             return editor.GetChangedDocument();
-         }
+        }
 
         private class MyCodeAction : DocumentChangeAction
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     AnalyzeSymbol((INamedTypeSymbol)symbolContext.Symbol, flagsAttributeType, symbolContext.ReportDiagnostic);
                 }, SymbolKind.NamedType);
             });
-            
+
         }
 
         private static void AnalyzeSymbol(INamedTypeSymbol symbol, INamedTypeSymbol flagsAttributeType, Action<Diagnostic> addDiagnostic)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
     [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic), Shared]
     public sealed class EquatableFixer : CodeFixProvider
     {
-        public override ImmutableArray<string> FixableDiagnosticIds => 
+        public override ImmutableArray<string> FixableDiagnosticIds =>
             ImmutableArray.Create(EquatableAnalyzer.ImplementIEquatableRuleId, EquatableAnalyzer.OverrideObjectEqualsRuleId);
 
         public override FixAllProvider GetFixAllProvider()
@@ -145,7 +145,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 returnType: generator.TypeExpression(SpecialType.System_Boolean),
                 accessibility: Accessibility.Public,
                 modifiers: DeclarationModifiers.Override,
-                statements: new[] {returnStatement});
+                statements: new[] { returnStatement });
 
             editor.AddMember(declaration, equalsMethod);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
@@ -114,8 +114,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         }
 
                         AnalyzeSymbol(symbolContext.Symbol, symbolContext);
-                    }, 
-                    SymbolKind.Property, 
+                    },
+                    SymbolKind.Property,
                     SymbolKind.Method);
             });
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffix.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffix.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffix.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         (SymbolAnalysisContext symbolAnalysisContext) =>
                         {
                             var namedTypeSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
-                            if (namedTypeSymbol.GetResultantVisibility()!= SymbolVisibility.Public)
+                            if (namedTypeSymbol.GetResultantVisibility() != SymbolVisibility.Public)
                             {
                                 return;
                             }
@@ -273,7 +273,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return false;
             }
 
-            return namedTypeSymbol.Name.HasSuffix(suffix)               
+            return namedTypeSymbol.Name.HasSuffix(suffix)
                 && !parentTypes.Any(parentType => namedTypeSymbol.DerivesFromOrImplementsAnyConstructionOf(parentType));
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywords.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywords.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementStandardExceptionConstructors.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementStandardExceptionConstructors.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(MissingConstructorRule);
-        
+
         public override void Initialize(AnalysisContext analysisContext)
         {
             analysisContext.EnableConcurrentExecution();

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithAssemblyVersion.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithAssemblyVersion.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithClsCompliant.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithClsCompliant.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithComVisible.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithComVisible.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MovePInvokesToNativeMethodsClass.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MovePInvokesToNativeMethodsClass.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisible.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisible.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisible.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 var field = (IFieldSymbol)obj.Symbol;
 
                 // Only report diagnostic on public non-readonly static fields
-                if(field.IsPublic() && !field.IsConst && field.IsStatic && !field.IsReadOnly)
+                if (field.IsPublic() && !field.IsConst && field.IsStatic && !field.IsReadOnly)
                 {
                     obj.ReportDiagnostic(field.CreateDiagnostic(Rule));
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.Fixer.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                     generator.ReturnStatement(generator.LiteralExpression(1))
                                 });
 
-                            bodyStatements = new[] {nullCheck}.Concat(bodyStatements);
+                            bodyStatements = new[] { nullCheck }.Concat(bodyStatements);
                         }
 
                         addedMember = generator.MethodDeclaration(

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.Fixer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private OperatorKind GetInvertedOperatorKind(IMethodSymbol containingOperator)
         {
-            switch(containingOperator.Name)
+            switch (containingOperator.Name)
             {
                 case WellKnownMemberNames.EqualityOperatorName: return OperatorKind.Inequality;
                 case WellKnownMemberNames.InequalityOperatorName: return OperatorKind.Equality;

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static readonly string s_category = DiagnosticCategory.Performance;
         private const string s_helpLinkUri = "https://msdn.microsoft.com/en-us/library/ms182276.aspx";
-        
+
         internal static DiagnosticDescriptor EqualsRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageEquals,

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 return;
             }
-            
+
             // not raising a violation for when: 
             //     property is overridden because the issue can only be fixed in the base type 
             //     property is the implementaton of any interface member 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             // Iterate through all declared types, including base
             foreach (INamedTypeSymbol type in symbol.ContainingType.GetBaseTypesAndThis())
-            {                
+            {
                 Diagnostic diagnostic = null;
 
                 var exposedMembers = type.GetMembers(identifier).Where(member => ExposedAccessibilities.Contains(member.DeclaredAccessibility));
@@ -90,8 +90,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     }
 
                     // If the declared type is a method, was a matching property found?
-                    if (symbol.Kind == SymbolKind.Method 
-                        && member.Kind == SymbolKind.Property 
+                    if (symbol.Kind == SymbolKind.Method
+                        && member.Kind == SymbolKind.Property
                         && !symbol.ContainingType.Equals(type)) // prevent reporting duplicate diagnostics
                     {
                         diagnostic = Diagnostic.Create(Rule, symbol.Locations[0], identifier, symbol.Name);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespaces.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespaces.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriParametersShouldNotBeStrings.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriParametersShouldNotBeStrings.Fixer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 return;
             }
-            
+
             var generator = SyntaxGenerator.GetGenerator(document);
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseEventsWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseEventsWhereAppropriate.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseGenericEventHandlerInstances.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseGenericEventHandlerInstances.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePreferredTerms.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePreferredTerms.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePropertiesWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePropertiesWhereAppropriate.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiReview/AvoidCallingProblematicMethods.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiReview/AvoidCallingProblematicMethods.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiReview
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Documentation/AvoidUsingCrefTagsWithAPrefix.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Documentation/AvoidUsingCrefTagsWithAPrefix.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.Documentation
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUninstantiatedInternalClasses.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUninstantiatedInternalClasses.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/RemoveUnusedLocals.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/RemoveUnusedLocals.Fixer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/VariableNamesShouldNotMatchFieldNames.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/VariableNamesShouldNotMatchFieldNames.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DisposeObjectsBeforeLosingScope.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DisposeObjectsBeforeLosingScope.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             {
                 return false;
             }
-            
+
             // CA1000 says one shouldn't declare static members on generic types. So don't flag such cases.
             if (methodSymbol.ContainingType.IsGenericType && methodSymbol.GetResultantVisibility() == SymbolVisibility.Public)
             {
@@ -127,7 +127,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             }
 
             // If this looks like an event handler don't flag such cases.
-            if (methodSymbol.Parameters.Length == 2 && 
+            if (methodSymbol.Parameters.Length == 2 &&
                 methodSymbol.Parameters[0].Type.SpecialType == SpecialType.System_Object &&
                 IsEventArgs(methodSymbol.Parameters[1].Type, compilation))
             {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/PreferJaggedArraysOverMultidimensional.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/PreferJaggedArraysOverMultidimensional.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ReviewVisibleEventHandlers.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ReviewVisibleEventHandlers.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.Fixer.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
-using System.Threading.Tasks;     
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -82,7 +82,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             }
         }
 
-        private abstract class ChangeSymbolAction :  CodeAction
+        private abstract class ChangeSymbolAction : CodeAction
         {
             public ChangeSymbolAction(string title, string equivalenceKey, Solution solution, ISymbol symbol)
             {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
             analysisContext.RegisterSymbolAction(CheckTypes, SymbolKind.NamedType);
         }
-        
+
         private static void CheckTypes(SymbolAnalysisContext context)
         {
             var type = (INamedTypeSymbol)context.Symbol;

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/UseLiteralsWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/UseLiteralsWhereAppropriate.Fixer.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
         protected abstract SyntaxTokenList GetModifiers(SyntaxNode fieldSyntax);
         protected abstract SyntaxNode WithModifiers(SyntaxNode fieldSyntax, SyntaxTokenList modifiers);
-        
+
         /// <remarks>
         /// This type exists for telemetry purposes - it has the same functionality as 
         /// <see cref="DocumentChangeAction"/> but different metadata.

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -244,7 +244,7 @@ class Derived : Base
     public override void Method(object input)
     {
     }
-}", 
+}",
                 TestValidationMode.AllowCompileErrors);
 
             VerifyBasic(@"
@@ -468,8 +468,8 @@ End Class
         private DiagnosticResult GetCA1061CSharpResultAt(int line, int column, string derivedMethod, string baseMethod)
         {
             var message = string.Format(
-                MicrosoftApiDesignGuidelinesAnalyzersResources.DoNotHideBaseClassMethodsMessage, 
-                derivedMethod, 
+                MicrosoftApiDesignGuidelinesAnalyzersResources.DoNotHideBaseClassMethodsMessage,
+                derivedMethod,
                 baseMethod);
 
             return GetCSharpResultAt(line, column, DoNotHideBaseClassMethodsAnalyzer.RuleId, message);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
@@ -600,15 +600,15 @@ End Class",
         [Fact]
         public void CA1707_ForDelegates_VisualBasic()
         {
-    VerifyBasic(@"
+            VerifyBasic(@"
 Public Delegate Sub Dele(intPublic_ As Integer, stringPublic_ As String)
 ' No diagnostics
 Friend Delegate Sub Dele2(intInternal_ As Integer, stringInternal_ As String)
 Public Delegate Function Del(Of T)(t_ As Integer) As T
 ",
-            GetCA1707BasicResultAt(2, 26, SymbolKind.DelegateParameter, "Dele", "intPublic_"),
-            GetCA1707BasicResultAt(2, 49, SymbolKind.DelegateParameter, "Dele", "stringPublic_"),
-            GetCA1707BasicResultAt(5, 36, SymbolKind.DelegateParameter, "Del(Of T)", "t_"));
+                    GetCA1707BasicResultAt(2, 26, SymbolKind.DelegateParameter, "Dele", "intPublic_"),
+                    GetCA1707BasicResultAt(2, 49, SymbolKind.DelegateParameter, "Dele", "stringPublic_"),
+                    GetCA1707BasicResultAt(5, 36, SymbolKind.DelegateParameter, "Del(Of T)", "t_"));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
@@ -1373,7 +1373,7 @@ End Class",
                     "MyBadDataTableCollection",
                     IdentifiersShouldNotHaveIncorrectSuffixAnalyzer.CollectionSuffix));
         }
-        
+
         [Fact]
         public void CA1711_CSharp_Diagnostic_TypeNameEndsWithEx()
         {
@@ -1385,7 +1385,7 @@ End Class",
                     IdentifiersShouldNotHaveIncorrectSuffixAnalyzer.ExSuffix,
                     "MyClassEx"));
         }
-        
+
         [Fact]
         public void CA1711_Basic_Diagnostic_TypeNameEndsWithEx()
         {
@@ -1398,14 +1398,14 @@ End Class",
                     IdentifiersShouldNotHaveIncorrectSuffixAnalyzer.ExSuffix,
                     "MyClassEx"));
         }
-        
+
         [Fact]
         public void CA1711_CSharp_NoDiagnostic_TypeNameNameIsEx()
         {
             VerifyCSharp(
 @"public class Ex { }");
         }
-        
+
         [Fact]
         public void CA1711_Basic_NoDiagnostic_TypeNameNameIsEx()
         {
@@ -1426,7 +1426,7 @@ End Class");
                     IdentifiersShouldNotHaveIncorrectSuffixAnalyzer.NewSuffix,
                     "MyClassNew"));
         }
-        
+
         [Fact]
         public void CA1711_Basic_Diagnostic_TypeNameEndsWithNew()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
@@ -209,7 +209,7 @@ public class NestedExplicitInterfaceImplementation
             CSharpResult(50, 13, "ImplementsNestedGeneral", "NestedExplicitInterfaceImplementation.INestedGeneral.remove_TheEvent"));
         }
 
-        [Fact(Skip= "https://github.com/dotnet/roslyn-analyzers/issues/1008")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1008")]
         public void CA1033NoDiagnosticCasesCSharp()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisibleTests.cs
@@ -36,7 +36,7 @@ Class A
     Dim field As System.String
 End Class");
         }
-        
+
         [Fact]
         public void PublicVariableCS()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnlyTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return new  PropertiesShouldNotBeWriteOnlyAnalyzer();
+            return new PropertiesShouldNotBeWriteOnlyAnalyzer();
         }
 
         // Valid C# Tests that should not be flagged based on CA1044 (good tests)
@@ -41,7 +41,8 @@ namespace CS_DesignLibrary
 
         [Fact]
         public void CS_CA1044Good_Read_Write1()
-        { var code = @"
+        {
+            var code = @"
 using System;
 namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests1
 {
@@ -298,9 +299,9 @@ End Namespace
             VerifyBasic(code);
         }
 
-         [Fact]
-         public void VB_CA1044Good_public_Read_private_Write()
-         {
+        [Fact]
+        public void VB_CA1044Good_public_Read_private_Write()
+        {
             var code = @"
 Imports System
 Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests2
@@ -897,10 +898,10 @@ End NameSpace
 ";
             VerifyBasic(code, GetCA1044BasicResultAt(6, 25, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty3"));
         }
-                
+
         private static readonly string CA1044MessageAddGetter = MicrosoftApiDesignGuidelinesAnalyzersResources.PropertiesShouldNotBeWriteOnlyMessageAddGetter;
         private static readonly string CA1044MessageMakeMoreAccessible = MicrosoftApiDesignGuidelinesAnalyzersResources.PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible;
-        
+
         private static DiagnosticResult GetCA1044CSharpResultAt(int line, int column, string CA1044Message, string objectName)
         {
             return GetCSharpResultAt(line, column, PropertiesShouldNotBeWriteOnlyAnalyzer.RuleId, string.Format(CA1044Message, objectName));

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
@@ -60,7 +60,7 @@ public class Test
 }");
         }
 
-        [Theory] 
+        [Theory]
         [InlineData("public", "public")]
         [InlineData("public", "protected")]
         [InlineData("public", "protected internal")]
@@ -75,9 +75,9 @@ public class Test
             VerifyCSharp(
                 string.Format(CSharpTestTemplate, propertyAccessibility, methodAccessibility),
                 GetCA1721CSharpResultAt(
-                    line: 6, 
+                    line: 6,
                     column: $"    {propertyAccessibility} DateTime ".Length + 1,
-                    identifierName: "Date", 
+                    identifierName: "Date",
                     otherIdentifierName: "GetDate"));
         }
 
@@ -198,9 +198,9 @@ End Class");
             VerifyBasic(
                 string.Format(BasicTestTemplate, propertyAccessibility, methodAccessibility),
                 GetCA1721BasicResultAt(
-                    line: 5, 
-                    column: $"    {propertyAccessibility} ReadOnly Property ".Length + 1, 
-                    identifierName: "Date", 
+                    line: 5,
+                    column: $"    {propertyAccessibility} ReadOnly Property ".Length + 1,
+                    identifierName: "Date",
                     otherIdentifierName: "GetDate"));
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/RemoveUnusedLocalsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/RemoveUnusedLocalsTests.cs
@@ -77,7 +77,7 @@ Public Class Tester
     Sub Calculate(ByVal rate As Double, ByRef debt As Double)
         debt = debt + (debt * rate / 100)
     End Sub
-End Class", 
+End Class",
             GetBasicResultAt(6, 13, CA1804RuleId, _CA1804RemoveUnusedLocalMessage),
             GetBasicResultAt(8, 13, CA1804RuleId, _CA1804RemoveUnusedLocalMessage),
             GetBasicResultAt(9, 40, CA1804RuleId, _CA1804RemoveUnusedLocalMessage));

--- a/src/Microsoft.NetCore.Analyzers/Core/Composition/DoNotMixAttributesFromDifferentVersionsOfMEF.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Composition/DoNotMixAttributesFromDifferentVersionsOfMEF.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetCore.Analyzers.Composition
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Composition/PartsExportedWithMEFv2MustBeMarkedAsShared.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Composition/PartsExportedWithMEFv2MustBeMarkedAsShared.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetCore.Analyzers.Composition
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/InteropServices/MarkBooleanPInvokeArgumentsWithMarshalAs.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/InteropServices/MarkBooleanPInvokeArgumentsWithMarshalAs.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/InteropServices/UseManagedEquivalentsOfWin32Api.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/InteropServices/UseManagedEquivalentsOfWin32Api.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/CallGCSuppressFinalizeCorrectly.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/CallGCSuppressFinalizeCorrectly.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableTypesShouldDeclareFinalizer.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableTypesShouldDeclareFinalizer.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeMethodsShouldCallBaseClassDispose.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeMethodsShouldCallBaseClassDispose.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotUseTimersThatPreventPowerStateChanges.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotUseTimersThatPreventPowerStateChanges.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/InstantiateArgumentExceptionsCorrectly.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/InstantiateArgumentExceptionsCorrectly.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/NormalizeStringsToUppercase.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/NormalizeStringsToUppercase.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyCultureInfo.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyCultureInfo.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 var stringFormatMembers = stringType?.GetMembers("Format").OfType<IMethodSymbol>();
 
                 var stringFormatMemberWithStringAndObjectParameter = stringFormatMembers.GetSingleOrDefaultMemberWithParameterInfos(
-                                                                         GetParameterInfo(stringType), 
+                                                                         GetParameterInfo(stringType),
                                                                          GetParameterInfo(objectType));
                 var stringFormatMemberWithStringObjectAndObjectParameter = stringFormatMembers.GetSingleOrDefaultMemberWithParameterInfos(
                                                                                GetParameterInfo(stringType),
@@ -119,7 +119,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 var computerInfoType = csaContext.Compilation.GetTypeByMetadataName("Microsoft.VisualBasic.Devices.ComputerInfo");
                 var installedUICulturePropertyOfComputerInfoType = computerInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().SingleOrDefault();
-                
+
                 var obsoleteAttributeType = WellKnownTypes.ObsoleteAttribute(csaContext.Compilation);
                 #endregion
 
@@ -130,7 +130,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                     #region "Exceptions"
                     if (targetMethod.IsGenericMethod || targetMethod.ContainingType == null || targetMethod.ContainingType.IsErrorType() ||
-                        (targetMethod.ContainingType != null && 
+                        (targetMethod.ContainingType != null &&
                          (activatorType != null && activatorType.Equals(targetMethod.ContainingType)) ||
                          (resourceManagerType != null && resourceManagerType.Equals(targetMethod.ContainingType))))
                     {
@@ -164,7 +164,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     if (methodsWithSameNameAsTargetMethod.Count() > 1)
                     {
                         var correctOverloads = methodsWithSameNameAsTargetMethod.GetMethodOverloadsWithDesiredParameterAtLeadingOrTrailing(targetMethod, iformatProviderType).ToList();
-                        
+
                         // If there are two matching overloads, one with CultureInfo as the first parameter and one with CultureInfo as the last parameter,
                         // report the diagnostic on the overload with CultureInfo as the last parameter, to match the behavior of FxCop.
                         var correctOverload = correctOverloads.FirstOrDefault(overload => overload.Parameters.Last().Type.Equals(iformatProviderType)) ?? correctOverloads.FirstOrDefault();
@@ -175,7 +175,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         {
                             oaContext.ReportDiagnostic(
                                 invocationExpression.Syntax.CreateDiagnostic(
-                                    targetMethod.ReturnType.Equals(stringType) ? 
+                                    targetMethod.ReturnType.Equals(stringType) ?
                                      IFormatProviderAlternateStringRule :
                                      IFormatProviderAlternateRule,
                                     targetMethod.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyStringComparison.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyStringComparison.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Composition/PartsExportedWithMEFv2MustBeMarkedAsSharedTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Composition/PartsExportedWithMEFv2MustBeMarkedAsSharedTests.cs
@@ -70,7 +70,7 @@ Public Class C
 End Class
 " + BasicWellKnownAttributesDefinition);
         }
-        
+
         [Fact]
         public void NoDiagnosticCases_UnresolvedTypes()
         {

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
@@ -507,10 +507,10 @@ GetIFormatProviderAlternateStringRuleBasicResultAt(23, 16, "String.Format(String
                                                            "String.Format(IFormatProvider, String, ParamArray Object())"));
         }
 
-       [Fact]
-       public void CA1305_StringReturningUserMethodOverloads_VisualBasic()
-       {
-           VerifyBasic(@"
+        [Fact]
+        public void CA1305_StringReturningUserMethodOverloads_VisualBasic()
+        {
+            VerifyBasic(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -556,20 +556,20 @@ Friend NotInheritable Class IFormatProviderOverloads
         Return Nothing
     End Function
 End Class",
-GetIFormatProviderAlternateStringRuleBasicResultAt(10, 9, "IFormatProviderOverloads.LeadingIFormatProviderReturningString(String)",
-                                                          "IFormatProviderStringTest.SpecifyIFormatProvider()",
-                                                          "IFormatProviderOverloads.LeadingIFormatProviderReturningString(IFormatProvider, String)"),
-GetIFormatProviderAlternateStringRuleBasicResultAt(11, 9, "IFormatProviderOverloads.TrailingIFormatProviderReturningString(String)",
-                                                          "IFormatProviderStringTest.SpecifyIFormatProvider()",
-                                                          "IFormatProviderOverloads.TrailingIFormatProviderReturningString(String, IFormatProvider)"),
-GetIFormatProviderAlternateStringRuleBasicResultAt(12, 9, "IFormatProviderOverloads.UserDefinedParamsMatchMethodOverload(String, ParamArray Object())",
-                                                          "IFormatProviderStringTest.SpecifyIFormatProvider()",
-                                                          "IFormatProviderOverloads.UserDefinedParamsMatchMethodOverload(IFormatProvider, String, ParamArray Object())"));
-       }
+ GetIFormatProviderAlternateStringRuleBasicResultAt(10, 9, "IFormatProviderOverloads.LeadingIFormatProviderReturningString(String)",
+                                                           "IFormatProviderStringTest.SpecifyIFormatProvider()",
+                                                           "IFormatProviderOverloads.LeadingIFormatProviderReturningString(IFormatProvider, String)"),
+ GetIFormatProviderAlternateStringRuleBasicResultAt(11, 9, "IFormatProviderOverloads.TrailingIFormatProviderReturningString(String)",
+                                                           "IFormatProviderStringTest.SpecifyIFormatProvider()",
+                                                           "IFormatProviderOverloads.TrailingIFormatProviderReturningString(String, IFormatProvider)"),
+ GetIFormatProviderAlternateStringRuleBasicResultAt(12, 9, "IFormatProviderOverloads.UserDefinedParamsMatchMethodOverload(String, ParamArray Object())",
+                                                           "IFormatProviderStringTest.SpecifyIFormatProvider()",
+                                                           "IFormatProviderOverloads.UserDefinedParamsMatchMethodOverload(IFormatProvider, String, ParamArray Object())"));
+        }
 
-       [Fact]
-       public void CA1305_StringReturningNoDiagnostics_VisualBasic()
-       {
+        [Fact]
+        public void CA1305_StringReturningNoDiagnostics_VisualBasic()
+        {
             VerifyBasic(@"
 Imports System
 Imports System.Globalization
@@ -615,12 +615,12 @@ Public Class DerivedClass
         Throw New NotImplementedException()
     End Function
 End Class");
-       }
+        }
 
-       [Fact]
-       public void CA1305_NonStringReturningStringFormatOverloads_VisualBasic()
-       {
-           VerifyBasic(@"
+        [Fact]
+        public void CA1305_NonStringReturningStringFormatOverloads_VisualBasic()
+        {
+            VerifyBasic(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -655,24 +655,24 @@ Friend NotInheritable Class IFormatProviderOverloads
         Console.WriteLine(String.Format(provider, format))
     End Sub
 End Class",
-GetIFormatProviderAlternateRuleBasicResultAt(10, 28, "Convert.ToInt32(String)",
+ GetIFormatProviderAlternateRuleBasicResultAt(10, 28, "Convert.ToInt32(String)",
+                                                      "IFormatProviderStringTest.TestMethod()",
+                                                      "Convert.ToInt32(String, IFormatProvider)"),
+ GetIFormatProviderAlternateRuleBasicResultAt(11, 25, "Convert.ToInt64(String)",
+                                                      "IFormatProviderStringTest.TestMethod()",
+                                                      "Convert.ToInt64(String, IFormatProvider)"),
+ GetIFormatProviderAlternateRuleBasicResultAt(12, 9, "IFormatProviderOverloads.LeadingIFormatProvider(String)",
                                                      "IFormatProviderStringTest.TestMethod()",
-                                                     "Convert.ToInt32(String, IFormatProvider)"),
-GetIFormatProviderAlternateRuleBasicResultAt(11, 25, "Convert.ToInt64(String)",
+                                                     "IFormatProviderOverloads.LeadingIFormatProvider(IFormatProvider, String)"),
+ GetIFormatProviderAlternateRuleBasicResultAt(13, 9, "IFormatProviderOverloads.TrailingIFormatProvider(String)",
                                                      "IFormatProviderStringTest.TestMethod()",
-                                                     "Convert.ToInt64(String, IFormatProvider)"),
-GetIFormatProviderAlternateRuleBasicResultAt(12, 9, "IFormatProviderOverloads.LeadingIFormatProvider(String)",
-                                                    "IFormatProviderStringTest.TestMethod()",
-                                                    "IFormatProviderOverloads.LeadingIFormatProvider(IFormatProvider, String)"),
-GetIFormatProviderAlternateRuleBasicResultAt(13, 9, "IFormatProviderOverloads.TrailingIFormatProvider(String)",
-                                                    "IFormatProviderStringTest.TestMethod()",
-                                                    "IFormatProviderOverloads.TrailingIFormatProvider(String, IFormatProvider)"));
-       }
+                                                     "IFormatProviderOverloads.TrailingIFormatProvider(String, IFormatProvider)"));
+        }
 
         [Fact]
-       public void CA1305_StringReturningUICultureIFormatProvider_VisualBasic()
-       {
-           VerifyBasic(@"
+        public void CA1305_StringReturningUICultureIFormatProvider_VisualBasic()
+        {
+            VerifyBasic(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -699,36 +699,36 @@ Friend NotInheritable Class IFormatProviderOverloads
         Return Nothing
     End Function
 End Class",
-GetIFormatProviderAlternateStringRuleBasicResultAt(10, 9, "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)",
-                                                          "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
-                                                          "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"),
-GetIFormatProviderUICultureStringRuleBasicResultAt(10, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
-                                                          "CultureInfo.CurrentUICulture",
-                                                          "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)"),
-GetIFormatProviderAlternateStringRuleBasicResultAt(11, 9, "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)",
-                                                          "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
-                                                          "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"),
-GetIFormatProviderUICultureStringRuleBasicResultAt(11, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
-                                                          "CultureInfo.InstalledUICulture",
-                                                          "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)"),
-GetIFormatProviderAlternateStringRuleBasicResultAt(12, 9, "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)",
-                                                          "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
-                                                          "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"),
-GetIFormatProviderUICultureStringRuleBasicResultAt(12, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
-                                                          "Thread.CurrentUICulture",
-                                                          "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)"),
-GetIFormatProviderUICultureStringRuleBasicResultAt(13, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
-                                                          "Thread.CurrentUICulture",
-                                                          "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"),
-GetIFormatProviderUICultureStringRuleBasicResultAt(13, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
-                                                          "CultureInfo.InstalledUICulture",
-                                                          "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"));
-       }
+ GetIFormatProviderAlternateStringRuleBasicResultAt(10, 9, "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)",
+                                                           "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
+                                                           "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"),
+ GetIFormatProviderUICultureStringRuleBasicResultAt(10, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
+                                                           "CultureInfo.CurrentUICulture",
+                                                           "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)"),
+ GetIFormatProviderAlternateStringRuleBasicResultAt(11, 9, "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)",
+                                                           "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
+                                                           "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"),
+ GetIFormatProviderUICultureStringRuleBasicResultAt(11, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
+                                                           "CultureInfo.InstalledUICulture",
+                                                           "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)"),
+ GetIFormatProviderAlternateStringRuleBasicResultAt(12, 9, "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)",
+                                                           "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
+                                                           "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"),
+ GetIFormatProviderUICultureStringRuleBasicResultAt(12, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
+                                                           "Thread.CurrentUICulture",
+                                                           "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider)"),
+ GetIFormatProviderUICultureStringRuleBasicResultAt(13, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
+                                                           "Thread.CurrentUICulture",
+                                                           "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"),
+ GetIFormatProviderUICultureStringRuleBasicResultAt(13, 9, "UICultureAsIFormatProviderReturningStringTest.TestMethod()",
+                                                           "CultureInfo.InstalledUICulture",
+                                                           "IFormatProviderOverloads.IFormatProviderReturningString(String, IFormatProvider, IFormatProvider)"));
+        }
 
-       [Fact]
-       public void CA1305_NonStringReturningUICultureIFormatProvider_VisualBasic()
-       {
-           VerifyBasic(@"
+        [Fact]
+        public void CA1305_NonStringReturningUICultureIFormatProvider_VisualBasic()
+        {
+            VerifyBasic(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -753,31 +753,31 @@ Friend NotInheritable Class IFormatProviderOverloads
     Public Shared Sub IFormatProviderReturningNonString(format As String, provider As IFormatProvider, provider2 As IFormatProvider)
     End Sub
 End Class",
-GetIFormatProviderAlternateRuleBasicResultAt(10, 9, "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)",
-                                                    "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
-                                                    "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"),
-GetIFormatProviderUICultureRuleBasicResultAt(10, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
-                                                    "CultureInfo.CurrentUICulture",
-                                                    "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)"),
-GetIFormatProviderAlternateRuleBasicResultAt(11, 9, "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)",
-                                                    "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
-                                                    "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"),
-GetIFormatProviderUICultureRuleBasicResultAt(11, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
-                                                    "CultureInfo.InstalledUICulture",
-                                                    "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)"),
-GetIFormatProviderAlternateRuleBasicResultAt(12, 9, "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)",
-                                                    "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
-                                                    "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"),
-GetIFormatProviderUICultureRuleBasicResultAt(12, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
-                                                    "Thread.CurrentUICulture",
-                                                    "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)"),
-GetIFormatProviderUICultureRuleBasicResultAt(13, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
-                                                    "Thread.CurrentUICulture",
-                                                    "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"),
-GetIFormatProviderUICultureRuleBasicResultAt(13, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
-                                                    "CultureInfo.InstalledUICulture",
-                                                    "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"));
-       }
+ GetIFormatProviderAlternateRuleBasicResultAt(10, 9, "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)",
+                                                     "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
+                                                     "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"),
+ GetIFormatProviderUICultureRuleBasicResultAt(10, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
+                                                     "CultureInfo.CurrentUICulture",
+                                                     "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)"),
+ GetIFormatProviderAlternateRuleBasicResultAt(11, 9, "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)",
+                                                     "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
+                                                     "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"),
+ GetIFormatProviderUICultureRuleBasicResultAt(11, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
+                                                     "CultureInfo.InstalledUICulture",
+                                                     "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)"),
+ GetIFormatProviderAlternateRuleBasicResultAt(12, 9, "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)",
+                                                     "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
+                                                     "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"),
+ GetIFormatProviderUICultureRuleBasicResultAt(12, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
+                                                     "Thread.CurrentUICulture",
+                                                     "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider)"),
+ GetIFormatProviderUICultureRuleBasicResultAt(13, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
+                                                     "Thread.CurrentUICulture",
+                                                     "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"),
+ GetIFormatProviderUICultureRuleBasicResultAt(13, 9, "UICultureAsIFormatProviderReturningNonStringTest.TestMethod()",
+                                                     "CultureInfo.InstalledUICulture",
+                                                     "IFormatProviderOverloads.IFormatProviderReturningNonString(String, IFormatProvider, IFormatProvider)"));
+        }
 
         [Fact]
         public void CA1305_NonStringReturningComputerInfoInstalledUICultureIFormatProvider_VisualBasic()
@@ -809,9 +809,9 @@ GetIFormatProviderUICultureRuleBasicResultAt(12, 9, "UICultureAsIFormatProviderR
         }
 
         [Fact]
-       public void CA1305_RuleException_NoDiagnostics_VisualBasic()
-       {
-           VerifyBasic(@"
+        public void CA1305_RuleException_NoDiagnostics_VisualBasic()
+        {
+            VerifyBasic(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -829,7 +829,7 @@ Public NotInheritable Class IFormatProviderStringTest
         Console.WriteLine(activator__1)
     End Sub
 End Class");
-       }
+        }
 
         private DiagnosticResult GetIFormatProviderAlternateStringRuleCSharpResultAt(int line, int column, string arg1, string arg2, string arg3)
         {

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.Fixer.cs
@@ -281,7 +281,7 @@ Public Class A
 End Class
 ");
         }
-        
+
         [Fact]
         public void CA2242_FixForComparisonWithNaNInTernaryOperator()
         {
@@ -380,7 +380,7 @@ public class A
 }
 ");
         }
-        
+
         [Fact]
         public void CA2242_FixForComparisonWithNaNInYieldReturnStatement()
         {
@@ -538,7 +538,7 @@ public class A
 }
 ");
         }
-        
+
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
             return new TestForNaNCorrectlyAnalyzer();

--- a/src/Microsoft.NetFramework.Analyzers/Core/AvoidDuplicateAccelerators.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/AvoidDuplicateAccelerators.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.NetFramework.Analyzers
                         return;
                     }
 
-                    var method = (IMethodSymbol) operationBlockAnalysisContext.OwningSymbol;
+                    var method = (IMethodSymbol)operationBlockAnalysisContext.OwningSymbol;
 
                     if (!ContainsHandleProcessCorruptedStateExceptionsAttribute(method, compilationTypes))
                     {

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NetFramework.Analyzers
     {
         internal const string RuleId = "CA3075";
         private const string HelpLink = "http://aka.ms/CA3075";
-        
+
         internal static DiagnosticDescriptor RuleDoNotUseInsecureDtdProcessing = CreateDiagnosticDescriptor(
                                                                                     SecurityDiagnosticHelpers.GetLocalizableResourceString(nameof(MicrosoftNetFrameworkAnalyzersResources.DoNotUseInsecureDtdProcessingGenericMessage)),
                                                                                     SecurityDiagnosticHelpers.GetLocalizableResourceString(nameof(MicrosoftNetFrameworkAnalyzersResources.DoNotUseInsecureDtdProcessingDescription)),
@@ -210,14 +210,14 @@ namespace Microsoft.NetFramework.Analyzers
             {
                 IInvocationExpression invocationExpression = context.Operation as IInvocationExpression;
 
-                if(invocationExpression == null)
+                if (invocationExpression == null)
                 {
                     return;
                 }
 
                 IMethodSymbol method = invocationExpression.TargetMethod;
 
-                if(method == null)
+                if (method == null)
                 {
                     return;
                 }
@@ -273,8 +273,8 @@ namespace Microsoft.NetFramework.Analyzers
                         SemanticModel model = context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree);
                         IArgument arg = expression.ArgumentsInParameterOrder[xmlReaderSettingsIndex];
                         ISymbol settingsSymbol = arg.Value.Syntax.GetDeclaredOrReferencedSymbol(model);
-                        
-                        if(settingsSymbol == null)
+
+                        if (settingsSymbol == null)
                         {
                             return;
                         }
@@ -325,7 +325,7 @@ namespace Microsoft.NetFramework.Analyzers
             {
                 IFieldInitializer fieldInit = context.Operation as IFieldInitializer;
 
-                if(fieldInit == null)
+                if (fieldInit == null)
                 {
                     return;
                 }
@@ -651,7 +651,7 @@ namespace Microsoft.NetFramework.Analyzers
                 }
 
                 IConversionExpression conv = expression.Value as IConversionExpression;
-                
+
                 if (isXmlTextReaderXmlResolverProperty && conv != null && SecurityDiagnosticHelpers.IsXmlSecureResolverType(conv.Operand.Type, _xmlTypes))
                 {
                     env.IsSecureResolver = true;
@@ -717,10 +717,10 @@ namespace Microsoft.NetFramework.Analyzers
                         bool isXmlTextReaderXmlResolverProperty =
                             SecurityDiagnosticHelpers.IsXmlTextReaderXmlResolverPropertyDerived(propRef.Property, _xmlTypes);
                         bool isXmlTextReaderDtdProcessingProperty = !isXmlTextReaderXmlResolverProperty &&
-                            SecurityDiagnosticHelpers.IsXmlTextReaderDtdProcessingPropertyDerived(propRef.Property,_xmlTypes);
+                            SecurityDiagnosticHelpers.IsXmlTextReaderDtdProcessingPropertyDerived(propRef.Property, _xmlTypes);
                         if (isXmlTextReaderXmlResolverProperty || isXmlTextReaderDtdProcessingProperty)
                         {
-                            AnalyzeXmlTextReaderProperties(context, assignedSymbol, expression, isXmlTextReaderXmlResolverProperty, 
+                            AnalyzeXmlTextReaderProperties(context, assignedSymbol, expression, isXmlTextReaderXmlResolverProperty,
                                 isXmlTextReaderDtdProcessingProperty);
                         }
                         else if (SecurityDiagnosticHelpers.IsXmlReaderSettingsType(propRef.Instance.Type, _xmlTypes))

--- a/src/Microsoft.NetFramework.Analyzers/Core/Helpers/SecurityDiagnosticHelpers.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/Helpers/SecurityDiagnosticHelpers.cs
@@ -150,7 +150,7 @@ namespace Microsoft.NetFramework.Analyzers.Helpers
         public static bool IsExpressionEqualsNull(IOperation operation)
         {
             ILiteralExpression literal = operation as ILiteralExpression;
-            return literal != null && literal.HasNullConstantValue(); 
+            return literal != null && literal.HasNullConstantValue();
         }
 
         public static bool IsExpressionEqualsDtdProcessingParse(IOperation operation)
@@ -163,7 +163,7 @@ namespace Microsoft.NetFramework.Analyzers.Helpers
         {
             ILiteralExpression literal = operation as ILiteralExpression;
 
-            if(literal == null || !literal.ConstantValue.HasValue)
+            if (literal == null || !literal.ConstantValue.HasValue)
             {
                 return false;
             }

--- a/src/Microsoft.NetFramework.Analyzers/Core/ImplementISerializableCorrectly.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/ImplementISerializableCorrectly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/ImplementSerializationMethodsCorrectly.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/ImplementSerializationMethodsCorrectly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/SetLocaleForDataTypes.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SetLocaleForDataTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/SpecifyMessageBoxOptions.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SpecifyMessageBoxOptions.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetFramework.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotCatchCorruptedStateExceptionsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotCatchCorruptedStateExceptionsTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
            GetCA2153BasicResultAt(11, 25, "Public Shared Function TestMethod() As Double", "System.Exception")
            );
         }
-        
+
         [Fact]
         public void CA2153TestCatchRethrowExceptionInMethodWithHpcseAndSecurityCriticalAttributes()
         {
@@ -220,7 +220,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             End Namespace
             ");
         }
-        
+
         [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAndSecurityCriticalAttributes()
         {
@@ -579,7 +579,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             GetCA2153CSharpResultAt(19, 25, "TestNamespace.TestClass.TestMethod()", "System.Exception")
             );
         }
-        
+
         [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAndSecurityCriticalL1Attributes()
         {
@@ -611,7 +611,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             GetCA2153CSharpResultAt(20, 25, "TestNamespace.TestClass.TestMethod()", "System.Exception")
             );
         }
-        
+
         [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAndSecurityCriticalL2Attributes()
         {
@@ -643,7 +643,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             GetCA2153CSharpResultAt(20, 25, "TestNamespace.TestClass.TestMethod()", "System.Exception")
             );
         }
-        
+
         [Fact]
         public void CA2153TestCatchExceptionInNestedClassMethodWithOuterHpcseAndSecurityCriticalScopeEverythingAttributes()
         {
@@ -677,7 +677,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             GetCA2153CSharpResultAt(21, 29, "TestNamespace.TestClass.NestedClass.TestMethod()", "System.Exception")
             );
         }
-        
+
         [Fact]
         public void CA2153TestCatchExceptionInNestedClassMethodWithInnerHpcseAndSecurityCriticalScopeEverythingAttributes()
         {
@@ -711,7 +711,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             GetCA2153CSharpResultAt(21, 29, "TestNamespace.TestClass.NestedClass.TestMethod()", "System.Exception")
             );
         }
-        
+
         [Fact]
         public void CA2153TestCatchExceptionInNestedClassMethodwithInnerHpcseAndOuterSecurityCriticalAttributes()
         {
@@ -745,7 +745,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             GetCA2153CSharpResultAt(21, 29, "TestNamespace.TestClass.NestedClass.TestMethod()", "System.Exception")
             );
         }
-        
+
         [Fact]
         public void CA2153TestCatchExceptionInGetAccessorWithHpcseAttribute()
         {
@@ -990,7 +990,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
            GetCA2153BasicResultAt(16, 29, "Public Property Set X(Value As Integer)", "System.Exception")
            );
         }
-        
+
         [Fact]
         public void CA2153TestCatchIOExceptionInMethodHpcseAttribute()
         {
@@ -1064,7 +1064,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             GetCA2153CSharpResultAt(22, 25, "TestNamespace.TestClass.TestMethod()", "object")
             );
         }
-        
+
         [Fact]
         public void CA2153TestSwallowAccessViolationExceptionInMethodHpcseAttribute()
         {
@@ -1099,7 +1099,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
                 }
             }");
         }
-        
+
         [Fact]
         public void CA2153TestSwallowAccessViolationExceptionThenSwallowOtherExceptionInMethodHpcseAttribute()
         {
@@ -1139,7 +1139,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             GetCA2153CSharpResultAt(25, 25, "TestNamespace.TestClass.SaveNewFile7(string)", "object")
             );
         }
-        
+
         [Fact]
         public void CA2153TestCatchExceptionThrowNotImplementedExceptionInMethodHpcseAttribute()
         {
@@ -1218,7 +1218,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             GetCA2153BasicResultAt(14, 25, "Public Shared Function TestMethod() As Double", "System.Exception")
             );
         }
-        
+
         [Fact]
         public void CA2153TestCatchExceptionInnerCatchThrowIOExceptionInMethodHpcseAttribute()
         {

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
@@ -178,7 +178,7 @@ End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
             );
         }
-        
+
         [Fact]
         public void XmlDocumentUseSecureResolverShouldNotGenerateDiagnostic()
         {
@@ -211,7 +211,7 @@ Namespace TestNamespace
 End Namespace"
             );
         }
-        
+
         [Fact]
         public void XmlDocumentSetSecureResolverInInitializerShouldNotGenerateDiagnostic()
         {
@@ -247,7 +247,7 @@ Namespace TestNamespace
 End Namespace"
             );
         }
-        
+
         [Fact]
         public void XmlDocumentUseSecureResolverWithPermissionsShouldNotGenerateDiagnostic()
         {
@@ -300,7 +300,7 @@ Namespace TestNamespace
 End Namespace"
             );
         }
-        
+
         [Fact]
         public void XmlDocumentSetResolverToNullInTryClauseShouldNotGenerateDiagnostic()
         {
@@ -374,7 +374,7 @@ End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(7, 24)
             );
         }
-        
+
         [Fact]
         public void XmlDocumentUseNonSecureResolverShouldGenerateDiagnostic()
         {
@@ -410,7 +410,7 @@ End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 13)
             );
         }
-        
+
         [Fact]
         public void XmlDocumentUseNonSecureResolverInTryClauseShouldGenerateDiagnostic()
         {
@@ -533,7 +533,7 @@ End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(10, 19)
             );
         }
-        
+
         [Fact]
         public void XmlDocumentSetResolversInDifferentBlock()
         {
@@ -578,7 +578,7 @@ End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 28)
             );
         }
-        
+
         [Fact]
         public void XmlDocumentAsFieldSetResolverToInsecureResolverInOnlyMethodShouldGenerateDiagnostics()
         {
@@ -617,7 +617,7 @@ End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(9, 13)
             );
         }
-        
+
         [Fact]
         public void XmlDocumentAsFieldSetResolverToInsecureResolverInSomeMethodShouldGenerateDiagnostics()
         {
@@ -666,7 +666,7 @@ End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(13, 13)
             );
         }
-        
+
         [Fact]
         public void XmlDocumentAsFieldSetResolverToNullInSomeMethodShouldGenerateDiagnostics()
         {
@@ -712,7 +712,7 @@ End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
             );
         }
-        
+
         [Fact]
         public void XmlDocumentCreatedAsTempNotSetResolverShouldGenerateDiagnostics()
         {
@@ -752,7 +752,7 @@ End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 21)
             );
         }
-        
+
         [Fact]
         public void XmlDocumentDerivedTypeNotSetResolverShouldNotGenerateDiagnostics()
         {
@@ -799,7 +799,7 @@ End Namespace
 "
             );
         }
-        
+
         [Fact]
         public void XmlDocumentDerivedTypeWithNoSecureResolverShouldNotGenerateDiagnostic()
         {

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
@@ -264,7 +264,7 @@ namespace Roslyn.Diagnostics.Analyzers
                 {
                     return GetSiblingNamesToRemoveFromUnshippedTextCore(symbol);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     Debug.Assert(false, ex.Message);
                     return string.Empty;
@@ -390,7 +390,7 @@ namespace Roslyn.Diagnostics.Analyzers
                 {
                     publicApiName += $" (forwarded, contained in {symbol.ContainingAssembly.Name})";
                 }
-    
+
                 return publicApiName;
             }
 

--- a/src/Test/Utilities/CodeFixTestBase.cs
+++ b/src/Test/Utilities/CodeFixTestBase.cs
@@ -117,7 +117,7 @@ namespace Test.Utilities
                     break;
                 }
 
-                analyzerDiagnostics = GetSortedDiagnostics(analyzerOpt, new [] { document }, additionalFiles: additionalFiles, validationMode: validationMode);
+                analyzerDiagnostics = GetSortedDiagnostics(analyzerOpt, new[] { document }, additionalFiles: additionalFiles, validationMode: validationMode);
                 var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, document.GetSemanticModelAsync().Result.GetDiagnostics());
                 if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
                 {

--- a/src/Test/Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test/Utilities/DiagnosticAnalyzerTestBase.cs
@@ -420,7 +420,7 @@ namespace Test.Utilities
                 Compilation compilation = project.GetCompilationAsync().Result;
                 compilation = EnableAnalyzer(analyzerOpt, compilation);
 
-                ImmutableArray <Diagnostic> diags = compilation.GetAnalyzerDiagnostics(new[] { analyzerOpt }, validationMode, analyzerOptions);
+                ImmutableArray<Diagnostic> diags = compilation.GetAnalyzerDiagnostics(new[] { analyzerOpt }, validationMode, analyzerOptions);
                 if (spans == null)
                 {
                     diagnostics.AddRange(diags);

--- a/src/Test/Utilities/DiagnosticResult.cs
+++ b/src/Test/Utilities/DiagnosticResult.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Test.Utilities
 {
-    public struct DiagnosticResultLocation: IEquatable<DiagnosticResultLocation>
+    public struct DiagnosticResultLocation : IEquatable<DiagnosticResultLocation>
     {
         public DiagnosticResultLocation(string path, int line, int column)
         {
@@ -34,7 +34,7 @@ namespace Test.Utilities
 
         public override int GetHashCode()
         {
-            return Hash.CombineValues(new []{ this.Path.GetHashCode(), this.Line, this.Column });
+            return Hash.CombineValues(new[] { this.Path.GetHashCode(), this.Line, this.Column });
         }
 
         public bool Equals(DiagnosticResultLocation other)
@@ -55,7 +55,7 @@ namespace Test.Utilities
         }
     }
 
-    public struct DiagnosticResult: IEquatable<DiagnosticResult>
+    public struct DiagnosticResult : IEquatable<DiagnosticResult>
     {
         private DiagnosticResultLocation[] _locations;
 

--- a/src/Test/Utilities/TestAdditionalDocument.cs
+++ b/src/Test/Utilities/TestAdditionalDocument.cs
@@ -14,8 +14,8 @@ namespace Test.Utilities
         private readonly SourceText _sourceText;
 
         public TestAdditionalDocument(string fileName, string text)
-            : this (fileName, fileName, text)
-        {            
+            : this(fileName, fileName, text)
+        {
         }
 
         public TestAdditionalDocument(TextDocument textDocument)

--- a/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.Fixer.cs
+++ b/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.Fixer.cs
@@ -24,7 +24,7 @@ namespace Text.Analyzers
         {
             // Fixer not yet implemented.
             return Task.CompletedTask;
-            
+
         }
     }
 }


### PR DESCRIPTION
This adds the roslyn .editorconfig for the repo. I then ran the formatter over all documents in the solution (thanks @TyOverby for https://github.com/TyOverby/roslyn-diff-formatter, which I hacked up). Finally, I added the .editorconfig and README to the solution for ease of editing. Tagging @dotnet/roslyn-analysis for review.