### PR TITLE
Make the Microsoft.Net.RoslyDiagnostics metapackage work as a PackageReference

### DIFF
--- a/src/AggregateNugetPackages/Microsoft.Net.RoslynDiagnostics/NuGet/Microsoft.Net.RoslynDiagnostics.nuspec
+++ b/src/AggregateNugetPackages/Microsoft.Net.RoslynDiagnostics/NuGet/Microsoft.Net.RoslynDiagnostics.nuspec
@@ -27,7 +27,7 @@
     <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
-    <file src="Microsoft.Net.RoslynDiagnostics.props" target="build" />
+    <file src="Microsoft.Net.RoslynDiagnostics.props" target="roslyn" />
     <file src="ThirdPartyNotices.rtf" target="" />
   </files>
 </package>


### PR DESCRIPTION
This metapackage is used the roslyn repos and they explicit import the build\Microsoft.Net.RoslynDiagnostics.props file in the package and don't import the package through regular nuget mechanisms. However, because this props file follows nuget convetions, if it is imported as a PackageReference, then all analyzers get imported twice. I want to pull this package in the project system repo as a PackageReference. Ideally we would just delete the props file entirely but that would break roslyn. So making a smaller breaking change here by just changing the folder that the props gets laid out in to something custom so that nuget is not aware of this props when included as a PackageReference. When roslyn updates to a newer version, they need to adjust the path to the props.

@mavasani @dotnet/roslyn-analysis 