### PR TITLE
Fix a false positive with RS0006 (DoNotMixAttributesFromDifferentVersionsOfMEFAnalyzer) analyzer

### DIFF
--- a/src/Analyzer.Utilities/WellKnownTypes.cs
+++ b/src/Analyzer.Utilities/WellKnownTypes.cs
@@ -345,5 +345,15 @@ namespace Analyzer.Utilities
         {
             return compilation.GetTypeByMetadataName("System.Diagnostics.Contracts.PureAttribute");
         }
+
+        public static INamedTypeSymbol MEFV1ExportAttribute(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.ComponentModel.Composition.ExportAttribute");
+        }
+
+        public static INamedTypeSymbol MEFV2ExportAttribute(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Composition.ExportAttribute");
+        }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Composition/DoNotMixAttributesFromDifferentVersionsOfMEF.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Composition/DoNotMixAttributesFromDifferentVersionsOfMEF.cs
@@ -78,12 +78,16 @@ namespace Microsoft.NetCore.Analyzers.Composition
             }
 
             var badNamespaces = exportAttributes.Except(appliedExportAttributes).Select(s => s.ContainingNamespace).ToSet();
+            var goodNamespaces = appliedExportAttributes.Select(s => s.ContainingNamespace).ToSet();
 
-            // Now look at all attributes and see if any are metadata attributes
+            // Now look at all attributes and see if any are metadata attributes from badNamespaces, but none from good namepaces.
             foreach (var namedTypeAttribute in namedTypeAttributes)
             {
-                if (namedTypeAttribute.AttributeClass.GetApplicableAttributes().Any(ad => badNamespaces.Contains(ad.AttributeClass.ContainingNamespace) &&
-                                                                                                          ad.AttributeClass.Name == "MetadataAttributeAttribute"))
+                var appliedAttributes = namedTypeAttribute.AttributeClass.GetApplicableAttributes();
+                if (appliedAttributes.Any(ad => badNamespaces.Contains(ad.AttributeClass.ContainingNamespace) &&
+                        ad.AttributeClass.Name == "MetadataAttributeAttribute") &&
+                    !appliedAttributes.Any(ad => goodNamespaces.Contains(ad.AttributeClass.ContainingNamespace) &&
+                        ad.AttributeClass.Name == "MetadataAttributeAttribute"))
                 {
                     ReportDiagnostic(symbolContext, namedType, namedTypeAttribute);
                 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Composition/DoNotMixAttributesFromDifferentVersionsOfMEFTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Composition/DoNotMixAttributesFromDifferentVersionsOfMEFTests.cs
@@ -353,6 +353,42 @@ End Class
 ", TestValidationMode.AllowCompileErrors);
         }
 
+        [Fact]
+        public void NoDiagnosticCases_MultiMefMetadataAttribute()
+        {
+            VerifyCSharp(@"
+using System;
+
+[System.ComponentModel.Composition.Export(typeof(C)), MyNamespace.MultiMefMetadataAttribute]
+public class C
+{
+}
+
+namespace MyNamespace
+{
+    [System.ComponentModel.Composition.MetadataAttribute, System.Composition.MetadataAttribute]
+    public class MultiMefMetadataAttribute : System.Attribute
+    {
+    }
+}
+" + CSharpWellKnownAttributesDefinition);
+
+            VerifyBasic(@"
+Imports System
+
+<System.ComponentModel.Composition.Export(GetType(C)), MyNamespace.MultiMefMetadataAttribute> _
+Public Class C
+End Class
+
+Namespace MyNamespace
+    <System.ComponentModel.Composition.MetadataAttribute, System.Composition.MetadataAttribute> _
+	Public Class MultiMefMetadataAttribute
+		Inherits System.Attribute
+	End Class
+End Namespace
+" + BasicWellKnownAttributesDefinition);
+        }
+
         #endregion
 
         #region Diagnostic Tests


### PR DESCRIPTION
Handle metadata attributes such as CPS AppliesToAttribute, which has MetadataAttribute from more than one MEF namespace. We now report RS0006 (DoNotMixAttributesFromDifferentVersionsOfMEFAnalyzer) only if applied attribute has no metadata attribute from a good namespace (namespace from which ExportAttribute was applied).

Verified that the new test fails prior to the fix, and passes fine now.

Fixes #955