### PR TITLE
Move RemoveEmptyFinalizersAnalyzer to syntax analyzer

### DIFF
--- a/src/Analyzer.Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -77,7 +77,7 @@ namespace Analyzer.Utilities.Extensions
                 return true; // for C#
             }
 
-            if (method.Name != "Finalize" || method.Parameters.Length != 0 || !method.ReturnsVoid)
+            if (method.Name != WellKnownMemberNames.DestructorName || method.Parameters.Length != 0 || !method.ReturnsVoid)
             {
                 return false;
             }

--- a/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -58,7 +59,17 @@ namespace Analyzer.Utilities.Extensions
 
         public static bool IsDestructor(this ISymbol symbol)
         {
-            return (symbol as IMethodSymbol)?.MethodKind == MethodKind.Destructor;
+            if (symbol.Language.Equals(LanguageNames.CSharp, StringComparison.Ordinal))
+            {
+                return (symbol as IMethodSymbol)?.MethodKind == MethodKind.Destructor;
+            }
+            else
+            {
+                return symbol is IMethodSymbol methodSymbol &&
+                       methodSymbol.MethodKind == MethodKind.Ordinary &&
+                       methodSymbol.IsProtected() &&
+                       methodSymbol.Name.Equals("Finalize", StringComparison.Ordinal);
+            }
         }
 
         public static bool IsIndexer(this ISymbol symbol)

--- a/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/ISymbolExtensions.cs
@@ -59,17 +59,7 @@ namespace Analyzer.Utilities.Extensions
 
         public static bool IsDestructor(this ISymbol symbol)
         {
-            if (symbol.Language.Equals(LanguageNames.CSharp, StringComparison.Ordinal))
-            {
-                return (symbol as IMethodSymbol)?.MethodKind == MethodKind.Destructor;
-            }
-            else
-            {
-                return symbol is IMethodSymbol methodSymbol &&
-                       methodSymbol.MethodKind == MethodKind.Ordinary &&
-                       methodSymbol.IsProtected() &&
-                       methodSymbol.Name.Equals("Finalize", StringComparison.Ordinal);
-            }
+            return (symbol as IMethodSymbol)?.IsFinalizer() ?? false;
         }
 
         public static bool IsIndexer(this ISymbol symbol)

--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpRemoveEmptyFinalizersAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpRemoveEmptyFinalizersAnalyzer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class CSharpRemoveEmptyFinalizersAnalyzer : AbstractRemoveEmptyFinalizersAnalyzer
     {
-        protected override bool IsEmptyFinalizer(SyntaxNode methodBody, SymbolAnalysisContext analysisContext)
+        protected override bool IsEmptyFinalizer(SyntaxNode methodBody, CodeBlockAnalysisContext analysisContext)
         {
             var destructorDeclaration = (DestructorDeclarationSyntax)methodBody;
 
@@ -34,9 +34,8 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines
                     expr.Expression.Kind() == CodeAnalysis.CSharp.SyntaxKind.InvocationExpression)
                 {
                     var invocation = (InvocationExpressionSyntax)expr.Expression;
-                    var semanticModel = analysisContext.Compilation.GetSemanticModel(invocation.SyntaxTree);
-                    var invocationSymbol = (IMethodSymbol)semanticModel.GetSymbolInfo(invocation).Symbol;
-                    var conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(analysisContext.Compilation);
+                    var invocationSymbol = (IMethodSymbol)analysisContext.SemanticModel.GetSymbolInfo(invocation).Symbol;
+                    var conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(analysisContext.SemanticModel.Compilation);
                     return InvocationIsConditional(invocationSymbol, conditionalAttributeSymbol);
                 }
             }

--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpRemoveEmptyFinalizersAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpRemoveEmptyFinalizersAnalyzer.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeQuality.Analyzers.QualityGuidelines;
+
+namespace Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class CSharpRemoveEmptyFinalizersAnalyzer : AbstractRemoveEmptyFinalizersAnalyzer
+    {
+        protected override bool IsEmptyFinalizer(SyntaxNode methodBody, SymbolAnalysisContext analysisContext)
+        {
+            var destructorDeclaration = (DestructorDeclarationSyntax)methodBody;
+
+            if ((destructorDeclaration?.Body?.Statements.Count ?? 0) == 0)
+            {
+                return true;
+            }
+
+            if (destructorDeclaration.Body.Statements.Count == 1)
+            {
+                var body = destructorDeclaration.Body.Statements[0];
+
+                if (body.Kind() == CodeAnalysis.CSharp.SyntaxKind.ThrowStatement)
+                {
+                    return true;
+                }
+
+                if (body.Kind() == CodeAnalysis.CSharp.SyntaxKind.ExpressionStatement &&
+                    body is ExpressionStatementSyntax expr &&
+                    expr.Expression.Kind() == CodeAnalysis.CSharp.SyntaxKind.InvocationExpression)
+                {
+                    var invocation = (InvocationExpressionSyntax)expr.Expression;
+                    var semanticModel = analysisContext.Compilation.GetSemanticModel(invocation.SyntaxTree);
+                    var invocationSymbol = (IMethodSymbol)semanticModel.GetSymbolInfo(invocation).Symbol;
+                    var conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(analysisContext.Compilation);
+                    return InvocationIsConditional(invocationSymbol, conditionalAttributeSymbol);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AbstractRemoveEmptyFinalizers.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AbstractRemoveEmptyFinalizers.cs
@@ -33,9 +33,14 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            analysisContext.RegisterCodeBlockAction(methodContext =>
+            analysisContext.RegisterCodeBlockAction(codeBlockContext =>
             {
-                var methodSymbol = (IMethodSymbol)methodContext.OwningSymbol;
+                if (codeBlockContext.OwningSymbol.Kind != SymbolKind.Method)
+                {
+                    return;
+                }
+
+                var methodSymbol = (IMethodSymbol)codeBlockContext.OwningSymbol;
                 if (!methodSymbol.IsDestructor())
                 {
                     return;
@@ -43,9 +48,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
                 var methodBody = methodSymbol.DeclaringSyntaxReferences.Single().GetSyntax();
 
-                if (IsEmptyFinalizer(methodBody, methodContext))
+                if (IsEmptyFinalizer(methodBody, codeBlockContext))
                 {
-                    methodContext.ReportDiagnostic(methodSymbol.CreateDiagnostic(Rule));
+                    codeBlockContext.ReportDiagnostic(methodSymbol.CreateDiagnostic(Rule));
                 }
             });
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AbstractRemoveEmptyFinalizers.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AbstractRemoveEmptyFinalizers.cs
@@ -33,9 +33,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            analysisContext.RegisterSymbolAction(methodContext =>
+            analysisContext.RegisterCodeBlockAction(methodContext =>
             {
-                var methodSymbol = (IMethodSymbol)methodContext.Symbol;
+                var methodSymbol = (IMethodSymbol)methodContext.OwningSymbol;
                 if (!methodSymbol.IsDestructor())
                 {
                     return;
@@ -47,12 +47,12 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 {
                     methodContext.ReportDiagnostic(methodSymbol.CreateDiagnostic(Rule));
                 }
-            }, SymbolKind.Method);
+            });
         }
 
         protected bool InvocationIsConditional(IMethodSymbol methodSymbol, INamedTypeSymbol conditionalAttributeSymbol) =>
             methodSymbol.GetAttributes().Any(n => n.AttributeClass.Equals(conditionalAttributeSymbol));
 
-        protected abstract bool IsEmptyFinalizer(SyntaxNode methodBody, SymbolAnalysisContext analysisContext);
+        protected abstract bool IsEmptyFinalizer(SyntaxNode methodBody, CodeBlockAnalysisContext analysisContext);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.Fixer.cs
@@ -2,6 +2,8 @@
 
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines;
+using Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines;
 using Test.Utilities;
 using Xunit;
 
@@ -11,7 +13,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
     {
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
-            return new RemoveEmptyFinalizersAnalyzer();
+            return new BasicRemoveEmptyFinalizersAnalyzer();
         }
 
         protected override CodeFixProvider GetBasicCodeFixProvider()
@@ -21,7 +23,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return new RemoveEmptyFinalizersAnalyzer();
+            return new CSharpRemoveEmptyFinalizersAnalyzer();
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines;
+using Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines;
 using Test.Utilities;
 using Xunit;
 
@@ -10,15 +12,15 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
     {
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
-            return new RemoveEmptyFinalizersAnalyzer();
+            return new BasicRemoveEmptyFinalizersAnalyzer();
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return new RemoveEmptyFinalizersAnalyzer();
+            return new CSharpRemoveEmptyFinalizersAnalyzer();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7428")]
+        [Fact]
         public void CA1821CSharpTestNoWarning()
         {
             VerifyCSharp(@"
@@ -190,7 +192,7 @@ public class Class1
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7428")]
+        [Fact]
         public void CA1821CSharpTestRemoveEmptyFinalizersWithDebugFailAndDirectiveAroundStatements()
         {
             VerifyCSharp(@"
@@ -223,7 +225,7 @@ public class Class2
         }
 
         [WorkItem(820941, "DevDiv")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7428")]
+        [Fact]
         public void CA1821CSharpTestRemoveEmptyFinalizersWithNonInvocationBody()
         {
             VerifyCSharp(@"
@@ -242,6 +244,7 @@ public class Class2
 ");
         }
 
+        [Fact]
         public void CA1821BasicTestNoWarning()
         {
             VerifyBasic(@"
@@ -283,12 +286,13 @@ Public Class Class5
     Protected Overrides Sub Finalize()
         If True Then
             Debug.Fail(""Finalizer called!"")
-        End If    End Sub
+        End If    
+    End Sub
 End Class
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7428")]
+        [Fact]
         public void CA1821BasicTestRemoveEmptyFinalizers()
         {
             VerifyBasic(@"
@@ -350,7 +354,7 @@ End Class
                 GetCA1821BasicResultAt(13, 29));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7428")]
+        [Fact]
         public void CA1821BasicTestRemoveEmptyFinalizersWithDebugFail()
         {
             VerifyBasic(@"
@@ -376,12 +380,12 @@ End Class
 
         private static DiagnosticResult GetCA1821CSharpResultAt(int line, int column)
         {
-            return GetCSharpResultAt(line, column, RemoveEmptyFinalizersAnalyzer.RuleId, MicrosoftQualityGuidelinesAnalyzersResources.RemoveEmptyFinalizers);
+            return GetCSharpResultAt(line, column, AbstractRemoveEmptyFinalizersAnalyzer.RuleId, MicrosoftQualityGuidelinesAnalyzersResources.RemoveEmptyFinalizers);
         }
 
         private static DiagnosticResult GetCA1821BasicResultAt(int line, int column)
         {
-            return GetBasicResultAt(line, column, RemoveEmptyFinalizersAnalyzer.RuleId, MicrosoftQualityGuidelinesAnalyzersResources.RemoveEmptyFinalizers);
+            return GetBasicResultAt(line, column, AbstractRemoveEmptyFinalizersAnalyzer.RuleId, MicrosoftQualityGuidelinesAnalyzersResources.RemoveEmptyFinalizers);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
@@ -378,6 +378,34 @@ End Class
                 GetCA1821BasicResultAt(6, 29));
         }
 
+        [Fact]
+        public void CA1821CSharpTestRemoveEmptyFinalizersWithThrowStatement()
+        {
+            VerifyCSharp(@"
+public class Class1
+{
+    ~Class1()
+    {
+        throw new System.Exception();
+    }
+}", 
+                GetCA1821CSharpResultAt(4, 6));
+        }
+
+        [Fact]
+        public void CA1821BasicTestRemoveEmptyFinalizersWithThrowStatement()
+        {
+            VerifyBasic(@"
+Public Class Class1
+	' Violation occurs because Debug.Fail is a conditional method.
+    Protected Overrides Sub Finalize()
+        Throw New System.Exception()
+    End Sub
+End Class
+",
+                GetCA1821BasicResultAt(4, 29));
+        }
+
         private static DiagnosticResult GetCA1821CSharpResultAt(int line, int column)
         {
             return GetCSharpResultAt(line, column, AbstractRemoveEmptyFinalizersAnalyzer.RuleId, MicrosoftQualityGuidelinesAnalyzersResources.RemoveEmptyFinalizers);

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
@@ -1,18 +1,37 @@
-﻿Imports Microsoft.CodeAnalysis
+﻿Imports Analyzer.Utilities
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
-<DiagnosticAnalyzer(LanguageNames.VisualBasic)>
-Public Class BasicRemoveEmptyFinalizersAnalyzer
-    Inherits AbstractRemoveEmptyFinalizersAnalyzer
+Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines
 
-    Protected Overrides Function IsEmptyFinalizer(methodBody As SyntaxNode, analysisContext As SymbolAnalysisContext) As Boolean
-        Dim destructorDeclaration = DirectCast(methodBody, MethodBlockSyntax)
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+    Public Class BasicRemoveEmptyFinalizersAnalyzer
+        Inherits AbstractRemoveEmptyFinalizersAnalyzer
 
-    End Function
+        Protected Overrides Function IsEmptyFinalizer(methodBody As SyntaxNode, analysisContext As SymbolAnalysisContext) As Boolean
+            Dim destructorStatement = DirectCast(methodBody, MethodStatementSyntax)
+            Dim destructorBlock = DirectCast(destructorStatement.Parent, MethodBlockSyntax)
 
-    Protected Overrides Sub Finalize()
+            If (destructorBlock.Statements.Count = 0) Then
+                Return True
+            ElseIf (destructorBlock.Statements.Count = 1) Then
+                If (destructorBlock.Statements(0).Kind() = CodeAnalysis.VisualBasic.SyntaxKind.ExpressionStatement) Then
+                    Dim destructorExpression = DirectCast(destructorBlock.Statements(0), ExpressionStatementSyntax)
+                    If (destructorExpression.Expression.Kind() = CodeAnalysis.VisualBasic.SyntaxKind.InvocationExpression) Then
+                        Dim invocationExpression = DirectCast(destructorExpression.Expression, InvocationExpressionSyntax)
+                        Dim semanticModel = analysisContext.Compilation.GetSemanticModel(invocationExpression.SyntaxTree)
+                        Dim invocationSymbol = DirectCast(semanticModel.GetSymbolInfo(invocationExpression).Symbol, IMethodSymbol)
+                        Dim conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(analysisContext.Compilation)
+                        Return InvocationIsConditional(invocationSymbol, conditionalAttributeSymbol)
+                    End If
+                End If
+            End If
+            Return False
+        End Function
+        Protected Overrides Sub Finalize()
 
-    End Sub
-End Class
+        End Sub
+    End Class
+End Namespace

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
@@ -1,0 +1,18 @@
+﻿Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.CodeQuality.Analyzers.QualityGuidelines
+
+<DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+Public Class BasicRemoveEmptyFinalizersAnalyzer
+    Inherits AbstractRemoveEmptyFinalizersAnalyzer
+
+    Protected Overrides Function IsEmptyFinalizer(methodBody As SyntaxNode, analysisContext As SymbolAnalysisContext) As Boolean
+        Dim destructorDeclaration = DirectCast(methodBody, MethodBlockSyntax)
+
+    End Function
+
+    Protected Overrides Sub Finalize()
+
+    End Sub
+End Class

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
@@ -30,8 +30,5 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines
             End If
             Return False
         End Function
-        Protected Overrides Sub Finalize()
-
-        End Sub
     End Class
 End Namespace

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
@@ -17,18 +17,22 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines
             If (destructorBlock.Statements.Count = 0) Then
                 Return True
             ElseIf (destructorBlock.Statements.Count = 1) Then
+                If (destructorBlock.Statements(0).Kind() = CodeAnalysis.VisualBasic.SyntaxKind.ThrowStatement) Then
+                    Return True
+                End If
+
                 If (destructorBlock.Statements(0).Kind() = CodeAnalysis.VisualBasic.SyntaxKind.ExpressionStatement) Then
-                    Dim destructorExpression = DirectCast(destructorBlock.Statements(0), ExpressionStatementSyntax)
-                    If (destructorExpression.Expression.Kind() = CodeAnalysis.VisualBasic.SyntaxKind.InvocationExpression) Then
-                        Dim invocationExpression = DirectCast(destructorExpression.Expression, InvocationExpressionSyntax)
-                        Dim semanticModel = analysisContext.Compilation.GetSemanticModel(invocationExpression.SyntaxTree)
-                        Dim invocationSymbol = DirectCast(semanticModel.GetSymbolInfo(invocationExpression).Symbol, IMethodSymbol)
-                        Dim conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(analysisContext.Compilation)
-                        Return InvocationIsConditional(invocationSymbol, conditionalAttributeSymbol)
+                        Dim destructorExpression = DirectCast(destructorBlock.Statements(0), ExpressionStatementSyntax)
+                        If (destructorExpression.Expression.Kind() = CodeAnalysis.VisualBasic.SyntaxKind.InvocationExpression) Then
+                            Dim invocationExpression = DirectCast(destructorExpression.Expression, InvocationExpressionSyntax)
+                            Dim semanticModel = analysisContext.Compilation.GetSemanticModel(invocationExpression.SyntaxTree)
+                            Dim invocationSymbol = DirectCast(semanticModel.GetSymbolInfo(invocationExpression).Symbol, IMethodSymbol)
+                            Dim conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(analysisContext.Compilation)
+                            Return InvocationIsConditional(invocationSymbol, conditionalAttributeSymbol)
+                        End If
                     End If
                 End If
-            End If
-            Return False
+                Return False
         End Function
     End Class
 End Namespace

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRemoveEmptyFinalizersAnalyzer.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines
     Public Class BasicRemoveEmptyFinalizersAnalyzer
         Inherits AbstractRemoveEmptyFinalizersAnalyzer
 
-        Protected Overrides Function IsEmptyFinalizer(methodBody As SyntaxNode, analysisContext As SymbolAnalysisContext) As Boolean
+        Protected Overrides Function IsEmptyFinalizer(methodBody As SyntaxNode, analysisContext As CodeBlockAnalysisContext) As Boolean
             Dim destructorStatement = DirectCast(methodBody, MethodStatementSyntax)
             Dim destructorBlock = DirectCast(destructorStatement.Parent, MethodBlockSyntax)
 
@@ -22,17 +22,16 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines
                 End If
 
                 If (destructorBlock.Statements(0).Kind() = CodeAnalysis.VisualBasic.SyntaxKind.ExpressionStatement) Then
-                        Dim destructorExpression = DirectCast(destructorBlock.Statements(0), ExpressionStatementSyntax)
-                        If (destructorExpression.Expression.Kind() = CodeAnalysis.VisualBasic.SyntaxKind.InvocationExpression) Then
-                            Dim invocationExpression = DirectCast(destructorExpression.Expression, InvocationExpressionSyntax)
-                            Dim semanticModel = analysisContext.Compilation.GetSemanticModel(invocationExpression.SyntaxTree)
-                            Dim invocationSymbol = DirectCast(semanticModel.GetSymbolInfo(invocationExpression).Symbol, IMethodSymbol)
-                            Dim conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(analysisContext.Compilation)
-                            Return InvocationIsConditional(invocationSymbol, conditionalAttributeSymbol)
-                        End If
+                    Dim destructorExpression = DirectCast(destructorBlock.Statements(0), ExpressionStatementSyntax)
+                    If (destructorExpression.Expression.Kind() = CodeAnalysis.VisualBasic.SyntaxKind.InvocationExpression) Then
+                        Dim invocationExpression = DirectCast(destructorExpression.Expression, InvocationExpressionSyntax)
+                        Dim invocationSymbol = DirectCast(analysisContext.SemanticModel.GetSymbolInfo(invocationExpression).Symbol, IMethodSymbol)
+                        Dim conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(analysisContext.SemanticModel.Compilation)
+                        Return InvocationIsConditional(invocationSymbol, conditionalAttributeSymbol)
                     End If
                 End If
-                Return False
+            End If
+            Return False
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Because of the Higher vs Lower issue in IOperation right now, and since we want to ship this analyzer as part of our default set, we need to move RemoveEmptyFinalizersAnalyzer back to Symbol+Syntax for now. Tagging @dotnet/roslyn-analysis @mavasani for review.