### PR TITLE
Change the default values for isEnabledByDefault for rules when build…

### DIFF
--- a/src/Analyzer.Utilities/AbstractVersionCheckAnalyzer.cs
+++ b/src/Analyzer.Utilities/AbstractVersionCheckAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Analyzer.Utilities
                                                         s_localizableMessageFormat,
                                                         DiagnosticCategory.Reliability,
                                                         DiagnosticSeverity.Warning,
-                                                        isEnabledByDefault: true,
+                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                         description: s_localizableDescription);
 
         protected abstract string AnalyzerPackageName { get; }

--- a/src/Analyzer.Utilities/DiagnosticHelpers.cs
+++ b/src/Analyzer.Utilities/DiagnosticHelpers.cs
@@ -16,6 +16,22 @@ namespace Analyzer.Utilities
             DiagnosticSeverity.Warning;
 #endif
 
+        public const bool EnabledByDefaultIfNotBuildingVSIX =
+#if USE_INTERNAL_IOPERATION_APIS // Building Analyzer VSIX
+            false;
+#else
+            true;
+#endif
+
+        public const bool EnabledByDefaultOnlyIfBuildingVSIX =
+#if USE_INTERNAL_IOPERATION_APIS // Building Analyzer VSIX
+            true;
+#else
+            false;
+#endif
+
+        public const bool EnabledByDefaultForVsixAndNuget = true;
+
         public static bool TryConvertToUInt64(object value, SpecialType specialType, out ulong convertedValue)
         {
             bool success = false;

--- a/src/FxCopAnalyzersSetup/FxCopAnalyzersSetup/FxCopAnalyzersPackage.cs
+++ b/src/FxCopAnalyzersSetup/FxCopAnalyzersSetup/FxCopAnalyzersPackage.cs
@@ -9,8 +9,10 @@ namespace FxCopAnalyzersSetup
     [Guid(PackageGuid)]
 #pragma warning disable CA1812
     class FxCopAnalyzersPackage : Package
-#pragma warning disable CA1812
+#pragma warning restore CA1812
     {
+#pragma warning disable CA1823 // False unused field diagnostic: https://github.com/dotnet/roslyn-analyzers/issues/1191
         private const string PackageGuid = "4A41D270-A97F-4639-A352-28732FC410E4";
+#pragma warning restore CA1823
     }
 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpImmutableObjectMethodAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpImmutableObjectMethodAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers
             s_localizableMessage,
             AnalyzerDiagnosticCategory.AnalyzerCorrectness,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
             "Correctness",
             DiagnosticHelpers.DefaultDiagnosticSeverity,
             description: s_localizableCodeActionNeedsEquivalenceKeyDescription,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         internal static readonly DiagnosticDescriptor OverrideCodeActionEquivalenceKeyRule = new DiagnosticDescriptor(
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
             "Correctness",
             DiagnosticHelpers.DefaultDiagnosticSeverity,
             description: s_localizableCodeActionNeedsEquivalenceKeyDescription,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAttributeAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAttributeAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessageMissingAttribute,
             AnalyzerDiagnosticCategory.AnalyzerCorrectness,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionMissingAttribute,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessageAddLanguageSupportToAnalyzer,
             AnalyzerDiagnosticCategory.AnalyzerCorrectness,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionAddLanguageSupportToAnalyzer,
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerFieldsAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerFieldsAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessage,
             AnalyzerDiagnosticCategory.AnalyzerPerformance,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessageMissingSymbolKindArgument,
             AnalyzerDiagnosticCategory.AnalyzerCorrectness,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionMissingKindArgument,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessageMissingSyntaxKindArgument,
             AnalyzerDiagnosticCategory.AnalyzerCorrectness,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionMissingKindArgument,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessageMissingOperationKindArgument,
             AnalyzerDiagnosticCategory.AnalyzerCorrectness,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionMissingKindArgument,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessageUnsupportedSymbolKindArgument,
             AnalyzerDiagnosticCategory.AnalyzerCorrectness,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         private static readonly LocalizableString s_localizableTitleInvalidSyntaxKindTypeArgument = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.InvalidSyntaxKindTypeArgumentTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessageInvalidSyntaxKindTypeArgument,
             AnalyzerDiagnosticCategory.AnalyzerCorrectness,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionInvalidSyntaxKindTypeArgument,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessageStartActionWithNoRegisteredActions,
             AnalyzerDiagnosticCategory.AnalyzerPerformance,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionStatefulAnalyzerRegisterActionsDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessageStartActionWithOnlyEndAction,
             AnalyzerDiagnosticCategory.AnalyzerPerformance,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionStatefulAnalyzerRegisterActionsDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ReportDiagnosticAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ReportDiagnosticAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             s_localizableMessage,
             AnalyzerDiagnosticCategory.AnalyzerCorrectness,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructors.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructors.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                          s_localizableMessage,
                                                                          DiagnosticCategory.Design,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: false,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultOnlyIfBuildingVSIX,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182126.aspx",
                                                                          description: s_localizableDescription,
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AvoidEmptyInterfaces.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AvoidEmptyInterfaces.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182128.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CancellationTokenParametersMustComeLast.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CancellationTokenParametersMustComeLast.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             s_localizableMessage,
             DiagnosticCategory.Design,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true);
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                     s_localizableMessage,
                                                                     DiagnosticCategory.Usage,
                                                                     DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                    isEnabledByDefault: true,
+                                                                    isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                     description: s_localizableDescription,
                                                                     helpLinkUri: "https://msdn.microsoft.com/library/ms182327.aspx",
                                                                     customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionsShouldImplementGenericInterface.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionsShouldImplementGenericInterface.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 s_localizableMessage,
                 DiagnosticCategory.Design,
                 DiagnosticHelpers.DefaultDiagnosticSeverity,
-                isEnabledByDefault: true,
+                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                 description: s_localizableDescription,
                 helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182132.aspx",
                 customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypes.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182139.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182141.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDecreaseInheritedMemberVisibility.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDecreaseInheritedMemberVisibility.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182332.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             s_localizableMessage,
             DiagnosticCategory.Reliability,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             s_localizableMessage,
             DiagnosticCategory.Design,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescription,
             helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182143.aspx",
             customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessagePropertyGetter,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: helpLinkUri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -42,7 +42,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageHasAllowedExceptions,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: helpLinkUri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -51,7 +51,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageNoAllowedExceptions,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: helpLinkUri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumStorageShouldBeInt32.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumStorageShouldBeInt32.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageNotInt32,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182147.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageCA1027,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: false,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultOnlyIfBuildingVSIX,
                                                                              description: s_localizableDescriptionCA1027,
                                                                              helpLinkUri: "http://msdn.microsoft.com/library/ms182159.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -57,7 +57,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageCA2217,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: false,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultOnlyIfBuildingVSIX,
                                                                              description: s_localizableDescriptionCA2217,
                                                                              helpLinkUri: "http://msdn.microsoft.com/library/ms182335.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 s_localizableMessage_CA1714,
                 DiagnosticCategory.Naming,
                 DiagnosticHelpers.DefaultDiagnosticSeverity,
-                isEnabledByDefault: true,
+                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                 description: s_localizableDescription_CA1714,
                 helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb264486.aspx",
                 customTags: WellKnownDiagnosticTags.Telemetry);
@@ -79,7 +79,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 s_localizableMessage_CA1717,
                 DiagnosticCategory.Naming,
                 DiagnosticHelpers.DefaultDiagnosticSeverity,
-                isEnabledByDefault: true,
+                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                 description: s_localizableDescription_CA1717,
                 helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb264487.aspx",
                 customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             s_localizableMessageImplementIEquatable,
             DiagnosticCategory.Design,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionImplementIEquatable,
             helpLinkUri: "http://go.microsoft.com/fwlink/?LinkId=734907");
 
@@ -39,7 +39,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             s_localizableMessageOverridesObjectEquals,
             DiagnosticCategory.Design,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescriptionOverridesObjectEquals,
             helpLinkUri: "http://go.microsoft.com/fwlink/?LinkId=734909");
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ExceptionsShouldBePublic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ExceptionsShouldBePublic.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb264484.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                                     s_localizableMessageInterfaceRule,
                                                                                     DiagnosticCategory.Naming,
                                                                                     DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                    isEnabledByDefault: true,
+                                                                                    isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                                     description: s_localizableDescription,
                                                                                     helpLinkUri: "http://msdn.microsoft.com/library/ms182243.aspx",
                                                                                     customTags: WellKnownDiagnosticTags.Telemetry);
@@ -34,7 +34,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                                       s_localizableMessageTypeParameterRule,
                                                                                       DiagnosticCategory.Naming,
                                                                                       DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                      isEnabledByDefault: true,
+                                                                                      isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                                       description: s_localizableDescription,
                                                                                       helpLinkUri: "http://msdn.microsoft.com/library/ms182243.aspx",
                                                                                       customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageDefault,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -39,7 +39,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageSpecialCollection,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb531486.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageAssembly,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -44,7 +44,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageNamespace,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -53,7 +53,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageType,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -62,7 +62,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageMember,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -71,7 +71,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageTypeTypeParameter,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -80,7 +80,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageMethodTypeParameter,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -89,7 +89,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageMemberParameter,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -98,7 +98,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageDelegateParameter,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementStandardExceptionConstructors.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementStandardExceptionConstructors.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageMissingConstructor,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182151.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithAttributesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithAttributesDiagnosticAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                          s_localizableMessageCA1016,
                                                                          DiagnosticCategory.Design,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: true,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                          description: s_localizableDescriptionCA1016,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182155.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAttributesWithAttributeUsage.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAttributesWithAttributeUsage.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                     s_localizableMessage,
                                                                     DiagnosticCategory.Design,
                                                                     DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                    isEnabledByDefault: true,
+                                                                    isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                     helpLinkUri: "http://msdn.microsoft.com/library/ms182158.aspx",
                                                                     customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisible.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182353.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageDefault,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: MsdnUrl,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -48,7 +48,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageProperty,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: MsdnUrl,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -57,7 +57,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageMultiple,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: MsdnUrl,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -66,7 +66,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageVisibility,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: MsdnUrl,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182356.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                          s_localizableMessageAndTitle,
                                                                          DiagnosticCategory.Usage,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: true,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                          description: s_localizableDescription,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182359.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
@@ -30,11 +30,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableTitle,
                                                                              s_localizableMessageEquals,
                                                                              s_category,
-                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             true,
-                                                                             s_localizableDescription,
-                                                                             s_helpLinkUri,
-                                                                             WellKnownDiagnosticTags.Telemetry);
+                                                                             defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
+                                                                             description: s_localizableDescription,
+                                                                             helpLinkUri: s_helpLinkUri,
+                                                                             customTags: WellKnownDiagnosticTags.Telemetry);
 
         internal static DiagnosticDescriptor OpEqualityRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideMethodsOnComparableTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideMethodsOnComparableTypes.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                                   s_localizableMessage,
                                                                                   DiagnosticCategory.Design,
                                                                                   DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                  isEnabledByDefault: true,
+                                                                                  isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                                   description: s_localizableDescription,
                                                                                   helpLinkUri: "http://msdn.microsoft.com/library/ms182163.aspx",
                                                                                   customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStrings.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182360.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageAddGetter,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpLinkUri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -36,7 +36,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageMakeMoreAccessible,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpLinkUri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182253.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ProvideObsoleteAttributeMessage.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ProvideObsoleteAttributeMessage.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182166.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/StaticHolderTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/StaticHolderTypes.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             s_messageFormat,
             DiagnosticCategory.Design,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
             helpLinkUri: "http://msdn.microsoft.com/library/ms182168.aspx",
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespaces.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespaces.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageDefault,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182257.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -39,7 +39,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessageSystem,
                                                                              DiagnosticCategory.Naming,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182257.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                          new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.TypesThatOwnDisposableFieldsShouldBeDisposableMessageNonBreaking), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources)),
                                                                          DiagnosticCategory.Design,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: true,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                          description: new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.TypesThatOwnDisposableFieldsShouldBeDisposableDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources)),
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182172.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriParametersShouldNotBeStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriParametersShouldNotBeStrings.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182174.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriPropertiesShouldNotBeStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriPropertiesShouldNotBeStrings.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182175.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriReturnValuesShouldNotBeStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriReturnValuesShouldNotBeStrings.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182176.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseEventsWhereAppropriate.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseEventsWhereAppropriate.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182177.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexers.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexers.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182180.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Documentation/AvoidUsingCrefTagsWithAPrefix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Documentation/AvoidUsingCrefTagsWithAPrefix.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.Documentation
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Documentation,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: null,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182265.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUnusedPrivateFields.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUnusedPrivateFields.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                                       s_localizableMessage,
                                                                                       DiagnosticCategory.Performance,
                                                                                       DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                      isEnabledByDefault: true,
+                                                                                      isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                                       description: s_localizableDescription,
                                                                                       helpLinkUri: "http://msdn.microsoft.com/library/ms245042.aspx",
                                                                                       customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/DoNotIgnoreMethodResults.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/DoNotIgnoreMethodResults.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              s_localizableMessageObjectCreation,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182273.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -67,7 +67,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              s_localizableMessageStringCreation,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182273.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -77,7 +77,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              s_localizableMessageHResultOrErrorCode,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182273.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -87,7 +87,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              s_localizableMessagePureMethod,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182273.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -98,7 +98,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              s_localizableMessageTryParse,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182273.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182268.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AbstractRemoveEmptyFinalizers.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AbstractRemoveEmptyFinalizers.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                          s_localizableMessage,
                                                                          DiagnosticCategory.Performance,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: true,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                          description: s_localizableDescription,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/bb264476.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotCallOverridableMethodsInConstructors.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotCallOverridableMethodsInConstructors.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                          s_localizableMessageAndTitle,
                                                                          DiagnosticCategory.Usage,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: true,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                          description: s_localizableDescription,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182331.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotRaiseExceptionsInExceptionClauses.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotRaiseExceptionsInExceptionClauses.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpLinkUrl,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/PreferJaggedArraysOverMultidimensional.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/PreferJaggedArraysOverMultidimensional.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              s_localizableMessageDefault,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: helpLink,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -40,7 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              s_localizableMessageReturn,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: helpLink,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -49,7 +49,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              s_localizableMessageBody,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: helpLink,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/RethrowToPreserveStackDetails.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/RethrowToPreserveStackDetails.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                          s_localizableMessage,
                                                                          DiagnosticCategory.Usage,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: true,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182363.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Security,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182313.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/UseLiteralsWhereAppropriate.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/UseLiteralsWhereAppropriate.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              s_localizableMessageDefault,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -39,7 +39,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              s_localizableMessageEmptyString,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Composition/DoNotMixAttributesFromDifferentVersionsOfMEF.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Composition/DoNotMixAttributesFromDifferentVersionsOfMEF.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetCore.Analyzers.Composition
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Reliability,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: null,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Composition/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Composition/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NetCore.Analyzers.Composition
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Reliability,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: null,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableArrayOnAnImmutableArrayValue.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableArrayOnAnImmutableArrayValue.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Reliability,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              helpLinkUri: null,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.NetCore.Analyzers/Core/InteropServices/AlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttribute.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/InteropServices/AlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttribute.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             s_localizableMessage,
             DiagnosticCategory.Reliability,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: s_localizableDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Microsoft.NetCore.Analyzers/Core/InteropServices/PInvokeDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/InteropServices/PInvokeDiagnosticAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                                          s_localizableMessageCA1401,
                                                                          DiagnosticCategory.Interoperability,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: true,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                          description: s_localizableDescriptionCA1401,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182209.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
@@ -36,7 +36,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                                          s_localizableMessageAndTitleCA2101,
                                                                          DiagnosticCategory.Globalization,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: true,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                          description: s_localizableDescriptionCA2101,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182319.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Resources
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb385967.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AttributeStringLiteralsShouldParseCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AttributeStringLiteralsShouldParseCorrectly.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageDefault,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb264490.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -41,7 +41,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageEmpty,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb264490.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidUnsealedAttributes.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidUnsealedAttributes.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                          s_localizableMessage,
                                                                          DiagnosticCategory.Performance,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: false,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultOnlyIfBuildingVSIX,
                                                                          description: s_localizableDescription,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182267.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -37,7 +37,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             s_localizableMessage,
             DiagnosticCategory.Performance,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true);
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX);
 
         /// <summary>Gets the set of supported diagnostic descriptors from this analyzer.</summary>
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(UseArrayEmptyDescriptor);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/CallGCSuppressFinalizeCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/CallGCSuppressFinalizeCorrectly.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageNotCalledWithFinalizer,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-US/library/ms182269.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -40,7 +40,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageNotCalled,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-US/library/ms182269.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -49,7 +49,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageNotPassedThis,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-US/library/ms182269.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -58,7 +58,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageOutsideDispose,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-US/library/ms182269.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableTypesShouldDeclareFinalizer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableTypesShouldDeclareFinalizer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182329.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                          s_localizableMessage,
                                                                          DiagnosticCategory.Reliability,
                                                                          DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                         isEnabledByDefault: true,
+                                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182290.aspx",
                                                                          description: s_localizableDescription,
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: null,     // TODO: add MSDN url
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/InitializeStaticFieldsInline.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/InitializeStaticFieldsInline.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_CA1810_LocalizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182275.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -40,7 +40,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_CA2207_LocalizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182346.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/InstantiateArgumentExceptionsCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/InstantiateArgumentExceptionsCorrectly.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              "{0}",
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpUri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/NormalizeStringsToUppercase.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/NormalizeStringsToUppercase.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageToUpper,
                                                                              DiagnosticCategory.Globalization,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: @"https://msdn.microsoft.com/en-us/library/bb386042.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: @"https://msdn.microsoft.com/en-us/library/ms182361.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyCultureInfo.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyCultureInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Globalization,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageIFormatProviderAlternateString,
                                                                              DiagnosticCategory.Globalization,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -42,7 +42,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageIFormatProviderAlternate,
                                                                              DiagnosticCategory.Globalization,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -51,7 +51,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageUICultureString,
                                                                              DiagnosticCategory.Globalization,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
@@ -60,7 +60,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessageUICulture,
                                                                              DiagnosticCategory.Globalization,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: Uri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyStringComparison.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyStringComparison.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Globalization,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb386080.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb264491.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Tasks/DoNotCreateTasksWithoutPassingATaskScheduler.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Tasks/DoNotCreateTasksWithoutPassingATaskScheduler.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Reliability,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: null,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Security,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "http://aka.ms/CA2153",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureCryptographicAlgorithms.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureCryptographicAlgorithms.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NetFramework.Analyzers
                                             message,
                                             DiagnosticCategory.Security,
                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                            isEnabledByDefault: true,
+                                            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                             description: description,
                                             helpLinkUri: uri,
                                             customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
@@ -846,7 +846,7 @@ namespace Microsoft.NetFramework.Analyzers
                                             messageFormat,
                                             DiagnosticCategory.Security,
                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                            isEnabledByDefault: true,
+                                            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                             description: description,
                                             helpLinkUri: helpLink,
                                             customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessingInApiDesign.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessingInApiDesign.cs
@@ -65,7 +65,7 @@ namespace Microsoft.NetFramework.Analyzers
                                             messageFormat,
                                             DiagnosticCategory.Security,
                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                            isEnabledByDefault: true,
+                                            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                             description: description,
                                             helpLinkUri: helpLink,
                                             customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
@@ -52,7 +52,7 @@ namespace Microsoft.NetFramework.Analyzers
                                             messageFormat,
                                             DiagnosticCategory.Security,
                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                            isEnabledByDefault: true,
+                                            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                             description: description,
                                             helpLinkUri: helpLink,
                                             customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationDiagnosticAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                         "{0}",
                                                                         DiagnosticCategory.Usage,
                                                                         DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                        isEnabledByDefault: true,
+                                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                         description: s_localizableDescriptionCA2229,
                                                                         helpLinkUri: "http://msdn.microsoft.com/library/ms182343.aspx",
                                                                         customTags: WellKnownDiagnosticTags.Telemetry);
@@ -55,7 +55,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                         s_localizableMessageCA2237,
                                                                         DiagnosticCategory.Usage,
                                                                         DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                        isEnabledByDefault: true,
+                                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                         description: s_localizableDescriptionCA2237,
                                                                         helpLinkUri: "http://msdn.microsoft.com/library/ms182350.aspx",
                                                                         customTags: WellKnownDiagnosticTags.Telemetry);
@@ -81,7 +81,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                         s_localizableMessageCA2235,
                                                                         DiagnosticCategory.Usage,
                                                                         DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                        isEnabledByDefault: true,
+                                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                         description: s_localizableDescriptionCA2235,
                                                                         helpLinkUri: "http://msdn.microsoft.com/library/ms182349.aspx",
                                                                         customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetFramework.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              "{0}",
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: true,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182171.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.cs
@@ -30,7 +30,7 @@ namespace Roslyn.Diagnostics.Analyzers
             messageFormat: RoslynDiagnosticsAnalyzersResources.DeclarePublicApiMessage,
             category: "ApiDesign",
             defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: RoslynDiagnosticsAnalyzersResources.DeclarePublicApiDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -40,7 +40,7 @@ namespace Roslyn.Diagnostics.Analyzers
             messageFormat: RoslynDiagnosticsAnalyzersResources.RemoveDeletedApiMessage,
             category: "ApiDesign",
             defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             description: RoslynDiagnosticsAnalyzersResources.RemoveDeletedApiDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -50,7 +50,7 @@ namespace Roslyn.Diagnostics.Analyzers
             messageFormat: RoslynDiagnosticsAnalyzersResources.ExposedNoninstantiableTypeMessage,
             category: "ApiDesign",
             defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         internal static readonly DiagnosticDescriptor PublicApiFilesInvalid = new DiagnosticDescriptor(
@@ -59,7 +59,7 @@ namespace Roslyn.Diagnostics.Analyzers
             messageFormat: RoslynDiagnosticsAnalyzersResources.PublicApiFilesInvalidMessage,
             category: "ApiDesign",
             defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         internal static readonly DiagnosticDescriptor DuplicateSymbolInApiFiles = new DiagnosticDescriptor(
@@ -68,7 +68,7 @@ namespace Roslyn.Diagnostics.Analyzers
             messageFormat: RoslynDiagnosticsAnalyzersResources.DuplicateSymbolsInPublicApiFilesMessage,
             category: "ApiDesign",
             defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         internal static readonly DiagnosticDescriptor AvoidMultipleOverloadsWithOptionalParameters = new DiagnosticDescriptor(
@@ -77,7 +77,7 @@ namespace Roslyn.Diagnostics.Analyzers
             messageFormat: RoslynDiagnosticsAnalyzersResources.AvoidMultipleOverloadsWithOptionalParametersMessage,
             category: "ApiDesign",
             defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             helpLinkUri: @"https://github.com/dotnet/roslyn/blob/master/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md",
             customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -87,7 +87,7 @@ namespace Roslyn.Diagnostics.Analyzers
             messageFormat: RoslynDiagnosticsAnalyzersResources.OverloadWithOptionalParametersShouldHaveMostParametersMessage,
             category: "ApiDesign",
             defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             helpLinkUri: @"https://github.com/dotnet/roslyn/blob/master/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md",
             customTags: WellKnownDiagnosticTags.Telemetry);
 

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DoNotUseGenericCodeActionCreateToCreateCodeAction.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DoNotUseGenericCodeActionCreateToCreateCodeAction.cs
@@ -24,7 +24,7 @@ namespace Roslyn.Diagnostics.Analyzers
             s_localizableMessage,
             "Performance",
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DoNotUseCodeActionCreateRule);

--- a/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Roslyn.Diagnostics.Analyzers
             s_localizableMessageUseEmptyEnumerable,
             "Performance",
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         private static readonly LocalizableString s_localizableTitleUseSingletonEnumerable = new LocalizableResourceString(nameof(RoslynDiagnosticsAnalyzersResources.UseSpecializedCollectionsSingletonEnumerableTitle), RoslynDiagnosticsAnalyzersResources.ResourceManager, typeof(RoslynDiagnosticsAnalyzersResources));
@@ -40,7 +40,7 @@ namespace Roslyn.Diagnostics.Analyzers
             s_localizableMessageUseSingletonEnumerable,
             "Performance",
             DiagnosticHelpers.DefaultDiagnosticSeverity,
-            isEnabledByDefault: true,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(UseEmptyEnumerableRule, UseSingletonEnumerableRule);


### PR DESCRIPTION
…ing the FxCop Analyzers VSIX

The value of this flag is unchanged for local builds and NuGet package builds. We are only tweaking the values for FxCop analyzers VSIX to reduce the noise from these rules.