### PR TITLE
Add a missing trailing backslash for NuGetPackageRoot property.

### DIFF
--- a/build/Targets/Analyzers.Settings.targets
+++ b/build/Targets/Analyzers.Settings.targets
@@ -19,9 +19,9 @@
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot>
     <!-- Respect environment variable if set -->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and
-                                 '$(OS)' == 'Windows_NT'">$(UserProfile)\.nuget\packages</NuGetPackageRoot>
+                                 '$(OS)' == 'Windows_NT'">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and
-                                 '$(OS)' != 'Windows_NT'">$(HOME)\.nuget\packages</NuGetPackageRoot>
+                                 '$(OS)' != 'Windows_NT'">$(HOME)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
 
   <!-- Project language -->


### PR DESCRIPTION
This was causing https://github.com/dotnet/sdk/issues/1250