### PR TITLE
Fix AvoidZeroLengthArrayAllocationsAnalyzer (CA1825) to handle compil…

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -118,15 +118,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             }
 
             ISymbol targetSymbol;
-            var invocation = parent as IInvocationExpression;
-            if (invocation != null)
+            if (parent is IInvocationExpression invocation)
             {
                 targetSymbol = invocation.TargetMethod;
             }
             else
             {
-                var objectCreation = parent as IObjectCreationExpression;
-                if (objectCreation != null)
+                if (parent is IObjectCreationExpression objectCreation)
                 {
                     targetSymbol = objectCreation.Constructor;
                 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -117,18 +117,32 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return false;
             }
 
-            IMethodSymbol targetMethod;
+            ISymbol targetSymbol;
             var invocation = parent as IInvocationExpression;
             if (invocation != null)
             {
-                targetMethod = invocation.TargetMethod;
+                targetSymbol = invocation.TargetMethod;
             }
             else
             {
-                targetMethod = (parent as IObjectCreationExpression)?.Constructor;
+                var objectCreation = parent as IObjectCreationExpression;
+                if (objectCreation != null)
+                {
+                    targetSymbol = objectCreation.Constructor;
+                }
+                else
+                {
+                    targetSymbol = (parent as IIndexedPropertyReferenceExpression)?.Property;
+                }
             }
-            
-            if (targetMethod == null || targetMethod.Parameters.Length == 0 || !targetMethod.Parameters.Last().IsParams)
+
+            if (targetSymbol == null)
+            {
+                return false;
+            }
+
+            var parameters = targetSymbol.GetParameters();
+            if (parameters.Length == 0 || !parameters[parameters.Length - 1].IsParams)
             {
                 return false;
             }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -111,7 +111,6 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             var model = context.Compilation.GetSemanticModel(arrayCreationExpression.Syntax.SyntaxTree);
 
             // Compiler generated array creation seems to just use the syntax from the parent.
-            // Compiler generated array creation seems to just use the syntax from the parent.
             var parent = model.GetOperationInternal(arrayCreationExpression.Syntax, context.CancellationToken) as IHasArgumentsExpression;
             if (parent == null)
             {

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -256,7 +256,7 @@ Class C
     Private Sub F(ParamArray args As String())
     End Sub
 
-    Private Sub G()
+Private Sub G()
         F()     ' Compiler seems to generate a param array with size 0 for the invocation.
     End Sub
 End Class
@@ -267,6 +267,51 @@ End Class
             // Should we be flagging diagnostics on compiler generated code?
             // Should the analyzer even be invoked for compiler generated code?
             VerifyBasic(source + arrayEmptySource);
+        }
+
+        [WorkItem(1209, "https://github.com/dotnet/roslyn-analyzers/issues/1209")]
+        [Fact]
+        public void EmptyArrayCSharp_CompilerGeneratedArrayCreation()
+        {
+            const string arrayEmptySourceRaw = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System
+{
+	public class Array
+	{
+		public static T[] Empty<T>()
+		{
+			return null;
+		}
+	}
+}
+";
+            const string source = @"
+namespace N
+{
+    using Microsoft.CodeAnalysis;
+    class C
+    {
+	    public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            ""RuleId"",
+            ""Title"",
+            ""MessageFormat"",
+            ""Dummy"",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: ""Description"");
+    }
+}
+";
+
+            string arrayEmptySource = IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
+
+            // Should we be flagging diagnostics on compiler generated code?
+            // Should the analyzer even be invoked for compiler generated code?
+            VerifyCSharp(source + arrayEmptySource, addLanguageSpecificCodeAnalysisReference: true);
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -271,7 +271,7 @@ End Class
 
         [WorkItem(1209, "https://github.com/dotnet/roslyn-analyzers/issues/1209")]
         [Fact]
-        public void EmptyArrayCSharp_CompilerGeneratedArrayCreation()
+        public void EmptyArrayCSharp_CompilerGeneratedArrayCreationInObjectCreation()
         {
             const string arrayEmptySourceRaw = @"
 using System;
@@ -303,6 +303,44 @@ namespace N
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: ""Description"");
+    }
+}
+";
+
+            string arrayEmptySource = IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
+
+            // Should we be flagging diagnostics on compiler generated code?
+            // Should the analyzer even be invoked for compiler generated code?
+            VerifyCSharp(source + arrayEmptySource, addLanguageSpecificCodeAnalysisReference: true);
+        }
+        
+        [WorkItem(1209, "https://github.com/dotnet/roslyn-analyzers/issues/1209")]
+        [Fact]
+        public void EmptyArrayCSharp_CompilerGeneratedArrayCreationInIndexerAccess()
+        {
+            const string arrayEmptySourceRaw = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System
+{
+	public class Array
+	{
+		public static T[] Empty<T>()
+		{
+			return null;
+		}
+	}
+}
+";
+            const string source = @"
+public abstract class C
+{
+    protected abstract int this[int p1, params int[] p2] {get; set;}
+    public void M()
+    {
+        var x = this[0];
     }
 }
 ";


### PR DESCRIPTION
…er generated param array in object creation expression.

The temporary workaround in this analyzer to detect compiler generated param array only handled invocation expressions. This leads to false positives in object creation expressions with param array constructor.

Fixes #1209