### PR TITLE
Ca1801 false positives

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
@@ -59,8 +59,15 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 INamedTypeSymbol onDeserializedAttribute = WellKnownTypes.OnDeserializedAttribute(compilationStartContext.Compilation);
                 INamedTypeSymbol onSerializingAttribute = WellKnownTypes.OnSerializingAttribute(compilationStartContext.Compilation);
                 INamedTypeSymbol onSerializedAttribute = WellKnownTypes.OnSerializedAttribute(compilationStartContext.Compilation);
+                INamedTypeSymbol obsoleteAttribute = WellKnownTypes.ObsoleteAttribute(compilationStartContext.Compilation);
 
-                ImmutableHashSet<INamedTypeSymbol> attributeSetForMethodsToIgnore = ImmutableHashSet.Create(conditionalAttributeSymbol, onDeserializedAttribute, onDeserializingAttribute, onSerializedAttribute, onSerializingAttribute);
+                ImmutableHashSet<INamedTypeSymbol> attributeSetForMethodsToIgnore = ImmutableHashSet.Create(
+                    conditionalAttributeSymbol,
+                    onDeserializedAttribute,
+                    onDeserializingAttribute,
+                    onSerializedAttribute,
+                    onSerializingAttribute,
+                    obsoleteAttribute);
 
                 UnusedParameterDictionary unusedMethodParameters = new ConcurrentDictionary<IMethodSymbol, ISet<IParameterSymbol>>();
                 ISet<IMethodSymbol> methodsUsedAsDelegates = new HashSet<IMethodSymbol>();

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
             public void OperationBlockEndAction(OperationBlockAnalysisContext context)
             {
-                _finalUnusedParameters[_method] = _unusedParameters;
+                _finalUnusedParameters.Add(_method, _unusedParameters);
             }
 
             #endregion

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -514,6 +514,30 @@ End Class
 ");
         }
 
+        [Fact, WorkItem(1801, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
+        public void NoDiagnosticForObsoleteMethods()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C1
+{
+    [Obsolete]
+    public void ObsoleteMethod(object o1)
+    {
+    }
+}");
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C1
+    <Obsolete>
+    Public Sub ObsoleteMethod(o1 as Object)
+    End Sub
+End Class");
+        }
+
         #endregion
 
         #region Unit tests for analyzer diagnostic(s)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -420,7 +420,7 @@ End Class
 ");
         }
 
-        [Fact, WorkItem(1801, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
+        [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
         public void NoDiagnosticForMethodsUsedAsDelegatesCSharp()
         {
             VerifyCSharp(@"
@@ -472,7 +472,7 @@ public class C3
 }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19917"), WorkItem(1801, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19917"), WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
         public void NoDiagnosticForMethodsUsedAsDelegatesBasic()
         {
             VerifyBasic(@"
@@ -514,7 +514,7 @@ End Class
 ");
         }
 
-        [Fact, WorkItem(1801, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
+        [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
         public void NoDiagnosticForObsoleteMethods()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -420,6 +420,100 @@ End Class
 ");
         }
 
+        [Fact, WorkItem(1801, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
+        public void NoDiagnosticForMethodsUsedAsDelegatesCSharp()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C1
+{
+    private Action<object> _handler;
+
+    public void Handler(object o1)
+    {
+    }
+
+    public void SetupHandler()
+    {
+        _handler = Handler;
+    }
+}
+
+public class C2
+{
+    public void Handler(object o1)
+    {
+    }
+
+    public void TakesHandler(Action<object> handler)
+    {
+        handler(null);
+    }
+
+    public void SetupHandler()
+    {
+        TakesHandler(Handler);
+    }
+}
+
+public class C3
+{
+    private Action<object> _handler;
+
+    public C3()
+    {
+        _handler = Handler;
+    }
+
+    public void Handler(object o1)
+    {
+    }
+}");
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19917"), WorkItem(1801, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
+        public void NoDiagnosticForMethodsUsedAsDelegatesBasic()
+        {
+            VerifyBasic(@"
+Imports System
+Public Class C1
+    Private _handler As Action(Of Object)
+
+    Public Sub Handler(o As Object)
+    End Sub
+
+    Public Sub SetupHandler()
+        _handler = AddressOf Handler
+    End Sub
+End Class
+
+Module M2
+    Sub Handler(o As Object)
+    End Sub
+
+    Sub TakesHandler(handler As Action(Of Object))
+        handler(Nothing)
+    End Sub
+
+    Sub SetupHandler()
+        TakesHandler(AddressOf Handler)
+    End Sub
+End Module
+
+Class C3
+    Private _handler As Action(Of Object)
+
+    Sub New()
+        _handler = AddressOf Handler
+    End Sub
+
+    Sub Handler(o As Object)
+    End Sub
+End Class
+");
+        }
+
         #endregion
 
         #region Unit tests for analyzer diagnostic(s)


### PR DESCRIPTION
Makes CA1801 aware of methods that are used as delegates, and does not warn on unused variables for them. It also makes it aware of methods annotated with the `Obsolete` attribute.
VB delegate warning is currently blocked on https://github.com/dotnet/roslyn/issues/19917.
Tagging @mavasani @dotnet/roslyn-analysis for review.