### PR TITLE
Fix the VSIX break introduced from prior manifest change

### DIFF
--- a/src/Analyzer.Utilities/AbstractVersionCheckAnalyzer.cs
+++ b/src/Analyzer.Utilities/AbstractVersionCheckAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Analyzer.Utilities
                                                         s_localizableMessageFormat,
                                                         DiagnosticCategory.Reliability,
                                                         DiagnosticSeverity.Warning,
-                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                         description: s_localizableDescription);
 
         protected abstract string AnalyzerPackageName { get; }

--- a/src/FxCopAnalyzersSetup/FxCopAnalyzersSetup/source.extension.vsixmanifest
+++ b/src/FxCopAnalyzersSetup/FxCopAnalyzersSetup/source.extension.vsixmanifest
@@ -10,8 +10,8 @@
     <Tags>code analysis; roslyn; analyzer; analyzers; live; fxcop; code quality;</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.3,]" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.3,]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
We changed the minimum required VS version for FxCop analyzers VSIX from 15.0 to 15.3. However, the version of vsixinstaller.exe in Dev15.3 preview is still 15.0, and hence this blocks the VSIX installation. So, we are reverting this change.
Additionally, I also enabled our version check analyzer to be turned on by default for both VSIX and NuGet (currently it was on only for NuGet packages).