### PR TITLE
made roslyn analyzers not to use IsInvalid which will be removed soon.

### DIFF
--- a/src/Analyzer.Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/IOperationExtensions.cs
@@ -110,8 +110,23 @@ namespace Analyzer.Utilities.Extensions
                 return (double)constantValue.Value == comparand;
             }
 
-            return DiagnosticHelpers.TryConvertToUInt64(constantValue.Value, constantValueType.SpecialType, out ulong convertedValue) &&
-    convertedValue == comparand;
+            return DiagnosticHelpers.TryConvertToUInt64(constantValue.Value, constantValueType.SpecialType, out ulong convertedValue) && convertedValue == comparand;
+        }
+
+        /// <summary>
+        /// This will check context around the operation has any errors such as syntax or semantic errors
+        /// </summary>
+        public static bool IsInvalid(this IOperation operation, Compilation compilation, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // once we made sure every operation has Syntax, we will return this condition
+            if (operation.Syntax == null)
+            {
+                return true;
+            }
+
+            // if given compilation is wrong, we will throw null ref exception
+            var model = compilation.GetSemanticModel(operation.Syntax.SyntaxTree);
+            return model.GetDiagnostics(operation.Syntax.Span, cancellationToken).Any(d => d.Severity == DiagnosticSeverity.Error);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStrings.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             public void Analyze(OperationAnalysisContext context, ISymbol owningSymbol)
             {
-                if (context.Operation.IsInvalid)
+                if (context.Operation.IsInvalid(context.Compilation, context.CancellationToken))
                 {
                     // not interested in invalid expression
                     return;

--- a/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableArrayOnAnImmutableArrayValue.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableArrayOnAnImmutableArrayValue.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
                 compilationStartContext.RegisterOperationActionInternal(operationContext =>
                 {
                     var invocation = (IInvocationExpression)operationContext.Operation;
-                    if (invocation.IsInvalid ||
+                    if (invocation.IsInvalid(operationContext.Compilation, operationContext.CancellationToken) ||
                         invocation.TargetMethod?.Name != "ToImmutableArray")
                     {
                         return;

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/NormalizeStringsToUppercase.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/NormalizeStringsToUppercase.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Semantics;
@@ -79,7 +80,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 compilationStartContext.RegisterOperationActionInternal(operationAnalysisContext =>
                 {
-                    if (operationAnalysisContext.Operation.IsInvalid)
+                    if (operationAnalysisContext.Operation.IsInvalid(operationAnalysisContext.Compilation, operationAnalysisContext.CancellationToken))
                     {
                         return;
                     }

--- a/src/Microsoft.NetCore.Analyzers/Core/Tasks/DoNotCreateTasksWithoutPassingATaskScheduler.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Tasks/DoNotCreateTasksWithoutPassingATaskScheduler.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Semantics;
@@ -53,7 +54,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                 compilationContext.RegisterOperationActionInternal(operationContext =>
                 {
                     var invocation = (IInvocationExpression)operationContext.Operation;
-                    if (invocation.IsInvalid)
+                    if (invocation.IsInvalid(operationContext.Compilation, operationContext.CancellationToken))
                     {
                         return;
                     }


### PR DESCRIPTION
we are trying to remove IOperation.IsInvalid from IOperation interface. made roslyn analyzers not to rely on the obsolete API.