### PR TITLE
Disabled suppressions of 1801, 1804, and 1823

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -2,7 +2,7 @@
 Param(
   [string] $configuration = "Debug",
   [string] $solution = "",
-  [string] $verbosity = "normal",
+  [string] $verbosity = "minimal",
   [switch] $restore,
   [switch] $build,
   [switch] $test,

--- a/src/Analyzer.Utilities/Extensions/IEnumerableExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/IEnumerableExtensions.cs
@@ -71,9 +71,7 @@ namespace Analyzer.Utilities.Extensions
             return source.Where((Func<T, bool>)s_notNullTest);
         }
 
-#pragma warning disable CA1812
         private class ComparisonComparer<T> : Comparer<T>
-#pragma warning disable CA1812
         {
             private readonly Comparison<T> _compare;
 

--- a/src/Analyzers.ruleset
+++ b/src/Analyzers.ruleset
@@ -24,9 +24,4 @@
     <Rule Id="CA1305" Action="None" />
   </Rules>
 
-  <!-- TODO: Remove the below suppression once https://github.com/dotnet/roslyn/issues/8884 has been fixed. -->
-  <Rules AnalyzerId="Microsoft.Maintainability.Analyzers" RuleNamespace="Microsoft.Maintainability.Analyzers">
-    <!-- ReviewUnusedParameters -->
-    <Rule Id="CA1801" Action="None" />
-  </Rules>
 </RuleSet>

--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/FxCopAnalyzersPackage.cs
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/FxCopAnalyzersPackage.cs
@@ -7,9 +7,7 @@ using Microsoft.VisualStudio.Shell;
 namespace FxCopAnalyzersSetup
 {
     [Guid(PackageGuid)]
-#pragma warning disable CA1812
     class FxCopAnalyzersPackage : Package
-#pragma warning restore CA1812
     {
         private const string PackageGuid = "4A41D270-A97F-4639-A352-28732FC410E4";
     }

--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/FxCopAnalyzersPackage.cs
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/FxCopAnalyzersPackage.cs
@@ -11,8 +11,6 @@ namespace FxCopAnalyzersSetup
     class FxCopAnalyzersPackage : Package
 #pragma warning restore CA1812
     {
-#pragma warning disable CA1823 // False unused field diagnostic: https://github.com/dotnet/roslyn-analyzers/issues/1191
         private const string PackageGuid = "4A41D270-A97F-4639-A352-28732FC410E4";
-#pragma warning restore CA1823
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/VisualBasic/Helpers/SyntaxNodeHelper.vb
+++ b/src/Microsoft.NetFramework.Analyzers/VisualBasic/Helpers/SyntaxNodeHelper.vb
@@ -213,9 +213,7 @@ Namespace Microsoft.NetFramework.VisualBasic.Analyzers.Helpers
 
             ' CA1804: Remove unused locals
             ' TODO: Remove the below suppression once https://github.com/dotnet/roslyn-analyzers/issues/935 is fixed.
-#Disable Warning CA1804
             Dim initializer As ObjectMemberInitializerSyntax = CType(objectCreationNode.Initializer, ObjectMemberInitializerSyntax)
-#Enable Warning CA1804
             Return From fieldInitializer In initializer.Initializers
                    Where fieldInitializer.Kind() = SyntaxKind.NamedFieldInitializer
                    Select CType(fieldInitializer, NamedFieldInitializerSyntax)

--- a/src/Microsoft.NetFramework.Analyzers/VisualBasic/Helpers/SyntaxNodeHelper.vb
+++ b/src/Microsoft.NetFramework.Analyzers/VisualBasic/Helpers/SyntaxNodeHelper.vb
@@ -212,7 +212,6 @@ Namespace Microsoft.NetFramework.VisualBasic.Analyzers.Helpers
             End If
 
             ' CA1804: Remove unused locals
-            ' TODO: Remove the below suppression once https://github.com/dotnet/roslyn-analyzers/issues/935 is fixed.
             Dim initializer As ObjectMemberInitializerSyntax = CType(objectCreationNode.Initializer, ObjectMemberInitializerSyntax)
             Return From fieldInitializer In initializer.Initializers
                    Where fieldInitializer.Kind() = SyntaxKind.NamedFieldInitializer

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/BasicInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnostics.vb
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/BasicInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnostics.vb
@@ -38,8 +38,6 @@ Namespace Roslyn.Diagnostics.VisualBasic.Analyzers
                 }.ToImmutableDictionary()
 
         ' CA1823: AvoidUnusedPrivateFieldsAnalyzer 
-        ' TODO: Remove the below suppression once https://github.com/dotnet/roslyn-analyzers/issues/933 is fixed.
-#Disable Warning CA1823
         Private Const s_baseTypeString = "BaseType"
         Private Const s_interfacesString = "Interfaces"
         Private Const s_allInterfacesString = "AllInterfaces"
@@ -49,7 +47,6 @@ Namespace Roslyn.Diagnostics.VisualBasic.Analyzers
         Private Const s_typeSymbolFullyQualifiedName = "Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol"
         Private Const s_namedTypeSymbolFullyQualifiedName = "Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol"
         Private Const s_typeParameterSymbolFullyQualifiedName = "Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeParameterSymbol"
-#Enable Warning CA1823
 
         Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
             Get


### PR DESCRIPTION
The underlying IOp issues have been fixed. Fixes #1103, #933, and #935. Tagging @dotnet/roslyn-analysis for review.