### PR TITLE
Copy test runner configuration json

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,9 +7,14 @@
     <!-- TODO: Remove suppressions of Xunit warnings: https://github.com/dotnet/roslyn-analyzers/issues/1257 -->
     <NoWarn>$(NoWarn);xUnit1004;xUnit2000;xUnit2003;xUnit2004;xUnit2009;xUnit2010;xUnit1013</NoWarn>
     
-    <XUnitConfigurationFile>Default</XUnitConfigurationFile>
-
     <DefineConstants Condition="'$(USE_INTERNAL_IOPERATION_APIS)' == 'true'">$(DefineConstants),USE_INTERNAL_IOPERATION_APIS,DEFAULT_SEVERITY_SUGGESTION</DefineConstants>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Analyzers.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+
+  <!-- Test runner configuration -->
+  <ItemGroup>
+    <None Include="$(MSBuildProjectName).xunit.runner.json" Condition="'$(IsUnitTestProject)' == 'true'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Previous RepoToolset change broke test runs in microbuild. Avoid using ```<XUnitConfigurationFile>``` for now.