### PR TITLE
RepoToolset v28 and misc infra improvements

### DIFF
--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -6,6 +6,8 @@
       "values": [
         "bin/Analyzer.Utilities/netstandard1.3/Analyzer.Utilities.dll",
         "bin/Analyzer.Utilities/netstandard1.3/*/Analyzer.Utilities.resources.dll",
+        "bin/MetaCompilation.Analyzers/netstandard1.3/MetaCompilation.Analyzers.dll",
+        "bin/MetaCompilation.Analyzers/netstandard1.3/*/MetaCompilation.Analyzers.resources.dll",
         "bin/Microsoft.CodeAnalysis.Analyzers/netstandard1.3/Microsoft.CodeAnalysis.Analyzers.dll",
         "bin/Microsoft.CodeAnalysis.Analyzers/netstandard1.3/*/Microsoft.CodeAnalysis.Analyzers.resources.dll",
         "bin/Microsoft.CodeAnalysis.CSharp.Analyzers/netstandard1.3/Microsoft.CodeAnalysis.CSharp.Analyzers.dll",

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -7,7 +7,7 @@
     <UsingToolVSSDK>true</UsingToolVSSDK>
 
     <!-- Toolset -->
-    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha27</RoslynToolsMicrosoftRepoToolsetVersion>
+    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha28</RoslynToolsMicrosoftRepoToolsetVersion>
     <VSWhereVersion>1.0.47</VSWhereVersion>
     <MicrosoftVSSDKVersion>15.0.26201-alpha</MicrosoftVSSDKVersion>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <!-- TODO: Remove suppressions of Xunit warnings: https://github.com/dotnet/roslyn-analyzers/issues/1257 -->
     <NoWarn>$(NoWarn);xUnit1004;xUnit2000;xUnit2003;xUnit2004;xUnit2009;xUnit2010;xUnit1013</NoWarn>
-    
+
     <DefineConstants Condition="'$(USE_INTERNAL_IOPERATION_APIS)' == 'true'">$(DefineConstants),USE_INTERNAL_IOPERATION_APIS,DEFAULT_SEVERITY_SUGGESTION</DefineConstants>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Analyzers.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.cs.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.cs.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.de.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.de.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.es.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.es.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.fr.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.fr.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.it.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.it.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.ja.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.ja.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.ko.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.ko.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.pl.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.pl.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.pt-BR.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.pt-BR.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.ru.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.ru.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.tr.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.tr.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.zh-Hans.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.zh-Hans.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.zh-Hant.xlf
+++ b/src/MetaCompilation.Analyzers/Core/xlf/MetaCompilationResources.zh-Hant.xlf
@@ -5,15 +5,18 @@
       <trans-unit id="AnalyzerDescription">
         <source>Type names should be all uppercase.</source>
         <target state="new">Type names should be all uppercase.</target>
-        <note>An optional longer localizable description of the diagnostic.</note>An optional longer localizable description of the diagnostic.</trans-unit>
+        <note>An optional longer localizable description of the diagnostic.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerMessageFormat">
         <source>Type name '{0}' contains lowercase letters</source>
         <target state="new">Type name '{0}' contains lowercase letters</target>
-        <note>The format-able message the diagnostic displays.</note>The format-able message the diagnostic displays.</trans-unit>
+        <note>The format-able message the diagnostic displays.</note>
+      </trans-unit>
       <trans-unit id="AnalyzerTitle">
         <source>Type name contains lowercase letters</source>
         <target state="new">Type name contains lowercase letters</target>
-        <note>The title of the diagnostic.</note>The title of the diagnostic.</trans-unit>
+        <note>The title of the diagnostic.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MetaCompilation.Analyzers/UnitTests/MetaCompilation.Analyzers.UnitTests.xunit.runner.json
+++ b/src/MetaCompilation.Analyzers/UnitTests/MetaCompilation.Analyzers.UnitTests.xunit.runner.json
@@ -1,3 +1,0 @@
-{
-  "shadowCopy": false
-}

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/Microsoft.CodeAnalysis.Analyzers.UnitTests.xunit.runner.json
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/Microsoft.CodeAnalysis.Analyzers.UnitTests.xunit.runner.json
@@ -1,3 +1,0 @@
-{
-  "shadowCopy": false
-}

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Microsoft.CodeQuality.Analyzers.UnitTests.xunit.runner.json
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Microsoft.CodeQuality.Analyzers.UnitTests.xunit.runner.json
@@ -1,3 +1,0 @@
-{
-  "shadowCopy": false
-}

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Microsoft.NetCore.Analyzers.UnitTests.xunit.runner.json
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Microsoft.NetCore.Analyzers.UnitTests.xunit.runner.json
@@ -1,3 +1,0 @@
-{
-  "shadowCopy": false
-}

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.cs.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.cs.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.de.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.de.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.es.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.es.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.fr.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.fr.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.it.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.it.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.ja.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.ja.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.ko.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.ko.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.pl.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.pl.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.pt-BR.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.ru.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.ru.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.tr.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.tr.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.zh-Hans.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftNetFrameworkAnalyzersResources.zh-Hant.xlf
@@ -415,103 +415,128 @@
       <trans-unit id="DoNotUseInsecureDtdProcessingDescription">
         <source>Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </source>
         <target state="new">Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null. </target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloadsMessage">
         <source>Unsafe overload of '{0}' method</source>
         <target state="new">Unsafe overload of '{0}' method</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseDtdProcessingOverloads">
         <source>Insecure DTD Processing</source>
         <target state="new">Insecure DTD Processing</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseSetInnerXmlMessage">
         <source>Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</source>
         <target state="new">Uses the unsafe setter of InnerXml property of System.Xml.XmlDocument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureXmlDtdProcessing">
         <source>Insecure DTD processing in XML</source>
         <target state="new">Insecure DTD processing in XML</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="ReviewDtdProcessingPropertiesMessage">
         <source>Property in {0} might be set from an untrusted source.</source>
         <target state="new">Property in {0} might be set from an untrusted source.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentWithNoSecureResolverMessage">
         <source>An XmlDocument instance is created without setting its XmlResolver property to a secure value.</source>
         <target state="new">An XmlDocument instance is created without setting its XmlResolver property to a secure value.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureConstructedMessage">
         <source>An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">An insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateInsecureInputMessage">
         <source>A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</source>
         <target state="new">A potentially insecure XmlReaderSettings instance is provided to XmlReader.Create method.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlReaderCreateWrongOverloadMessage">
         <source>An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</source>
         <target state="new">An insecure overload of XmlReader.Create which does not accept an XmlReaderSettings argument.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderConstructedWithNoSecureResolutionMessage">
         <source>XmlTextReader instance created with insecure default settings.</source>
         <target state="new">XmlTextReader instance created with insecure default settings.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderSetInsecureResolutionMessage">
         <source>XmlTextReader instance is set with insecure values.</source>
         <target state="new">XmlTextReader instance is set with insecure values.</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingGenericMessage">
         <source>{0}</source>
         <target state="new">{0}</target>
-        <note>CA3075</note>CA3075</trans-unit>
+        <note>CA3075</note>
+      </trans-unit>
       <trans-unit id="InsecureDtdProcessingInApiDesign">
         <source>Insecure Processing in API Design, XmlDocument and XmlTextReader</source>
         <target state="new">Insecure Processing in API Design, XmlDocument and XmlTextReader</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureDtdProcessingInApiDesignDescription">
         <source>Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </source>
         <target state="new">Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. </target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassConstructorNoSecureXmlResolverMessage">
         <source>Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</source>
         <target state="new">Constructor of XmlDocument derived class {0} implicitly uses insecure default value for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassNoConstructorMessage">
         <source>XmlDocument derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlDocument derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlDocumentDerivedClassSetInsecureXmlResolverInMethodMessage">
         <source>Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</source>
         <target state="new">Method {0} of XmlDocument derived class sets XmlResolver property to an insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassConstructorNoSecureSettingsMessage">
         <source>Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</source>
         <target state="new">Constructor of XmlTextReader derived class {0} uses insecure default values for DTD processing.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassNoConstructorMessage">
         <source>XmlTextReader derived class {0} doesn't explictily define a constructor.</source>
         <target state="new">XmlTextReader derived class {0} doesn't explictily define a constructor.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="XmlTextReaderDerivedClassSetInsecureSettingsInMethodMessage">
         <source>{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</source>
         <target state="new">{0} method of XmlTextReader derived class sets XmlResolver and/or DtdProcessing property to insecure value.</target>
-        <note>CA3077</note>CA3077</trans-unit>
+        <note>CA3077</note>
+      </trans-unit>
       <trans-unit id="InsecureXsltScriptProcessingMessage">
         <source>Insecure XSLT script processing.</source>
         <target state="new">Insecure XSLT script processing.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="DoNotUseInsecureXSLTScriptExecutionDescription">
         <source>Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</source>
         <target state="new">Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argurment with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureConstructedMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
       <trans-unit id="XslCompiledTransformLoadInsecureInputMessage">
         <source>In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</source>
         <target state="new">In {0} an insecure combination of XsltSettings and XmlResolver instances are provided to XslCompiledTransfor.Load as arguments.</target>
-        <note>CA3076</note>CA3076</trans-unit>
+        <note>CA3076</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/Microsoft.NetFramework.Analyzers.UnitTests.xunit.runner.json
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/Microsoft.NetFramework.Analyzers.UnitTests.xunit.runner.json
@@ -1,3 +1,0 @@
-{
-  "shadowCopy": false
-}

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/Roslyn.Diagnostics.Analyzers.UnitTests.xunit.runner.json
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/Roslyn.Diagnostics.Analyzers.UnitTests.xunit.runner.json
@@ -1,3 +1,0 @@
-{
-  "shadowCopy": false
-}

--- a/src/Text.Analyzers/UnitTests/Text.Analyzers.UnitTests.xunit.runner.json
+++ b/src/Text.Analyzers/UnitTests/Text.Analyzers.UnitTests.xunit.runner.json
@@ -1,3 +1,0 @@
-{
-  "shadowCopy": false
-}


### PR DESCRIPTION
Sign meta-analyzers - we don't ship them but we produce nupkg and VSIX for them. Everything we publish to should be signed.

Delete xunit.runner.json files - not needed anymore, the toolset passes -noshadow flag to desktop xunit runner directly.

Upgrade to toolset v28, which fixes signing issue that broke microbuild and comes with a new version of xliff build task that corrects generated xml.

Kill msbuild and vbcscompiler processes at the end of CI run to avoid access violation in the next run.