### PR TITLE
Change IsInvalid to use only syntax diagnostics

### DIFF
--- a/src/Analyzer.Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/IOperationExtensions.cs
@@ -126,7 +126,7 @@ namespace Analyzer.Utilities.Extensions
 
             // if given compilation is wrong, we will throw null ref exception
             var model = compilation.GetSemanticModel(operation.Syntax.SyntaxTree);
-            return model.GetDiagnostics(operation.Syntax.Span, cancellationToken).Any(d => d.Severity == DiagnosticSeverity.Error);
+            return model.GetSyntaxDiagnostics(operation.Syntax.Span, cancellationToken).Any(d => d.Severity == DiagnosticSeverity.Error);
         }
     }
 }


### PR DESCRIPTION
Computing semantic diagnostics is causing a large perf regression. Until we can figure out a performant implementation, we will just use syntax errors to determine if the operation is invalid.