### PR TITLE
Disable a bunch of analyzers in the FxCop analyzers VSIX that were no…

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotHideBaseClassMethods.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182143.aspx",
             customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
@@ -56,7 +56,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              helpLinkUri: helpLinkUri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(PropertyGetterRule, HasAllowedExceptionsRule, NoAllowedExceptionsRule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ?
+            ImmutableArray.Create(PropertyGetterRule, HasAllowedExceptionsRule, NoAllowedExceptionsRule) :
+            ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
@@ -118,7 +118,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              helpLinkUri: HelpLinkUri,
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(IDisposableReimplementationRule, FinalizeOverrideRule, DisposeOverrideRule, DisposeSignatureRule, RenameDisposeRule, DisposeBoolSignatureRule, DisposeImplementationRule, FinalizeImplementationRule, ProvideDisposeBoolRule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ?
+            ImmutableArray.Create(IDisposableReimplementationRule, FinalizeOverrideRule, DisposeOverrideRule, DisposeSignatureRule, RenameDisposeRule, DisposeBoolSignatureRule, DisposeImplementationRule, FinalizeImplementationRule, ProvideDisposeBoolRule) :
+            ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                           helpLinkUri: "https://msdn.microsoft.com/library/ms182153.aspx",
                                                                           customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public sealed override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithAttributesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithAttributesDiagnosticAnalyzer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182156.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(CA1016Rule, CA1014Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(CA1016Rule, CA1014Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MovePInvokesToNativeMethodsClass.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MovePInvokesToNativeMethodsClass.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private const string SafeNativeMethodsText = "SafeNativeMethods";
         private const string UnsafeNativeMethodsText = "UnsafeNativeMethods";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182359.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -34,10 +34,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            if (!DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX)
-            {
-            }
-
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -30,10 +30,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182172.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {
+            if (!DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX)
+            {
+            }
+
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotCallOverridableMethodsInConstructors.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotCallOverridableMethodsInConstructors.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182331.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/RethrowToPreserveStackDetails.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/RethrowToPreserveStackDetails.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182363.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         protected static Diagnostic CreateDiagnostic(SyntaxNode node)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/InteropServices/PInvokeDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/InteropServices/PInvokeDiagnosticAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                                          helpLinkUri: "http://msdn.microsoft.com/library/ms182319.aspx",
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RuleCA1401, RuleCA2101);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(RuleCA1401, RuleCA2101) : ImmutableArray.Create(RuleCA2101);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableTypesShouldDeclareFinalizer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableTypesShouldDeclareFinalizer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182329.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                          description: s_localizableDescription,
                                                                          customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/InitializeStaticFieldsInline.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/InitializeStaticFieldsInline.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182346.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(CA1810Rule, CA2207Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(CA1810Rule, CA2207Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         protected abstract bool InitialiesStaticField(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken);
         protected abstract TLanguageKindEnum AssignmentNodeKind { get; }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              helpLinkUri: @"https://msdn.microsoft.com/en-us/library/ms182361.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/bb264491.aspx",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         private readonly BinaryOperationKind[] _comparisonOperators = new[]
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/ImplementISerializableCorrectly.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/ImplementISerializableCorrectly.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              helpLinkUri: null,     // TODO: add MSDN url
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DefaultRule, MakeVisibleRule, MakeOverridableRule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(DefaultRule, MakeVisibleRule, MakeOverridableRule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/ImplementSerializationMethodsCorrectly.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/ImplementSerializationMethodsCorrectly.cs
@@ -69,7 +69,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              helpLinkUri: null,     // TODO: add MSDN url
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(VisibilityRule, ReturnTypeRule, ParametersRule, GenericRule, StaticRule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(VisibilityRule, ReturnTypeRule, ParametersRule, GenericRule, StaticRule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationDiagnosticAnalyzer.cs
@@ -86,7 +86,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                         helpLinkUri: "http://msdn.microsoft.com/library/ms182349.aspx",
                                                                         customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RuleCA2229, RuleCA2235, RuleCA2237);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(RuleCA2229, RuleCA2235, RuleCA2237) : ImmutableArray.Create(RuleCA2229, RuleCA2237);
 
         public override void Initialize(AnalysisContext analysisContext)
         {


### PR DESCRIPTION
…t intended to be enabled by default, but got turned on by the default ManagedMinimumRecommended ruleset that ships with FxCop.

This implements @sharwell's proposal from today's meeting.

Tagging @kuhlenh @jinujoseph @heejaechang for review 

**Disabled Rules** 

CA1061: Do not hide base class methods
CA1065: Do not raise exceptions in unexpected locations
CA1063: Implement IDisposable Correctly
CA1033: Interface methods should be callable by child types
CA1016: Mark assemblies with assembly version 
CA1014: Mark assemblies with CLSCompliant
CA1060: Move pinvokes to native methods class
CA2231: Overload operator equals on overriding value type Equals
CA2235 : Mark all non-serializable fields
CA2238 :Implement serialization methods correctly
CA2240 : Implement ISerializable correctly
CA2242: Test for NaN correctly
CA2241: Provide correct arguments to formatting methods
CA1810: Initialize reference type static fields inline
CA2207: Initialize value type static fields inline
CA2216: Disposable types should declare finalizer
CA2200: Rethrow to preserve stack details.
CA2214: Do not call overridable methods in constructors 
CA1001: Types that own disposable fields should be disposable