### PR TITLE
Skip tests for disabled analyzers

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/UnitTests/InteropServices/PInvokeDiagnosticAnalyzerTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/InteropServices/PInvokeDiagnosticAnalyzerTests.cs
@@ -45,6 +45,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
 
         #endregion
 
+#if !USE_INTERNAL_IOPERATION_APIS
         #region CA1401 tests 
 
         [Fact]
@@ -256,6 +257,7 @@ End Class
         }
 
         #endregion
+#endif
 
         #region CA2101 tests 
 

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.Fixer.cs
@@ -33,6 +33,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             return new CSharpMarkAllNonSerializableFieldsFixer();
         }
 
+#if !USE_INTERNAL_IOPERATION_APIS
         #region CA2235
 
         [Fact]
@@ -238,5 +239,6 @@ codeFixIndex: 1);
         }
 
         #endregion
+#endif
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             return new SerializationRulesDiagnosticAnalyzer();
         }
 
+#if !USE_INTERNAL_IOPERATION_APIS
         [WorkItem(858655, "DevDiv")]
         #region CA2235
 
@@ -394,5 +395,6 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             return GetBasicResultAt(line, column, SerializationRulesDiagnosticAnalyzer.RuleCA2235Id, string.Format(CA2235Message, fieldName, containerName, typeName));
         }
         #endregion
+#endif
     }
 }

--- a/src/Test/Utilities/CodeFixTestBase.cs
+++ b/src/Test/Utilities/CodeFixTestBase.cs
@@ -87,6 +87,12 @@ namespace Test.Utilities
             var compilerDiagnostics = document.GetSemanticModelAsync().Result.GetDiagnostics();
             var fixableDiagnostics = getFixableDiagnostics(analyzerDiagnostics.Concat(compilerDiagnostics));
 
+            if (fixableDiagnostics.IsDefaultOrEmpty && analyzerOpt != null && analyzerOpt.SupportedDiagnostics.Length == 0)
+            {
+                // Not implemented analyzer
+                return;
+            }
+
             var diagnosticIndexToFix = 0;
             while (diagnosticIndexToFix < fixableDiagnostics.Length)
             {

--- a/src/Test/Utilities/DiagnosticAnalyzerTests.Extensions.cs
+++ b/src/Test/Utilities/DiagnosticAnalyzerTests.Extensions.cs
@@ -20,6 +20,12 @@ namespace Test.Utilities
             string expectedDiagnosticsAssertionTemplate,
             params DiagnosticResult[] expectedResults)
         {
+            if (analyzer != null && analyzer.SupportedDiagnostics.Length == 0)
+            {
+                // Not implemented analyzer
+                return;
+            }
+
             int expectedCount = expectedResults.Count();
             int actualCount = actualResults.Count();
 


### PR DESCRIPTION
Skip tests for analyzers returning no supported diagnostics and also for couple of analyzers that have rules enabled only for NuGet build. This is basically a falloff from https://github.com/dotnet/roslyn-analyzers/pull/1276.