### PR TITLE
Disable CA2242 until it can be switched to the new IOperation API

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     /// <summary>
     /// CA2242: Test for NaN correctly
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    // [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)] - See https://github.com/dotnet/roslyn/issues/21448
     public sealed class TestForNaNCorrectlyAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA2242";


### PR DESCRIPTION
Fixing and re-enabling tracked by https://github.com/dotnet/roslyn/issues/21448