### PR TITLE
Fix many code fix tests failing when git clone changes newlines

### DIFF
--- a/src/MetaCompilation.Analyzers/UnitTests/Verifiers/CodeFixVerifier.cs
+++ b/src/MetaCompilation.Analyzers/UnitTests/Verifiers/CodeFixVerifier.cs
@@ -124,7 +124,7 @@ namespace MetaCompilation.Analyzers.UnitTests
 
             //after applying all of the code fixes, compare the resulting string to the inputted one
             string actual = GetStringFromDocument(document);
-            Assert.Equal(newSource, actual);
+            Assert.Equal(newSource.Replace("\r\n", "\n"), actual.Replace("\r\n", "\n"));
         }
     }
 }

--- a/src/Test.Utilities/CodeFixTestBase.cs
+++ b/src/Test.Utilities/CodeFixTestBase.cs
@@ -143,7 +143,7 @@ namespace Test.Utilities
             }
 
             var actualText = GetActualTextForNewDocument(document, newSourceFileName);
-            Assert.Equal(newSource, actualText.ToString());
+            Assert.Equal(newSource.Replace("\r\n", "\n"), actualText.ToString().Replace("\r\n", "\n"));
         }
 
         private sealed class DiagnosticComparer : IEqualityComparer<Diagnostic>

--- a/src/Unfactored/AsyncPackage/AsyncPackage.Test/CodeFixVerifier.cs
+++ b/src/Unfactored/AsyncPackage/AsyncPackage.Test/CodeFixVerifier.cs
@@ -123,7 +123,7 @@ namespace TestTemplate
 
             // After applying all of the code fixes, compare the resulting string to the inputted one
             var actual = GetStringFromDocument(document);
-            Assert.Equal(newSource, actual);
+            Assert.Equal(newSource.Replace("\r\n", "\n"), actual.Replace("\r\n", "\n"));
         }
     }
 }

--- a/tools/AnalyzerCodeGenerator/template/src/Test/Utilities/CodeFixTestBase.cs
+++ b/tools/AnalyzerCodeGenerator/template/src/Test/Utilities/CodeFixTestBase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var root = newDocument.GetSyntaxRootAsync().Result;
             root = Formatter.Format(root, Formatter.Annotation, newDocument.Project.Solution.Workspace);
             var actual = root.GetText().ToString();
-            Assert.Equal(newSource, actual);
+            Assert.Equal(newSource.Replace("\r\n", "\n"), actual.Replace("\r\n", "\n"));
         }
 
         private static IEnumerable<Diagnostic> GetNewDiagnostics(IEnumerable<Diagnostic> diagnostics, IEnumerable<Diagnostic> newDiagnostics)


### PR DESCRIPTION
When I `git cloned` this repo and ran the tests, nearly every one related to code fixes failed. It's likely due to `git` changing the line endings because all of the error messages looked like this:

```
Fixer.cs:line 215
[xUnit.net 00:00:05.0215300]     Microsoft.NetCore.Analyzers.Runtime.UnitTests.TestForNaNCorrectlyFixerTests.CA2242_FixForComparisonWithNaNOnLeft [FAIL]
[xUnit.net 00:00:05.0217452]       Assert.Equal() Failure
[xUnit.net 00:00:05.0218238]                                         Γåô (pos 99)
[xUnit.net 00:00:05.0218815]       Expected: ┬╖┬╖┬╖urn Single.IsNaN(s\n)\n    End Function\nEnd Class\n
[xUnit.net 00:00:05.0219404]       Actual:   ┬╖┬╖┬╖urn Single.IsNaN(s\n)\r\n    End Function\nEnd Class\n
[xUnit.net 00:00:05.0219982]                                         Γåæ (pos 99)
```

Replacing `\r\n` with `\n` in all the asserts for the code fix providers fixes this problem.