### PR TITLE
Add analyzer for TypeArguments and other C# properties to avoid

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnostics.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnostics.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Diagnostics.Analyzers;
+
+namespace Roslyn.Diagnostics.CSharp.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CSharpInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly LocalizableString s_localizableTitle =
+            new LocalizableResourceString(nameof(RoslynDiagnosticsAnalyzersResources.InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTitle),
+                RoslynDiagnosticsAnalyzersResources.ResourceManager, typeof(RoslynDiagnosticsAnalyzersResources));
+
+        private static readonly LocalizableString s_localizableMessage =
+            new LocalizableResourceString(nameof(RoslynDiagnosticsAnalyzersResources.InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsMessage),
+                RoslynDiagnosticsAnalyzersResources.ResourceManager, typeof(RoslynDiagnosticsAnalyzersResources));
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            RoslynDiagnosticIds.UseSiteDiagnosticsCheckerRuleId,
+            s_localizableTitle,
+            s_localizableMessage,
+            "Usage",
+            DiagnosticSeverity.Error,
+            false,
+            null,
+            null,
+            WellKnownDiagnosticTags.Telemetry);
+
+        private static readonly ImmutableDictionary<string, string> s_propertiesToValidateMap =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { s_baseTypeString, s_typeSymbolFullyQualifiedName},
+                { s_interfacesString, s_typeSymbolFullyQualifiedName},
+                { s_allInterfacesString, s_typeSymbolFullyQualifiedName},
+                { s_typeArgumentsString, s_namedTypeSymbolFullyQualifiedName},
+                { s_constraintTypesString, s_typeParameterSymbolFullyQualifiedName}
+            }.ToImmutableDictionary();
+
+        private const string s_baseTypeString = "BaseType";
+        private const string s_interfacesString = "Interfaces";
+        private const string s_allInterfacesString = "AllInterfaces";
+        private const string s_typeArgumentsString = "TypeArguments";
+        private const string s_constraintTypesString = "ConstraintTypes";
+
+        private const string s_typeSymbolFullyQualifiedName = "Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol";
+        private const string s_namedTypeSymbolFullyQualifiedName = "Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol";
+        private const string s_typeParameterSymbolFullyQualifiedName = "Microsoft.CodeAnalysis.CSharp.Symbols.TypeParameterSymbol";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.SimpleMemberAccessExpression);
+        }
+
+        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var name = ((MemberAccessExpressionSyntax)context.Node).Name;
+
+            if (name.Kind() == SyntaxKind.IdentifierName)
+            {
+                var identifier = (IdentifierNameSyntax)name;
+                string containingTypeName = null;
+                if (s_propertiesToValidateMap.TryGetValue(identifier.ToString(), out containingTypeName))
+                {
+                    ISymbol sym = context.SemanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol;
+                    if (sym != null && sym.Kind == SymbolKind.Property)
+                    {
+                        if (containingTypeName == sym.ContainingType.ToDisplayString())
+                        {
+                            context.ReportDiagnostic(identifier.CreateDiagnostic(Rule, identifier.ToString()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/Roslyn.Diagnostics.CSharp.Analyzers.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/Roslyn.Diagnostics.CSharp.Analyzers.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="CSharpInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnostics.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Core\Roslyn.Diagnostics.Analyzers.csproj" />
+    <InternalsVisibleTo Include="Roslyn.Diagnostics.Analyzers.UnitTests" />
   </ItemGroup>
 </Project>

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Diagnostics.CSharp.Analyzers;
 using Roslyn.Diagnostics.VisualBasic.Analyzers;
 using Test.Utilities;
 using Xunit;
@@ -16,11 +17,11 @@ namespace Roslyn.Diagnostics.Analyzers.UnitTests
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return null;
+            return new CSharpInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsAnalyzer();
         }
 
         [Fact]
-        public void TestTypeArgumentsInVB()
+        public void TestTypeArgumentsInBasic()
         {
             var source = @"
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
@@ -42,6 +43,38 @@ End Class
 ";
 
             VerifyBasic(source, GetRS0004BasicResultAt(14, 19));
+        }
+
+        [Fact]
+        public void TestTypeArgumentsInCSharp()
+        {
+            var source = @"
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    public class NamedTypeSymbol
+    {
+        public int TypeArguments
+        {
+            get => 1;
+        }
+    }
+}
+class C
+{
+    void M(Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol c)
+    {
+        var x = c.TypeArguments;
+        System.Console.Write(x);
+    }
+}
+";
+
+            VerifyCSharp(source, GetRS0004CSharpResultAt(16, 19));
+        }
+
+        private static DiagnosticResult GetRS0004CSharpResultAt(int line, int column, params string[] args)
+        {
+            return GetCSharpResultAt(line, column, CSharpInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsAnalyzer.Rule, args);
         }
 
         private static DiagnosticResult GetRS0004BasicResultAt(int line, int column, params string[] args)

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTests.cs
@@ -3,6 +3,7 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Diagnostics.VisualBasic.Analyzers;
 using Test.Utilities;
+using Xunit;
 
 namespace Roslyn.Diagnostics.Analyzers.UnitTests
 {
@@ -16,6 +17,36 @@ namespace Roslyn.Diagnostics.Analyzers.UnitTests
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return null;
+        }
+
+        [Fact]
+        public void TestTypeArgumentsInVB()
+        {
+            var source = @"
+Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
+    Public Class NamedTypeSymbol
+        Public ReadOnly Property TypeArguments As Integer
+            Get
+                Return 1
+            End Get
+        End Property
+    End Class
+End Namespace
+
+Class C
+    Sub M(c As Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol)
+        Dim x = c.TypeArguments
+        System.Console.Write(x)
+    End Sub
+End Class
+";
+
+            VerifyBasic(source, GetRS0004BasicResultAt(14, 19));
+        }
+
+        private static DiagnosticResult GetRS0004BasicResultAt(int line, int column, params string[] args)
+        {
+            return GetBasicResultAt(line, column, BasicInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsAnalyzer.Rule, args);
         }
     }
 }

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/BasicInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnostics.vb
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/BasicInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnostics.vb
@@ -1,7 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections.Generic
 Imports System.Collections.Immutable
 Imports Analyzer.Utilities.Extensions
 Imports Microsoft.CodeAnalysis

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/BasicInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnostics.vb
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/BasicInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnostics.vb
@@ -18,7 +18,7 @@ Namespace Roslyn.Diagnostics.VisualBasic.Analyzers
         Private Shared ReadOnly s_localizableTitle As LocalizableString = New LocalizableResourceString(NameOf(RoslynDiagnosticsAnalyzersResources.InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTitle), RoslynDiagnosticsAnalyzersResources.ResourceManager, GetType(RoslynDiagnosticsAnalyzersResources))
         Private Shared ReadOnly s_localizableMessage As LocalizableString = New LocalizableResourceString(NameOf(RoslynDiagnosticsAnalyzersResources.InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsMessage), RoslynDiagnosticsAnalyzersResources.ResourceManager, GetType(RoslynDiagnosticsAnalyzersResources))
 
-        Private Shared ReadOnly s_descriptor As DiagnosticDescriptor = New DiagnosticDescriptor(RoslynDiagnosticIds.UseSiteDiagnosticsCheckerRuleId,
+        Friend Shared ReadOnly Rule As DiagnosticDescriptor = New DiagnosticDescriptor(RoslynDiagnosticIds.UseSiteDiagnosticsCheckerRuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessage,
                                                                              "Usage",
@@ -50,7 +50,7 @@ Namespace Roslyn.Diagnostics.VisualBasic.Analyzers
 
         Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
             Get
-                Return ImmutableArray.Create(s_descriptor)
+                Return ImmutableArray.Create(Rule)
             End Get
         End Property
 
@@ -70,7 +70,7 @@ Namespace Roslyn.Diagnostics.VisualBasic.Analyzers
                     Dim sym As ISymbol = context.SemanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol
                     If sym IsNot Nothing AndAlso sym.Kind = SymbolKind.Property Then
                         If containingTypeName = sym.ContainingType.ToDisplayString() Then
-                            context.ReportDiagnostic(identifier.CreateDiagnostic(s_descriptor, identifier.ToString()))
+                            context.ReportDiagnostic(identifier.CreateDiagnostic(Rule, identifier.ToString()))
                         End If
                     End If
                 End If

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/Roslyn.Diagnostics.VisualBasic.Analyzers.vbproj
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/Roslyn.Diagnostics.VisualBasic.Analyzers.vbproj
@@ -6,5 +6,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Analyzer.Utilities\Analyzer.Utilities.csproj" />
     <ProjectReference Include="..\Core\Roslyn.Diagnostics.Analyzers.csproj" />
+    <InternalsVisibleTo Include="Roslyn.Diagnostics.Analyzers.UnitTests" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The compiler code should avoid calling TypeArguments and a couple of other properties. 
There was already an analyzer for VB, but none for C#.
I added one VB unittest and one C#. I'm not sure how to deploy and test on Roslyn.

Fixes https://github.com/dotnet/roslyn/issues/10265

@AlekseyTs @cston @mavasani @333fred for review. Thanks