### PR TITLE
Disable CA2242 until it can be switched to the new IOperation API

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
@@ -14,7 +14,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     /// CA2242: Test for NaN correctly
     /// </summary>
     // [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)] - See https://github.com/dotnet/roslyn/issues/21448
+#pragma warning disable RS1001 // Missing diagnostic analyzer attribute.
     public sealed class TestForNaNCorrectlyAnalyzer : DiagnosticAnalyzer
+#pragma warning restore RS1001 // Missing diagnostic analyzer attribute.
     {
         internal const string RuleId = "CA2242";
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     /// <summary>
     /// CA2242: Test for NaN correctly
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    // [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)] - See https://github.com/dotnet/roslyn/issues/21448
     public sealed class TestForNaNCorrectlyAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA2242";


### PR DESCRIPTION
Ports https://github.com/dotnet/roslyn-analyzers/pull/1281 from master to dev15.3 to enable creating a new analyzer package to unblock https://github.com/dotnet/roslyn/pull/22173.

Fixing and re-enabling tracked by https://github.com/dotnet/roslyn/issues/21448