### PR TITLE
Correctly fix the generated package version to 2.3.0-beta2

### DIFF
--- a/build/Targets/Analyzers.Imports.targets
+++ b/build/Targets/Analyzers.Imports.targets
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <Version>2.3.0</Version>
     <RoslynSemanticVersion>$(Version)</RoslynSemanticVersion>
-    <PreReleaseVersion Condition="'$(PreReleaseVersion)' == ''">beta1</PreReleaseVersion>
+    <PreReleaseVersion Condition="'$(PreReleaseVersion)' == ''">beta2</PreReleaseVersion>
     <ToolsSemanticVersion>0.0.0</ToolsSemanticVersion>
     <ToolsPreReleaseVersion>beta1</ToolsPreReleaseVersion>
 

--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <FakeSignVersion>0.9.2</FakeSignVersion>
     <RoslynVersion>2.3.0-beta2-61719-05</RoslynVersion>
-    <RoslynAnalyzersVersion>2.3.0-beta2</RoslynAnalyzersVersion>
+    <RoslynAnalyzersVersion>2.3.0-beta1</RoslynAnalyzersVersion>
     <SignToolVersion>0.3.0-beta</SignToolVersion>
     <VSSDKBuildToolsVersion>15.0.26201</VSSDKBuildToolsVersion>
     <XUnitVersion>2.2.0</XUnitVersion>


### PR DESCRIPTION
My previous change broke the build by updating the consumed analyzer package version instead of the generated package version.