### PR TITLE
Remove usage of IFieldInitializer in UseLiteralsWhereAppropriate anal…

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
             return new UseLiteralsWhereAppropriateAnalyzer();
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1299")]
         public void CA1802_Diagnostics_CSharp()
         {
             VerifyCSharp(@"
@@ -61,14 +61,14 @@ public class Class1
 }");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1299")]
         public void CA1802_Diagnostics_VisualBasic()
         {
             VerifyBasic(@"
 Public Class Class1
     Shared ReadOnly f1 As String = """"
     Shared ReadOnly f2 As String = ""Nothing""
-    Shared ReadOnly f3 As String, f4 As String = ""Message is shown only for f4""
+    Shared ReadOnly f3, f4 As String = ""Message is shown only for f4""
     Shared ReadOnly f5 As Integer = 3
     Const f6 As Integer = 3
     Shared ReadOnly f7 As Integer = 8 + f6
@@ -76,7 +76,7 @@ Public Class Class1
 End Class",
                 GetBasicEmptyStringResultAt(line: 3, column: 21, symbolName: "f1"),
                 GetBasicDefaultResultAt(line: 4, column: 21, symbolName: "f2"),
-                GetBasicDefaultResultAt(line: 5, column: 35, symbolName: "f4"),
+                GetBasicDefaultResultAt(line: 5, column: 25, symbolName: "f3"), // Reporting on f4 is blocked by https://github.com/dotnet/roslyn/issues/22252
                 GetBasicDefaultResultAt(line: 6, column: 21, symbolName: "f5"),
                 GetBasicDefaultResultAt(line: 8, column: 21, symbolName: "f7"),
                 GetBasicDefaultResultAt(line: 9, column: 28, symbolName: "f8"));


### PR DESCRIPTION
…yzer

This API will be removed with https://github.com/dotnet/roslyn/issues/21293, and this change moves the analyzer to use operation blocks.
The analyzer doesn't work now as the operation block root node is still an IFieldInitializer, not the expression to the right of the equals token.
Additionally, even when https://github.com/dotnet/roslyn/issues/21293 is implemented, we will need to fix the back compat issue https://github.com/dotnet/roslyn-analyzers/issues/1300.