### PR TITLE
 Move to the latest IOperation APIs

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -12,7 +12,7 @@
     <MicrosoftVSSDKVersion>15.0.26201-alpha</MicrosoftVSSDKVersion>
 
     <!-- Roslyn -->
-    <MicrosoftCodeAnalysisVersion>2.6.0-beta1-62122-07</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>2.6.0-beta2-62210-01</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
 
     <!-- CoreFX -->

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
@@ -13,10 +13,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
     /// <summary>
     /// CA2007: Do not directly await a Task in libraries. Append ConfigureAwait(false) to the task.
     /// </summary>
-    //[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-#pragma warning disable RS1001 // Missing diagnostic analyzer attribute.
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class DoNotDirectlyAwaitATaskAnalyzer : DiagnosticAnalyzer
-#pragma warning restore RS1001 // Missing diagnostic analyzer attribute.
     {
         internal const string RuleId = "CA2007";
 
@@ -41,29 +39,29 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            //analysisContext.RegisterCompilationStartAction(context =>
-            //{
-            //    ImmutableArray<INamedTypeSymbol> taskTypes = GetTaskTypes(context.Compilation);
-            //    if (taskTypes.Any(t => t == null))
-            //    {
-            //        return;
-            //    }
+            analysisContext.RegisterCompilationStartAction(context =>
+            {
+                ImmutableArray<INamedTypeSymbol> taskTypes = GetTaskTypes(context.Compilation);
+                if (taskTypes.Any(t => t == null))
+                {
+                    return;
+                }
 
-            //    context.RegisterOperationActionInternal(oc => AnalyzeOperation(oc, taskTypes), OperationKind.AwaitExpression);
-            //});
+                context.RegisterOperationActionInternal(oc => AnalyzeOperation(oc, taskTypes), OperationKind.AwaitExpression);
+            });
         }
 
-        //private static void AnalyzeOperation(OperationAnalysisContext context, ImmutableArray<INamedTypeSymbol> taskTypes)
-        //{
-        //    IAwaitExpression awaitExpression = context.Operation as IAwaitExpression;
+        private static void AnalyzeOperation(OperationAnalysisContext context, ImmutableArray<INamedTypeSymbol> taskTypes)
+        {
+            IAwaitExpression awaitExpression = context.Operation as IAwaitExpression;
 
-        //    // Get the type of the expression being awaited and check it's a task type.
-        //    ITypeSymbol typeOfAwaitedExpression = awaitExpression?.AwaitedValue?.Type;
-        //    if (typeOfAwaitedExpression != null && taskTypes.Contains(typeOfAwaitedExpression.OriginalDefinition))
-        //    {
-        //        context.ReportDiagnostic(awaitExpression.AwaitedValue.Syntax.CreateDiagnostic(Rule));
-        //    }
-        //}
+            // Get the type of the expression being awaited and check it's a task type.
+            ITypeSymbol typeOfAwaitedExpression = awaitExpression?.AwaitedValue?.Type;
+            if (typeOfAwaitedExpression != null && taskTypes.Contains(typeOfAwaitedExpression.OriginalDefinition))
+            {
+                context.ReportDiagnostic(awaitExpression.AwaitedValue.Syntax.CreateDiagnostic(Rule));
+            }
+        }
 
         private static ImmutableArray<INamedTypeSymbol> GetTaskTypes(Compilation compilation)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
@@ -56,10 +56,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             IAwaitExpression awaitExpression = context.Operation as IAwaitExpression;
 
             // Get the type of the expression being awaited and check it's a task type.
-            ITypeSymbol typeOfAwaitedExpression = awaitExpression?.AwaitedValue?.Type;
+            ITypeSymbol typeOfAwaitedExpression = awaitExpression?.Expression?.Type;
             if (typeOfAwaitedExpression != null && taskTypes.Contains(typeOfAwaitedExpression.OriginalDefinition))
             {
-                context.ReportDiagnostic(awaitExpression.AwaitedValue.Syntax.CreateDiagnostic(Rule));
+                context.ReportDiagnostic(awaitExpression.Expression.Syntax.CreateDiagnostic(Rule));
             }
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotRaiseExceptionsInExceptionClauses.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotRaiseExceptionsInExceptionClauses.cs
@@ -19,10 +19,8 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
     /// inside a filter block and there is no language representation for fault blocks in either language.
     /// So this analyzer just checks for throw statements inside finally blocks.
     /// </remarks>
-    //[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-#pragma warning disable RS1001 // Missing diagnostic analyzer attribute.
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class DoNotRaiseExceptionsInExceptionClausesAnalyzer : DiagnosticAnalyzer
-#pragma warning restore RS1001 // Missing diagnostic analyzer attribute.
     {
         internal const string RuleId = "CA2219";
 
@@ -49,22 +47,21 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            //analysisContext.RegisterOperationBlockActionInternal(operationBlockContext =>
-            //{
-            //    foreach (var block in operationBlockContext.OperationBlocks)
-            //    {
-            //        var walker = new ThrowInsideFinallyWalker();
-            //        walker.Visit(block);
+            analysisContext.RegisterOperationBlockActionInternal(operationBlockContext =>
+            {
+                foreach (var block in operationBlockContext.OperationBlocks)
+                {
+                    var walker = new ThrowInsideFinallyWalker();
+                    walker.Visit(block);
 
-            //        foreach (var throwStatement in walker.ThrowStatements)
-            //        {
-            //            operationBlockContext.ReportDiagnostic(throwStatement.Syntax.CreateDiagnostic(Rule));
-            //        }
-            //    }
-            //});
+                    foreach (var throwStatement in walker.ThrowStatements)
+                    {
+                        operationBlockContext.ReportDiagnostic(throwStatement.Syntax.CreateDiagnostic(Rule));
+                    }
+                }
+            });
         }
 
-        /*
         /// <summary>
         /// Walks an IOperation tree to find throw statements inside finally blocks.
         /// </summary>
@@ -97,6 +94,5 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 base.VisitThrowStatement(operation);
             }
         }
-        */
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotRaiseExceptionsInExceptionClauses.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotRaiseExceptionsInExceptionClauses.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                     var walker = new ThrowInsideFinallyWalker();
                     walker.Visit(block);
 
-                    foreach (var throwStatement in walker.ThrowStatements)
+                    foreach (var throwStatement in walker.ThrowExpressions)
                     {
                         operationBlockContext.ReportDiagnostic(throwStatement.Syntax.CreateDiagnostic(Rule));
                     }
@@ -63,13 +63,13 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         }
 
         /// <summary>
-        /// Walks an IOperation tree to find throw statements inside finally blocks.
+        /// Walks an IOperation tree to find throw expressions inside finally blocks.
         /// </summary>
         private class ThrowInsideFinallyWalker : OperationWalker
         {
             private int _finallyBlockNestingDepth;
 
-            public List<IThrowStatement> ThrowStatements { get; private set; } = new List<IThrowStatement>();
+            public List<IThrowExpression> ThrowExpressions { get; private set; } = new List<IThrowExpression>();
 
             public override void VisitTryStatement(ITryStatement operation)
             {
@@ -80,18 +80,18 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 }
 
                 _finallyBlockNestingDepth++;
-                Visit(operation.FinallyHandler);
+                Visit(operation.Finally);
                 _finallyBlockNestingDepth--;
             }
 
-            public override void VisitThrowStatement(IThrowStatement operation)
+            public override void VisitThrowExpression(IThrowExpression operation)
             {
                 if (_finallyBlockNestingDepth > 0)
                 {
-                    ThrowStatements.Add(operation);
+                    ThrowExpressions.Add(operation);
                 }
 
-                base.VisitThrowStatement(operation);
+                base.VisitThrowExpression(operation);
             }
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.Fixer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             return new DoNotDirectlyAwaitATaskFixer();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CSharpSimpleAwaitTask()
         {
             var code = @"
@@ -59,7 +59,7 @@ public class C
             VerifyCSharpFix(code, fixedCode);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void BasicSimpleAwaitTask()
         {
             var code = @"
@@ -86,7 +86,7 @@ End Class
             VerifyBasicFix(code, fixedCode);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CSharpSimpleAwaitTaskWithTrivia()
         {
             var code = @"
@@ -116,7 +116,7 @@ public class C
             VerifyCSharpFix(code, fixedCode);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void BasicSimpleAwaitTaskWithTrivia()
         {
             var code = @"
@@ -143,7 +143,7 @@ End Class
             VerifyBasicFix(code, fixedCode);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CSharpAwaitAwaitTask()
         {
             var code = @"
@@ -178,7 +178,7 @@ public class C
             VerifyCSharpFix(code, fixedCode);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void BasicAwaitAwaitTask()
         {
             var code = @"
@@ -208,7 +208,7 @@ End Class
             VerifyBasicFix(code, fixedCode);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CSharpComplexAwaitTask()
         {
             var code = @"
@@ -246,7 +246,7 @@ public class C
             VerifyCSharpFix(code, fixedCode);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void BasicComplexeAwaitTask()
         {
             var code = @"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             return new DoNotDirectlyAwaitATaskAnalyzer();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CSharpSimpleAwaitTask()
         {
             var code = @"
@@ -36,7 +36,7 @@ public class C
             VerifyCSharp(code, GetCSharpResultAt(9, 15));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void BasicSimpleAwaitTask()
         {
             var code = @"
@@ -52,7 +52,7 @@ End Class
             VerifyBasic(code, GetBasicResultAt(7, 15));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CSharpSimpleAwaitTaskOfT()
         {
             var code = @"
@@ -70,7 +70,7 @@ public class C
             VerifyCSharp(code, GetCSharpResultAt(9, 23));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void BasicSimpleAwaitTaskOfT()
         {
             var code = @"
@@ -86,7 +86,7 @@ End Class
             VerifyBasic(code, GetBasicResultAt(7, 34));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CSharpNoDiagnostic()
         {
             var code = @"
@@ -132,7 +132,7 @@ public class SomeAwaiter : INotifyCompletion
             VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void BasicNoDiagnostic()
         {
             var code = @"
@@ -176,7 +176,7 @@ End Class
             VerifyBasic(code, TestValidationMode.AllowCompileErrors);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CSharpAwaitAwaitTask()
         {
             var code = @"
@@ -200,7 +200,7 @@ public class C
                 GetCSharpResultAt(11, 22));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void BasicAwaitAwaitTask()
         {
             var code = @"
@@ -222,7 +222,7 @@ End Class
                 GetBasicResultAt(9, 22));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CSharpComplexAwaitTask()
         {
             var code = @"
@@ -247,7 +247,7 @@ public class C
                 GetCSharpResultAt(11, 33));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void BasicComplexeAwaitTask()
         {
             var code = @"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotRaiseExceptionsInExceptionClausesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotRaiseExceptionsInExceptionClausesTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
             return new DoNotRaiseExceptionsInExceptionClausesAnalyzer();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1305")]
+        [Fact]
         public void CSharpSimpleCase()
         {
             var code = @"
@@ -52,7 +52,7 @@ public class Test
                 GetCSharpResultAt(22, 13, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1305")]
+        [Fact]
         public void BasicSimpleCase()
         {
             var code = @"
@@ -76,7 +76,7 @@ End Class
                 GetBasicResultAt(13, 13, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1305")]
+        [Fact]
         public void CSharpNestedFinally()
         {
             var code = @"
@@ -115,7 +115,7 @@ public class Test
                 GetCSharpResultAt(25, 13, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1305")]
+        [Fact]
         public void BasicNestedFinally()
         {
             var code = @"

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -117,7 +117,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             var model = context.Compilation.GetSemanticModel(arrayCreationExpression.Syntax.SyntaxTree);
 
             // Compiler generated array creation seems to just use the syntax from the parent.
-            var parent = model.GetOperationInternal(arrayCreationExpression.Syntax, context.CancellationToken) as IHasArgumentsExpression;
+            var parent = model.GetOperationInternal(arrayCreationExpression.Syntax, context.CancellationToken) as IHasArguments;
             if (parent == null)
             {
                 return false;

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
@@ -12,10 +12,8 @@ using Microsoft.CodeAnalysis.Semantics;
 
 namespace Microsoft.NetFramework.Analyzers
 {
-    //[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-#pragma warning disable RS1001 // Missing diagnostic analyzer attribute.
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class DoNotCatchCorruptedStateExceptionsAnalyzer : DiagnosticAnalyzer
-#pragma warning restore RS1001 // Missing diagnostic analyzer attribute.
     {
         internal const string RuleId = "CA2153";
 
@@ -40,44 +38,43 @@ namespace Microsoft.NetFramework.Analyzers
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
 
-            //analysisContext.RegisterCompilationStartAction(compilationStartAnalysisContext =>
-            //{
-            //    var compilationTypes = new CompilationSecurityTypes(compilationStartAnalysisContext.Compilation);
-            //    if (compilationTypes.HandleProcessCorruptedStateExceptionsAttribute == null)
-            //    {
-            //        return;
-            //    }
+            analysisContext.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+            {
+                var compilationTypes = new CompilationSecurityTypes(compilationStartAnalysisContext.Compilation);
+                if (compilationTypes.HandleProcessCorruptedStateExceptionsAttribute == null)
+                {
+                    return;
+                }
 
-            //    compilationStartAnalysisContext.RegisterOperationBlockActionInternal(operationBlockAnalysisContext =>
-            //    {
-            //        if (operationBlockAnalysisContext.OwningSymbol.Kind != SymbolKind.Method)
-            //        {
-            //            return;
-            //        }
+                compilationStartAnalysisContext.RegisterOperationBlockActionInternal(operationBlockAnalysisContext =>
+                {
+                    if (operationBlockAnalysisContext.OwningSymbol.Kind != SymbolKind.Method)
+                    {
+                        return;
+                    }
 
-            //        var method = (IMethodSymbol)operationBlockAnalysisContext.OwningSymbol;
+                    var method = (IMethodSymbol)operationBlockAnalysisContext.OwningSymbol;
 
-            //        if (!ContainsHandleProcessCorruptedStateExceptionsAttribute(method, compilationTypes))
-            //        {
-            //            return;
-            //        }
+                    if (!ContainsHandleProcessCorruptedStateExceptionsAttribute(method, compilationTypes))
+                    {
+                        return;
+                    }
 
-            //        foreach (var operation in operationBlockAnalysisContext.OperationBlocks)
-            //        {
-            //            var walker = new EmptyThrowInsideCatchAllWalker(compilationTypes);
-            //            walker.Visit(operation);
+                    foreach (var operation in operationBlockAnalysisContext.OperationBlocks)
+                    {
+                        var walker = new EmptyThrowInsideCatchAllWalker(compilationTypes);
+                        walker.Visit(operation);
 
-            //            foreach (var catchClause in walker.CatchAllCatchClausesWithoutEmptyThrow)
-            //            {
-            //                operationBlockAnalysisContext.ReportDiagnostic(catchClause.Syntax.CreateDiagnostic(Rule,
-            //                    method.ToDisplayString()));
-            //            }
-            //        }
-            //    });
-            //});
+                        foreach (var catchClause in walker.CatchAllCatchClausesWithoutEmptyThrow)
+                        {
+                            operationBlockAnalysisContext.ReportDiagnostic(catchClause.Syntax.CreateDiagnostic(Rule,
+                                method.ToDisplayString()));
+                        }
+                    }
+                });
+            });
         }
 
-    /*
         private bool ContainsHandleProcessCorruptedStateExceptionsAttribute(IMethodSymbol method, CompilationSecurityTypes compilationTypes)
         {
             ImmutableArray<AttributeData> attributes = method.GetAttributes();
@@ -139,6 +136,5 @@ namespace Microsoft.NetFramework.Analyzers
                        caughtType == _compilationTypes.SystemObject;
             }
         }
-    */
-}
+    }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.NetFramework.Analyzers
                 _compilationTypes = compilationTypes;
             }
 
-            public override void VisitLambdaExpression(ILambdaExpression operation)
+            public override void VisitAnonymousFunctionExpression(IAnonymousFunctionExpression operation)
             {
                 // for now there doesn't seem to be any way to annotate lambdas with attributes
             }
@@ -111,21 +111,21 @@ namespace Microsoft.NetFramework.Analyzers
 
                 bool seenEmptyThrow = _seenEmptyThrowInCatchClauses.Pop();
 
-                if (IsCaughtTypeTooGeneral(operation.CaughtType) && !seenEmptyThrow)
+                if (IsCaughtTypeTooGeneral(operation.ExceptionType) && !seenEmptyThrow)
                 {
                     CatchAllCatchClausesWithoutEmptyThrow.Add(operation);
                 }
             }
 
-            public override void VisitThrowStatement(IThrowStatement operation)
+            public override void VisitThrowExpression(IThrowExpression operation)
             {
-                if (operation.ThrownObject == null && _seenEmptyThrowInCatchClauses.Count > 0 && !_seenEmptyThrowInCatchClauses.Peek())
+                if (operation.Expression == null && _seenEmptyThrowInCatchClauses.Count > 0 && !_seenEmptyThrowInCatchClauses.Peek())
                 {
                     _seenEmptyThrowInCatchClauses.Pop();
                     _seenEmptyThrowInCatchClauses.Push(true);
                 }
 
-                base.VisitThrowStatement(operation);
+                base.VisitThrowExpression(operation);
             }
 
             private bool IsCaughtTypeTooGeneral(ITypeSymbol caughtType)

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
@@ -227,7 +227,7 @@ namespace Microsoft.NetFramework.Analyzers
                 AnalyzeMethodOverloads(context, method, invocationExpression);
             }
 
-            private void AnalyzeMethodOverloads(OperationAnalysisContext context, IMethodSymbol method, IHasArgumentsExpression expression)
+            private void AnalyzeMethodOverloads(OperationAnalysisContext context, IMethodSymbol method, IHasArguments expression)
             {
                 if (method.MatchMethodDerivedByName(_xmlTypes.XmlDocument, SecurityMemberNames.Load) ||                                    //FxCop CA3056
                     method.MatchMethodDerivedByName(_xmlTypes.XmlDocument, SecurityMemberNames.LoadXml) ||                                 //FxCop CA3057

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotCatchCorruptedStateExceptionsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotCatchCorruptedStateExceptionsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             return new DoNotCatchCorruptedStateExceptionsAnalyzer();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInMethodWithSecurityCriticalAttribute()
         {
             VerifyCSharp(@"
@@ -80,7 +80,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAttribute()
         {
             // Note this is a change from FxCop's previous behavior since we no longer consider SystemCritical.
@@ -150,7 +150,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
            );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchRethrowExceptionInMethodWithHpcseAndSecurityCriticalAttributes()
         {
             VerifyCSharp(@"
@@ -221,7 +221,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAndSecurityCriticalAttributes()
         {
             VerifyCSharp(@"
@@ -318,7 +318,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchInMethodWithHpcseAndSecurityCriticalAttributes()
         {
             VerifyCSharp(@"
@@ -392,7 +392,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchsystemExceptionInMethodWithHpcseAndSecurityCriticalAttributes()
         {
             VerifyCSharp(@"
@@ -466,7 +466,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAndSecurityCriticalClassScopeEverythingAttributes()
         {
             VerifyCSharp(@"
@@ -518,7 +518,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAndSecurityCriticalClassAttributes()
         {
             VerifyCSharp(@"
@@ -549,7 +549,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAndSecurityCriticalClassScopeExcplicitAttributes()
         {
             VerifyCSharp(@"
@@ -580,7 +580,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAndSecurityCriticalL1Attributes()
         {
             VerifyCSharp(@"
@@ -612,7 +612,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInMethodWithHpcseAndSecurityCriticalL2Attributes()
         {
             VerifyCSharp(@"
@@ -644,7 +644,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInNestedClassMethodWithOuterHpcseAndSecurityCriticalScopeEverythingAttributes()
         {
             VerifyCSharp(@"
@@ -678,7 +678,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInNestedClassMethodWithInnerHpcseAndSecurityCriticalScopeEverythingAttributes()
         {
             VerifyCSharp(@"
@@ -712,7 +712,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInNestedClassMethodwithInnerHpcseAndOuterSecurityCriticalAttributes()
         {
             VerifyCSharp(@"
@@ -746,7 +746,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInGetAccessorWithHpcseAttribute()
         {
             VerifyCSharp(@"
@@ -810,7 +810,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchInGetAccessorWithHpcseAttribute()
         {
             VerifyCSharp(@"
@@ -849,7 +849,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchSystemExceptionInGetAccessorWithHpcseAttribute()
         {
             VerifyCSharp(@"
@@ -888,7 +888,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchInSetAccessorWithHpcseAttribute()
         {
             VerifyCSharp(@"
@@ -926,7 +926,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInSetAccessorWithHpcseAttribute()
         {
             VerifyCSharp(@"
@@ -991,7 +991,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
            );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchIOExceptionInMethodHpcseAttribute()
         {
             VerifyCSharp(@"
@@ -1028,7 +1028,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchIOExceptionSwallowOtherExceptionInMethodHpcseAttribute()
         {
             VerifyCSharp(@"
@@ -1065,7 +1065,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestSwallowAccessViolationExceptionInMethodHpcseAttribute()
         {
             VerifyCSharpUnsafeCode(@"
@@ -1100,7 +1100,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestSwallowAccessViolationExceptionThenSwallowOtherExceptionInMethodHpcseAttribute()
         {
             VerifyCSharpUnsafeCode(@"
@@ -1140,7 +1140,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionThrowNotImplementedExceptionInMethodHpcseAttribute()
         {
             VerifyCSharp(@"
@@ -1219,7 +1219,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchExceptionInnerCatchThrowIOExceptionInMethodHpcseAttribute()
         {
             VerifyCSharp(@"
@@ -1314,7 +1314,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchGeneralException()
         {
             VerifyCSharp(@"
@@ -1382,7 +1382,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1303")]
+        [Fact]
         public void CA2153TestCatchInsideLambdaExpression()
         {
             VerifyCSharp(@"


### PR DESCRIPTION
This change moves the analyzers to the latest IOperation APIs. Additionally, it reverts a bunch of commits from https://github.com/dotnet/roslyn-analyzers/pull/1308/ when we moved to the prior IOperation APIs with many of them internalized.

Fixes #1303
Fixes #1304 
Fixes #1305

Once this change is merged, we should be good to kick off a signed build for the analyzers.