### PR TITLE
Update to RepoToolset 43

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -5,9 +5,10 @@
 
     <!-- Opt-in RepoToolset tools -->
     <UsingToolVSSDK>true</UsingToolVSSDK>
+    <UsingToolPdbConverter>true</UsingToolPdbConverter>
 
     <!-- Toolset -->
-    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha40</RoslynToolsMicrosoftRepoToolsetVersion>
+    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha43</RoslynToolsMicrosoftRepoToolsetVersion>
     <VSWhereVersion>2.1.4</VSWhereVersion>
     <MicrosoftVSSDKVersion>15.0.26201-alpha</MicrosoftVSSDKVersion>
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -14,12 +14,49 @@ Param(
   [switch] $pack,
   [switch] $ci,
   [switch] $clearCaches,
+  [switch] $log,
+  [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
 set-strictmode -version 2.0
 $ErrorActionPreference = "Stop"
 
+function Print-Usage() {
+    Write-Host "Common settings:"
+    Write-Host "  -configuration <value>  Build configuration Debug, Release"
+    Write-Host "  -verbosity <value>      Msbuild verbosity (q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic])"
+    Write-Host "  -help                   Print help and exit"
+    Write-Host ""
+
+    Write-Host "Actions:"
+    Write-Host "  -restore                Restore dependencies"
+    Write-Host "  -build                  Build solution"
+    Write-Host "  -rebuild                Rebuild solution"
+    Write-Host "  -deploy                 Deploy built VSIXes"
+    Write-Host "  -deployDeps             Deploy dependencies (Roslyn VSIXes for integration tests)"
+    Write-Host "  -test                   Run all unit tests in the solution"
+    Write-Host "  -integrationTest        Run all integration tests in the solution"
+    Write-Host "  -sign                   Sign build outputs"
+    Write-Host "  -pack                   Package build outputs into NuGet packages and Willow components"
+    Write-Host ""
+
+    Write-Host "Advanced settings:"
+    Write-Host "  -solution <value>       Path to solution to build"
+    Write-Host "  -ci                     Set when running on CI server"
+    Write-Host "  -log                    Enable logging (by default on CI)"
+    Write-Host "  -clearCaches            Prepare machine for CI run"
+    Write-Host ""
+    Write-Host "Command line arguments not listed above are passed thru to msbuild."
+    Write-Host "The above arguments can be shortened as much as to be unambiguous (e.g. -co for configuration, -t for test, etc.)."
+}
+
+if ($help -or (($properties -ne $null) -and ($properties.Contains("/help") -or $properties.Contains("/?")))) {
+  Print-Usage
+  exit 0
+}
+
+$InVSEnvironment = !($env:VS150COMNTOOLS -eq $null) -and (Test-Path $env:VS150COMNTOOLS)
 $RepoRoot = Join-Path $PSScriptRoot "..\"
 $ToolsRoot = Join-Path $RepoRoot ".tools"
 $BuildProj = Join-Path $PSScriptRoot "build.proj"
@@ -40,47 +77,54 @@ function GetVSWhereVersion {
   return $xml.Project.PropertyGroup.VSWhereVersion
 }
 
-function LocateMsbuild {
-  
+function LocateVisualStudio {
+  if ($InVSEnvironment) {
+    return Join-Path $env:VS150COMNTOOLS "..\.."
+  }
+
   $vswhereVersion = GetVSWhereVersion
   $vsWhereDir = Join-Path $ToolsRoot "vswhere\$vswhereVersion"
   $vsWhereExe = Join-Path $vsWhereDir "vswhere.exe"
-    
+  
   if (!(Test-Path $vsWhereExe)) {
     Create-Directory $vsWhereDir   
+    Write-Host "Downloading vswhere"
     Invoke-WebRequest "http://github.com/Microsoft/vswhere/releases/download/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
   }
   
   $vsInstallDir = & $vsWhereExe -latest -property installationPath -requires Microsoft.Component.MSBuild -requires Microsoft.VisualStudio.Component.VSSDK -requires Microsoft.Net.Component.4.6.TargetingPack -requires Microsoft.VisualStudio.Component.Roslyn.Compiler -requires Microsoft.VisualStudio.Component.VSSDK
-  $msbuildExe = Join-Path $vsInstallDir "MSBuild\15.0\Bin\msbuild.exe"
   
-  if (!(Test-Path $msbuildExe)) {
-    throw "Failed to locate msbuild (exit code '$lastExitCode')."
+  if (!(Test-Path $vsInstallDir)) {
+    throw "Failed to locate Visual Studio (exit code '$lastExitCode')."
   }
 
-  return $msbuildExe
+  return $vsInstallDir
 }
 
 function Build {
-  $msbuildExe = LocateMsbuild
-  
-  if ($ci) {
-  Create-Directory($logDir)
-    # Microbuild is on 15.1 which doesn't support binary log
-    if ($env:BUILD_BUILDNUMBER -eq "") {
-      $log = "/bl:" + (Join-Path $LogDir "Build.binlog")
-    } else {
-      $log = "/flp1:Summary;Verbosity=diagnostic;Encoding=UTF-8;LogFile=" + (Join-Path $LogDir "Build.log")
-    }
+  $vsInstallDir = LocateVisualStudio
+  $msbuildExe = Join-Path $vsInstallDir "MSBuild\15.0\Bin\msbuild.exe"
+
+  if (!$InVSEnvironment) {
+    $env:VS150COMNTOOLS = Join-Path $vsInstallDir "Common7\Tools\"
+    $env:VSSDK150Install = Join-Path $vsInstallDir "VSSDK\"
+    $env:VSSDKInstall = Join-Path $vsInstallDir "VSSDK\"
+  }
+
+  if ($ci -or $log) {
+    Create-Directory($logDir)
+    $logCmd = "/bl:" + (Join-Path $LogDir "Build.binlog")
   } else {
-    $log = ""
+    $logCmd = ""
   }
 
-  & $msbuildExe $BuildProj /m /v:$verbosity $log /p:Configuration=$configuration /p:SolutionPath=$solution /p:Restore=$restore /p:DeployDeps=$deployDeps /p:Build=$build /p:Rebuild=$rebuild /p:Deploy=$deploy /p:Test=$test /p:IntegrationTest=$integrationTest /p:Sign=$sign /p:Pack=$pack /p:CIBuild=$ci  /p:RestoreConfigFile=$NugetConfig $properties
-
-  if ($lastExitCode -ne 0) {
-    throw "Build failed (exit code '$lastExitCode')."
+  if ($ci) {
+    Write-Host "Using $msbuildExe"
   }
+
+  $nodeReuse = !$ci
+
+  & $msbuildExe $BuildProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:$verbosity $logCmd /p:Configuration=$configuration /p:SolutionPath=$solution /p:Restore=$restore /p:DeployDeps=$deployDeps /p:Build=$build /p:Rebuild=$rebuild /p:Deploy=$deploy /p:Test=$test /p:IntegrationTest=$integrationTest /p:Sign=$sign /p:Pack=$pack /p:CIBuild=$ci /p:RestoreConfigFile=$NugetConfig $properties
 }
 
 function Stop-Processes() {
@@ -104,12 +148,13 @@ try {
     $env:TMP = $TempDir
   }
 
+  # Preparation of a CI machine
   if ($clearCaches) {
     Clear-NuGetCache
   }
 
   Build
-  exit 0
+  exit $lastExitCode
 }
 catch {
   Write-Host $_
@@ -123,3 +168,4 @@ finally {
     Stop-Processes
   }
 }
+

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -64,7 +64,6 @@ $DependenciesProps = Join-Path $PSScriptRoot "Versions.props"
 $ArtifactsDir = Join-Path $RepoRoot "artifacts"
 $LogDir = Join-Path (Join-Path $ArtifactsDir $configuration) "log"
 $TempDir = Join-Path (Join-Path $ArtifactsDir $configuration) "tmp"
-$NugetConfig = Join-Path $RepoRoot "NuGet.config"
 
 function Create-Directory([string[]] $path) {
   if (!(Test-Path -path $path)) {
@@ -124,7 +123,7 @@ function Build {
 
   $nodeReuse = !$ci
 
-  & $msbuildExe $BuildProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:$verbosity $logCmd /p:Configuration=$configuration /p:SolutionPath=$solution /p:Restore=$restore /p:DeployDeps=$deployDeps /p:Build=$build /p:Rebuild=$rebuild /p:Deploy=$deploy /p:Test=$test /p:IntegrationTest=$integrationTest /p:Sign=$sign /p:Pack=$pack /p:CIBuild=$ci /p:RestoreConfigFile=$NugetConfig $properties
+  & $msbuildExe $BuildProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:$verbosity $logCmd /p:Configuration=$configuration /p:SolutionPath=$solution /p:Restore=$restore /p:DeployDeps=$deployDeps /p:Build=$build /p:Rebuild=$rebuild /p:Deploy=$deploy /p:Test=$test /p:IntegrationTest=$integrationTest /p:Sign=$sign /p:Pack=$pack /p:CIBuild=$ci $properties
 }
 
 function Stop-Processes() {

--- a/netci.groovy
+++ b/netci.groovy
@@ -69,7 +69,7 @@ static addBuildSteps(def job, def projectName, def opsysName, def configName, de
       addArchival(myJob, filesToArchive, filesToExclude)
       addXUnitDotNETResults(myJob, configName)
 
-      Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-dev15-3-preview1')
+      Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-dev15-3')
 
       addBuildSteps(myJob, projectName, opsysName, configName, isPR)
     }

--- a/src/MetaCompilation.Analyzers/Setup/MetaCompilation.Analyzers.Setup.csproj
+++ b/src/MetaCompilation.Analyzers/Setup/MetaCompilation.Analyzers.Setup.csproj
@@ -7,6 +7,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Setup/Microsoft.CodeAnalysis.Analyzers.Setup.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Setup/Microsoft.CodeAnalysis.Analyzers.Setup.csproj
@@ -14,6 +14,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/Microsoft.CodeAnalysis.FxCopAnalyzers.Setup.csproj
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/Microsoft.CodeAnalysis.FxCopAnalyzers.Setup.csproj
@@ -8,6 +8,7 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
     <CreateVsixContainer>true</CreateVsixContainer>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201" />

--- a/src/Microsoft.CodeQuality.Analyzers/Setup/Microsoft.CodeQuality.Analyzers.Setup.csproj
+++ b/src/Microsoft.CodeQuality.Analyzers/Setup/Microsoft.CodeQuality.Analyzers.Setup.csproj
@@ -7,6 +7,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.NetCore.Analyzers/Setup/Microsoft.NetCore.Analyzers.Setup.csproj
+++ b/src/Microsoft.NetCore.Analyzers/Setup/Microsoft.NetCore.Analyzers.Setup.csproj
@@ -7,6 +7,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/ImmutableCollections/DoNotCallToImmutableArrayOnAnImmutableArrayValueTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/ImmutableCollections/DoNotCallToImmutableArrayOnAnImmutableArrayValueTests.cs
@@ -81,7 +81,7 @@ End Class
 
         #region Diagnostic Tests
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1318")]
         public void DiagnosticCases()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.NetFramework.Analyzers/Setup/Microsoft.NetFramework.Analyzers.Setup.csproj
+++ b/src/Microsoft.NetFramework.Analyzers/Setup/Microsoft.NetFramework.Analyzers.Setup.csproj
@@ -7,6 +7,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Roslyn.Diagnostics.Analyzers/Setup/Roslyn.Diagnostics.Analyzers.Setup.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/Setup/Roslyn.Diagnostics.Analyzers.Setup.csproj
@@ -7,6 +7,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Test.Utilities/Test.Utilities.csproj
+++ b/src/Test.Utilities/Test.Utilities.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
     <!-- 
       Currently the tests depend on compiler having InternalsVisibleTo("Roslyn.Test.Utilities").
       See https://github.com/dotnet/roslyn-analyzers/issues/1225

--- a/src/Text.Analyzers/Setup/Text.Analyzers.Setup.csproj
+++ b/src/Text.Analyzers/Setup/Text.Analyzers.Setup.csproj
@@ -7,6 +7,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Infrastructure-only change. The new toolset allows us to publish symbols only for binaries we build and ship from this repo.