### PR TITLE
Fix NRE in CA1825: AvoidZeroLengthArrayAllocations

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.Fixer.cs
@@ -66,6 +66,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             switch (operation.Kind)
             {
                 case OperationKind.Argument:
+                    // Happens if the array is passed as a method argument as it's being created.
+                    // e.g. M(new object[0])
                     return FindArrayCreation(
                         ((IArgument)operation).Value);
 
@@ -73,6 +75,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return (IArrayCreationExpression)operation;
 
                 case OperationKind.ConversionExpression:
+                    // Happens when the array is converted to a different type as it's created.
+                    // e.g. M's signature is M(object obj), M(new object[0])
+                    //      In this case, the IConversionExpression is the child of the IArgument.
                     return FindArrayCreation(
                         ((IConversionExpression)operation).Operand);
             }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.Fixer.cs
@@ -64,9 +64,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         private static ITypeSymbol GetArrayElementType(SyntaxNode arrayCreationExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             var typeInfo = semanticModel.GetTypeInfo(arrayCreationExpression, cancellationToken);
-            // Use ConvertedType instead of Type to handle cases like 'T[] goo = { }'.
-            // https://github.com/dotnet/roslyn/issues/23545
-            var arrayType = (IArrayTypeSymbol)typeInfo.ConvertedType;
+            // When Type is null in cases like 'T[] goo = { }', use ConvertedType instead (https://github.com/dotnet/roslyn/issues/23545).
+            // When Type isn't null, do not use ConvertedType. For cases like `object[] goo = new string[0]`,
+            // we want to return the string type symbol, not the object one.
+            var arrayType = (IArrayTypeSymbol)(typeInfo.Type ?? typeInfo.ConvertedType);
             return arrayType?.ElementType;
         }
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -86,7 +86,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 if (dimensionSize.HasConstantValue(0))
                 {
                     // Workaround for https://github.com/dotnet/roslyn/issues/10214
-                    // Bail out for compiler generated param array creation.
+                    // Bail out for compiler generated params array creation.
                     if (IsCompilerGeneratedParamsArray(arrayCreationExpression, context))
                     {
                         return;
@@ -106,7 +106,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         var constructed = emptyMethod.Construct(elementType);
 
                         string typeName = constructed.ToDisplayString(ReportFormat);
-                        context.ReportDiagnostic(context.Operation.Syntax.CreateDiagnostic(UseArrayEmptyDescriptor, typeName));
+                        context.ReportDiagnostic(arrayCreationExpression.Syntax.CreateDiagnostic(UseArrayEmptyDescriptor, typeName));
                     }
                 }
             }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -329,7 +329,7 @@ public abstract class C
 
         [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
-        public void WipEmptyArrayCSharp_FieldOrPropertyInitializer()
+        public void EmptyArrayCSharp_FieldOrPropertyInitializer()
         {
             const string badSource = @"
 using System;
@@ -363,7 +363,7 @@ class C
         }
         
         [Fact]
-        public void WipEmptyArrayCSharp_UsedInAttribute_NoDiagnostics()
+        public void EmptyArrayCSharp_UsedInAttribute_NoDiagnostics()
         {
             const string source = @"
 using System;
@@ -387,7 +387,7 @@ class C
 
         [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
-        public void WipEmptyArrayCSharp_UsedInAssignment()
+        public void EmptyArrayCSharp_UsedInAssignment()
         {
             const string badSource = @"
 using System;
@@ -426,7 +426,7 @@ class C
 
         [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
-        public void WipEmptyArrayCSharp_DeclarationTypeDoesNotMatch_NotArray()
+        public void EmptyArrayCSharp_DeclarationTypeDoesNotMatch_NotArray()
         {
             const string badSource = @"
 using System;
@@ -483,7 +483,7 @@ class C
 
         [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
-        public void WipEmptyArrayCSharp_DeclarationTypeDoesNotMatch_DifferentElementType()
+        public void EmptyArrayCSharp_DeclarationTypeDoesNotMatch_DifferentElementType()
         {
             const string badSource = @"
 using System;
@@ -511,7 +511,7 @@ class C
 
         [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
-        public void WipEmptyArrayCSharp_UsedAsExpression()
+        public void EmptyArrayCSharp_UsedAsExpression()
         {
             const string badSource = @"
 using System;
@@ -581,7 +581,7 @@ class C
         }
 
         [Fact]
-        public void WipEmptyArrayCSharp_SystemNotImported()
+        public void EmptyArrayCSharp_SystemNotImported()
         {
             const string badSource = @"
 class C

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -29,12 +29,40 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             return type.GetMethod("Empty", BindingFlags.Public | BindingFlags.Static) != null;
         }
 
+        private static string GetArrayEmptySourceBasic()
+        {
+            const string arrayEmptySourceRaw = @"
+Namespace System
+    Public Class Array
+       Public Shared Function Empty(Of T)() As T()
+           Return Nothing
+       End Function
+    End Class
+End Namespace";
+
+            return IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
+        }
+
+        private static string GetArrayEmptySourceCSharp()
+        {
+            const string arrayEmptySourceRaw = @"
+namespace System
+{
+    public class Array
+    {
+        public static T[] Empty<T>()
+        {
+            return null;
+        }
+    }
+}";
+
+            return IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
+        }
+
         [Fact]
         public void EmptyArrayCSharp()
         {
-            const string arrayEmptySourceRaw =
-                @"namespace System { public class Array { public static T[] Empty<T>() { return null; } } }";
-
             const string badSource = @"
 using System.Collections.Generic;
 
@@ -82,7 +110,7 @@ class C
         List<int> list1 = new List<int>() { };         // no
     }
 }";
-            string arrayEmptySource = IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
+            string arrayEmptySource = GetArrayEmptySourceCSharp();
 
             VerifyCSharpUnsafeCode(badSource + arrayEmptySource, new[]
             {
@@ -117,15 +145,6 @@ class C
         [Fact]
         public void EmptyArrayVisualBasic()
         {
-            const string arrayEmptySourceRaw = @"
-Namespace System
-    Public Class Array
-       Public Shared Function Empty(Of T)() As T()
-           Return Nothing
-       End Function
-    End Class
-End Namespace
-";
             const string badSource = @"
 Imports System.Collections.Generic
 
@@ -172,7 +191,7 @@ Class C
     End Sub
 End Class";
 
-            string arrayEmptySource = IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
+            string arrayEmptySource = GetArrayEmptySourceBasic();
 
             VerifyBasic(badSource + arrayEmptySource, new[]
             {
@@ -220,7 +239,7 @@ class C
         double[] arr3 = new double[(long)1];         // no
     }
 }";
-            string arrayEmptySource = IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
+            string arrayEmptySource = GetArrayEmptySourceCSharp();
 
             VerifyCSharp(badSource + arrayEmptySource, new[]
             {
@@ -242,15 +261,6 @@ class C
         [Fact]
         public void EmptyArrayVisualBasic_CompilerGeneratedArrayCreation()
         {
-            const string arrayEmptySourceRaw = @"
-Namespace System
-    Public Class Array
-       Public Shared Function Empty(Of T)() As T()
-           Return Nothing
-       End Function
-    End Class
-End Namespace
-";
             const string source = @"
 Class C
     Private Sub F(ParamArray args As String())
@@ -262,7 +272,7 @@ Private Sub G()
 End Class
 ";
 
-            string arrayEmptySource = IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
+            string arrayEmptySource = GetArrayEmptySourceBasic();
 
             // Should we be flagging diagnostics on compiler generated code?
             // Should the analyzer even be invoked for compiler generated code?
@@ -273,29 +283,13 @@ End Class
         [Fact]
         public void EmptyArrayCSharp_CompilerGeneratedArrayCreationInObjectCreation()
         {
-            const string arrayEmptySourceRaw = @"
-using System;
-using System.Collections;
-using System.Collections.Generic;
-
-namespace System
-{
-	public class Array
-	{
-		public static T[] Empty<T>()
-		{
-			return null;
-		}
-	}
-}
-";
             const string source = @"
 namespace N
 {
     using Microsoft.CodeAnalysis;
     class C
     {
-	    public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             ""RuleId"",
             ""Title"",
             ""MessageFormat"",
@@ -307,7 +301,7 @@ namespace N
 }
 ";
 
-            string arrayEmptySource = IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
+            string arrayEmptySource = GetArrayEmptySourceCSharp();
 
             // Should we be flagging diagnostics on compiler generated code?
             // Should the analyzer even be invoked for compiler generated code?
@@ -318,22 +312,6 @@ namespace N
         [Fact]
         public void EmptyArrayCSharp_CompilerGeneratedArrayCreationInIndexerAccess()
         {
-            const string arrayEmptySourceRaw = @"
-using System;
-using System.Collections;
-using System.Collections.Generic;
-
-namespace System
-{
-	public class Array
-	{
-		public static T[] Empty<T>()
-		{
-			return null;
-		}
-	}
-}
-";
             const string source = @"
 public abstract class C
 {

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -332,6 +332,8 @@ public abstract class C
         public void WipEmptyArrayCSharp_FieldOrPropertyInitializer()
         {
             const string badSource = @"
+using System;
+
 class C
 {
     public int[] f1 = new int[] { };
@@ -343,11 +345,13 @@ class C
 
             VerifyCSharp(badSource + arrayEmptySource, new[]
             {
-                GetCSharpResultAt(4, 23, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(6, 23, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
                 GetCSharpResultAt(7, 37, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()")
             });
 
             const string fixedSource = @"
+using System;
+
 class C
 {
     public int[] f1 = Array.Empty<int>();
@@ -387,6 +391,8 @@ class C
         public void WipEmptyArrayCSharp_UsedInAssignment()
         {
             const string badSource = @"
+using System;
+
 class C
 {
     void M()
@@ -399,11 +405,13 @@ class C
 ";
             VerifyCSharp(badSource, new DiagnosticResult[]
             {
-                GetCSharpResultAt(7, 14, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(8, 14, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()")
+                GetCSharpResultAt(8, 14, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(9, 14, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()")
             });
 
             const string fixedSource = @"
+using System;
+
 class C
 {
     void M()
@@ -422,6 +430,7 @@ class C
         public void WipEmptyArrayCSharp_DeclarationTypeDoesNotMatch_NotArray()
         {
             const string badSource = @"
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -441,17 +450,18 @@ class C
 ";
             VerifyCSharp(badSource, new DiagnosticResult[]
             {
-                GetCSharpResultAt(8, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
                 GetCSharpResultAt(9, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
                 GetCSharpResultAt(10, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
                 GetCSharpResultAt(11, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
                 GetCSharpResultAt(12, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(14, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(13, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
                 GetCSharpResultAt(15, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(16, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()")
+                GetCSharpResultAt(16, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(17, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()")
             });
 
             const string fixedSource = @"
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -477,6 +487,8 @@ class C
         public void WipEmptyArrayCSharp_DeclarationTypeDoesNotMatch_DifferentElementType()
         {
             const string badSource = @"
+using System;
+
 class C
 {
     public object[] f1 = new string[0];
@@ -484,10 +496,12 @@ class C
 ";
             VerifyCSharp(badSource, new DiagnosticResult[]
             {
-                GetCSharpResultAt(4, 26, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<string>()")
+                GetCSharpResultAt(6, 26, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<string>()")
             });
 
             const string fixedSource = @"
+using System;
+
 class C
 {
     public object[] f1 = Array.Empty<string>();
@@ -501,6 +515,8 @@ class C
         public void WipEmptyArrayCSharp_UsedAsExpression()
         {
             const string badSource = @"
+using System;
+
 class C
 {
     void M1(object obj)
@@ -522,12 +538,14 @@ class C
 ";
             VerifyCSharp(badSource, new DiagnosticResult[]
             {
-                GetCSharpResultAt(10, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
-                GetCSharpResultAt(13, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
-                GetCSharpResultAt(17, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(12, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(15, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(19, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
             });
 
             const string fixedSource = @"
+using System;
+
 class C
 {
     void M1(object obj)
@@ -545,6 +563,29 @@ class C
     {
         return     Array.Empty<object>();
     }
+}
+";
+            VerifyCSharpFix(badSource, fixedSource);
+        }
+
+        [Fact]
+        public void WipEmptyArrayCSharp_SystemNotImported()
+        {
+            const string badSource = @"
+class C
+{
+    public object[] f1 = new object[0];
+}
+";
+            VerifyCSharp(badSource, new DiagnosticResult[]
+            {
+                GetCSharpResultAt(4, 26, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()")
+            });
+
+            const string fixedSource = @"
+class C
+{
+    public object[] f1 = System.Array.Empty<object>();
 }
 ";
             VerifyCSharpFix(badSource, fixedSource);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -518,18 +518,24 @@ using System;
 
 class C
 {
-    void M1(object[] obj)
+    void M1(object[] array)
     {
     }
 
-    void M2()
+    // Tests handling of implicit conversion. Do not change to 'object[] obj'.
+    void M2(object obj)
+    {
+    }
+
+    void M3()
     {
         M1(new object[0]);
+        M2(new object[0]);
     }
 
-    object M3() => new object[0];
+    object M4() => new object[0];
 
-    object M4()
+    object M5()
     {
         return new object[0];
     }
@@ -537,9 +543,10 @@ class C
 ";
             VerifyCSharp(badSource, new DiagnosticResult[]
             {
-                GetCSharpResultAt(12, 12, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
-                GetCSharpResultAt(15, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
-                GetCSharpResultAt(19, 16, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(17, 12, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(18, 12, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(21, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(25, 16, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
             });
 
             const string fixedSource = @"
@@ -547,18 +554,24 @@ using System;
 
 class C
 {
-    void M1(object[] obj)
+    void M1(object[] array)
     {
     }
 
-    void M2()
+    // Tests handling of implicit conversion. Do not change to 'object[] obj'.
+    void M2(object obj)
+    {
+    }
+
+    void M3()
     {
         M1(Array.Empty<object>());
+        M2(Array.Empty<object>());
     }
 
-    object M3() => Array.Empty<object>();
+    object M4() => Array.Empty<object>();
 
-    object M4()
+    object M5()
     {
         return Array.Empty<object>();
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -327,6 +327,29 @@ public abstract class C
             VerifyCSharp(source + arrayEmptySource, addLanguageSpecificCodeAnalysisReference: true);
         }
 
+        [Fact]
+        public void EmptyArrayCSharp_UsedInAttribute_NoDiagnostics()
+        {
+            const string source = @"
+using System;
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]  
+class CustomAttribute : Attribute
+{
+    public CustomAttribute(object o)
+    {
+    }
+}
+
+[Custom(new int[0])]
+[Custom(new string[] { })]
+class C
+{
+}
+";
+            VerifyCSharp(source);
+        }
+
         [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
         public void EmptyArrayCSharp_FieldOrPropertyInitializer()
@@ -360,29 +383,6 @@ class C
 ";
 
             VerifyCSharpFix(badSource, fixedSource);
-        }
-        
-        [Fact]
-        public void EmptyArrayCSharp_UsedInAttribute_NoDiagnostics()
-        {
-            const string source = @"
-using System;
-
-[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]  
-class CustomAttribute : Attribute
-{
-    public CustomAttribute(object o)
-    {
-    }
-}
-
-[Custom(new int[0])]
-[Custom(new string[] { })]
-class C
-{
-}
-";
-            VerifyCSharp(source);
         }
 
         [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -361,10 +361,9 @@ class C
 
             VerifyCSharpFix(badSource, fixedSource);
         }
-
-        [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
+        
         [Fact]
-        public void EmptyArrayCSharp_UsedInAttribute_NoDiagnostics()
+        public void WipEmptyArrayCSharp_UsedInAttribute_NoDiagnostics()
         {
             const string source = @"
 using System;
@@ -405,8 +404,8 @@ class C
 ";
             VerifyCSharp(badSource, new DiagnosticResult[]
             {
-                GetCSharpResultAt(8, 14, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(9, 14, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()")
+                GetCSharpResultAt(9, 14, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(10, 14, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()")
             });
 
             const string fixedSource = @"
@@ -437,27 +436,27 @@ using System.Collections.ObjectModel;
 
 class C
 {
-    public IEnumerable<int> f1 =         new int[0];
-    public ICollection<int> f2 =         new int[0];
+    public IEnumerable<int> f1 = new int[0];
+    public ICollection<int> f2 = new int[0];
     public IReadOnlyCollection<int> f3 = new int[0];
-    public IList<int> f4 =               new int[0];
-    public IReadOnlyList<int> f5 =       new int[0];
+    public IList<int> f4 = new int[0];
+    public IReadOnlyList<int> f5 = new int[0];
 
-    public IEnumerable f6 =              new int[0];
-    public ICollection f7 =              new int[0];
-    public IList f8 =                    new int[0];
+    public IEnumerable f6 = new int[0];
+    public ICollection f7 = new int[0];
+    public IList f8 = new int[0];
 }
 ";
             VerifyCSharp(badSource, new DiagnosticResult[]
             {
-                GetCSharpResultAt(9, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(10, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(9, 34, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(10, 34, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
                 GetCSharpResultAt(11, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(12, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(13, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(15, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(16, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
-                GetCSharpResultAt(17, 42, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()")
+                GetCSharpResultAt(12, 28, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(13, 36, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(15, 29, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(16, 29, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()"),
+                GetCSharpResultAt(17, 23, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<int>()")
             });
 
             const string fixedSource = @"
@@ -468,15 +467,15 @@ using System.Collections.ObjectModel;
 
 class C
 {
-    public IEnumerable<int> f1 =         Array.Empty<int>();
-    public ICollection<int> f2 =         Array.Empty<int>();
+    public IEnumerable<int> f1 = Array.Empty<int>();
+    public ICollection<int> f2 = Array.Empty<int>();
     public IReadOnlyCollection<int> f3 = Array.Empty<int>();
-    public IList<int> f4 =               Array.Empty<int>();
-    public IReadOnlyList<int> f5 =       Array.Empty<int>();
+    public IList<int> f4 = Array.Empty<int>();
+    public IReadOnlyList<int> f5 = Array.Empty<int>();
 
-    public IEnumerable f6 =              Array.Empty<int>();
-    public ICollection f7 =              Array.Empty<int>();
-    public IList f8 =                    Array.Empty<int>();
+    public IEnumerable f6 = Array.Empty<int>();
+    public ICollection f7 = Array.Empty<int>();
+    public IList f8 = Array.Empty<int>();
 }
 ";
             VerifyCSharpFix(badSource, fixedSource);
@@ -519,28 +518,28 @@ using System;
 
 class C
 {
-    void M1(object obj)
+    void M1(object[] obj)
     {
     }
 
     void M2()
     {
-        M1(        new object[0]);
+        M1(new object[0]);
     }
 
     object M3() => new object[0];
 
     object M4()
     {
-        return     new object[0];
+        return new object[0];
     }
 }
 ";
             VerifyCSharp(badSource, new DiagnosticResult[]
             {
-                GetCSharpResultAt(12, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(12, 12, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
                 GetCSharpResultAt(15, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
-                GetCSharpResultAt(19, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(19, 16, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
             });
 
             const string fixedSource = @"
@@ -548,20 +547,20 @@ using System;
 
 class C
 {
-    void M1(object obj)
+    void M1(object[] obj)
     {
     }
 
     void M2()
     {
-        M1(        Array.Empty<object>());
+        M1(Array.Empty<object>());
     }
 
     object M3() => Array.Empty<object>();
 
     object M4()
     {
-        return     Array.Empty<object>();
+        return Array.Empty<object>();
     }
 }
 ";

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -494,5 +494,58 @@ class C
 ";
             VerifyCSharpFix(badSource, fixedSource);
         }
+
+        [Fact]
+        public void WipEmptyArrayCSharp_UsedAsExpression()
+        {
+            const string badSource = @"
+class C
+{
+    void M1(object obj)
+    {
+    }
+
+    void M2()
+    {
+        M1(        new object[0]);
+    }
+
+    object M3() => new object[0];
+
+    object M4()
+    {
+        return     new object[0];
+    }
+}
+";
+            VerifyCSharp(badSource, new DiagnosticResult[]
+            {
+                GetCSharpResultAt(10, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(13, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+                GetCSharpResultAt(17, 20, AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor, "Array.Empty<object>()"),
+            });
+
+            const string fixedSource = @"
+class C
+{
+    void M1(object obj)
+    {
+    }
+
+    void M2()
+    {
+        M1(        Array.Empty<object>());
+    }
+
+    object M3() => Array.Empty<object>();
+
+    object M4()
+    {
+        return     Array.Empty<object>();
+    }
+}
+";
+            VerifyCSharpFix(badSource, fixedSource);
+        }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -361,6 +361,7 @@ class C
             VerifyCSharpFix(badSource, fixedSource);
         }
         
+        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
         [Fact]
         public void EmptyArrayCSharp_UsedInAttribute_NoDiagnostics()
         {
@@ -384,6 +385,7 @@ class C
             VerifyCSharp(source);
         }
 
+        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
         [Fact]
         public void WipEmptyArrayCSharp_UsedInAssignment()
         {
@@ -418,6 +420,7 @@ class C
             VerifyCSharpFix(badSource, fixedSource);
         }
 
+        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
         [Fact]
         public void WipEmptyArrayCSharp_DeclarationTypeDoesNotMatch_NotArray()
         {
@@ -472,6 +475,7 @@ class C
             VerifyCSharpFix(badSource, fixedSource);
         }
 
+        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
         [Fact]
         public void WipEmptyArrayCSharp_DeclarationTypeDoesNotMatch_DifferentElementType()
         {
@@ -495,6 +499,7 @@ class C
             VerifyCSharpFix(badSource, fixedSource);
         }
 
+        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
         [Fact]
         public void WipEmptyArrayCSharp_UsedAsExpression()
         {

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -38,8 +38,8 @@ Namespace System
            Return Nothing
        End Function
     End Class
-End Namespace";
-
+End Namespace
+";
             return IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
         }
 
@@ -55,8 +55,8 @@ namespace System
             return null;
         }
     }
-}";
-
+}
+";
             return IsArrayEmptyDefined() ? string.Empty : arrayEmptySourceRaw;
         }
 
@@ -215,9 +215,6 @@ End Class";
         [Fact]
         public void EmptyArrayCSharp_DifferentTypeKind()
         {
-            const string arrayEmptySourceRaw =
-                @"namespace System { public class Array { public static T[] Empty<T>() { return null; } } }";
-
             const string badSource = @"
 class C
 {
@@ -360,8 +357,8 @@ class C
 
             VerifyCSharpFix(badSource, fixedSource);
         }
-        
-        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
+
+        [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
         public void EmptyArrayCSharp_UsedInAttribute_NoDiagnostics()
         {
@@ -385,7 +382,7 @@ class C
             VerifyCSharp(source);
         }
 
-        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
+        [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
         public void WipEmptyArrayCSharp_UsedInAssignment()
         {
@@ -420,7 +417,7 @@ class C
             VerifyCSharpFix(badSource, fixedSource);
         }
 
-        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
+        [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
         public void WipEmptyArrayCSharp_DeclarationTypeDoesNotMatch_NotArray()
         {
@@ -475,7 +472,7 @@ class C
             VerifyCSharpFix(badSource, fixedSource);
         }
 
-        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
+        [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
         public void WipEmptyArrayCSharp_DeclarationTypeDoesNotMatch_DifferentElementType()
         {
@@ -499,7 +496,7 @@ class C
             VerifyCSharpFix(badSource, fixedSource);
         }
 
-        [WorkItem(1337, "https://github.com/dotnet/roslyn-analyzers/issues/1337")]
+        [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [Fact]
         public void WipEmptyArrayCSharp_UsedAsExpression()
         {


### PR DESCRIPTION
Fixes #1298 

The original case was failing because it assumed the type of the declaration would match up with the type of the expression. e.g. for `object[] a = new string[0]`, the codefix would be `Array.Empty<object>()`. This PR changes that approach so it doesn't look at the declaration, and determines the element type solely from the expression using IOperation APIs.

/cc @333fred 