### PR TITLE
Make ca1801 aware of methods that just throw NotImplementedException

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
@@ -69,6 +69,10 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                     onSerializingAttribute,
                     obsoleteAttribute);
 
+                ImmutableHashSet<INamedTypeSymbol> exceptionsToSkip = ImmutableHashSet.Create(
+                    WellKnownTypes.NotImplementedException(compilationStartContext.Compilation),
+                    WellKnownTypes.NotSupportedException(compilationStartContext.Compilation));
+
                 UnusedParameterDictionary unusedMethodParameters = new ConcurrentDictionary<IMethodSymbol, ISet<IParameterSymbol>>();
                 ISet<IMethodSymbol> methodsUsedAsDelegates = new HashSet<IMethodSymbol>();
 
@@ -128,7 +132,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                     }
 
                     // Initialize local mutable state in the start action.
-                    var analyzer = new UnusedParametersAnalyzer(method, unusedMethodParameters);
+                    var analyzer = new UnusedParametersAnalyzer(method, unusedMethodParameters, exceptionsToSkip);
 
                     // Register an intermediate non-end action that accesses and modifies the state.
                     startOperationBlockContext.RegisterOperationAction(analyzer.AnalyzeOperation, OperationKind.ParameterReference);
@@ -156,6 +160,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         {
             #region Per-CodeBlock mutable state
 
+            private readonly ImmutableHashSet<INamedTypeSymbol> _exceptionsToSkip;
             private readonly HashSet<IParameterSymbol> _unusedParameters;
             private readonly UnusedParameterDictionary _finalUnusedParameters;
             private readonly IMethodSymbol _method;
@@ -164,10 +169,11 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
             #region State intialization
 
-            public UnusedParametersAnalyzer(IMethodSymbol method, UnusedParameterDictionary finalUnusedParameters)
+            public UnusedParametersAnalyzer(IMethodSymbol method, UnusedParameterDictionary finalUnusedParameters, ImmutableHashSet<INamedTypeSymbol> exceptionsToSkip)
             {
                 // Initialization: Assume all parameters are unused.
                 _unusedParameters = new HashSet<IParameterSymbol>(method.Parameters);
+                _exceptionsToSkip = exceptionsToSkip;
                 _finalUnusedParameters = finalUnusedParameters;
                 _method = method;
             }
@@ -195,8 +201,9 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
             public void OperationBlockEndAction(OperationBlockAnalysisContext context)
             {
-                // Check to see if the method just throws a NotImplementedException. If it does, we shouldn't warn
-                // about parameters. Note that VB method bodies with 1 action have 3 operations.
+                // Check to see if the method just throws a NotImplementedException/NotSupportedException. If it does,
+                // we shouldn't warn about parameters.
+                // Note that VB method bodies with 1 action have 3 operations.
                 // The first is the actual operation, the second is a label statement, and the third is a return
                 // statement. The last two are implicit in these scenarios.
                 if (context.OperationBlocks.Length == 1)
@@ -227,8 +234,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                             throwOperation.Exception.Kind == OperationKind.ObjectCreation &&
                             throwOperation.Exception is IObjectCreationOperation createdException)
                         {
-                            var notImplementedType = WellKnownTypes.NotImplementedException(context.Compilation);
-                            if (notImplementedType.Equals(createdException.Type))
+                            if (_exceptionsToSkip.Contains(createdException.Type.OriginalDefinition))
                             {
                                 return;
                             }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -538,6 +538,53 @@ Public Class C1
 End Class");
         }
 
+        [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
+        public void NoDiagnosticMethodJustThrowsNotImplemented()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C1
+{
+    public int Prop1
+    {
+        get
+        {
+            throw new NotImplementedException();
+        }
+        set
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public void Method1(object o1)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Method2(object o1) => throw new NotImplementedException();
+}");
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C1
+    Property Prop1 As Integer
+        Get
+            Throw New NotImplementedException()
+        End Get
+        Set(ByVal value As Integer)
+            Throw New NotImplementedException()
+        End Set
+    End Property
+
+    Public Sub Method1(o1 As Object)
+        Throw New NotImplementedException()
+    End Sub
+End Class");
+        }
+
         #endregion
 
         #region Unit tests for analyzer diagnostic(s)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -585,6 +585,53 @@ Public Class C1
 End Class");
         }
 
+        [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
+        public void NoDiagnosticMethodJustThrowsNotSupported()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C1
+{
+    public int Prop1
+    {
+        get
+        {
+            throw new NotSupportedException();
+        }
+        set
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    public void Method1(object o1)
+    {
+        throw new NotSupportedException();
+    }
+
+    public void Method2(object o1) => throw new NotSupportedException();
+}");
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C1
+    Property Prop1 As Integer
+        Get
+            Throw New NotSupportedException()
+        End Get
+        Set(ByVal value As Integer)
+            Throw New NotSupportedException()
+        End Set
+    End Property
+
+    Public Sub Method1(o1 As Object)
+        Throw New NotSupportedException()
+    End Sub
+End Class");
+        }
+
         #endregion
 
         #region Unit tests for analyzer diagnostic(s)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/1220
Fixes #1357

This updates CA1801 to be aware of method bodies that are only `throw NotImplementedException()`, and makes sure that diagnostics aren't registered for them.