### PR TITLE
CA1052 should ignore sealed types.

### DIFF
--- a/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Analyzer.Utilities/Extensions/INamedTypeSymbolExtensions.cs
@@ -183,6 +183,12 @@ namespace Analyzer.Utilities.Extensions
                 return false;
             }
 
+            // Sealed objects are presumed to be non-static holder types
+            if (symbol.IsSealed)
+            {
+                return false;
+            }
+
             IEnumerable<ISymbol> declaredMembers = symbol.GetMembers().Where(m => !m.IsImplicitlyDeclared);
 
             return declaredMembers.Any(IsQualifyingMember) && !declaredMembers.Any(IsDisqualifyingMember);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.Fixer.cs
@@ -32,26 +32,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1052FixesSealedClassWithOnlyStaticDeclaredMembersCSharp()
-        {
-            const string Code = @"
-public sealed class C
-{
-    public static void Foo() { }
-}
-";
-
-            const string FixedCode = @"
-public static class C
-{
-    public static void Foo() { }
-}
-";
-
-            VerifyCSharpFix(Code, FixedCode);
-        }
-
-        [Fact]
         public void CA1052FixesNonStaticClassWithOnlyStaticDeclaredMembersCSharp()
         {
             const string Code = @"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -63,28 +63,56 @@ public static class C2
 ");
         }
 
-        [Fact]
-        public void CA1052DiagnosticForSealedClassWithOnlyStaticDeclaredMembersCSharp()
+        [Fact, WorkItem(1320, "https://github.com/dotnet/roslyn-analyzers/issues/1320")]
+        public void CA1052NoDiagnosticForSealedClassWithOnlyStaticDeclaredMembersCSharp()
         {
             VerifyCSharp(@"
 public sealed class C3
 {
     public static void Foo() { }
 }
-",
-                CSharpResult(2, 21, "C3"));
+");
         }
 
-        [Fact]
-        public void CA1052DiagnosticForNonInheritableClassWithOnlySharedDeclaredMembersBasic()
+        [Fact, WorkItem(1320, "https://github.com/dotnet/roslyn-analyzers/issues/1320")]
+        public void CA1052NoDiagnosticForNonInheritableClassWithOnlySharedDeclaredMembersBasic()
         {
             VerifyBasic(@"
 Public NotInheritable Class B3
     Public Shared Sub Foo()
     End Sub
 End Class
-",
-                BasicResult(2, 29, "B3"));
+");
+        }
+
+        [Fact, WorkItem(1292, "https://github.com/dotnet/roslyn-analyzers/issues/1292")]
+        public void CA1052NoDiagnosticForSealedClassWithPublicConstructorAndStaticMembers()
+        {
+            VerifyCSharp(@"
+using System.Threading;
+
+public sealed class ConcurrentCreationDummy
+{
+    private static int creationAttempts;
+
+    public ConcurrentCreationDummy()
+    {
+        if (IsCreatingFirstInstance())
+        {
+            CreatingFirstInstance.Set();
+            CreatedSecondInstance.Wait();
+        }
+    }
+
+    public static ManualResetEventSlim CreatingFirstInstance { get; } = new ManualResetEventSlim();
+
+    public static ManualResetEventSlim CreatedSecondInstance { get; } = new ManualResetEventSlim();
+
+    private static bool IsCreatingFirstInstance()
+    {
+        return Interlocked.Increment(ref creationAttempts) == 1;
+    }
+}");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/1320
Fixes https://github.com/dotnet/roslyn-analyzers/issues/1292

This PR is adjusting the implementation to match FxCop behavior.