### PR TITLE
Implement analyzer for Async005: PropagateCancellationTokensWhenPossible

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -157,10 +157,10 @@
     <value>Propagate CancellationToken '{0}'</value>
   </data>
   <data name="PropagateCancellationTokensWhenPossibleDescription" xml:space="preserve">
-    <value>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</value>
+    <value>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</value>
   </data>
   <data name="PropagateCancellationTokensWhenPossibleMessage" xml:space="preserve">
-    <value>Propagate CancellationToken in method invocation. Available tokens: {0}</value>
+    <value>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</value>
   </data>
   <data name="DoNotMixBlockingAndAsyncTitle" xml:space="preserve">
     <value>Don't Mix Blocking and Async</value>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -154,13 +154,13 @@
     <value>Don't Store Async Lambdas as Void Returning Delegate Types</value>
   </data>
   <data name="PropagateCancellationTokensWhenPossibleTitle" xml:space="preserve">
-    <value>Propagate CancellationTokens When Possible</value>
+    <value>Propagate CancellationToken '{0}'</value>
   </data>
   <data name="PropagateCancellationTokensWhenPossibleDescription" xml:space="preserve">
-    <value>#N/A</value>
+    <value>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</value>
   </data>
   <data name="PropagateCancellationTokensWhenPossibleMessage" xml:space="preserve">
-    <value>Propagate CancellationTokens When Possible</value>
+    <value>Propagate CancellationToken in method invocation. Available tokens: {0}</value>
   </data>
   <data name="DoNotMixBlockingAndAsyncTitle" xml:space="preserve">
     <value>Don't Mix Blocking and Async</value>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
@@ -149,13 +149,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         return field.Type == cancellationTokenType;
                     case SymbolKind.Local:
                         var local = (ILocalSymbol)symbol;
-                        return local.Type == cancellationTokenType &&
-                            !local.IsInaccessibleLocal(position) &&
-                            !(local.IsUninitializedVariable(invocation.Syntax, semanticModel) ?? true);
+                        return local.Type == cancellationTokenType && !local.IsInaccessibleLocal(position);
                     case SymbolKind.Parameter:
                         var parameter = (IParameterSymbol)symbol;
-                        return parameter.Type == cancellationTokenType &&
-                            !(parameter.IsUninitializedVariable(invocation.Syntax, semanticModel) ?? true);
+                        return parameter.Type == cancellationTokenType;
                     default:
                         return false;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
@@ -2,8 +2,13 @@
 
 using System.Collections.Immutable;
 using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis.Operations;
+using System;
+using System.Diagnostics;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
@@ -33,11 +38,96 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            // TODO: Enable concurrent execution of analyzer actions.
-            //analysisContext.EnableConcurrentExecution();
+            analysisContext.EnableConcurrentExecution();
 
-            // TODO: Configure generated code analysis.
-            //analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // TODO: Include this?
+            // analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            analysisContext.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        }
+
+        private static void AnalyzeInvocation(OperationAnalysisContext context)
+        {
+            var invocation = (IInvocationOperation)context.Operation;
+            if (InvocationShouldPassCancellationToken(invocation, context.Compilation))
+            {
+                context.ReportDiagnostic(invocation.Syntax.CreateDiagnostic(Rule));
+            }
+        }
+
+        private static bool InvocationShouldPassCancellationToken(IInvocationOperation invocation, Compilation compilation)
+        {
+            var cancellationTokenType = WellKnownTypes.CancellationToken(compilation);
+
+            var targetMethod = invocation.TargetMethod;
+            if (targetMethod == null)
+            {
+                return false;
+            }
+
+            if (!AcceptsCancellationTokens(targetMethod))
+            {
+                // Check if there is a different overload of the method that accepts a CancellationToken.
+                var methodName = targetMethod.Name;
+                var overloads = targetMethod.ContainingType.GetMembers(methodName).OfType<IMethodSymbol>();
+                var targetOverload = overloads.FirstOrDefault(
+                    m => AcceptsCancellationTokens(m) && StartsWithSameParameters(m, targetMethod));
+
+                if (targetOverload == null)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                // Check if default(CancellationToken) or CancellationToken.None is being passed in.
+                var argument = invocation.Arguments.FirstOrDefault(a => a.Type == cancellationTokenType);
+                if (argument != null && !IsCancellationTokenNone(argument))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+
+            bool AcceptsCancellationTokens(IMethodSymbol method)
+            {
+                return method.Parameters.Any(p => p.Type == cancellationTokenType);
+            }
+
+            bool IsCancellationTokenNone(IArgumentOperation argument)
+            {
+                var argumentValue = argument.Value;
+                switch (argumentValue.Kind)
+                {
+                    case OperationKind.DefaultValue:
+                        return true;
+                    case OperationKind.PropertyReference:
+                        var property = ((IPropertyReferenceOperation)argumentValue).Property;
+                        if (property.Name == "None" && property.ContainingType == cancellationTokenType)
+                        {
+                            return true;
+                        }
+                        break;
+                }
+
+                return false;
+            }
+        }
+
+        private static bool StartsWithSameParameters(IMethodSymbol first, IMethodSymbol second)
+        {
+            int count = Math.Min(first.Parameters.Length, second.Parameters.Length);
+
+            for (int i = 0; i < count; i++)
+            {
+                if (first.Parameters[i].Type != second.Parameters[i].Type)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
@@ -158,9 +158,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 switch (symbol.Kind)
                 {
-                    case SymbolKind.Field:
-                        var field = (IFieldSymbol)symbol;
-                        return field.Type == cancellationTokenType;
                     case SymbolKind.Local:
                         var local = (ILocalSymbol)symbol;
                         return local.Type == cancellationTokenType && !local.IsInaccessibleLocal(position);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
@@ -115,6 +115,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             // Note that default(CancellationToken) is equivalent to CancellationToken.None.
 
             var argumentValue = argument.Value;
+            Debug.Assert(argumentValue.Type == cancellationTokenType);
+
             switch (argumentValue.Kind)
             {
                 case OperationKind.DefaultValue:

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
     /// <summary>
     /// Async005: Propagate CancellationTokens When Possible
     /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public abstract class PropagateCancellationTokensWhenPossibleAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "Async005";

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
@@ -86,7 +86,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 // All valid code should result in 'argument' being non-null. Even if the CancellationToken is an optional
                 // parameter and the caller does not explicitly pass it, 'argument' will still correspond to a compiler-generated
                 // CancellationToken value. However, check for null to ensure we don't crash on invalid code.
-                if (argument != null && !IsCancellationTokenNone(argument, cancellationTokenType))
+                if (argument == null)
+                {
+                    // The code is invalid. The compiler error will be enough warning for the developer.
+                    return false;
+                }
+
+                if (!IsCancellationTokenNone(argument, cancellationTokenType))
                 {
                     // A non-default CancellationToken is being passed.
                     return false;
@@ -139,6 +145,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         return field.Type == cancellationTokenType;
                     case ILocalSymbol local:
                         return local.Type == cancellationTokenType && !local.IsInaccessibleLocal(position);
+                    case IParameterSymbol parameter:
+                        return parameter.Type == cancellationTokenType;
                     default:
                         return false;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
@@ -40,9 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         public override void Initialize(AnalysisContext analysisContext)
         {
             analysisContext.EnableConcurrentExecution();
-
-            // TODO: Include this?
-            // analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
             analysisContext.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Když je to možné, rozšiřte objekty CancellationToken.</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">Když je to možné, rozšiřte objekty CancellationToken.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">Není k dispozici</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">Není k dispozici</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Když je to možné, rozšiřte objekty CancellationToken.</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">Když je to možné, rozšiřte objekty CancellationToken.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">Není k dispozici</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">Když je to možné, rozšiřte objekty CancellationToken.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#Nicht zutreffend</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">Nach Möglichkeit CancellationTokens verteilen</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Nach Möglichkeit CancellationTokens verteilen</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">Nach Möglichkeit CancellationTokens verteilen</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#Nicht zutreffend</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#Nicht zutreffend</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Nach Möglichkeit CancellationTokens verteilen</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">Nach Möglichkeit CancellationTokens verteilen</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#N/D</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">Propagar elementos CancellationToken cuando sea posible</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagar elementos CancellationToken cuando sea posible</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">Propagar elementos CancellationToken cuando sea posible</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#N/D</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#N/D</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagar elementos CancellationToken cuando sea posible</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">Propagar elementos CancellationToken cuando sea posible</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">Propager CancellationTokens quand cela est possible</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propager CancellationTokens quand cela est possible</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">Propager CancellationTokens quand cela est possible</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#N/A</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propager CancellationTokens quand cela est possible</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">Propager CancellationTokens quand cela est possible</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">Propagare parametri CancellationToken quando possibile</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagare parametri CancellationToken quando possibile</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">Propagare parametri CancellationToken quando possibile</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#N/A</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagare parametri CancellationToken quando possibile</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">Propagare parametri CancellationToken quando possibile</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">可能な場合は CancellationToken を伝達してください</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">可能な場合は CancellationToken を伝達してください</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">可能な場合は CancellationToken を伝達してください</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#N/A</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">可能な場合は CancellationToken を伝達してください</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">可能な場合は CancellationToken を伝達してください</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">가능한 경우 취소 토큰을 전파하세요.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">가능한 경우 취소 토큰을 전파하세요.</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">가능한 경우 취소 토큰을 전파하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#N/A</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">가능한 경우 취소 토큰을 전파하세요.</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">가능한 경우 취소 토큰을 전파하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propaguj elementy CancellationToken, jeśli to możliwe</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">Propaguj elementy CancellationToken, jeśli to możliwe</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">ND</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">ND</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propaguj elementy CancellationToken, jeśli to możliwe</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">Propaguj elementy CancellationToken, jeśli to możliwe</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">ND</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">Propaguj elementy CancellationToken, jeśli to możliwe</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#N/D</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">Propagar CancellationTokens quando possível</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagar CancellationTokens quando possível</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">Propagar CancellationTokens quando possível</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#N/D</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#N/D</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagar CancellationTokens quando possível</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">Propagar CancellationTokens quando possível</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#Н/Д</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">По мере возможности распространяйте токены CancellationToken</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">По мере возможности распространяйте токены CancellationToken</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">По мере возможности распространяйте токены CancellationToken</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#Н/Д</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#Н/Д</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">По мере возможности распространяйте токены CancellationToken</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">По мере возможности распространяйте токены CancellationToken</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Mümkün Olduğunda CancellationToken’ları Yay</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">Mümkün Olduğunda CancellationToken’ları Yay</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#N/A</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Mümkün Olduğunda CancellationToken’ları Yay</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">Mümkün Olduğunda CancellationToken’ları Yay</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">Mümkün Olduğunda CancellationToken’ları Yay</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">如有可能，传播 CancellationTokens</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">如有可能，传播 CancellationTokens</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">如有可能，传播 CancellationTokens</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#N/A</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">如有可能，传播 CancellationTokens</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">如有可能，传播 CancellationTokens</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
@@ -68,12 +68,12 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <source>A CancellationToken should be passed to method invocations when the method accepts a CancellationToken and a local variable/parameter of that type is in scope. This ensures that setting a token's state to canceled actually cancels operations the token was passed to.</source>
         <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <source>Propagate CancellationToken to method invocation. Tokens in scope are: {0}</source>
         <target state="needs-review-translation">於可能時散佈 CancellationToken</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
@@ -63,18 +63,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">於可能時散佈 CancellationToken</target>
+        <source>Propagate CancellationToken '{0}'</source>
+        <target state="needs-review-translation">於可能時散佈 CancellationToken</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
-        <source>#N/A</source>
-        <target state="translated">#N/A</target>
+        <source>A CancellationToken should be passed to method invocations if the method accepts a CancellationToken and one is in scope. This ensures that CancellationTokens stay true to their name: setting a token's state to canceled should cancel any operations the token was passed to.</source>
+        <target state="needs-review-translation">#N/A</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">於可能時散佈 CancellationToken</target>
+        <source>Propagate CancellationToken in method invocation. Available tokens: {0}</source>
+        <target state="needs-review-translation">於可能時散佈 CancellationToken</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
     public class PropagateCancellationTokensWhenPossibleTests : DiagnosticAnalyzerTestBase
     {
         [Fact]
-        public void WipCSharp_CancellationTokenOverloadAvailable()
+        public void CSharp_CancellationTokenOverloadAvailable()
         {
             var source = @"
 using System.Threading;
@@ -30,7 +30,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_OptionalCancellationTokenParameter()
+        public void CSharp_OptionalCancellationTokenParameter()
         {
             var source = @"
 using System.Threading;
@@ -47,7 +47,7 @@ class C
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1476")]
-        public void WipCSharp_UninitializedCancellationTokenOutParameter_NoDiagnostics()
+        public void CSharp_UninitializedCancellationTokenOutParameter_NoDiagnostics()
         {
             var source = @"
 using System.Threading;
@@ -69,7 +69,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_DefaultCancellationTokenPassed()
+        public void CSharp_DefaultCancellationTokenPassed()
         {
             var source = @"
 using System.Threading;
@@ -86,7 +86,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_CancellationTokenNonePassed()
+        public void CSharp_CancellationTokenNonePassed()
         {
             var source = @"
 using System.Threading;
@@ -103,7 +103,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_CancellationTokenInScope_InstanceField()
+        public void CSharp_CancellationTokenInScope_InstanceField()
         {
             var source = @"
 using System.Threading;
@@ -124,7 +124,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_CancellationTokenInScope_StaticField()
+        public void CSharp_CancellationTokenInScope_StaticField()
         {
             var source = @"
 using System.Threading;
@@ -145,7 +145,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_CancellationTokenInScope_LocalVariable()
+        public void CSharp_CancellationTokenInScope_LocalVariable()
         {
             var source = @"
 using System.Threading;
@@ -168,7 +168,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_CancellationTokenIsPropagated_NoDiagnostics()
+        public void CSharp_CancellationTokenIsPropagated_NoDiagnostics()
         {
             var source = @"
 using System.Threading;
@@ -187,7 +187,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_NoCancellationTokenOverloadAvailable_NoDiagnostics()
+        public void CSharp_NoCancellationTokenOverloadAvailable_NoDiagnostics()
         {
             var source = @"
 using System.Threading;
@@ -204,7 +204,7 @@ class C
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1476")]
-        public void WipCSharp_CancellationTokenInScope_UninitializedLocalVariable_NoDiagnostics()
+        public void CSharp_CancellationTokenInScope_UninitializedLocalVariable_NoDiagnostics()
         {
             var source = @"
 using System.Threading;
@@ -226,7 +226,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_CancellationTokenInScope_LocalVariableDeclaredAfterwards_NoDiagnostics()
+        public void CSharp_CancellationTokenInScope_LocalVariableDeclaredAfterwards_NoDiagnostics()
         {
             var source = @"
 using System.Threading;
@@ -248,7 +248,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_RequiredCancellationTokenParameterIsNotPassed_NoCrash()
+        public void CSharp_RequiredCancellationTokenParameterIsNotPassed_NoCrash()
         {
             var source = @"
 using System.Threading;

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
@@ -4,11 +4,124 @@ using Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines;
 using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
+using Xunit;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
     public class PropagateCancellationTokensWhenPossibleTests : DiagnosticAnalyzerTestBase
     {
+        [Fact]
+        public void WipCSharp_CancellationTokenOverloadAvailable()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1() => throw null;
+
+    Task M1(CancellationToken p1) => throw null;
+
+    Task M2(CancellationToken p1) => M1();
+}
+";
+            VerifyCSharp(source, GetCSharpResultAt(11, 38));
+        }
+
+        [Fact]
+        public void WipCSharp_OptionalCancellationTokenParameter()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1(CancellationToken p1 = default(CancellationToken)) => throw null;
+
+    Task M2(CancellationToken p1) => M1();
+}
+";
+            VerifyCSharp(source, GetCSharpResultAt(9, 38));
+        }
+
+        [Fact]
+        public void WipCSharp_DefaultCancellationTokenPassed()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1(CancellationToken p1) => throw null;
+
+    Task M2(CancellationToken p1) => M1(default(CancellationToken));
+}
+";
+            VerifyCSharp(source, GetCSharpResultAt(9, 38));
+        }
+
+        [Fact]
+        public void WipCSharp_CancellationTokenNonePassed()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1(CancellationToken p1) => throw null;
+
+    Task M2(CancellationToken p1) => M1(CancellationToken.None);
+}
+";
+            VerifyCSharp(source, GetCSharpResultAt(9, 38));
+        }
+
+        [Fact]
+        public void WipCSharp_InstanceCancellationTokenFieldInScope()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    private CancellationToken _f1;
+
+    Task M1() => throw null;
+
+    Task M1(CancellationToken p1) => throw null;
+
+    Task M2() => M1();
+}
+";
+            VerifyCSharp(source, GetCSharpResultAt(13, 18));
+        }
+
+        [Fact]
+        public void WipCSharp_StaticCancellationTokenFieldInScope()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    private static CancellationToken _s1;
+
+    Task M1() => throw null;
+
+    Task M1(CancellationToken p1) => throw null;
+
+    Task M2() => M1();
+}
+";
+            VerifyCSharp(source, GetCSharpResultAt(13, 18));
+        }
+
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
             return new BasicPropagateCancellationTokensWhenPossibleAnalyzer();
@@ -17,6 +130,16 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new CSharpPropagateCancellationTokensWhenPossibleAnalyzer();
+        }
+
+        private DiagnosticResult GetBasicResultAt(int line, int column)
+        {
+            return GetBasicResultAt(line, column, PropagateCancellationTokensWhenPossibleAnalyzer.Rule);
+        }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        {
+            return GetCSharpResultAt(line, column, PropagateCancellationTokensWhenPossibleAnalyzer.Rule);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
@@ -26,7 +26,7 @@ class C
     Task M2(CancellationToken p1) => M1();
 }
 ";
-            VerifyCSharp(source, GetCSharpResultAt(11, 38));
+            VerifyCSharp(source, GetCSharpResultAt(11, 38, "p1"));
         }
 
         [Fact]
@@ -43,7 +43,7 @@ class C
     Task M2(CancellationToken p1) => M1();
 }
 ";
-            VerifyCSharp(source, GetCSharpResultAt(9, 38));
+            VerifyCSharp(source, GetCSharpResultAt(9, 38, "p1"));
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1476")]
@@ -82,7 +82,7 @@ class C
     Task M2(CancellationToken p1) => M1(default(CancellationToken));
 }
 ";
-            VerifyCSharp(source, GetCSharpResultAt(9, 38));
+            VerifyCSharp(source, GetCSharpResultAt(9, 38, "p1"));
         }
 
         [Fact]
@@ -99,7 +99,7 @@ class C
     Task M2(CancellationToken p1) => M1(CancellationToken.None);
 }
 ";
-            VerifyCSharp(source, GetCSharpResultAt(9, 38));
+            VerifyCSharp(source, GetCSharpResultAt(9, 38, "p1"));
         }
 
         [Fact]
@@ -164,7 +164,7 @@ class C
     }
 }
 ";
-            VerifyCSharp(source, GetCSharpResultAt(14, 16));
+            VerifyCSharp(source, GetCSharpResultAt(14, 16, "l1"));
         }
 
         [Fact]
@@ -274,14 +274,14 @@ class C
             return new CSharpPropagateCancellationTokensWhenPossibleAnalyzer();
         }
 
-        private DiagnosticResult GetBasicResultAt(int line, int column)
+        private DiagnosticResult GetBasicResultAt(int line, int column, string variableName)
         {
-            return GetBasicResultAt(line, column, PropagateCancellationTokensWhenPossibleAnalyzer.Rule);
+            return GetBasicResultAt(line, column, PropagateCancellationTokensWhenPossibleAnalyzer.Rule, $"'{variableName}'");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private DiagnosticResult GetCSharpResultAt(int line, int column, string variableName)
         {
-            return GetCSharpResultAt(line, column, PropagateCancellationTokensWhenPossibleAnalyzer.Rule);
+            return GetCSharpResultAt(line, column, PropagateCancellationTokensWhenPossibleAnalyzer.Rule, $"'{variableName}'");
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
@@ -47,6 +47,28 @@ class C
         }
 
         [Fact]
+        public void WipCSharp_UninitializedCancellationTokenOutParameter_NoDiagnostics()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1(CancellationToken p1 = default(CancellationToken)) => throw null;
+
+    Task M2(out CancellationToken p1)
+    {
+        var l1 = M1();
+        p1 = default(CancellationToken);
+        return l1;
+    }
+}
+";
+            VerifyCSharp(source);
+        }
+
+        [Fact]
         public void WipCSharp_DefaultCancellationTokenPassed()
         {
             var source = @"
@@ -223,6 +245,23 @@ class C
 }
 ";
             VerifyCSharp(source);
+        }
+
+        [Fact]
+        public void WipCSharp_RequiredCancellationTokenParameterIsNotPassed_NoCrash()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1(CancellationToken p1) => throw null;
+
+    Task M2() => M1();
+}
+";
+            VerifyCSharp(source, TestValidationMode.AllowCompileErrors);
         }
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
@@ -103,7 +103,7 @@ class C
         }
 
         [Fact]
-        public void CSharp_CancellationTokenInScope_InstanceField()
+        public void CSharp_CancellationTokenInScope_InstanceField_NoDiagnostics()
         {
             var source = @"
 using System.Threading;
@@ -120,11 +120,11 @@ class C
     Task M2() => M1();
 }
 ";
-            VerifyCSharp(source, GetCSharpResultAt(13, 18));
+            VerifyCSharp(source);
         }
 
         [Fact]
-        public void CSharp_CancellationTokenInScope_StaticField()
+        public void CSharp_CancellationTokenInScope_StaticField_NoDiagnostics()
         {
             var source = @"
 using System.Threading;
@@ -141,7 +141,7 @@ class C
     Task M2() => M1();
 }
 ";
-            VerifyCSharp(source, GetCSharpResultAt(13, 18));
+            VerifyCSharp(source);
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
@@ -81,7 +81,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_InstanceCancellationTokenFieldInScope()
+        public void WipCSharp_CancellationTokenInScope_InstanceField()
         {
             var source = @"
 using System.Threading;
@@ -102,7 +102,7 @@ class C
         }
 
         [Fact]
-        public void WipCSharp_StaticCancellationTokenFieldInScope()
+        public void WipCSharp_CancellationTokenInScope_StaticField()
         {
             var source = @"
 using System.Threading;
@@ -120,6 +120,65 @@ class C
 }
 ";
             VerifyCSharp(source, GetCSharpResultAt(13, 18));
+        }
+
+        [Fact]
+        public void WipCSharp_CancellationTokenInScope_LocalVariable()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1() => throw null;
+
+    Task M1(CancellationToken p1) => throw null;
+
+    Task M2()
+    {
+        var l1 = CancellationToken.None; // No dataflow
+        return M1();
+    }
+}
+";
+            VerifyCSharp(source, GetCSharpResultAt(14, 16));
+        }
+
+        [Fact]
+        public void WipCSharp_CancellationTokenIsPropagated_NoDiagnostics()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1() => throw null;
+
+    Task M1(CancellationToken p1) => throw null;
+
+    Task M2(CancellationToken p1) => M1(p1);
+}
+";
+            VerifyCSharp(source);
+        }
+
+        [Fact]
+        public void WipCSharp_NoCancellationTokenOverloadAvailable_NoDiagnostics()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1() => throw null;
+
+    Task M2(CancellationToken p1) => M1();
+}
+";
+            VerifyCSharp(source);
         }
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
@@ -181,6 +181,50 @@ class C
             VerifyCSharp(source);
         }
 
+        [Fact]
+        public void WipCSharp_CancellationTokenInScope_UninitializedLocalVariable_NoDiagnostics()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1(CancellationToken p1 = default(CancellationToken)) => throw null;
+
+    Task M2()
+    {
+        CancellationToken l1;
+        var l2 = M1();
+        return l2;
+    }
+}
+";
+            VerifyCSharp(source);
+        }
+
+        [Fact]
+        public void WipCSharp_CancellationTokenInScope_LocalVariableDeclaredAfterwards_NoDiagnostics()
+        {
+            var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class C
+{
+    Task M1(CancellationToken p1 = default(CancellationToken)) => throw null;
+
+    Task M2()
+    {
+        var l1 = M1();
+        var l2 = CancellationToken.None;
+        return l1;
+    }
+}
+";
+            VerifyCSharp(source);
+        }
+
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
             return new BasicPropagateCancellationTokensWhenPossibleAnalyzer();

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropagateCancellationTokensWhenPossibleTests.cs
@@ -46,7 +46,7 @@ class C
             VerifyCSharp(source, GetCSharpResultAt(9, 38));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1476")]
         public void WipCSharp_UninitializedCancellationTokenOutParameter_NoDiagnostics()
         {
             var source = @"
@@ -203,7 +203,7 @@ class C
             VerifyCSharp(source);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1476")]
         public void WipCSharp_CancellationTokenInScope_UninitializedLocalVariable_NoDiagnostics()
         {
             var source = @"

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -406,26 +406,5 @@ namespace Analyzer.Utilities.Extensions
             var declarationSyntax = symbol.DeclaringSyntaxReferences.Select(r => r.GetSyntax()).FirstOrDefault();
             return declarationSyntax != null && position < declarationSyntax.SpanStart;
         }
-
-        /// <summary>
-        /// Checks if a symbol corresponds to a local variable or parameter that is uninitialized at a particular statement/expression.
-        /// Returns <see langword="null"/> if data flow analysis fails, and the result could not be determined.
-        /// </summary>
-        public static bool? IsUninitializedVariable(this ISymbol symbol, SyntaxNode statementOrExpression, SemanticModel semanticModel)
-        {
-            switch (symbol.Kind)
-            {
-                case SymbolKind.Local:
-                case SymbolKind.Parameter:
-                    var analysis = semanticModel.AnalyzeDataFlow(statementOrExpression);
-                    if (!analysis.Succeeded)
-                    {
-                        return null;
-                    }
-                    return !analysis.DataFlowsIn.Contains(symbol);
-                default:
-                    return false;
-            }
-        }
     }
 }

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -383,5 +383,27 @@ namespace Analyzer.Utilities.Extensions
 
             return false;
         }
+
+        /// <returns>
+        /// Returns true if symbol is a local variable and its declaring syntax node is 
+        /// after the current position, false otherwise (including for non-local symbols)
+        /// </returns>
+        public static bool IsInaccessibleLocal(this ISymbol symbol, int position)
+        {
+            if (symbol.Kind != SymbolKind.Local)
+            {
+                return false;
+            }
+
+            // Implicitly declared locals (with Option Explicit Off in VB) are scoped to the entire
+            // method and should always be considered accessible from within the same method.
+            if (symbol.IsImplicitlyDeclared)
+            {
+                return false;
+            }
+
+            var declarationSyntax = symbol.DeclaringSyntaxReferences.Select(r => r.GetSyntax()).FirstOrDefault();
+            return declarationSyntax != null && position < declarationSyntax.SpanStart;
+        }
     }
 }

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -405,5 +405,25 @@ namespace Analyzer.Utilities.Extensions
             var declarationSyntax = symbol.DeclaringSyntaxReferences.Select(r => r.GetSyntax()).FirstOrDefault();
             return declarationSyntax != null && position < declarationSyntax.SpanStart;
         }
+
+        /// <summary>
+        /// Checks if a symbol corresponds to an uninitialized local variable or parameter.
+        /// </summary>
+        public static bool? IsUninitializedVariable(this ISymbol symbol, SyntaxNode statementOrExpression, SemanticModel semanticModel)
+        {
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Local:
+                case SymbolKind.Parameter:
+                    var analysis = semanticModel.AnalyzeDataFlow(statementOrExpression);
+                    if (!analysis.Succeeded)
+                    {
+                        return null;
+                    }
+                    return analysis.DataFlowsIn.Contains(symbol);
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -407,7 +408,8 @@ namespace Analyzer.Utilities.Extensions
         }
 
         /// <summary>
-        /// Checks if a symbol corresponds to an uninitialized local variable or parameter.
+        /// Checks if a symbol corresponds to a local variable or parameter that is uninitialized at a particular statement/expression.
+        /// Returns <see langword="null"/> if data flow analysis fails, and the result could not be determined.
         /// </summary>
         public static bool? IsUninitializedVariable(this ISymbol symbol, SyntaxNode statementOrExpression, SemanticModel semanticModel)
         {
@@ -420,7 +422,7 @@ namespace Analyzer.Utilities.Extensions
                     {
                         return null;
                     }
-                    return analysis.DataFlowsIn.Contains(symbol);
+                    return !analysis.DataFlowsIn.Contains(symbol);
                 default:
                     return false;
             }

--- a/src/Utilities/WellKnownTypes.cs
+++ b/src/Utilities/WellKnownTypes.cs
@@ -201,6 +201,11 @@ namespace Analyzer.Utilities
             return compilation.GetTypeByMetadataName("System.Reflection.AssemblyVersionAttribute");
         }
 
+        public static INamedTypeSymbol CancellationToken(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Threading.CancellationToken");
+        }
+
         public static INamedTypeSymbol CLSCompliantAttribute(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.CLSCompliantAttribute");


### PR DESCRIPTION
/cc @333fred, @mavasani 

I implemented the analyzer for Async005 in this PR. I changed the conditions under which the analyzer should be fired from the original FxCop implementation, so please critique whether you think these new conditions are a good idea.

Originally, the FxCop analyzer ([here](https://github.com/dotnet/roslyn-analyzers/blob/master/src/Unfactored/AsyncPackage/AsyncPackage/CancellationAnalyzer.cs)) would fire if a method accepted CancellationToken parameters, and InvocationExpressions within that method's body referred to a method that accepted CancellationTokens, but no CancellationTokens were passed to that method. (i.e. It was probably checking for optional arguments not being passed)

My new implementation loosens the requirements: it fires whenever a CancellationToken is in scope (in an instance field, static field, or local var) and:

- the method referenced does not accept CancellationTokens, and an overload with the same name & signature is available, except the last parameter is a CancellationToken
- `CancellationToken.None` or `default(CancellationToken)` is passed

This fixes https://github.com/dotnet/roslyn-analyzers/issues/1387.