### PR TITLE
Do not skip FixAllProvider analysis for abstract types

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -167,12 +167,6 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
             internal void AnalyzeNamedTypeSymbol(SymbolAnalysisContext context)
             {
                 var namedType = (INamedTypeSymbol)context.Symbol;
-
-                if (namedType.IsAbstract)
-                {
-                    return;
-                }
-
                 if (namedType.DerivesFrom(_codeFixProviderSymbol))
                 {
                     _codeFixProviders = _codeFixProviders ?? new HashSet<INamedTypeSymbol>();


### PR DESCRIPTION
This bug is causing quite a few code fixers to be skipped during analysis.
Fixes #1413