### PR TITLE
Fix Nameof in response to issue #1426

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/UseNameofInPlaceOfString.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/UseNameofInPlaceOfString.cs
@@ -49,6 +49,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         {
             var argument = (IArgumentOperation)context.Operation;
             if ((argument.Value.Kind != OperationKind.Literal 
+                || argument.ArgumentKind != ArgumentKind.Explicit
                 || argument.Value.Type.SpecialType != SpecialType.System_String))
             {
                 return;

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -197,6 +197,29 @@ class C
 }");
         }
 
+        [WorkItem(1426, "https://github.com/dotnet/roslyn-analyzers/issues/1426")]
+        [Fact]
+        public void NoDiagnostic_1426()
+        {
+            VerifyCSharp(@"
+using System.Runtime.CompilerServices;
+
+public class C
+{
+    int M([CallerMemberName] string propertyName = """")
+    {
+        return 0;
+    }
+
+    public bool Property
+    {
+        set
+        {
+            M();
+        }
+    }
+}");
+        }
 
         #endregion
 


### PR DESCRIPTION
Added additional check for  `argument.ArgumentKind != ArgumentKind.Explicit` and a unit test.