### PR TITLE
Fix ported FxCop analyzers for Usage rules to analyze only externally visible symbols

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             // check whether it has a public setter
             IMethodSymbol setter = property.SetMethod;
-            if (setter == null || setter.DeclaredAccessibility != Accessibility.Public)
+            if (setter == null || !setter.IsExternallyVisible())
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisible.cs
@@ -42,8 +42,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 var field = (IFieldSymbol)obj.Symbol;
 
-                // Only report diagnostic on public non-readonly static fields
-                if (field.IsPublic() && !field.IsConst && field.IsStatic && !field.IsReadOnly)
+                // Only report diagnostic on externally visible non-readonly static fields
+                if (field.IsExternallyVisible() && !field.IsConst && field.IsStatic && !field.IsReadOnly)
                 {
                     obj.ReportDiagnostic(field.CreateDiagnostic(Rule));
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
@@ -84,6 +84,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static void AnalyzeSymbol(SymbolAnalysisContext symbolContext)
         {
             var methodSymbol = (IMethodSymbol)symbolContext.Symbol;
+
+            // FxCop compat: only analyze externally visible symbols.
+            if (!methodSymbol.IsExternallyVisible())
+            {
+                return;
+            }
+
             if (methodSymbol.ContainingSymbol is ITypeSymbol typeSymbol && (methodSymbol.MethodKind == MethodKind.UserDefinedOperator || methodSymbol.MethodKind == MethodKind.Conversion))
             {
                 string operatorName = methodSymbol.Name;

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.cs
@@ -44,9 +44,15 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.RegisterSymbolAction(symbolAnalysisContext =>
             {
                 var namedType = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
+                
+                // FxCop compat: only analyze externally visible symbols.
+                if (!namedType.IsExternallyVisible())
+                {
+                    return;
+                }
 
                 // NOTE(cyrusn): We use the C# syntax when reporting diagnostics for these issues.
-                // That's what the old FxCop rule did so it doesn't seem like a bug deal.
+                // That's what the old FxCop rule did so it doesn't seem like a big deal.
                 CheckOperators(symbolAnalysisContext, namedType, WellKnownMemberNames.EqualityOperatorName, WellKnownMemberNames.InequalityOperatorName, "==", "!=");
                 CheckOperators(symbolAnalysisContext, namedType, WellKnownMemberNames.GreaterThanOperatorName, WellKnownMemberNames.LessThanOperatorName, ">", "<");
                 CheckOperators(symbolAnalysisContext, namedType, WellKnownMemberNames.GreaterThanOrEqualOperatorName, WellKnownMemberNames.LessThanOrEqualOperatorName, ">=", "<=");
@@ -71,6 +77,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             foreach (var operator1 in operators1)
             {
+                // FxCop compat: only analyze externally visible symbols.
+                if (!operator1.IsExternallyVisible())
+                {
+                    return;
+                }
+
                 if (!operator1.IsUserDefinedOperator())
                 {
                     continue;

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
@@ -38,7 +38,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.RegisterSymbolAction(context =>
             {
                 var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
-                if (namedTypeSymbol.IsValueType && namedTypeSymbol.OverridesEquals() && !namedTypeSymbol.ImplementsEqualityOperators())
+                if (namedTypeSymbol.IsValueType &&
+                    namedTypeSymbol.IsExternallyVisible() &&
+                    namedTypeSymbol.OverridesEquals() && 
+                    !namedTypeSymbol.ImplementsEqualityOperators())
                 {
                     context.ReportDiagnostic(namedTypeSymbol.CreateDiagnostic(Rule));
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
@@ -24,11 +24,42 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             VerifyCSharp(@"
 using System;
 
-class A
+public class A
 {
     public System.Collections.ICollection Col { get; set; }
 }
 ", GetCSharpResultAt(6, 43, CollectionPropertiesShouldBeReadOnlyAnalyzer.RuleId, CollectionPropertiesShouldBeReadOnlyAnalyzer.Rule.MessageFormat.ToString()));
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CSharp_CA2227_Test_Internal()
+        {
+            VerifyCSharp(@"
+using System;
+
+internal class A
+{
+    public System.Collections.ICollection Col { get; set; }
+}
+
+public class A2
+{
+    public System.Collections.ICollection Col { get; private set; }
+}
+
+public class A3
+{
+    internal System.Collections.ICollection Col { get; set; }
+}
+
+public class A4
+{
+    private class A5
+    {
+        public System.Collections.ICollection Col { get; set; }
+    }
+}
+");
         }
 
         [Fact]
@@ -37,10 +68,54 @@ class A
             VerifyBasic(@"
 Imports System
 
-Class A
+Public Class A
     Public Property Col As System.Collections.ICollection
 End Class
 ", GetBasicResultAt(5, 21, CollectionPropertiesShouldBeReadOnlyAnalyzer.RuleId, CollectionPropertiesShouldBeReadOnlyAnalyzer.Rule.MessageFormat.ToString()));
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void Basic_CA2227_Test_Internal()
+        {
+            VerifyBasic(@"
+Imports System
+
+Friend Class A
+    Public Property Col As System.Collections.ICollection
+End Class
+
+Public Class A2
+    Public Property Col As System.Collections.ICollection
+        Get
+            Return Nothing
+        End Get
+        Private Set(value As System.Collections.ICollection)
+        End Set
+    End Property
+End Class
+
+Public Class A3
+    Friend Property Col As System.Collections.ICollection
+        Get
+            Return Nothing
+        End Get
+        Set(value As System.Collections.ICollection)
+        End Set
+    End Property
+End Class
+
+Public Class A4
+    Private Class A5
+        Public Property Col As System.Collections.ICollection
+            Get
+                Return Nothing
+            End Get
+            Set(value As System.Collections.ICollection)
+            End Set
+        End Property
+    End Class
+End Class
+");
         }
 
         [Fact]
@@ -49,7 +124,7 @@ End Class
             VerifyCSharp(@"
 using System;
 
-class A<T>
+public class A<T>
 {
     public System.Collections.Generic.List<T> Col { get; set; }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisibleTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void DefaultVisibilityCS()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     string field; 
 }");
@@ -32,7 +32,7 @@ class A
         public void DefaultVisibilityVB()
         {
             VerifyBasic(@"
-Class A
+Public Class A
     Dim field As System.String
 End Class");
         }
@@ -41,7 +41,7 @@ End Class");
         public void PublicVariableCS()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public string field; 
 }");
@@ -51,35 +51,70 @@ class A
         public void PublicVariableVB()
         {
             VerifyBasic(@"
-Class A
+Public Class A
     Public field As System.String
 End Class");
         }
 
         [Fact]
-        public void PublicStaticVariableCS()
+        public void ExternallyVisibleStaticVariableCS()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static string field; 
 }", GetCSharpResultAt(4, 26, NonConstantFieldsShouldNotBeVisibleAnalyzer.RuleId, NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString()));
         }
 
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void PublicNotExternallyVisibleStaticVariableCS()
+        {
+            VerifyCSharp(@"
+class A
+{
+    public static string field;
+}
+
+public class B
+{
+    private class C
+    {
+        public static string field;
+    }
+}
+");
+        }
+
         [Fact]
-        public void PublicStaticVariableVB()
+        public void ExternallyVisibleStaticVariableVB()
+        {
+            VerifyBasic(@"
+Public Class A
+    Public Shared field as System.String
+End Class", GetBasicResultAt(3, 19, NonConstantFieldsShouldNotBeVisibleAnalyzer.RuleId, NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString()));
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void PublicNotExternallyVisibleStaticVariableVB()
         {
             VerifyBasic(@"
 Class A
     Public Shared field as System.String
-End Class", GetBasicResultAt(3, 19, NonConstantFieldsShouldNotBeVisibleAnalyzer.RuleId, NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString()));
+End Class
+
+Public Class B
+    Private Class C
+        Public Shared field as System.String
+    End Class
+End Class
+");
         }
 
         [Fact]
         public void PublicStaticReadonlyVariableCS()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static readonly string field; 
 }");
@@ -89,7 +124,7 @@ class A
         public void PublicStaticReadonlyVariableVB()
         {
             VerifyBasic(@"
-Class A
+Public Class A
     Public Shared ReadOnly field as System.String
 End Class");
         }
@@ -98,7 +133,7 @@ End Class");
         public void PublicConstVariableCS()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public const string field = ""X""; 
 }");
@@ -108,7 +143,7 @@ class A
         public void PublicConstVariableVB()
         {
             VerifyBasic(@"
-Class A
+Public Class A
     Public Const field as System.String = ""X""
 End Class");
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.Fixer.cs
@@ -39,13 +39,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void AddAlternateMethod_CSharp()
         {
             VerifyCSharpFix(@"
-class C
+public class C
 {
     public static C operator +(C left, C right) { return new C(); }
 }
 ",
 @"
-class C
+public class C
 {
     public static C operator +(C left, C right) { return new C(); }
 
@@ -61,13 +61,13 @@ class C
         public void AddAlternateOfMultiples_CSharp()
         {
             VerifyCSharpFix(@"
-class C
+public class C
 {
     public static C operator %(C left, C right) { return new C(); }
 }
 ",
 @"
-class C
+public class C
 {
     public static C operator %(C left, C right) { return new C(); }
 
@@ -83,14 +83,14 @@ class C
         public void AddAlternateProperty_CSharp()
         {
             VerifyCSharpFix(@"
-class C
+public class C
 {
     public static bool operator true(C item) { return true; }
     public static bool operator false(C item) { return false; }
 }
 ",
 @"
-class C
+public class C
 {
     public static bool operator true(C item) { return true; }
     public static bool operator false(C item) { return false; }
@@ -110,13 +110,13 @@ class C
         public void AddAlternateForConversion_CSharp()
         {
             VerifyCSharpFix(@"
-class C
+public class C
 {
     public static implicit operator int(C item) { return 0; }
 }
 ",
 @"
-class C
+public class C
 {
     public static implicit operator int(C item) { return 0; }
 
@@ -132,13 +132,13 @@ class C
         public void AddAlternateForCompare_CSharp()
         {
             VerifyCSharpFix(@"
-class C
+public class C
 {
     public static bool operator <(C left, C right) { return true; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 }
 ",
 @"
-class C
+public class C
 {
     public static bool operator <(C left, C right) { return true; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 
@@ -159,13 +159,13 @@ class C
         public void AddAlternateForStructCompare_CSharp()
         {
             VerifyCSharpFix(@"
-struct C
+public struct C
 {
     public static bool operator <(C left, C right) { return true; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 }
 ",
 @"
-struct C
+public struct C
 {
     public static bool operator <(C left, C right) { return true; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 
@@ -181,13 +181,13 @@ struct C
         public void AddAlternateForIncrement_CSharp()
         {
             VerifyCSharpFix(@"
-class C
+public class C
 {
     public static C operator ++(C item) { return new C(); }
 }
 ",
 @"
-class C
+public class C
 {
     public static C operator ++(C item) { return new C(); }
 
@@ -203,14 +203,14 @@ class C
         public void FixImproperMethodVisibility_CSharp()
         {
             VerifyCSharpFix(@"
-class C
+public class C
 {
     public static C operator +(C left, C right) { return new C(); }
     protected static C Add(C left, C right) { return new C(); }
 }
 ",
 @"
-class C
+public class C
 {
     public static C operator +(C left, C right) { return new C(); }
 
@@ -223,7 +223,7 @@ class C
         public void FixImproperPropertyVisibility_CSharp()
         {
             VerifyCSharpFix(@"
-class C
+public class C
 {
     public static bool operator true(C item) { return true; }
     public static bool operator false(C item) { return false; }
@@ -231,7 +231,7 @@ class C
 }
 ",
 @"
-class C
+public class C
 {
     public static bool operator true(C item) { return true; }
     public static bool operator false(C item) { return false; }
@@ -249,14 +249,14 @@ class C
         public void AddAlternateMethod_Basic()
         {
             VerifyBasicFix(@"
-Class C
+Public Class C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
     End Operator
 End Class
 ",
 @"
-Class C
+Public Class C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
     End Operator
@@ -272,14 +272,14 @@ End Class
         public void AddAlternateOfMultiples_Basic()
         {
             VerifyBasicFix(@"
-Class C
+Public Class C
     Public Shared Operator Mod(left As C, right As C) As C
         Return New C()
     End Operator
 End Class
 ",
 @"
-Class C
+Public Class C
     Public Shared Operator Mod(left As C, right As C) As C
         Return New C()
     End Operator
@@ -295,7 +295,7 @@ End Class
         public void AddAlternateProperty_Basic()
         {
             VerifyBasicFix(@"
-Class C
+Public Class C
     Public Shared Operator IsTrue(item As C) As Boolean
         Return True
     End Operator
@@ -305,7 +305,7 @@ Class C
 End Class
 ",
 @"
-Class C
+Public Class C
     Public Shared Operator IsTrue(item As C) As Boolean
         Return True
     End Operator
@@ -326,14 +326,14 @@ End Class
         public void AddAlternateForConversion_Basic()
         {
             VerifyBasicFix(@"
-Class C
+Public Class C
     Public Shared Widening Operator CType(ByVal item As C) As Integer
         Return 0
     End Operator
 End Class
 ",
 @"
-Class C
+Public Class C
     Public Shared Widening Operator CType(ByVal item As C) As Integer
         Return 0
     End Operator
@@ -349,14 +349,14 @@ End Class
         public void AddAlternateForCompare_Basic()
         {
             VerifyBasicFix(@"
-Class C
+Public Class C
     Public Shared Operator <(left As C, right As C) As Boolean   ' error BC33033: Matching '>' operator is required
         Return True
     End Operator
 End Class
 ",
 @"
-Class C
+Public Class C
     Public Shared Operator <(left As C, right As C) As Boolean   ' error BC33033: Matching '>' operator is required
         Return True
     End Operator
@@ -376,14 +376,14 @@ End Class
         public void AddAlternateForStructCompare_Basic()
         {
             VerifyBasicFix(@"
-Structure C
+Public Structure C
     Public Shared Operator <(left As C, right As C) As Boolean   ' error BC33033: Matching '>' operator is required
         Return True
     End Operator
 End Structure
 ",
 @"
-Structure C
+Public Structure C
     Public Shared Operator <(left As C, right As C) As Boolean   ' error BC33033: Matching '>' operator is required
         Return True
     End Operator
@@ -399,7 +399,7 @@ End Structure
         public void FixImproperMethodVisibility_Basic()
         {
             VerifyBasicFix(@"
-Class C
+Public Class C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
     End Operator
@@ -410,7 +410,7 @@ Class C
 End Class
 ",
 @"
-Class C
+Public Class C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
     End Operator
@@ -426,7 +426,7 @@ End Class
         public void FixImproperPropertyVisibility_Basic()
         {
             VerifyBasicFix(@"
-Class C
+Public Class C
     Public Shared Operator IsTrue(item As C) As Boolean
         Return True
     End Operator
@@ -442,7 +442,7 @@ Class C
 End Class
 ",
 @"
-Class C
+Public Class C
     Public Shared Operator IsTrue(item As C) As Boolean
         Return True
     End Operator

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void HasAlternateMethod_CSharp()
         {
             VerifyCSharp(@"
-class C
+public class C
 {
     public static C operator +(C left, C right) { return new C(); }
     public static C Add(C left, C right) { return new C(); }
@@ -75,7 +75,7 @@ class C
         public void HasMultipleAlternatePrimary_CSharp()
         {
             VerifyCSharp(@"
-class C
+public class C
 {
     public static C operator %(C left, C right) { return new C(); }
     public static C Mod(C left, C right) { return new C(); }
@@ -87,7 +87,7 @@ class C
         public void HasMultipleAlternateSecondary_CSharp()
         {
             VerifyCSharp(@"
-class C
+public class C
 {
     public static C operator %(C left, C right) { return new C(); }
     public static C Remainder(C left, C right) { return new C(); }
@@ -99,7 +99,7 @@ class C
         public void HasAppropriateConversionAlternate_CSharp()
         {
             VerifyCSharp(@"
-class C
+public class C
 {
     public static implicit operator int(C item) { return 0; }
     public int ToInt32() { return 0; }
@@ -111,7 +111,7 @@ class C
         public void MissingAlternateMethod_CSharp()
         {
             VerifyCSharp(@"
-class C
+public class C
 {
     public static C operator +(C left, C right) { return new C(); }
 }
@@ -119,11 +119,30 @@ class C
             GetCA2225CSharpDefaultResultAt(4, 30, "Add", "op_Addition"));
         }
 
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void MissingAlternateMethod_CSharp_Internal()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public static C operator +(C left, C right) { return new C(); }
+}
+
+public class C2
+{
+    private class C3
+    {
+        public static C3 operator +(C3 left, C3 right) { return new C3(); }
+    }
+}
+");
+        }
+
         [Fact]
         public void MissingAlternateProperty_CSharp()
         {
             VerifyCSharp(@"
-class C
+public class C
 {
     public static bool operator true(C item) { return true; }
     public static bool operator false(C item) { return false; }
@@ -136,7 +155,7 @@ class C
         public void MissingMultipleAlternates_CSharp()
         {
             VerifyCSharp(@"
-class C
+public class C
 {
     public static C operator %(C left, C right) { return new C(); }
 }
@@ -148,7 +167,7 @@ class C
         public void ImproperAlternateMethodVisibility_CSharp()
         {
             VerifyCSharp(@"
-class C
+public class C
 {
     public static C operator +(C left, C right) { return new C(); }
     protected static C Add(C left, C right) { return new C(); }
@@ -161,7 +180,7 @@ class C
         public void ImproperAlternatePropertyVisibility_CSharp()
         {
             VerifyCSharp(@"
-class C
+public class C
 {
     public static bool operator true(C item) { return true; }
     public static bool operator false(C item) { return false; }
@@ -195,7 +214,7 @@ struct C
         public void HasAlternateMethod_VisualBasic()
         {
             VerifyBasic(@"
-Class C
+Public Class C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
     End Operator
@@ -210,7 +229,7 @@ End Class
         public void MissingAlternateMethod_VisualBasic()
         {
             VerifyBasic(@"
-Class C
+Public Class C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
     End Operator
@@ -219,11 +238,31 @@ End Class
             GetCA2225BasicDefaultResultAt(3, 28, "Add", "op_Addition"));
         }
 
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void MissingAlternateMethod_VisualBasic_Internal()
+        {
+            VerifyBasic(@"
+Class C
+    Public Shared Operator +(left As C, right As C) As C
+        Return New C()
+    End Operator
+End Class
+
+Public Class C2
+    Private Class C3
+        Public Shared Operator +(left As C3, right As C3) As C3
+            Return New C3()
+        End Operator
+    End Class
+End Class
+");
+        }
+
         [Fact]
         public void StructHasAlternateMethod_VisualBasic()
         {
             VerifyBasic(@"
-Structure C
+Public Structure C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
     End Operator

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.Fixer.cs
@@ -34,11 +34,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         {
             VerifyCSharpFix(
                 @"
-class A
+public class A
 {
     public static bool operator==(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
 }", @"
-class A
+public class A
 {
     public static bool operator==(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
 
@@ -54,12 +54,12 @@ class A
         {
             VerifyCSharpFix(
                 @"
-class A
+public class A
 {
     public static bool operator==(A a1, A a2) { return false; }      // error CS0216: The operator requires a matching operator '!=' to also be defined
     public static bool operator==(A a1, bool a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
 }", @"
-class A
+public class A
 {
     public static bool operator==(A a1, A a2) { return false; }      // error CS0216: The operator requires a matching operator '!=' to also be defined
 
@@ -82,11 +82,11 @@ class A
         {
             VerifyCSharpFix(
                 @"
-class A
+public class A
 {
     public static bool operator!=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '==' to also be defined
 }", @"
-class A
+public class A
 {
     public static bool operator!=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '==' to also be defined
 
@@ -102,11 +102,11 @@ class A
         {
             VerifyCSharpFix(
                 @"
-class A
+public class A
 {
     public static bool operator<(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 }", @"
-class A
+public class A
 {
     public static bool operator<(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 
@@ -122,11 +122,11 @@ class A
         {
             VerifyCSharpFix(
                 @"
-class A
+public class A
 {
     public static bool operator<=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>=' to also be defined
 }", @"
-class A
+public class A
 {
     public static bool operator<=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>=' to also be defined
 
@@ -142,11 +142,11 @@ class A
         {
             VerifyCSharpFix(
                 @"
-class A
+public class A
 {
     public static bool operator>(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '<' to also be defined
 }", @"
-class A
+public class A
 {
     public static bool operator>(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '<' to also be defined
 
@@ -162,11 +162,11 @@ class A
         {
             VerifyCSharpFix(
                 @"
-class A
+public class A
 {
     public static bool operator>=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '<=' to also be defined
 }", @"
-class A
+public class A
 {
     public static bool operator>=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '<=' to also be defined
 
@@ -182,12 +182,12 @@ class A
         {
             VerifyBasicFix(
                 @"
-class A
+Public class A
     public shared operator =(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '<>' operator is required
         return false
     end operator
 end class", @"
-class A
+Public class A
     public shared operator =(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '<>' operator is required
         return false
     end operator
@@ -203,12 +203,12 @@ end class", validationMode: TestValidationMode.AllowCompileErrors);
         {
             VerifyBasicFix(
                 @"
-class A
+Public class A
     public shared operator <>(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '=' operator is required
         return false
     end operator
 end class", @"
-class A
+Public class A
     public shared operator <>(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '=' operator is required
         return false
     end operator
@@ -224,12 +224,12 @@ end class", validationMode: TestValidationMode.AllowCompileErrors);
         {
             VerifyBasicFix(
                 @"
-class A
+Public class A
     public shared operator <(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '>' operator is required
         return false
     end operator
 end class", @"
-class A
+Public class A
     public shared operator <(a1 as A, a2 as A) as boolean   ' error BC33033: Matching '>' operator is required
         return false
     end operator

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void CSharpTestMissingEquality()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static bool operator==(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
 }", TestValidationMode.AllowCompileErrors,
@@ -33,18 +33,67 @@ GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "
         public void CSharpTestMissingInequality()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static bool operator!=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '==' to also be defined
 }", TestValidationMode.AllowCompileErrors,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="));
         }
 
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CSharpTestMissingEquality_Internal()
+        {
+            VerifyCSharp(@"
+class A
+{
+    public static bool operator==(A a1, A a2) { return false; }
+}
+
+public class B
+{
+    private class C
+    {
+        public static bool operator==(C a1, C a2) { return false; }
+    }
+
+    public class D
+    {
+        internal static bool operator==(D a1, D a2) { return false; }
+    }
+}
+
+", TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CSharpTestMissingInequality_Internal()
+        {
+            VerifyCSharp(@"
+class A
+{
+    public static bool operator!=(A a1, A a2) { return false; }
+}
+
+public class B
+{
+    private class C
+    {
+        public static bool operator!=(C a1, C a2) { return false; }
+    }
+
+    public class D
+    {
+        internal static bool operator!=(D a1, D a2) { return false; }
+    }
+}
+", TestValidationMode.AllowCompileErrors);
+        }
+
         [Fact]
         public void CSharpTestBothEqualityOperators()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static bool operator==(A a1, A a2) { return false; }
     public static bool operator!=(A a1, A a2) { return false; }
@@ -55,7 +104,7 @@ class A
         public void CSharpTestMissingLessThan()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static bool operator<(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>' to also be defined
 }", TestValidationMode.AllowCompileErrors,
@@ -66,7 +115,7 @@ GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "
         public void CSharpTestNotMissingLessThan()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static bool operator<(A a1, A a2) { return false; }
     public static bool operator>(A a1, A a2) { return false; }
@@ -77,7 +126,7 @@ class A
         public void CSharpTestMissingLessThanOrEqualTo()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static bool operator<=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>=' to also be defined
 }", TestValidationMode.AllowCompileErrors,
@@ -88,7 +137,7 @@ GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "
         public void CSharpTestNotMissingLessThanOrEqualTo()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static bool operator<=(A a1, A a2) { return false; }
     public static bool operator>=(A a1, A a2) { return false; }
@@ -99,7 +148,7 @@ class A
         public void CSharpTestOperatorType()
         {
             VerifyCSharp(@"
-class A
+public class A
 {
     public static bool operator==(A a1, int a2) { return false; }
     public static bool operator!=(A a1, string a2) { return false; }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.cs
@@ -61,6 +61,33 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             GetCA2231CSharpResultAt(4, 19));
         }
 
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CA2231NoEqualsOperatorButNotExternallyVisibleCSharp()
+        {
+            VerifyCSharp(@"
+    using System;
+
+    struct A
+    {
+        public override bool Equals(Object obj)
+        {
+            return true;
+        }
+    }
+
+    public class A2
+    {
+        private struct B
+        {
+            public override bool Equals(Object obj)
+            {
+                return true;
+            }
+        }
+    }
+");
+        }
+
         [Fact]
         public void CA2231NoEqualsOperatorCSharpOutofScope()
         {
@@ -165,6 +192,28 @@ Public Structure A
 End Structure
 ",
             GetCA2231BasicResultAt(4, 18));
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CA2231NoEqualsOperatorButNotExternallyVisibleBasic()
+        {
+            VerifyBasic(@"
+Imports System
+
+Structure A
+    Public Overloads Overrides Function Equals(obj As Object) As Boolean
+        Return True
+    End Function
+End Structure
+
+Public Class A2
+    Private Structure B
+        Public Overloads Overrides Function Equals(obj As Object) As Boolean
+            Return True
+        End Function
+    End Structure
+End Class
+");
         }
 
         [Fact]

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/InstantiateArgumentExceptionsCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/InstantiateArgumentExceptionsCorrectly.cs
@@ -52,16 +52,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         return;
                     }
 
-                    compilationContext.RegisterOperationBlockStartAction(
-                        operationBlockStartContext =>
-                        {
-                            operationBlockStartContext.RegisterOperationAction(
-                                operationContext => AnalyzeObjectCreation(
-                                    operationContext,
-                                    operationBlockStartContext.OwningSymbol,
-                                    argumentExceptionType),
-                                OperationKind.ObjectCreation);
-                        });
+                    compilationContext.RegisterOperationAction(
+                        operationContext => AnalyzeObjectCreation(
+                            operationContext,
+                            operationContext.ContainingSymbol,
+                            argumentExceptionType),
+                        OperationKind.ObjectCreation);
                 });
         }
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/roslyn-analyzers/issues/1432#issuecomment-349475438