### PR TITLE
Ensure that ported analyzers for FxCop Naming rules analyze only externally visible symbols

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol flagsAttribute)
         {
             var symbol = (INamedTypeSymbol)context.Symbol;
-            if (symbol.TypeKind != TypeKind.Enum)
+            if (symbol.TypeKind != TypeKind.Enum || !symbol.IsExternallyVisible())
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.cs
@@ -49,6 +49,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.RegisterSymbolAction(
                 (context) =>
             {
+                // FxCop compat: only analyze externally visible symbols
+                if (!context.Symbol.IsExternallyVisible())
+                {
+                    return;
+                }
+
                 switch (context.Symbol.Kind)
                 {
                     case SymbolKind.NamedType:

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
@@ -122,6 +123,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static void AnalyzeSymbol(ISymbol symbol, SymbolAnalysisContext context)
         {
+            // FxCop compat: only analyze externally visible symbols.
+            if (!symbol.IsExternallyVisible())
+            {
+                return;
+            }
+
             var identifier = symbol.Name;
             if (s_typeNames.Contains(identifier))
             {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.cs
@@ -113,6 +113,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.RegisterSymbolAction(symbolAnalysisContext =>
             {
                 var symbol = symbolAnalysisContext.Symbol;
+
+                // FxCop compat: only analyze externally visible symbols
+                if (!symbol.IsExternallyVisible())
+                {
+                    return;
+                }
+
                 switch (symbol.Kind)
                 {
                     case SymbolKind.Namespace:
@@ -136,7 +143,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                 AnalyzeParameters(symbolAnalysisContext, namedType.DelegateInvokeMethod.Parameters);
                             }
 
-                            if (!ContainsUnderScore(symbol.Name) || !symbol.IsPublic())
+                            if (!ContainsUnderScore(symbol.Name))
                             {
                                 return;
                             }
@@ -148,7 +155,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     case SymbolKind.Field:
                         {
                             var fieldSymbol = symbol as IFieldSymbol;
-                            if (ContainsUnderScore(symbol.Name) && symbol.IsPublic() && (fieldSymbol.IsConst || (fieldSymbol.IsStatic && fieldSymbol.IsReadOnly)))
+                            if (ContainsUnderScore(symbol.Name) && (fieldSymbol.IsConst || (fieldSymbol.IsStatic && fieldSymbol.IsReadOnly)))
                             {
                                 symbolAnalysisContext.ReportDiagnostic(symbol.CreateDiagnostic(MemberRule, symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)));
                                 return;

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclaration.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclaration.cs
@@ -47,9 +47,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static void AnalyzeMethodSymbol(SymbolAnalysisContext analysisContext)
         {
-            var methodSymbol = analysisContext.Symbol as IMethodSymbol;
+            var methodSymbol = (IMethodSymbol)analysisContext.Symbol;
 
-            if (!(methodSymbol.CanBeReferencedByName || methodSymbol.IsImplementationOfAnyExplicitInterfaceMember())
+            if (!methodSymbol.IsExternallyVisible() ||
+                !(methodSymbol.CanBeReferencedByName || methodSymbol.IsImplementationOfAnyExplicitInterfaceMember())
                 || !methodSymbol.Locations.Any(x => x.IsInSource)
                 || string.IsNullOrWhiteSpace(methodSymbol.Name))
             {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
@@ -20,8 +20,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private const string Get = "Get";
 
-        private static readonly ImmutableHashSet<Accessibility> ExposedAccessibilities = ImmutableHashSet.Create(Accessibility.Public, Accessibility.Protected, Accessibility.ProtectedOrInternal);
-
         private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.PropertyNamesShouldNotMatchGetMethodsTitle), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
         private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.PropertyNamesShouldNotMatchGetMethodsMessage), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
         private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.PropertyNamesShouldNotMatchGetMethodsDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
@@ -53,7 +51,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             var symbol = context.Symbol;
 
             // Bail out if the method/property is not exposed (public, protected, or protected internal)
-            if (!ExposedAccessibilities.Contains(symbol.DeclaredAccessibility))
+            if (!symbol.IsExternallyVisible())
             {
                 return;
             }
@@ -79,7 +77,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 Diagnostic diagnostic = null;
 
-                var exposedMembers = type.GetMembers(identifier).Where(member => ExposedAccessibilities.Contains(member.DeclaredAccessibility));
+                var exposedMembers = type.GetMembers(identifier).Where(member => member.IsExternallyVisible());
                 foreach (var member in exposedMembers)
                 {
                     // Ignore Object.GetType, as it's commonly seen and Type is a commonly-used property name.

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespaces.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespaces.cs
@@ -57,13 +57,16 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.RegisterCompilationStartAction(
                 compilationStartAnalysisContext =>
                 {
-                    var namedTypesInCompilation = new ConcurrentBag<INamedTypeSymbol>();
+                    var externallyVisibleNamedTypes = new ConcurrentBag<INamedTypeSymbol>();
 
                     compilationStartAnalysisContext.RegisterSymbolAction(
                         symbolAnalysisContext =>
                         {
                             var namedType = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
-                            namedTypesInCompilation.Add(namedType);
+                            if (namedType.IsExternallyVisible())
+                            {
+                                externallyVisibleNamedTypes.Add(namedType);
+                            }
                         }, SymbolKind.NamedType);
 
                     compilationStartAnalysisContext.RegisterCompilationEndAction(
@@ -89,7 +92,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                             UpdateNamespaceTable(namespaceComponentToNamespaceNameDictionary, namespaceNamesInCompilation.ToImmutableSortedSet());
 
                             InitializeWellKnownSystemNamespaceTable();
-                            foreach (INamedTypeSymbol symbol in namedTypesInCompilation)
+                            foreach (INamedTypeSymbol symbol in externallyVisibleNamedTypes)
                             {
                                 string symbolName = symbol.Name;
                                 if (s_wellKnownSystemNamespaceTable.ContainsKey(symbolName))

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
@@ -22,9 +22,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void CA1714_CA1717_Test_EnumWithNoFlags_SingularName()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
-                               enum Day 
+                               public enum Day 
                                 {
                                     Sunday = 0,
                                     Monday = 1,
@@ -35,8 +35,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                           );
 
             VerifyBasic(@"
-                        Class A
-	                        Private Enum Day
+                        Public Class A
+	                        Public Enum Day
 		                           Sunday = 0
 		                           Monday = 1
 		                           Tuesday = 2
@@ -50,9 +50,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void CA1714_CA1717__Test_EnumWithNoFlags_PluralName()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
-                               enum Days 
+                               public enum Days 
                                 {
                                     sunday = 0,
                                     Monday = 1,
@@ -60,11 +60,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                        
                                 };
                             }",
-                            GetCSharpResultAt(4, 37, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717.MessageFormat.ToString()));
+                            GetCSharpResultAt(4, 44, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717.MessageFormat.ToString()));
 
             VerifyBasic(@"
-                        Class A
-	                        Private Enum Days
+                        Public Class A
+	                        Public Enum Days
 		                           Sunday = 0
 		                           Monday = 1
 		                           Tuesday = 2
@@ -72,15 +72,81 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 	                        End Enum
                         End Class
                         ",
-                        GetBasicResultAt(3, 39, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717.MessageFormat.ToString()));
+                        GetBasicResultAt(3, 38, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717.MessageFormat.ToString()));
         }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CA1714_CA1717__Test_EnumWithNoFlags_PluralName_Internal()
+        {
+            VerifyCSharp(@" 
+class A 
+{ 
+    enum Days 
+    {
+        sunday = 0,
+        Monday = 1,
+        Tuesday = 2
+                                       
+    };
+}
+
+public class A2
+{ 
+    private enum Days 
+    {
+        sunday = 0,
+        Monday = 1,
+        Tuesday = 2
+                                       
+    };
+}
+
+internal class A3
+{ 
+    public enum Days 
+    {
+        sunday = 0,
+        Monday = 1,
+        Tuesday = 2
+                                       
+    };
+}
+");
+
+            VerifyBasic(@"
+Class A
+	Private Enum Days
+		Sunday = 0
+		Monday = 1
+		Tuesday = 2
+	End Enum
+End Class
+
+Public Class A2
+	Private Enum Days
+		Sunday = 0
+		Monday = 1
+		Tuesday = 2
+	End Enum
+End Class
+
+Friend Class A3
+	Public Enum Days
+		Sunday = 0
+		Monday = 1
+		Tuesday = 2
+	End Enum
+End Class
+");
+        }
+
         [Fact]
         public void CA1714_CA1717__Test_EnumWithNoFlags_PluralName_UpperCase()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
-                               enum DAYS 
+                               public enum DAYS 
                                 {
                                     sunday = 0,
                                     Monday = 1,
@@ -88,11 +154,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                        
                                 };
                             }",
-                            GetCSharpResultAt(4, 37, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717.MessageFormat.ToString()));
+                            GetCSharpResultAt(4, 44, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717.MessageFormat.ToString()));
 
             VerifyBasic(@"
-                        Class A
-	                        Private Enum DAYS
+                        Public Class A
+	                        Public Enum DAYS
 		                           Sunday = 0
 		                           Monday = 1
 		                           Tuesday = 2
@@ -100,17 +166,17 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 	                        End Enum
                         End Class
                         ",
-                        GetBasicResultAt(3, 39, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717.MessageFormat.ToString()));
+                        GetBasicResultAt(3, 38, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717.MessageFormat.ToString()));
         }
 
         [Fact]
         public void CA1714_CA1717_Test_EnumWithFlags_SingularName()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
                                [System.Flags] 
-                               enum Day 
+                               public enum Day 
                                {
                                     sunday = 0,
                                     Monday = 1,
@@ -118,28 +184,99 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                        
                                 };
                             }",
-                            GetCSharpResultAt(5, 37, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714.MessageFormat.ToString()));
+                            GetCSharpResultAt(5, 44, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714.MessageFormat.ToString()));
 
             VerifyBasic(@"
-                       Class A
+                       Public Class A
 	                    <System.Flags> _
-	                    Private Enum Day
+	                    Public Enum Day
 		                    Sunday = 0
 		                    Monday = 1
 		                    Tuesday = 2
 	                    End Enum
                         End Class",
-                            GetBasicResultAt(4, 35, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714.MessageFormat.ToString()));
+                            GetBasicResultAt(4, 34, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714.MessageFormat.ToString()));
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CA1714_CA1717_Test_EnumWithFlags_SingularName_Internal()
+        {
+            VerifyCSharp(@" 
+class A 
+{ 
+    [System.Flags] 
+    enum Day 
+    {
+        sunday = 0,
+        Monday = 1,
+        Tuesday = 2
+                                       
+    }
+}
+
+public class A2
+{ 
+    [System.Flags] 
+    private enum Day 
+    {
+        sunday = 0,
+        Monday = 1,
+        Tuesday = 2
+                                       
+    }
+}
+
+internal class A3
+{ 
+    [System.Flags] 
+    public enum Day 
+    {
+        sunday = 0,
+        Monday = 1,
+        Tuesday = 2
+                                       
+    }
+}
+");
+
+            VerifyBasic(@"
+Class A
+    <System.Flags> _
+    Enum Day
+	    Sunday = 0
+	    Monday = 1
+	    Tuesday = 2
+    End Enum
+End Class
+
+Public Class A2
+    <System.Flags> _
+    Private Enum Day
+	    Sunday = 0
+	    Monday = 1
+	    Tuesday = 2
+    End Enum
+End Class
+
+Friend Class A3
+    <System.Flags> _
+    Public Enum Day
+	    Sunday = 0
+	    Monday = 1
+	    Tuesday = 2
+    End Enum
+End Class
+");
         }
 
         [Fact]
         public void CA1714_CA1717_Test_EnumWithFlags_PluralName()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
                                [System.Flags] 
-                               enum Days 
+                               public enum Days 
                                {
                                     sunday = 0,
                                     Monday = 1,
@@ -149,9 +286,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                             }");
 
             VerifyBasic(@"
-                       Class A
+                       Public Class A
 	                    <System.Flags> _
-	                    Private Enum Days
+	                    Public Enum Days
 		                    Sunday = 0
 		                    Monday = 1
 		                    Tuesday = 2
@@ -163,10 +300,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void CA1714_CA1717_Test_EnumWithFlags_PluralName_UpperCase()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
                                [System.Flags] 
-                               enum DAYS 
+                               public enum DAYS 
                                {
                                     sunday = 0,
                                     Monday = 1,
@@ -176,9 +313,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                             }");
 
             VerifyBasic(@"
-                       Class A
+                       Public Class A
 	                    <System.Flags> _
-	                    Private Enum DAYS
+	                    Public Enum DAYS
 		                    Sunday = 0
 		                    Monday = 1
 		                    Tuesday = 2
@@ -190,10 +327,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void CA1714_CA1717_Test_EnumWithFlags_NameEndsWithS()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
                                [System.Flags] 
-                               enum Axis 
+                               public enum Axis 
                                {
                                     x = 0,
                                     y = 1,
@@ -203,9 +340,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                             }");
 
             VerifyBasic(@"
-                       Class A
+                       Public Class A
 	                    <System.Flags> _
-	                    Private Enum Axis
+	                    Public Enum Axis
 		                    x = 0
 		                    y = 1
 		                    z = 2
@@ -219,10 +356,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void CA1714_CA1717_Test_EnumWithFlags_PluralName_NotEndingWithS()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
                                [System.Flags] 
-                               enum Men 
+                               public enum Men 
                                {
                                     M1 = 0,
                                     M2 = 1,
@@ -230,27 +367,27 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                        
                                 };
                             }",
-                            GetCSharpResultAt(5, 37, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714.MessageFormat.ToString()));
+                            GetCSharpResultAt(5, 44, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714.MessageFormat.ToString()));
 
             VerifyBasic(@"
-                       Class A
+                       Public Class A
                         < System.Flags > _
-                        Private Enum Men
+                        Public Enum Men
                             M1 = 0
                             M2 = 1
                             M3 = 2
                         End Enum
                         End Class",
-                            GetBasicResultAt(4, 38, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714.MessageFormat.ToString()));
+                            GetBasicResultAt(4, 37, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714.MessageFormat.ToString()));
         }
 
         [Fact]
         public void CA1714_CA1717_Test_EnumWithNoFlags_PluralWord_NotEndingWithS()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
-                               enum Men 
+                               public enum Men 
                                {
                                     M1 = 0,
                                     M2 = 1,
@@ -260,8 +397,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                             }");
 
             VerifyBasic(@"
-                       Class A
-                        Private Enum Men
+                       Public Class A
+                        Public Enum Men
                             M1 = 0
                             M2 = 1
                             M3 = 2
@@ -273,10 +410,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void CA1714_CA1717_Test_EnumWithNoFlags_irregularPluralWord_EndingWith_ae()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
                                [System.Flags] 
-                               enum formulae 
+                               public enum formulae 
                                {
                                     M1 = 0,
                                     M2 = 1,
@@ -286,9 +423,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                             }");
 
             VerifyBasic(@"
-                       Class A
+                       Public Class A
                         < System.Flags > _
-                        Private Enum formulae
+                        Public Enum formulae
                             M1 = 0
                             M2 = 1
                             M3 = 2
@@ -299,10 +436,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void CA1714_CA1717_Test_EnumWithNoFlags_irregularPluralWord_EndingWith_i()
         {
             VerifyCSharp(@" 
-                            class A 
+                            public class A 
                             { 
                                [System.Flags] 
-                               enum trophi 
+                               public enum trophi 
                                {
                                     M1 = 0,
                                     M2 = 1,
@@ -312,9 +449,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                             }");
 
             VerifyBasic(@"
-                       Class A
+                       Public Class A
                         < System.Flags > _
-                        Private Enum trophi
+                        Public Enum trophi
                             M1 = 0
                             M2 = 1
                             M3 = 2

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
@@ -165,6 +165,57 @@ public class Class6<TTypeParameter>
                 GetCA1715CSharpResultAt(58, 28, CA1715TypeParameterMessage, "_V"));
         }
 
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void TestInternalInterfaceNamesCSharp_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+internal interface Controller
+{
+    void SomeMethod();
+}
+
+internal class C
+{
+    public interface 日本語
+    {
+        void SomeMethod();
+    }
+}
+
+public class C2
+{
+    private interface _Controller
+    {
+        void SomeMethod();
+    }
+}
+");
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void TestTypeParameterNamesInternalCSharp_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+internal class IInterface<VSome>
+{
+}
+
+internal class C
+{
+    public class IAnotherInterface<本語>
+    {
+    }
+}
+
+public class C2
+{
+    private delegate void Callback<VSome>();
+}
+");
+        }
+
         [Fact]
         public void TestTypeParameterNamesCSharp_NoDiagnosticCases()
         {
@@ -317,6 +368,48 @@ End Class
                 GetCA1715BasicResultAt(45, 24, CA1715TypeParameterMessage, "_Type1"),
                 GetCA1715BasicResultAt(46, 26, CA1715TypeParameterMessage, "_K"),
                 GetCA1715BasicResultAt(46, 30, CA1715TypeParameterMessage, "_V"));
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void TestInterfaceNamesInternalBasic_NoDiagnostic()
+        {
+            VerifyBasic(@"
+Friend Interface Controller
+    Sub SomeMethod()
+End Interface
+
+Friend Class C
+    Public Interface 日本語
+        Sub SomeMethod()
+    End Interface
+End Class
+
+Public Class C2
+    Private Interface _Controller
+        Sub SomeMethod()
+    End Interface
+End Class
+");
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void TestTypeParameterNamesInternalBasic_NoDiagnostic()
+        {
+            VerifyBasic(@"
+Imports System
+
+Friend Class IInterface(Of VSome)
+End Class
+
+Friend Class C
+    Public Class IAnotherInterface(Of 本語)
+    End Class
+End Class
+
+Friend Class C2
+    Private Delegate Sub Callback(Of VSome)()
+End Class
+");
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNamesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNamesTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         public void CSharp_CA1720_NoDiagnostic()
         {
             VerifyCSharp(@"
-class IntA
+public class IntA
 {
 }
 ");
@@ -32,80 +32,104 @@ class IntA
         public void CSharp_CA1720_SomeDiagnostic1()
         {
             VerifyCSharp(@"
-class Int
+public class Int
 {
 }
 ",
-    GetCA1720CSharpResultAt(line: 2, column: 7, identifierName: "Int"));
+    GetCA1720CSharpResultAt(line: 2, column: 14, identifierName: "Int"));
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CSharp_CA1720_Internal_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Int
+{
+}
+
+public class C
+{
+    private class Int
+    {
+    }
+}
+
+internal class C2
+{
+    public class Int
+    {
+    }
+}
+");
         }
 
         [Fact]
         public void CSharp_CA1720_SomeDiagnostic2()
         {
             VerifyCSharp(@"
-struct Int32
+public struct Int32
 {
 }
 ",
-    GetCA1720CSharpResultAt(line: 2, column: 8, identifierName: "Int32"));
+    GetCA1720CSharpResultAt(line: 2, column: 15, identifierName: "Int32"));
         }
 
         [Fact]
         public void CSharp_CA1720_SomeDiagnostic3()
         {
             VerifyCSharp(@"
-enum Int64
+public enum Int64
 {
 }
 ",
-    GetCA1720CSharpResultAt(line: 2, column: 6, identifierName: "Int64"));
+    GetCA1720CSharpResultAt(line: 2, column: 13, identifierName: "Int64"));
         }
 
         [Fact]
         public void CSharp_CA1720_SomeDiagnostic4()
         {
             VerifyCSharp(@"
-class Derived
+public class Derived
 {
-   void Int ()
+   public void Int()
    {
    }
 }
 ",
-    GetCA1720CSharpResultAt(line: 4, column: 9, identifierName: "Int"));
+    GetCA1720CSharpResultAt(line: 4, column: 16, identifierName: "Int"));
         }
 
         [Fact]
         public void CSharp_CA1720_SomeDiagnostic5()
         {
             VerifyCSharp(@"
-class Bar
+public class Bar
 {
-   void BarMethod (int Int)
+   public void BarMethod(int Int)
    {
    }
 }
 ",
-    GetCA1720CSharpResultAt(line: 4, column: 24, identifierName: "Int"));
+    GetCA1720CSharpResultAt(line: 4, column: 30, identifierName: "Int"));
         }
 
         [Fact]
         public void CSharp_CA1720_SomeDiagnostic6()
         {
             VerifyCSharp(@"
-class DerivedBar
+public class DerivedBar
 {
-   int Int;
+   public int Int;
 }
 ",
-    GetCA1720CSharpResultAt(line: 4, column: 8, identifierName: "Int"));
+    GetCA1720CSharpResultAt(line: 4, column: 15, identifierName: "Int"));
         }
 
         [Fact]
         public void CSharp_CA1720_NoDiagnosticOnEqualsOverride()
         {
             VerifyCSharp(@"
-class Bar
+public class Bar
 {
    public override bool Equals(object obj)
    {
@@ -121,13 +145,13 @@ class Bar
             VerifyCSharp(@"
 using System;
 
-abstract class Base
+public abstract class Base
 {
     public abstract void BaseMethod(object okay, object obj);
     public abstract int this[Guid guid] { get; }
 }
 
-class Derived : Base
+public class Derived : Base
 {
     public override void BaseMethod(object okay, object obj)
     {
@@ -148,7 +172,7 @@ class Derived : Base
             VerifyCSharp(@"
 using System;
 
-class Base
+public class Base
 {
     public virtual void BaseMethod(object okay, object obj) 
     { 
@@ -160,7 +184,7 @@ class Base
     }
 }
 
-class Derived : Base
+public class Derived : Base
 {
     public override void BaseMethod(object okay, object obj) 
     { 
@@ -179,18 +203,18 @@ class Derived : Base
         public void CSharp_CA1720_DiagnosticOnBaseNotNestedImplementation()
         {
             VerifyCSharp(@"
-class Base
+public class Base
 {
     public virtual void BaseMethod(object okay, object obj)
     {
     }
 }
 
-class Derived : Base
+public class Derived : Base
 {
 }
 
-class Bar : Derived
+public class Bar : Derived
 {
     public override void BaseMethod(object okay, object obj)
     {
@@ -205,12 +229,12 @@ class Bar : Derived
             VerifyCSharp(@"
 using System;
 
-interface IDerived
+public interface IDerived
 {
     void DerivedMethod(object okay, object obj);
 }
 
-class Derived : IDerived
+public class Derived : IDerived
 {
     public void DerivedMethod(object okay, object obj) 
     {
@@ -225,12 +249,12 @@ class Derived : IDerived
             VerifyCSharp(@"
 using System;
 
-interface IDerived
+public interface IDerived
 {
     void DerivedMethod(object okay, object obj);
 }
 
-class Derived : IDerived
+public class Derived : IDerived
 {
     void IDerived.DerivedMethod(object okay, object obj) 
     {
@@ -245,12 +269,12 @@ class Derived : IDerived
             VerifyCSharp(@"
 using System;
 
-interface IDerived<in T1, in T2>
+public interface IDerived<in T1, in T2>
 {
     void DerivedMethod(int okay, T1 obj, T2 @int);
 }
 
-class Derived : IDerived<int, string>
+public class Derived : IDerived<int, string>
 {
     public void DerivedMethod(int okay, int obj, string @int)
     {
@@ -266,12 +290,12 @@ class Derived : IDerived<int, string>
             VerifyCSharp(@"
 using System;
 
-interface IDerived<in T1, in T2>
+public interface IDerived<in T1, in T2>
 {
     void DerivedMethod(int okay, T1 obj, T2 @int);
 }
 
-class Derived : IDerived<int, string>
+public class Derived : IDerived<int, string>
 {
     void IDerived<int, string>.DerivedMethod(int okay, int obj, string @int)
     {
@@ -287,16 +311,16 @@ class Derived : IDerived<int, string>
             VerifyCSharp(@"
 using System;
 
-interface IDerived
+public interface IDerived
 {
     void DerivedMethod(object okay, object obj);
 }
 
-interface IBar : IDerived
+public interface IBar : IDerived
 {
 }
 
-class Derived : IBar
+public class Derived : IBar
 {
     public void DerivedMethod(object okay, object obj) 
     {
@@ -311,16 +335,16 @@ class Derived : IBar
             VerifyCSharp(@"
 using System;
 
-interface IDerived
+public interface IDerived
 {
     void DerivedMethod(object okay, object obj);
 }
 
-interface IBar : IDerived
+public interface IBar : IDerived
 {
 }
 
-class Derived : IBar
+public class Derived : IBar
 {
     void IDerived.DerivedMethod(object okay, object obj) 
     {
@@ -335,16 +359,16 @@ class Derived : IBar
             VerifyCSharp(@"
 using System;
 
-interface IDerived<in T1, in T2>
+public interface IDerived<in T1, in T2>
 {
     void DerivedMethod(int okay, T1 obj, T2 @int);
 }
 
-interface IBar<in T1, in T2> : IDerived<T1, T2>
+public interface IBar<in T1, in T2> : IDerived<T1, T2>
 {
 }
 
-class Derived : IBar<int, string>
+public class Derived : IBar<int, string>
 {
     public void DerivedMethod(int okay, int obj, string @int)
     {
@@ -360,16 +384,16 @@ class Derived : IBar<int, string>
             VerifyCSharp(@"
 using System;
 
-interface IDerived<in T1, in T2>
+public interface IDerived<in T1, in T2>
 {
     void DerivedMethod(int okay, T1 obj, T2 @int);
 }
 
-interface IBar<in T1, in T2> : IDerived<T1, T2>
+public interface IBar<in T1, in T2> : IDerived<T1, T2>
 {
 }
 
-class Derived : IBar<int, string>
+public class Derived : IBar<int, string>
 {
     void IDerived<int, string>.DerivedMethod(int okay, int obj, string @int)
     {
@@ -428,13 +452,6 @@ public sealed class SomeEqualityComparer : IEqualityComparer<string>, IEqualityC
         throw new NotImplementedException();
     }
 }
-");
-        }
-
-        [Fact]
-        public void Basic_CA1720_NoDiagnostic()
-        {
-            VerifyBasic(@"
 ");
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
@@ -1,3 +1,4 @@
+
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis;
@@ -66,7 +67,7 @@ namespace HasNoUnderScore
             GetCA1707CSharpResultAt(line: 4, column: 15, symbolKind: SymbolKind.Namespace, identifierNames: "OuterNamespace.HasUnderScore_"));
         }
 
-        [Fact]
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
         public void CA1707_ForTypes_CSharp()
         {
             VerifyCSharp(@"
@@ -80,11 +81,22 @@ public class OuterType
     {
     }
 
-}",
+    internal class UnderScoreInNameButInternal_
+    {
+    }
+}
+
+internal class OuterType2
+{
+    public class UnderScoreInNameButNotExternallyVisible_
+    {
+    }
+}
+",
             GetCA1707CSharpResultAt(line: 4, column: 18, symbolKind: SymbolKind.NamedType, identifierNames: "OuterType.UnderScoreInName_"));
         }
 
-        [Fact]
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
         public void CA1707_ForFields_CSharp()
         {
             VerifyCSharp(@"
@@ -104,14 +116,23 @@ public enum DoesNotMatterEnum
 {
     _EnumWithUnderscore,
     _
-}",
+}
+
+public class C
+{
+    internal class C2
+    {
+        public const int ConstField_ = 5;
+    }
+}
+",
             GetCA1707CSharpResultAt(line: 4, column: 26, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.ConstField_"),
             GetCA1707CSharpResultAt(line: 5, column: 36, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.StaticReadOnlyField_"),
             GetCA1707CSharpResultAt(line: 16, column: 5, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatterEnum._EnumWithUnderscore"),
             GetCA1707CSharpResultAt(line: 17, column: 5, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatterEnum._"));
         }
 
-        [Fact]
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
         public void CA1707_ForMethods_CSharp()
         {
             VerifyCSharp(@"
@@ -137,6 +158,15 @@ public class ImplementI1 : I1
 public class Derives : ImplementI1
 {
     public override void M2_() { } // No diagnostic
+}
+
+internal class C
+{
+    public class DoesNotMatter2
+    {
+        public void PublicM1_() { } // No diagnostic
+        protected void ProtectedM4_() { } // No diagnostic
+    }
 }",
             GetCA1707CSharpResultAt(line: 4, column: 17, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.PublicM1_()"),
             GetCA1707CSharpResultAt(line: 7, column: 20, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.ProtectedM4_()"),
@@ -144,7 +174,7 @@ public class Derives : ImplementI1
             GetCA1707CSharpResultAt(line: 18, column: 25, symbolKind: SymbolKind.Member, identifierNames: "ImplementI1.M2_()"));
         }
 
-        [Fact]
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
         public void CA1707_ForProperties_CSharp()
         {
             VerifyCSharp(@"
@@ -170,6 +200,15 @@ public class ImplementI1 : I1
 public class Derives : ImplementI1
 {
     public override int P2_ { get; set; } // No diagnostic
+}
+
+internal class C
+{
+    public class DoesNotMatter2
+    {
+        public int PublicP1_ { get; set; }// No diagnostic
+        protected int ProtectedP4_ { get; set; } // No diagnostic
+    }
 }",
             GetCA1707CSharpResultAt(line: 4, column: 16, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.PublicP1_"),
             GetCA1707CSharpResultAt(line: 7, column: 19, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.ProtectedP4_"),
@@ -177,7 +216,7 @@ public class Derives : ImplementI1
             GetCA1707CSharpResultAt(line: 18, column: 24, symbolKind: SymbolKind.Member, identifierNames: "ImplementI1.P2_"));
         }
 
-        [Fact]
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
         public void CA1707_ForEvents_CSharp()
         {
             VerifyCSharp(@"
@@ -205,6 +244,15 @@ public class ImplementI1 : I1
 public class Derives : ImplementI1
 {
     public override event EventHandler E2_; // No diagnostic
+}
+
+internal class C
+{
+    public class DoesNotMatter
+    {
+        public event EventHandler PublicE1_; // No diagnostic
+        protected event EventHandler ProtectedE4_; // No diagnostic
+    }
 }",
             GetCA1707CSharpResultAt(line: 6, column: 31, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.PublicE1_"),
             GetCA1707CSharpResultAt(line: 9, column: 34, symbolKind: SymbolKind.Member, identifierNames: "DoesNotMatter.ProtectedE4_"),

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.Fixer.cs
@@ -215,10 +215,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                              End Class");
         }
 
-        [Fact]
-        public void VerifyExplicitInterfaceImplementationWithWrongParameterNames()
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void VerifyExplicitInterfaceImplementationWithWrongParameterNames_NoDiagnostic()
         {
-            VerifyCSharpFix(@"public interface IBase
+            var source = @"public interface IBase
                               {
                                   void TestMethod(string baseArg1, string baseArg2);
                               }
@@ -226,54 +226,30 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                               public class TestClass : IBase
                               {
                                   void IBase.TestMethod(string arg1, string arg2) { }
-                              }",
-                            @"public interface IBase
-                              {
-                                  void TestMethod(string baseArg1, string baseArg2);
-                              }
+                              }";
+            VerifyCSharpFix(source, source);
 
-                              public class TestClass : IBase
-                              {
-                                  void IBase.TestMethod(string baseArg1, string baseArg2) { }
-                              }");
+            source = @"public interface IBase
+                        {
+                            void TestMethod(string baseArg1, string baseArg2, __arglist);
+                        }
 
-            VerifyCSharpFix(@"public interface IBase
-                              {
-                                  void TestMethod(string baseArg1, string baseArg2, __arglist);
-                              }
+                        public class TestClass : IBase
+                        {
+                            void IBase.TestMethod(string arg1, string arg2, __arglist) { }
+                        }";
+            VerifyCSharpFix(source, source);
 
-                              public class TestClass : IBase
-                              {
-                                  void IBase.TestMethod(string arg1, string arg2, __arglist) { }
-                              }",
-                            @"public interface IBase
-                              {
-                                  void TestMethod(string baseArg1, string baseArg2, __arglist);
-                              }
+            source = @"public interface IBase
+                        {
+                            void TestMethod(string baseArg1, string baseArg2, params string[] baseArg3);
+                        }
 
-                              public class TestClass : IBase
-                              {
-                                  void IBase.TestMethod(string baseArg1, string baseArg2, __arglist) { }
-                              }");
-
-            VerifyCSharpFix(@"public interface IBase
-                              {
-                                  void TestMethod(string baseArg1, string baseArg2, params string[] baseArg3);
-                              }
-
-                              public class TestClass : IBase
-                              {
-                                  void IBase.TestMethod(string arg1, string arg2, params string[] arg3) { }
-                              }",
-                            @"public interface IBase
-                              {
-                                  void TestMethod(string baseArg1, string baseArg2, params string[] baseArg3);
-                              }
-
-                              public class TestClass : IBase
-                              {
-                                  void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3) { }
-                              }");
+                        public class TestClass : IBase
+                        {
+                            void IBase.TestMethod(string arg1, string arg2, params string[] arg3) { }
+                        }";
+            VerifyCSharpFix(source, source);
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
@@ -115,6 +115,78 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetBasicResultAt(8, 106, "Sub TestClass.TestMethod(arg1 As String, arg2 As String, ParamArray arg3 As String())", "arg3", "baseArg3", "Sub BaseClass.TestMethod(baseArg1 As String, baseArg2 As String, ParamArray baseArg3 As String())"));
         }
 
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void VerifyInternalOverrideWithWrongParameterNames_NoDiagnostic()
+        {
+            VerifyCSharp(@"public abstract class BaseClass
+                           {
+                               internal abstract void TestMethod(string baseArg1, string baseArg2);
+                           }
+
+                           public class TestClass : BaseClass
+                           {
+                               internal override void TestMethod(string arg1, string arg2) { }
+                           }");
+
+            VerifyCSharp(@"internal abstract class BaseClass
+                           {
+                               public abstract void TestMethod(string baseArg1, string baseArg2, __arglist);
+                           }
+
+                           internal class TestClass : BaseClass
+                           {
+                               public override void TestMethod(string arg1, string arg2, __arglist) { }
+                           }");
+
+            VerifyCSharp(@"internal class OuterClass
+                           {
+                               public abstract class BaseClass
+                               {
+                                   public abstract void TestMethod(string baseArg1, string baseArg2, params string[] baseArg3);
+                               }
+
+                               public class TestClass : BaseClass
+                               {
+                                   public override void TestMethod(string arg1, string arg2, params string[] arg3) { }
+                               }
+                           }");
+
+            VerifyBasic(@"Friend MustInherit Class BaseClass
+                              Public MustOverride Sub TestMethod(baseArg1 As String, baseArg2 As String)
+                          End Class
+
+                          Friend Class TestClass 
+                              Inherits BaseClass
+
+                              Public Overrides Sub TestMethod(arg1 As String, arg2 As String)
+                              End Sub
+                          End Class");
+
+            VerifyBasic(@"Public MustInherit Class BaseClass
+                              Friend MustOverride Sub TestMethod(baseArg1 As String, baseArg2 As String, ParamArray baseArg3 As String())
+                          End Class
+
+                          Public Class TestClass
+                              Inherits BaseClass
+
+                              Friend Overrides Sub TestMethod(arg1 As String, arg2 As String, ParamArray arg3 As String())
+                              End Sub
+                          End Class");
+
+            VerifyBasic(@"Friend Class OuterClass
+                              Public MustInherit Class BaseClass
+                                  Public MustOverride Sub TestMethod(baseArg1 As String, baseArg2 As String, ParamArray baseArg3 As String())
+                              End Class
+
+                              Public Class TestClass
+                                  Inherits BaseClass
+
+                                  Public Overrides Sub TestMethod(arg1 As String, arg2 As String, ParamArray arg3 As String())
+                                  End Sub
+                              End Class
+                          End Class");
+        }
+
         [Fact]
         public void VerifyInterfaceImplementationWithWrongParameterNames()
         {
@@ -183,8 +255,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                         GetBasicResultAt(8, 96, "Sub TestClass.TestMethod(arg1 As String, arg2 As String, ParamArray arg3 As String())", "arg3", "baseArg3", "Sub IBase.TestMethod(baseArg1 As String, baseArg2 As String, ParamArray baseArg3 As String())"));
         }
 
-        [Fact]
-        public void VerifyExplicitInterfaceImplementationWithWrongParameterNames()
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void VerifyExplicitInterfaceImplementationWithWrongParameterNames_NoDiagnostic()
         {
             VerifyCSharp(@"public interface IBase
                            {
@@ -194,9 +266,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                            public class TestClass : IBase
                            {
                                void IBase.TestMethod(string arg1, string arg2) { }
-                           }",
-                         GetCSharpResultAt(8, 61, "void TestClass.TestMethod(string arg1, string arg2)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2)"),
-                         GetCSharpResultAt(8, 74, "void TestClass.TestMethod(string arg1, string arg2)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2)"));
+                           }");
 
             VerifyCSharp(@"public interface IBase
                            {
@@ -206,9 +276,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                            public class TestClass : IBase
                            {
                                void IBase.TestMethod(string arg1, string arg2, __arglist) { }
-                           }",
-                         GetCSharpResultAt(8, 61, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2, __arglist)"),
-                         GetCSharpResultAt(8, 74, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2, __arglist)"));
+                           }");
 
             VerifyCSharp(@"public interface IBase
                            {
@@ -218,10 +286,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                            public class TestClass : IBase
                            {
                                void IBase.TestMethod(string arg1, string arg2, params string[] arg3) { }
-                           }",
-                         GetCSharpResultAt(8, 61, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
-                         GetCSharpResultAt(8, 74, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
-                         GetCSharpResultAt(8, 96, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg3", "baseArg3", "void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"));
+                           }");
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
@@ -20,6 +20,21 @@ public class Test
     }}
 }}";
 
+        private const string CSharpNotExternallyVisibleTestTemplate = @"
+using System;
+
+internal class OuterClass
+{{
+    public class Test
+    {{
+        {0} DateTime Date {{ get; }}
+        {1} string GetDate()
+        {{
+            return DateTime.Today.ToString();
+        }}
+    }}
+}}";
+
         private const string BasicTestTemplate = @"
 Imports System
 
@@ -33,6 +48,23 @@ Public Class Test
         Return Me.Date.ToString()
     End Function 
 End Class";
+
+        private const string BasicNotExternallyVisibleTestTemplate = @"
+Imports System
+
+Friend Class OuterClass
+    Public Class Test
+        {0} ReadOnly Property [Date]() As DateTime
+            Get
+                Return DateTime.Today
+            End Get
+        End Property
+        {1} Function GetDate() As String
+            Return Me.Date.ToString()
+        End Function 
+    End Class
+End Class
+";
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
@@ -79,6 +111,9 @@ public class Test
                     column: $"    {propertyAccessibility} DateTime ".Length + 1,
                     identifierName: "Date",
                     otherIdentifierName: "GetDate"));
+
+            VerifyCSharp(
+                string.Format(CSharpNotExternallyVisibleTestTemplate, propertyAccessibility, methodAccessibility));
         }
 
         [Theory]
@@ -92,7 +127,7 @@ public class Test
             VerifyCSharp(string.Format(CSharpTestTemplate, propertyAccessibility, methodAccessibility));
         }
 
-        [Theory]
+        [Theory, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
         [InlineData("public", "private")]
         [InlineData("protected", "private")]
         [InlineData("protected internal", "private")]
@@ -183,7 +218,7 @@ Public Class Test
 End Class");
         }
 
-        [Theory]
+        [Theory, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
         [InlineData("Public", "Public")]
         [InlineData("Public", "Protected")]
         [InlineData("Public", "Protected Friend")]
@@ -202,6 +237,9 @@ End Class");
                     column: $"    {propertyAccessibility} ReadOnly Property ".Length + 1,
                     identifierName: "Date",
                     otherIdentifierName: "GetDate"));
+
+            VerifyBasic(
+                string.Format(BasicNotExternallyVisibleTestTemplate, propertyAccessibility, methodAccessibility));
         }
 
         [Theory]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
@@ -59,6 +59,30 @@ public class Forms
         CSharpSystemResultAt(2, 14, "Forms", "System.Windows.Forms"));
         }
 
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CA1724CSharpInvalidNameMatchingFormsNamespaceInSystemRule_Internal_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+internal class Forms
+{
+}
+
+public class Outer
+{
+    private class Forms
+    {
+    }
+}
+
+internal class Outer2
+{
+    public class Forms
+    {
+    }
+}
+");
+        }
+
         [Fact]
         public void CA1724CSharpInvalidNameMatchingSdkNamespaceInDefaultRule()
         {
@@ -105,6 +129,25 @@ End Class");
 Public Class Forms
 End Class",
         BasicSystemResultAt(2, 14, "Forms", "System.Windows.Forms"));
+        }
+
+        [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
+        public void CA1724VisualBasicInvalidNameMatchingFormsNamespaceInSystemRule_Internal_NoDiagnostic()
+        {
+            VerifyBasic(@"
+Friend Class Forms
+End Class
+
+Public Class Outer
+    Private Class Forms
+    End Class
+End Class
+
+Friend Class Outer2
+    Public Class Forms
+    End Class
+End Class
+");
         }
 
         [Fact]


### PR DESCRIPTION
Addresses https://github.com/dotnet/roslyn-analyzers/issues/1432#issuecomment-349579767