### PR TITLE
Handle type parameter being passed as a type argument to a generic in…

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -113,19 +113,42 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                     {
                         if (typeParam.HasConstructorConstraint)
                         {
-                            var namedTypeArg = (INamedTypeSymbol)typeArg;
-                            instantiatedTypes.Add(namedTypeArg);
-
-                            // We need to handle if this type param also has type params that have a generic constraint. Take the following example:
-                            // new Factory1<Factory2<InstantiatedType>>();
-                            // In this example, Factory1 and Factory2 have type params with constructor constraints. Therefore, we need to add all 3
-                            // types to the list of types that have actually been instantiated. However, in the following example:
-                            // new List<Factory<InstantiatedType>>();
-                            // List does not have a constructor constraint, so we can't reasonably infer anything about its type parameters.
-                            if (namedTypeArg.IsGenericType)
+                            void ProcessNamedTypeParamConstraint(INamedTypeSymbol namedTypeArg)
                             {
-                                var newGenerics = namedTypeArg.TypeParameters.Zip(namedTypeArg.TypeArguments, (parameter, argument) => (parameter, argument));
-                                ProcessGenericTypes(newGenerics);
+                                instantiatedTypes.Add(namedTypeArg);
+
+                                // We need to handle if this type param also has type params that have a generic constraint. Take the following example:
+                                // new Factory1<Factory2<InstantiatedType>>();
+                                // In this example, Factory1 and Factory2 have type params with constructor constraints. Therefore, we need to add all 3
+                                // types to the list of types that have actually been instantiated. However, in the following example:
+                                // new List<Factory<InstantiatedType>>();
+                                // List does not have a constructor constraint, so we can't reasonably infer anything about its type parameters.
+                                if (namedTypeArg.IsGenericType)
+                                {
+                                    var newGenerics = namedTypeArg.TypeParameters.Zip(namedTypeArg.TypeArguments, (parameter, argument) => (parameter, argument));
+                                    ProcessGenericTypes(newGenerics);
+                                }
+                            };
+
+                            if (typeArg is INamedTypeSymbol namedType)
+                            {
+                                ProcessNamedTypeParamConstraint(namedType);
+                            }
+                            else if (typeArg is ITypeParameterSymbol typeParameterArg && !typeParameterArg.ConstraintTypes.IsEmpty)
+                            {
+                                IEnumerable<INamedTypeSymbol> GetAllNamedTypeConstraints(ITypeParameterSymbol t)
+                                {
+                                    var directConstraints = t.ConstraintTypes.OfType<INamedTypeSymbol>();
+                                    var inheritedConstraints = t.ConstraintTypes.OfType<ITypeParameterSymbol>()
+                                        .SelectMany(constraintT => GetAllNamedTypeConstraints(constraintT));
+                                    return directConstraints.Concat(inheritedConstraints);
+                                };
+
+                                var constraints = GetAllNamedTypeConstraints(typeParameterArg);
+                                foreach (INamedTypeSymbol constraint in constraints)
+                                {
+                                    ProcessNamedTypeParamConstraint(constraint);
+                                }
                             }
                         }
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -955,6 +955,69 @@ internal class Program
 }");
         }
 
+        [Fact, WorkItem(1447, "https://github.com/dotnet/roslyn-analyzers/issues/1447")]
+        public void CA1812_CSharp_NoDiagnostic_GenericMethodWithNewConstraintInvokedFromGenericMethod()
+        {
+            VerifyCSharp(@"
+internal class InstantiatedClass
+{
+    public InstantiatedClass()
+    {
+    }
+}
+
+internal class InstantiatedClass2
+{
+    public InstantiatedClass2()
+    {
+    }
+}
+
+internal class InstantiatedClass3
+{
+    public InstantiatedClass3()
+    {
+    }
+}
+
+internal static class C
+{
+    private static T Create<T>()
+        where T : new()
+    {
+        return new T();
+    }
+
+    public static void M<T>()
+        where T : InstantiatedClass, new()
+    {
+        Create<T>();
+    }
+
+    public static void M2<T, T2>()
+        where T : T2, new()
+        where T2 : InstantiatedClass2
+    {
+        Create<T>();
+    }
+
+    public static void M3<T, T2, T3>()
+        where T : T2, new()
+        where T2 : T3
+        where T3: InstantiatedClass3
+    {
+        Create<T>();
+    }
+
+    public static void M3()
+    {
+        M<InstantiatedClass>();
+        M2<InstantiatedClass2, InstantiatedClass2>();
+        M3<InstantiatedClass3, InstantiatedClass3, InstantiatedClass3>();
+    }
+}");
+        }
+
         [Fact, WorkItem(1158, "https://github.com/dotnet/roslyn-analyzers/issues/1158")]
         public void CA1812_Basic_NoDiagnostic_GenericMethodWithNewConstraint()
         {


### PR DESCRIPTION
…vocation in AvoidUninstantiatedInternalClassesAnalyzer

Fixes #1447