### PR TITLE
CA1000 should not fire for conversion operators on static classes

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypes.cs
@@ -52,10 +52,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                     if (symbol is IMethodSymbol methodSymbol &&
                         (methodSymbol.IsAccessorMethod() ||
-                         (methodSymbol.MethodKind == MethodKind.UserDefinedOperator &&
-                            (methodSymbol.Name == WellKnownMemberNames.EqualityOperatorName ||
-                             methodSymbol.Name == WellKnownMemberNames.InequalityOperatorName)) ||
-                             (methodSymbol.MethodKind == MethodKind.Conversion)))
+                        (methodSymbol.MethodKind == MethodKind.UserDefinedOperator &&
+                        (methodSymbol.Name == WellKnownMemberNames.EqualityOperatorName ||
+                        methodSymbol.Name == WellKnownMemberNames.InequalityOperatorName)) ||
+                        methodSymbol.MethodKind == MethodKind.Conversion))
                     {
                         return;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypes.cs
@@ -54,7 +54,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         (methodSymbol.IsAccessorMethod() ||
                          (methodSymbol.MethodKind == MethodKind.UserDefinedOperator &&
                             (methodSymbol.Name == WellKnownMemberNames.EqualityOperatorName ||
-                             methodSymbol.Name == WellKnownMemberNames.InequalityOperatorName))))
+                             methodSymbol.Name == WellKnownMemberNames.InequalityOperatorName)) ||
+                             (methodSymbol.MethodKind == MethodKind.Conversion)))
                     {
                         return;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypesTests.cs
@@ -348,5 +348,33 @@ Public NotInheritable Class ClosedType
     End Property
 End Class");
         }
+
+        [Fact]
+        public void CSharp_CA1000_ShouldNotGenerate_ConversionOperator()
+        {
+            VerifyCSharp(@"
+public class Class1<T>
+{
+    public static implicit operator Class1<T>(T value) => new Class1<T>();
+    public static explicit operator T(Class1<T> value) => default(T);
+}
+");
+        }
+
+        [Fact]
+        public void Basic_CA1000_ShouldNotGenerate_ConversionOperator()
+        {
+            VerifyBasic(@"
+Public Class Class1(Of T)
+    Public Shared Narrowing Operator CType(value As T) As Class1(Of T)
+        Return New Class1(Of T)()
+    End Operator
+
+    Public Shared Widening Operator CType(value As Class1(Of T)) As T
+        Return Nothing
+    End Operator
+End Class
+");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/1287