### PR TITLE
Restrict new FxCop analyzers VSIX to be installed on VS2017.5 RTW or …

### DIFF
--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/source.extension.vsixmanifest
@@ -12,8 +12,7 @@
     <Tags>code analysis; roslyn; analyzer; analyzers; live; fxcop; code quality;</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,]" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27130.0,]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
…later

Fixes #1253