### PR TITLE
Do not fire CA1608 if the CancellationToken is the first parameter of an extension method

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CancellationTokenParametersMustComeLast.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CancellationTokenParametersMustComeLast.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                             }
                         }
 
-                        // Skip ref, out and ref readonly parameters. By convention, they come at the end of a method signature.
+                        // Ignore parameters passed by reference when they appear at the end of the parameter list.
                         while (last >= 0 && methodSymbol.Parameters[last].RefKind != RefKind.None)
                         {
                             last--;

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CancellationTokenParametersMustComeLastTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CancellationTokenParametersMustComeLastTests.cs
@@ -228,16 +228,34 @@ static class C1
     public static void M1(this CancellationToken p1, object p2)
     {
     }
-}
-
-class C2
-{
-    void M2(CancellationToken p1)
-    {
-        p1.M1(null);
-    }
 }";
             VerifyCSharp(test);
+        }
+
+        [Fact]
+        public void DiagnosticOnExtensionMethodWhenCancellationTokenIsNotFirstParameter()
+        {
+            var test = @"
+using System.Threading;
+static class C1
+{
+    public static void M1(this object p1, CancellationToken p2, object p3)
+    {
+    }
+}";
+
+            var expected = new DiagnosticResult
+            {
+                Id = CancellationTokenParametersMustComeLastAnalyzer.RuleId,
+                Message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.CancellationTokenParametersMustComeLastMessage, "C1.M1(object, System.Threading.CancellationToken, object)"),
+                Severity = DiagnosticHelpers.DefaultDiagnosticSeverity,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 5, 24)
+                }
+            };
+
+            VerifyCSharp(test, expected);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CancellationTokenParametersMustComeLastTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CancellationTokenParametersMustComeLastTests.cs
@@ -218,6 +218,28 @@ class T : I
             VerifyCSharp(test, expected);
         }
 
+        [Fact, WorkItem(1491, "https://github.com/dotnet/roslyn-analyzers/issues/1491")]
+        public void NoDiagnosticOnCancellationTokenExtensionMethod()
+        {
+            var test = @"
+using System.Threading;
+static class C1
+{
+    public static void M1(this CancellationToken p1, object p2)
+    {
+    }
+}
+
+class C2
+{
+    void M2(CancellationToken p1)
+    {
+        p1.M1(null);
+    }
+}";
+            VerifyCSharp(test);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new CancellationTokenParametersMustComeLastAnalyzer();


### PR DESCRIPTION
Fixes #1491

/cc @333fred, @mavasani 