### PR TITLE
Allow tests to remove System.Collections.Immutable and include their …

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/InternalImplementationOnlyTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/InternalImplementationOnlyTests.cs
@@ -28,7 +28,7 @@ class Foo : IFoo { }
 ";
 
             // Verify no diagnostic since interface is in the same assembly.
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: false);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ class Bar : Microsoft.CodeAnalysis.IAssemblySymbol { }
             DiagnosticResult[] expected = new[] { GetCSharpExpectedDiagnostic(3, 7, "Foo", "ISymbol"), GetCSharpExpectedDiagnostic(4, 7, "Bar", "ISymbol") };
 
             // Verify that ISymbol is not implementable.
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ class Bar : Microsoft.CodeAnalysis.Operations.IInvocationOperation { }
             DiagnosticResult[] expected = new[] { GetCSharpExpectedDiagnostic(3, 7, "Foo", "IOperation"), GetCSharpExpectedDiagnostic(4, 7, "Bar", "IOperation") };
 
             // Verify that IOperation is not implementable.
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
         }
 
         private const string AttributeStringBasic = @"
@@ -126,7 +126,7 @@ End Class
 ";
 
             // Verify no diagnostic since interface is in the same assembly.
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: false);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis);
         }
 
         [Fact]
@@ -203,7 +203,7 @@ End Class
             DiagnosticResult[] expected = new[] { GetBasicExpectedDiagnostic(3, 7, "Foo", "ISymbol"), GetBasicExpectedDiagnostic(6, 7, "Bar", "ISymbol") };
 
             // Verify that ISymbol is not implementable.
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
         }
 
         [Fact]
@@ -221,15 +221,15 @@ End Class
             DiagnosticResult[] expected = new[] { GetBasicExpectedDiagnostic(3, 7, "Foo", "IOperation"), GetBasicExpectedDiagnostic(6, 7, "Bar", "IOperation") };
 
             // Verify that IOperation is not implementable.
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None, validationMode: TestValidationMode.AllowCompileErrors, expected: expected);
         }
 
         private void VerifyAcrossTwoAssemblies(string source1, string source2, string language, params DiagnosticResult[] expected)
         {
             Debug.Assert(language == LanguageNames.CSharp || language == LanguageNames.VisualBasic);
 
-            Project project1 = CreateProject(new[] { source1 }, language: language, addLanguageSpecificCodeAnalysisReference: false);
-            Project project2 = CreateProject(new[] { source2 }, language: language, addLanguageSpecificCodeAnalysisReference: false, addToSolution: project1.Solution)
+            Project project1 = CreateProject(new[] { source1 }, language: language, referenceFlags: ReferenceFlags.RemoveCodeAnalysis);
+            Project project2 = CreateProject(new[] { source2 }, language: language, referenceFlags: ReferenceFlags.RemoveCodeAnalysis, addToSolution: project1.Solution)
                            .AddProjectReference(new ProjectReference(project1.Id));
 
             DiagnosticAnalyzer analyzer = language == LanguageNames.CSharp ? GetCSharpDiagnosticAnalyzer() : GetBasicDiagnosticAnalyzer();

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/AddLanguageSupportToAnalyzerRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/AddLanguageSupportToAnalyzerRuleTests.cs
@@ -38,10 +38,10 @@ class MyAnalyzer : DiagnosticAnalyzer
             DiagnosticResult expected = GetCSharpExpectedDiagnostic(7, 2, "MyAnalyzer", missingLanguageName: LanguageNames.VisualBasic);
 
             // Verify diagnostic if analyzer assembly doesn't reference C# code analysis assembly.
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: false, expected: expected);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis, expected: expected);
 
             // Verify no diagnostic if analyzer assembly references C# code analysis assembly.
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -69,10 +69,10 @@ End Class
             DiagnosticResult expected = GetBasicExpectedDiagnostic(7, 2, "MyAnalyzer", missingLanguageName: LanguageNames.CSharp);
 
             // Verify diagnostic if analyzer assembly doesn't reference VB code analysis assembly.
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: false, expected: expected);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis, expected: expected);
 
             // Verify no diagnostic if analyzer assembly references VB code analysis assembly.
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -121,8 +121,8 @@ public abstract class MyAbstractAnalyzer : DiagnosticAnalyzer
 {
 }
 ";
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: false);
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -165,8 +165,8 @@ Public MustInherit Class MyAbstractAnalyzer
 	Inherits DiagnosticAnalyzer
 End Class
 ";
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: false);
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None);
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
@@ -64,7 +64,7 @@ class MyAnalyzer : DiagnosticAnalyzer
                 GetCSharpExpectedDiagnostic(38, 52, parameterName: "operationBlockContext", kind: StartActionKind.OperationBlockStartAction)
             };
 
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true, expected: expected);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None, expected: expected);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ End Class
                 GetBasicExpectedDiagnostic(34, 51, parameterName: "operationBlockContext", kind: StartActionKind.OperationBlockStartAction)
             };
 
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true, expected: expected);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None, expected: expected);
         }
 
         [Fact]
@@ -157,7 +157,7 @@ abstract class MyAnalyzer<T> : DiagnosticAnalyzer
     }
 }";
 
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -203,7 +203,7 @@ abstract class MyAnalyzer<T> : DiagnosticAnalyzer
     }
 }";
 
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -256,7 +256,7 @@ class MyAnalyzer2 : DiagnosticAnalyzer
     {
     }
 }";
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: false);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis);
         }
 
         [Fact]
@@ -314,7 +314,7 @@ class MyAnalyzer : DiagnosticAnalyzer
     }
 }";
 
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: false);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis);
         }
 
         [Fact]
@@ -354,7 +354,7 @@ Class MyAnalyzer(Of T As Structure)
 End Class
 ";
 
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -398,7 +398,7 @@ Class MyAnalyzer(Of T As Structure)
 End Class
 ";
 
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -444,7 +444,7 @@ Class MyAnalyzer2
 	End Sub
 End Class
 ";
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: false);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis);
         }
 
         [Fact]
@@ -493,7 +493,7 @@ MustInherit Class MyAnalyzer
 End Class
 ";
 
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: false);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.RemoveCodeAnalysis);
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithOnlyEndActionRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithOnlyEndActionRuleTests.cs
@@ -67,7 +67,7 @@ class MyAnalyzer : DiagnosticAnalyzer
                 GetCSharpExpectedDiagnostic(40, 52, parameterName: "operationBlockContext", kind: StartActionKind.OperationBlockStartAction)
             };
 
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true, expected: expected);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None, expected: expected);
         }
 
         [Fact]
@@ -120,7 +120,7 @@ End Class
                 GetBasicExpectedDiagnostic(36, 51, parameterName: "operationBlockContext", kind: StartActionKind.OperationBlockStartAction)
             };
 
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true, expected: expected);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None, expected: expected);
         }
 
         [Fact]
@@ -176,7 +176,7 @@ abstract class MyAnalyzer<T> : DiagnosticAnalyzer
     }
 }";
 
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -225,7 +225,7 @@ abstract class MyAnalyzer<T> : DiagnosticAnalyzer
     }
 }";
 
-            VerifyCSharp(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyCSharp(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -276,7 +276,7 @@ Class MyAnalyzer(Of T As Structure)
 End Class
 ";
 
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]
@@ -323,7 +323,7 @@ Class MyAnalyzer(Of T As Structure)
 End Class
 ";
 
-            VerifyBasic(source, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyBasic(source, referenceFlags: ReferenceFlags.None);
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
@@ -869,7 +869,7 @@ End Class
         private void Verify(string source, string language, DiagnosticAnalyzer analyzer, string testProjectName, DiagnosticResult[] expected)
         {
             var sources = new[] { source };
-            var diagnostics = GetSortedDiagnostics(sources.ToFileAndSource(), language, analyzer, compilationOptions: null, addLanguageSpecificCodeAnalysisReference: true, projectName: testProjectName);
+            var diagnostics = GetSortedDiagnostics(sources.ToFileAndSource(), language, analyzer, compilationOptions: null, referenceFlags: ReferenceFlags.None, projectName: testProjectName);
             diagnostics.Verify(analyzer, expected);
         }
 

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.cs
@@ -181,10 +181,9 @@ End Class
         [MemberData(nameof(CollectionNames_Arity1))]
         public void DiagnosticCases_Arity1(string collectionName)
         {
-            VerifyCSharp($@"
+            VerifyCSharp(new[] { $@"
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using static System.Collections.Immutable.{collectionName};
 
 static class Extensions
 {{
@@ -202,13 +201,14 @@ class C
         p3.To{collectionName}();
     }}
 }}
-",
-    // Test0.cs(18,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-    GetCSharpResultAt(18, 9, collectionName),
-    // Test0.cs(19,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-    GetCSharpResultAt(19, 9, collectionName));
+", MinimalImmutableCollectionsSource.CSharp },
+                ReferenceFlags.RemoveImmutable,
+                // Test0.cs(18,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetCSharpResultAt(17, 9, collectionName),
+                // Test0.cs(19,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetCSharpResultAt(18, 9, collectionName));
 
-            VerifyBasic($@"
+            VerifyBasic(new[] { $@"
 Imports System.Collections.Generic
 Imports System.Collections.Immutable
 
@@ -225,21 +225,21 @@ Class C
 		p3.To{collectionName}()
 	End Sub
 End Class
-",
-    // Test0.vb(14,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-    GetBasicResultAt(14, 3, collectionName),
-    // Test0.vb(15,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-    GetBasicResultAt(15, 3, collectionName));
+", MinimalImmutableCollectionsSource.Basic },
+                ReferenceFlags.RemoveImmutable,
+                // Test0.vb(14,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetBasicResultAt(14, 3, collectionName),
+                // Test0.vb(15,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetBasicResultAt(15, 3, collectionName));
         }
 
         [Theory]
         [MemberData(nameof(CollectionNames_Arity2))]
         public void DiagnosticCases_Arity2(string collectionName)
         {
-            VerifyCSharp($@"
+            VerifyCSharp(new[] { $@"
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using static System.Collections.Immutable.{collectionName};
 
 static class Extensions
 {{
@@ -257,13 +257,14 @@ class C
         p3.To{collectionName}();
     }}
 }}
-",
-    // Test0.cs(18,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-    GetCSharpResultAt(18, 9, collectionName),
-    // Test0.cs(19,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-    GetCSharpResultAt(19, 9, collectionName));
+", MinimalImmutableCollectionsSource.CSharp },
+                ReferenceFlags.RemoveImmutable,
+                // Test0.cs(18,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetCSharpResultAt(17, 9, collectionName),
+                // Test0.cs(19,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetCSharpResultAt(18, 9, collectionName));
 
-            VerifyBasic($@"
+            VerifyBasic(new[] { $@"
 Imports System.Collections.Generic
 Imports System.Collections.Immutable
 
@@ -280,11 +281,12 @@ Class C
 		p3.To{collectionName}()
 	End Sub
 End Class
-",
-    // Test0.vb(14,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-    GetBasicResultAt(14, 3, collectionName),
-    // Test0.vb(15,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-    GetBasicResultAt(15, 3, collectionName));
+", MinimalImmutableCollectionsSource.Basic },
+                ReferenceFlags.RemoveImmutable,
+                // Test0.vb(14, 3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetBasicResultAt(14, 3, collectionName),
+                // Test0.vb(15,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetBasicResultAt(15, 3, collectionName));
         }
 
         #endregion

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -302,7 +302,7 @@ namespace N
 
             // Should we be flagging diagnostics on compiler generated code?
             // Should the analyzer even be invoked for compiler generated code?
-            VerifyCSharp(source + arrayEmptySource, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyCSharp(source + arrayEmptySource, referenceFlags: ReferenceFlags.None);
         }
         
         [WorkItem(1209, "https://github.com/dotnet/roslyn-analyzers/issues/1209")]
@@ -324,7 +324,7 @@ public abstract class C
 
             // Should we be flagging diagnostics on compiler generated code?
             // Should the analyzer even be invoked for compiler generated code?
-            VerifyCSharp(source + arrayEmptySource, addLanguageSpecificCodeAnalysisReference: true);
+            VerifyCSharp(source + arrayEmptySource, referenceFlags: ReferenceFlags.None);
         }
 
         [Fact]

--- a/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
@@ -19,6 +19,14 @@ namespace Test.Utilities
 {
     public abstract class DiagnosticAnalyzerTestBase
     {
+        [Flags]
+        protected enum ReferenceFlags
+        {
+            None = 0b00,
+            RemoveCodeAnalysis = 0b01,
+            RemoveImmutable = 0b10
+        }
+
         private static readonly MetadataReference s_corlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
         private static readonly MetadataReference s_systemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
         private static readonly MetadataReference s_systemXmlReference = MetadataReference.CreateFromFile(typeof(System.Xml.XmlDocument).Assembly.Location);
@@ -216,42 +224,52 @@ namespace Test.Utilities
 
         protected void VerifyCSharpUnsafeCode(string source, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, true, compilationOptions: null, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, true, ReferenceFlags.None, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyCSharp(string source, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, false, compilationOptions: null, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, false, ReferenceFlags.None, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyCSharp(string source, CompilationOptions compilationOptions, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, false, compilationOptions, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, false, ReferenceFlags.None, compilationOptions, expected: expected);
         }
 
         protected void VerifyCSharp(string source, TestValidationMode validationMode, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), validationMode, false, compilationOptions: null, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), validationMode, false, ReferenceFlags.None, compilationOptions: null, expected: expected);
+        }
+
+        protected void VerifyCSharp(string source, ReferenceFlags referenceFlags, params DiagnosticResult[] expected)
+        {
+            Verify(source, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), referenceFlags, DefaultTestValidationMode, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyCSharp(string source, TestValidationMode validationMode, CompilationOptions compilationOptions, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), validationMode, false, compilationOptions, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), validationMode, false, ReferenceFlags.None, compilationOptions, expected: expected);
         }
 
-        protected void VerifyCSharp(string source, bool addLanguageSpecificCodeAnalysisReference, TestValidationMode validationMode = DefaultTestValidationMode, params DiagnosticResult[] expected)
+        protected void VerifyCSharp(string source, ReferenceFlags referenceFlags, TestValidationMode validationMode = DefaultTestValidationMode, params DiagnosticResult[] expected)
         {
-            Verify(source, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), addLanguageSpecificCodeAnalysisReference, validationMode, compilationOptions: null, expected: expected);
+            Verify(source, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), referenceFlags, validationMode, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyCSharp(string[] sources, params DiagnosticResult[] expected)
         {
-            Verify(sources.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, false, compilationOptions: null, expected: expected);
+            Verify(sources.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, false, ReferenceFlags.None, compilationOptions: null, expected: expected);
+        }
+
+        protected void VerifyCSharp(string[] sources, ReferenceFlags referenceFlags, params DiagnosticResult[] expected)
+        {
+            Verify(sources.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, false, referenceFlags, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyCSharp(FileAndSource[] sources, params DiagnosticResult[] expected)
         {
-            Verify(sources, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, false, compilationOptions: null, expected: expected);
+            Verify(sources, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, false, ReferenceFlags.None, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyCSharp(string source, FileAndSource additionalText, params DiagnosticResult[] expected)
@@ -262,37 +280,47 @@ namespace Test.Utilities
 
         protected void VerifyBasic(string source, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), DefaultTestValidationMode, false, compilationOptions: null, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), DefaultTestValidationMode, false, ReferenceFlags.None, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyBasic(string source, CompilationOptions compilationOptions, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), DefaultTestValidationMode, false, compilationOptions, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), DefaultTestValidationMode, false, ReferenceFlags.None, compilationOptions, expected: expected);
         }
 
         protected void VerifyBasic(string source, TestValidationMode validationMode, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), validationMode, false, compilationOptions: null, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), validationMode, false, ReferenceFlags.None, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyBasic(string source, TestValidationMode validationMode, CompilationOptions compilationOptions, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), validationMode, false, compilationOptions, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), validationMode, false, ReferenceFlags.None, compilationOptions, expected: expected);
         }
 
-        protected void VerifyBasic(string source, bool addLanguageSpecificCodeAnalysisReference, TestValidationMode validationMode = DefaultTestValidationMode, params DiagnosticResult[] expected)
+        protected void VerifyBasic(string source, ReferenceFlags referenceFlags, params DiagnosticResult[] expected)
         {
-            Verify(source, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), addLanguageSpecificCodeAnalysisReference, validationMode, compilationOptions: null, expected: expected);
+            Verify(source, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), referenceFlags, DefaultTestValidationMode, compilationOptions: null, expected: expected);
+        }
+
+        protected void VerifyBasic(string source, ReferenceFlags referenceFlags, TestValidationMode validationMode = DefaultTestValidationMode, params DiagnosticResult[] expected)
+        {
+            Verify(source, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), referenceFlags, validationMode, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyBasic(string[] sources, params DiagnosticResult[] expected)
         {
-            Verify(sources.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), DefaultTestValidationMode, false, compilationOptions: null, expected: expected);
+            Verify(sources.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), DefaultTestValidationMode, false, ReferenceFlags.None, compilationOptions: null, expected: expected);
+        }
+
+        protected void VerifyBasic(string[] sources, ReferenceFlags referenceFlags, params DiagnosticResult[] expected)
+        {
+            Verify(sources.ToFileAndSource(), LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), DefaultTestValidationMode, false, referenceFlags, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyBasic(FileAndSource[] sources, params DiagnosticResult[] expected)
         {
-            Verify(sources, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), DefaultTestValidationMode, false, compilationOptions: null, expected: expected);
+            Verify(sources, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), DefaultTestValidationMode, false, ReferenceFlags.None, compilationOptions: null, expected: expected);
         }
 
         protected void VerifyBasic(string source, FileAndSource additionalText, params DiagnosticResult[] expected)
@@ -307,15 +335,15 @@ namespace Test.Utilities
             diagnostics.Verify(analyzer, PrintActualDiagnosticsOnFailure, ExpectedDiagnosticsAssertionTemplate, expected);
         }
 
-        private void Verify(string source, string language, DiagnosticAnalyzer analyzer, bool addLanguageSpecificCodeAnalysisReference, TestValidationMode validationMode, CompilationOptions compilationOptions, params DiagnosticResult[] expected)
+        private void Verify(string source, string language, DiagnosticAnalyzer analyzer, ReferenceFlags referenceFlags, TestValidationMode validationMode, CompilationOptions compilationOptions, params DiagnosticResult[] expected)
         {
-            var diagnostics = GetSortedDiagnostics(new[] { source }.ToFileAndSource(), language, analyzer, compilationOptions, addLanguageSpecificCodeAnalysisReference: addLanguageSpecificCodeAnalysisReference, validationMode: validationMode);
+            var diagnostics = GetSortedDiagnostics(new[] { source }.ToFileAndSource(), language, analyzer, compilationOptions, referenceFlags: referenceFlags, validationMode: validationMode);
             diagnostics.Verify(analyzer, PrintActualDiagnosticsOnFailure, ExpectedDiagnosticsAssertionTemplate, expected);
         }
 
-        private void Verify(FileAndSource[] sources, string language, DiagnosticAnalyzer analyzer, TestValidationMode validationMode, bool allowUnsafeCode, CompilationOptions compilationOptions, params DiagnosticResult[] expected)
+        private void Verify(FileAndSource[] sources, string language, DiagnosticAnalyzer analyzer, TestValidationMode validationMode, bool allowUnsafeCode, ReferenceFlags referenceFlags, CompilationOptions compilationOptions, params DiagnosticResult[] expected)
         {
-            var diagnostics = GetSortedDiagnostics(sources, language, analyzer, compilationOptions, validationMode, allowUnsafeCode: allowUnsafeCode);
+            var diagnostics = GetSortedDiagnostics(sources, language, analyzer, compilationOptions, validationMode, referenceFlags: referenceFlags, allowUnsafeCode: allowUnsafeCode);
             diagnostics.Verify(analyzer, PrintActualDiagnosticsOnFailure, ExpectedDiagnosticsAssertionTemplate, expected);
         }
 
@@ -325,7 +353,7 @@ namespace Test.Utilities
         protected TestAdditionalDocument GetAdditionalTextFile(string fileName, string text) =>
             new TestAdditionalDocument(fileName, text);
 
-        private static Tuple<Document[], bool, TextSpan?[]> GetDocumentsAndSpans(FileAndSource[] sources, string language, CompilationOptions compilationOptions, bool addLanguageSpecificCodeAnalysisReference = true, string projectName = TestProjectName, bool allowUnsafeCode = false)
+        private static Tuple<Document[], bool, TextSpan?[]> GetDocumentsAndSpans(FileAndSource[] sources, string language, CompilationOptions compilationOptions, ReferenceFlags referenceFlags = ReferenceFlags.None, string projectName = TestProjectName, bool allowUnsafeCode = false)
         {
             Assert.True(language == LanguageNames.CSharp || language == LanguageNames.VisualBasic, "Unsupported language");
 
@@ -345,27 +373,27 @@ namespace Test.Utilities
                 }
             }
 
-            Project project = CreateProject(sources, language, addLanguageSpecificCodeAnalysisReference, null, projectName, allowUnsafeCode, compilationOptions: compilationOptions);
+            Project project = CreateProject(sources, language, referenceFlags, null, projectName, allowUnsafeCode, compilationOptions: compilationOptions);
             Document[] documents = project.Documents.ToArray();
             Assert.Equal(sources.Length, documents.Length);
 
             return Tuple.Create(documents, useSpans, spans);
         }
 
-        protected static Document CreateDocument(string source, string language = LanguageNames.CSharp, bool addLanguageSpecificCodeAnalysisReference = true, bool allowUnsafeCode = false)
+        protected static Document CreateDocument(string source, string language = LanguageNames.CSharp, ReferenceFlags referenceFlags = ReferenceFlags.None, bool allowUnsafeCode = false)
         {
-            return CreateProject(new[] { source }.ToFileAndSource(), language, addLanguageSpecificCodeAnalysisReference, allowUnsafeCode: allowUnsafeCode).Documents.First();
+            return CreateProject(new[] { source }.ToFileAndSource(), language, referenceFlags, allowUnsafeCode: allowUnsafeCode).Documents.First();
         }
 
-        protected static Project CreateProject(string[] sources, string language = LanguageNames.CSharp, bool addLanguageSpecificCodeAnalysisReference = true, Solution addToSolution = null)
+        protected static Project CreateProject(string[] sources, string language = LanguageNames.CSharp, ReferenceFlags referenceFlags = ReferenceFlags.None, Solution addToSolution = null)
         {
-            return CreateProject(sources.ToFileAndSource(), language, addLanguageSpecificCodeAnalysisReference, addToSolution);
+            return CreateProject(sources.ToFileAndSource(), language, referenceFlags, addToSolution);
         }
 
         private static Project CreateProject(
             FileAndSource[] sources,
             string language = LanguageNames.CSharp,
-            bool addLanguageSpecificCodeAnalysisReference = true,
+            ReferenceFlags referenceFlags = ReferenceFlags.None,
             Solution addToSolution = null,
             string projectName = TestProjectName,
             bool allowUnsafeCode = false,
@@ -390,17 +418,21 @@ namespace Test.Utilities
                 .AddMetadataReference(projectId, SystemRuntimeFacadeRef)
                 .AddMetadataReference(projectId, SystemThreadingFacadeRef)
                 .AddMetadataReference(projectId, SystemThreadingTaskFacadeRef)
-                .AddMetadataReference(projectId, s_immutableCollectionsReference)
                 .AddMetadataReference(projectId, s_workspacesReference)
                 .AddMetadataReference(projectId, s_systemDiagnosticsDebugReference)
                 .AddMetadataReference(projectId, s_systemDataReference)
                 .WithProjectCompilationOptions(projectId, options)
                 .GetProject(projectId);
 
-            if (addLanguageSpecificCodeAnalysisReference)
+            if ((referenceFlags & ReferenceFlags.RemoveCodeAnalysis) != ReferenceFlags.RemoveCodeAnalysis)
             {
                 MetadataReference symbolsReference = language == LanguageNames.CSharp ? s_csharpSymbolsReference : s_visualBasicSymbolsReference;
                 project = project.AddMetadataReference(symbolsReference);
+            }
+
+            if ((referenceFlags & ReferenceFlags.RemoveImmutable) != ReferenceFlags.RemoveImmutable)
+            {
+                project = project.AddMetadataReference(s_immutableCollectionsReference);
             }
 
             if (language == LanguageNames.VisualBasic)
@@ -419,9 +451,9 @@ namespace Test.Utilities
             return project;
         }
 
-        protected static Diagnostic[] GetSortedDiagnostics(FileAndSource[] sources, string language, DiagnosticAnalyzer analyzer, CompilationOptions compilationOptions, TestValidationMode validationMode = DefaultTestValidationMode, bool addLanguageSpecificCodeAnalysisReference = true, bool allowUnsafeCode = false, string projectName = TestProjectName, IEnumerable<TestAdditionalDocument> additionalFiles = null)
+        protected static Diagnostic[] GetSortedDiagnostics(FileAndSource[] sources, string language, DiagnosticAnalyzer analyzer, CompilationOptions compilationOptions, TestValidationMode validationMode = DefaultTestValidationMode, ReferenceFlags referenceFlags = ReferenceFlags.None, bool allowUnsafeCode = false, string projectName = TestProjectName, IEnumerable<TestAdditionalDocument> additionalFiles = null)
         {
-            Tuple<Document[], bool, TextSpan?[]> documentsAndUseSpan = GetDocumentsAndSpans(sources, language, compilationOptions, addLanguageSpecificCodeAnalysisReference, projectName, allowUnsafeCode);
+            Tuple<Document[], bool, TextSpan?[]> documentsAndUseSpan = GetDocumentsAndSpans(sources, language, compilationOptions, referenceFlags, projectName, allowUnsafeCode);
             Document[] documents = documentsAndUseSpan.Item1;
             bool useSpans = documentsAndUseSpan.Item2;
             TextSpan?[] spans = documentsAndUseSpan.Item3;

--- a/src/Test.Utilities/MinimalImmutableCollectionsSource.cs
+++ b/src/Test.Utilities/MinimalImmutableCollectionsSource.cs
@@ -1,0 +1,248 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Test.Utilities
+{
+    public static class MinimalImmutableCollectionsSource
+    {
+        public const string CSharp = @"
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using static System.Collections.Immutable.ImmutableExtensions;
+namespace System.Collections.Immutable
+{
+    public sealed partial class ImmutableArray<T> : IEnumerable<T>
+    {
+        public IEnumerator<T> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public sealed partial class ImmutableList<T> : IEnumerable<T>
+    {
+        public IEnumerator<T> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public sealed partial class ImmutableHashSet<T> : IEnumerable<T>
+    {
+        public IEnumerator<T> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public sealed partial class ImmutableSortedSet<T> : IEnumerable<T>
+    {
+        public IEnumerator<T> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+    {
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+    {
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public static class ImmutableExtensions
+    {
+        public static ImmutableArray<T> ToImmutableArray<T>(this IEnumerable<T> source)
+        {
+            return null;
+        }
+        public static ImmutableArray<T> ToImmutableArray<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer)
+        {
+            return null;
+        }
+        public static ImmutableList<T> ToImmutableList<T>(this IEnumerable<T> source)
+        {
+            return null;
+        }
+        public static ImmutableList<T> ToImmutableList<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer)
+        {
+            return null;
+        }
+        public static ImmutableHashSet<T> ToImmutableHashSet<T>(this IEnumerable<T> source)
+        {
+            return null;
+        }
+        public static ImmutableHashSet<T> ToImmutableHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer)
+        {
+            return null;
+        }
+        public static ImmutableSortedSet<T> ToImmutableSortedSet<T>(this IEnumerable<T> source)
+        {
+            return null;
+        }
+        public static ImmutableSortedSet<T> ToImmutableSortedSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer)
+        {
+            return null;
+        }
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
+        {
+            return null;
+        }
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source, IEqualityComparer<TKey> keyComparer)
+        {
+            return null;
+        }
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
+        {
+            return null;
+        }
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source, IEqualityComparer<TKey> keyComparer)
+        {
+            return null;
+        }
+    }
+}
+";
+
+        public const string Basic = @"
+Imports System
+Imports System.Collections
+Imports System.Collections.Generic
+Imports System.Collections.Immutable
+Imports System.Collections.Immutable.ImmutableExtensions
+Imports System.Runtime.CompilerServices
+Namespace System.Collections.Immutable
+    Partial Public NotInheritable Class ImmutableArray(Of T)
+        Implements IEnumerable(Of T)
+        Public Function GetEnumerator() As IEnumerator(Of T) Implements IEnumerable(Of T).GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+        Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+    End Class
+    Partial Public NotInheritable Class ImmutableList(Of T)
+        Implements IEnumerable(Of T)
+        Public Function GetEnumerator() As IEnumerator(Of T) Implements IEnumerable(Of T).GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+        Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+    End Class
+    Partial Public NotInheritable Class ImmutableHashSet(Of T)
+        Implements IEnumerable(Of T)
+        Public Function GetEnumerator() As IEnumerator(Of T) Implements IEnumerable(Of T).GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+        Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+    End Class
+    Partial Public NotInheritable Class ImmutableSortedSet(Of T)
+        Implements IEnumerable(Of T)
+        Public Function GetEnumerator() As IEnumerator(Of T) Implements IEnumerable(Of T).GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+        Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+    End Class
+    Partial Public NotInheritable Class ImmutableDictionary(Of TKey, TValue)
+        Implements IEnumerable(Of KeyValuePair(Of TKey, TValue))
+        Public Function GetEnumerator() As IEnumerator(Of KeyValuePair(Of TKey, TValue)) Implements IEnumerable(Of KeyValuePair(Of TKey, TValue)).GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+        Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+    End Class
+    Partial Public NotInheritable Class ImmutableSortedDictionary(Of TKey, TValue)
+        Implements IEnumerable(Of KeyValuePair(Of TKey, TValue))
+        Public Function GetEnumerator() As IEnumerator(Of KeyValuePair(Of TKey, TValue)) Implements IEnumerable(Of KeyValuePair(Of TKey, TValue)).GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+        Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+            Throw New NotImplementedException()
+        End Function
+    End Class
+    Module ImmutableExtensions
+        <Extension()>
+        Function ToImmutableArray(Of T)(ByVal source As IEnumerable(Of T)) As ImmutableArray(Of T)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableArray(Of T)(ByVal source As IEnumerable(Of T), ByVal comparer As IEqualityComparer(Of T)) As ImmutableArray(Of T)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableList(Of T)(ByVal source As IEnumerable(Of T)) As ImmutableList(Of T)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableList(Of T)(ByVal source As IEnumerable(Of T), ByVal comparer As IEqualityComparer(Of T)) As ImmutableList(Of T)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableHashSet(Of T)(ByVal source As IEnumerable(Of T)) As ImmutableHashSet(Of T)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableHashSet(Of T)(ByVal source As IEnumerable(Of T), ByVal comparer As IEqualityComparer(Of T)) As ImmutableHashSet(Of T)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableSortedSet(Of T)(ByVal source As IEnumerable(Of T)) As ImmutableSortedSet(Of T)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableSortedSet(Of T)(ByVal source As IEnumerable(Of T), ByVal comparer As IEqualityComparer(Of T)) As ImmutableSortedSet(Of T)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableDictionary(Of TKey, TValue)(ByVal source As IEnumerable(Of KeyValuePair(Of TKey, TValue))) As ImmutableDictionary(Of TKey, TValue)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableDictionary(Of TKey, TValue)(ByVal source As IEnumerable(Of KeyValuePair(Of TKey, TValue)), ByVal keyComparer As IEqualityComparer(Of TKey)) As ImmutableDictionary(Of TKey, TValue)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableSortedDictionary(Of TKey, TValue)(ByVal source As IEnumerable(Of KeyValuePair(Of TKey, TValue))) As ImmutableSortedDictionary(Of TKey, TValue)
+            Return Nothing
+        End Function
+        <Extension()>
+        Function ToImmutableSortedDictionary(Of TKey, TValue)(ByVal source As IEnumerable(Of KeyValuePair(Of TKey, TValue)), ByVal keyComparer As IEqualityComparer(Of TKey)) As ImmutableSortedDictionary(Of TKey, TValue)
+            Return Nothing
+        End Function
+    End Module
+End Namespace
+";
+    }
+}


### PR DESCRIPTION
…own version of a minimal implementation. Fixes #1318.

The DoNotCallToImmutableXXXX tests were failing locally for me, and it's only a matter of time before the Jenkins image changes in some way that breaks it there too. This update allows tests to skip inclusion of the System.Collections.Immutable assembly, and instead include a minimal version of the assembly. I made adding and removing this a flags enum that also controls including code analysis, since I couldn't create another Verify with a single bool controlling immutable.