### PR TITLE
Fixer for rule CA1801: ReviewUnusedParameters

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/Maintainability/CSharpReviewUnusedParameters.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/Maintainability/CSharpReviewUnusedParameters.Fixer.cs
@@ -3,6 +3,7 @@
 using System.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeQuality.Analyzers.Maintainability;
 
 namespace Microsoft.CodeQuality.CSharp.Analyzers.Maintainability
@@ -13,5 +14,15 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.Maintainability
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public sealed class CSharpReviewUnusedParametersFixer : ReviewUnusedParametersFixer
     {
+        protected override SyntaxNode GetParameterNode(SyntaxNode node)
+        {
+            return node;
+        }
+
+        protected override bool CanContinuouslyLeadToObjectCreationOrInvocation(SyntaxNode node)
+        {
+            var kind = node.Kind();
+            return kind == SyntaxKind.QualifiedName || kind == SyntaxKind.IdentifierName || kind == SyntaxKind.SimpleMemberAccessExpression;
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/Maintainability/CSharpReviewUnusedParameters.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/Maintainability/CSharpReviewUnusedParameters.Fixer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.Maintainability
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public sealed class CSharpReviewUnusedParametersFixer : ReviewUnusedParametersFixer
     {
-        protected override SyntaxNode GetParameterNode(SyntaxNode node)
+        protected override SyntaxNode GetParameterDeclarationNode(SyntaxNode node)
         {
             return node;
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.resx
@@ -147,6 +147,9 @@
   <data name="RemoveUnusedLocalsMessage" xml:space="preserve">
     <value>Remove unused locals</value>
   </data>
+  <data name="RemoveUnusedParameterMessage" xml:space="preserve">
+    <value>Remove unused parameter</value>
+  </data>
   <data name="DoNotIgnoreMethodResultsTitle" xml:space="preserve">
     <value>Do not ignore method results</value>
   </data>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.Fixer.cs
@@ -1,9 +1,17 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability
 {
@@ -23,8 +31,144 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             // Fixer not yet implemented.
-            return Task.CompletedTask;
+            Diagnostic diagnostic = context.Diagnostics.Single();
 
+            context.RegisterCodeFix(
+                new MyCodeAction(
+                    MicrosoftMaintainabilityAnalyzersResources.ReviewUnusedParametersMessage,
+                    async ct => await RemoveNodes(context.Document, diagnostic, ct).ConfigureAwait(false), diagnostic.Id),
+                diagnostic);
+
+            return Task.CompletedTask;
+        }
+
+        protected abstract SyntaxNode GetParameterNode(SyntaxNode node);
+
+        protected abstract bool CanContinuouslyLeadToObjectCreationOrInvocation(SyntaxNode node);
+
+        private async Task<Solution> RemoveNodes(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var solution = document.Project.Solution;
+            var pairs = await GetNodesToRemoveAsync(document, diagnostic, cancellationToken).ConfigureAwait(false);
+            foreach (var group in pairs.GroupBy(p => p.Key))
+            {
+                DocumentEditor editor = await DocumentEditor.CreateAsync(solution.GetDocument(group.Key), cancellationToken).ConfigureAwait(false);
+                // Start removing from bottom to top to keep spans of nodes that are removed later.
+                foreach (var value in group.OrderByDescending(v => v.Value.SpanStart))
+                {
+                    editor.RemoveNode(value.Value);
+                }
+
+                solution = solution.WithDocumentSyntaxRoot(group.Key, editor.GetChangedRoot());
+            }
+
+            return solution;
+        }
+
+        private ImmutableArray<IArgumentOperation>? GetOperationArguments(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            while (node != null)
+            {
+                // All nodes in the path should continuously lead to IObjectCreationOperation or IInvocationOperation.
+                if (!CanContinuouslyLeadToObjectCreationOrInvocation(node))
+                {
+                    return null;
+                }
+
+                node = node.Parent;
+
+                // For calls like A.B.C(0), it gets nulls for operations for first iterations. 
+                var operation = semanticModel.GetOperation(node, cancellationToken);
+
+                var arguments = (operation as IObjectCreationOperation)?.Arguments ?? (operation as IInvocationOperation)?.Arguments;
+
+                if (arguments.HasValue)
+                {
+                    return arguments.Value;
+                }
+            }
+
+            // Achieved the root and still could not find the node with parameters.
+            // Need to cancel the action.
+            return null;
+        }
+
+        private async Task<ImmutableArray<KeyValuePair<DocumentId, SyntaxNode>>> GetNodesToRemoveAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan);
+            node = GetParameterNode(node);
+
+            DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            ISymbol parameterSymbol = editor.SemanticModel.GetDeclaredSymbol(node);
+            ISymbol methodDeclarationSymbol = parameterSymbol.ContainingSymbol;
+
+            if (!IsSafeMethodToRemoveParameter(methodDeclarationSymbol))
+            {
+                // See https://github.com/dotnet/roslyn-analyzers/issues/1466
+                return ImmutableArray<KeyValuePair<DocumentId, SyntaxNode>>.Empty;
+            }
+
+            var nodesToRemove = ImmutableArray.CreateBuilder<KeyValuePair<DocumentId, SyntaxNode>>();
+            nodesToRemove.Add(new KeyValuePair<DocumentId, SyntaxNode>(document.Id, node));
+            var referencedSymbols = await SymbolFinder.FindReferencesAsync(methodDeclarationSymbol, document.Project.Solution, cancellationToken).ConfigureAwait(false);
+
+            foreach (var referencedSymbol in referencedSymbols)
+            {
+                if (referencedSymbol.Locations != null)
+                {
+                    foreach (var referenceLocation in referencedSymbol.Locations)
+                    {
+                        Location location = referenceLocation.Location;
+                        var referenceRoot = location.SourceTree.GetRoot();
+                        var referencedSymbolNode = referenceRoot.FindNode(location.SourceSpan);
+                        DocumentEditor localEditor = await DocumentEditor.CreateAsync(referenceLocation.Document, cancellationToken).ConfigureAwait(false);
+                        var arguments = GetOperationArguments(referencedSymbolNode, localEditor.SemanticModel, cancellationToken);
+
+                        if (arguments != null)
+                        {
+                            foreach (IArgumentOperation argument in arguments)
+                            {
+                                // The name comparison below looks fragile. However, symbol comparison does not work for Reduced Extension Methods. Need to consider more reliable options. 
+                                if (string.Equals(argument.Parameter.Name, parameterSymbol.Name, StringComparison.Ordinal) && argument.ArgumentKind == ArgumentKind.Explicit)
+                                {
+                                    nodesToRemove.Add(new KeyValuePair<DocumentId, SyntaxNode>(referenceLocation.Document.Id, referenceRoot.FindNode(argument.Syntax.GetLocation().SourceSpan)));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return nodesToRemove.ToImmutable();
+        }
+
+        private static bool IsSafeMethodToRemoveParameter(ISymbol methodDeclarationSymbol)
+        {
+            switch (methodDeclarationSymbol.Kind)
+            {
+                // Should not fix removing unused property indexer.
+                case SymbolKind.Property:
+                    return false;
+                case SymbolKind.Method:
+                    var methodSymbol = methodDeclarationSymbol as IMethodSymbol;
+                    // Should not remove parameter for a conversion operator.
+                    return (methodSymbol.MethodKind != MethodKind.Conversion);
+                default:
+                    return true;
+            }
+        }
+
+        private sealed class MyCodeAction : SolutionChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution, string equivalenceKey)
+                : base(title, createChangedSolution, equivalenceKey) { }
+        }
+
+        private sealed class RemoveParameterAction : SolutionChangeAction
+        {
+            public RemoveParameterAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution, string equivalenceKey)
+                : base(title, createChangedSolution, equivalenceKey) { }
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
@@ -110,6 +110,12 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                         return;
                     }
 
+                    // Ignore property accessors.
+                    if (method.IsPropertyAccessor())
+                    {
+                        return;
+                    }
+
                     // Ignore event handler methods "Handler(object, MyEventArgs)"
                     if (eventsArgSymbol != null &&
                         method.Parameters.Length == 2 &&
@@ -248,6 +254,13 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                             }
                         }
                     }
+                }
+
+                // Do not raise warning for unused 'this' parameter of an extension method.
+                if (_method.IsExtensionMethod)
+                {
+                    var thisParamter = _unusedParameters.Where(p => p.Ordinal == 0).FirstOrDefault();
+                    _unusedParameters.Remove(thisParamter);
                 }
 
                 _finalUnusedParameters.Add(_method, _unusedParameters);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.cs.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Odeberte nepoužité lokální proměnné.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">Neignorujte výsledky metod.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.de.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Nicht verwendete Gebietsschemas entfernen</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">Methodenergebnisse nicht ignorieren</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.es.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Quitar variables locales no utilizadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">No omitir resultados del método</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.fr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Supprimer les variables locales inutilisées</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">Ne pas ignorer les résultats des méthodes</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.it.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Rimuovere le variabili locali inutilizzate</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">Non ignorare i risultati del metodo</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ja.xlf
@@ -52,6 +52,11 @@
         <target state="translated">使用されていないローカルを削除します</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">メソッドの結果を無視しない</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ko.xlf
@@ -52,6 +52,11 @@
         <target state="translated">사용하지 않는 지역을 제거하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">메서드 결과를 무시하지 마세요.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pl.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Usuń nieużywane zmienne lokalne</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">Nie ignoruj wyników metody</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Remover locais não utilizados</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">Não ignorar resultados de métodos</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ru.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Удалите неиспользуемые локальные переменные</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="translated">Удалите неиспользуемый параметр</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">Не игнорируйте результаты метода</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.tr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Kullanılmayan yerelleri kaldırın</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">Yöntem sonuçlarını yoksaymayın</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="translated">删除未使用的局部变量</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">不要忽略方法结果</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="translated">移除未使用的區域變數</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveUnusedParameterMessage">
+        <source>Remove unused parameter</source>
+        <target state="new">Remove unused parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsTitle">
         <source>Do not ignore method results</source>
         <target state="translated">請勿略過方法結果</target>

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.Fixer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeQuality.CSharp.Analyzers.Maintainability;
 using Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability;
 using Test.Utilities;
+using Xunit;
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 {
@@ -28,6 +29,888 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new CSharpReviewUnusedParametersFixer();
+        }
+
+        [Fact]
+        public void BaseScenario_CSharp()
+        {
+            var code = @"
+using System;
+
+class C
+{
+    public int Property1 { get; set; }
+
+    public int Field1;
+
+    public C(int param)
+    {
+    }
+
+    public void UnusedParamMethod(int param)
+    {
+    }
+
+    public static void UnusedParamStaticMethod(int param1)
+    {
+    }
+
+    public void UnusedDefaultParamMethod(int defaultParam = 1)
+    {
+    }
+
+    public void UnusedParamsArrayParamMethod(params int[] paramsArr)
+    {
+    }
+
+    public void MultipleUnusedParamsMethod(int param1, int param2)
+    {
+    }
+
+    private void UnusedRefParamMethod(ref int param1)
+    {
+    }
+
+    public void UnusedErrorTypeParamMethod(UndefinedType param1) // error CS0246: The type or namespace name 'UndefinedType' could not be found.
+    {
+    }
+
+    public void Caller()
+    {
+        var c = new C(0);
+        UnusedParamMethod(this.Property1);
+        int b = 0;
+        UnusedParamMethod(b);
+        UnusedParamStaticMethod(1 + 1);
+        UnusedDefaultParamMethod(this.Field1);
+        UnusedParamsArrayParamMethod(new int[0]);
+        MultipleUnusedParamsMethod(0, 1);
+        int a = 0;
+        UnusedRefParamMethod(ref a);
+    }
+}
+";
+            var fix = @"
+using System;
+
+class C
+{
+    public int Property1 { get; set; }
+
+    public int Field1;
+
+    public C()
+    {
+    }
+
+    public void UnusedParamMethod()
+    {
+    }
+
+    public static void UnusedParamStaticMethod()
+    {
+    }
+
+    public void UnusedDefaultParamMethod()
+    {
+    }
+
+    public void UnusedParamsArrayParamMethod()
+    {
+    }
+
+    public void MultipleUnusedParamsMethod()
+    {
+    }
+
+    private void UnusedRefParamMethod()
+    {
+    }
+
+    public void UnusedErrorTypeParamMethod() // error CS0246: The type or namespace name 'UndefinedType' could not be found.
+    {
+    }
+
+    public void Caller()
+    {
+        var c = new C();
+        UnusedParamMethod();
+        int b = 0;
+        UnusedParamMethod();
+        UnusedParamStaticMethod();
+        UnusedDefaultParamMethod();
+        UnusedParamsArrayParamMethod();
+        MultipleUnusedParamsMethod();
+        int a = 0;
+        UnusedRefParamMethod();
+    }
+}
+";
+            VerifyCSharpFix(code, fix, allowNewCompilerDiagnostics: true, validationMode: TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void ExternalFileScenario_CSharp()
+        {
+            var code = @"
+class C
+{
+    public static void UnusedParamStaticMethod(int param1)
+    {
+    }
+}
+
+class D
+{
+    public void Caller()
+    {
+        C.UnusedParamStaticMethod(0);
+        E.M(0);
+    }
+}
+";
+            var fix = @"
+class C
+{
+    public static void UnusedParamStaticMethod()
+    {
+    }
+}
+
+class D
+{
+    public void Caller()
+    {
+        C.UnusedParamStaticMethod();
+        E.M();
+    }
+}
+";
+
+            var anotherCode = @"
+class E
+{
+    public static void M(int param1) { }
+}
+";
+            var anotherCodeFix = @"
+class E
+{
+    public static void M() { }
+}
+";
+            VerifyCSharpFix(new[] { code, anotherCode }, new[] { fix, anotherCodeFix });
+        }
+
+        [Fact]
+        public void CommentsNearParams_CSharp()
+        {
+            var code = @"
+class C
+{
+    public C(/* comment left */ int /* comment middle */ param /* comment right */)
+    {
+    }
+
+    public int M(/* comment 1 */ int /* comment 2 */ param1 /* comment 3 */, /* comment 4 */ int /* comment 5 */ param2 /* comment 6 */)
+    {   
+        return param2;
+    }
+
+    public void Caller()
+    {
+        var c = new C(/* caller comment left */ 0 /* caller comment right */);
+        M(/* comment 1 */ 0 /* comment 2 */, /* comment 3 */ 1 /* comment 4 */);
+    }
+}
+";
+            var fix = @"
+class C
+{
+    public C(/* comment left */ )
+    {
+    }
+
+    public int M(/* comment 1 */ int /* comment 5 */ param2 /* comment 6 */)
+    {   
+        return param2;
+    }
+
+    public void Caller()
+    {
+        var c = new C(/* caller comment left */ );
+        M(/* comment 1 */ 1 /* comment 4 */);
+    }
+}
+";
+            VerifyCSharpFix(code, fix);
+        }
+
+        [Fact]
+        public void NamedParams_CSharp()
+        {
+            var code = @"
+class C
+{
+    public int UnusedParamMethod(int param1, int param2)
+    {
+        return param1;
+    }
+
+    public void Caller()
+    {
+        UnusedParamMethod(param2: 0, param1: 1);
+    }
+}
+";
+            var fix = @"
+class C
+{
+    public int UnusedParamMethod(int param1)
+    {
+        return param1;
+    }
+
+    public void Caller()
+    {
+        UnusedParamMethod(param1: 1);
+    }
+}
+";
+            VerifyCSharpFix(code, fix);
+        }
+
+        [Fact]
+        public void MultipleNamespaces_CSharp()
+        {
+            var code = @"
+namespace A.B.C.D
+{
+    public class Test
+    {
+        public Test(int param1) { }
+        
+        public static void UnusedParamMethod(int param1) { }
+    }
+}
+
+namespace E
+{
+    class CallerClass
+    {
+        public void Caller()
+        {
+            var test = new A.B.C.D.Test(0);
+            A.B.C.D.Test.UnusedParamMethod(0);
+        }
+    }
+}
+";
+            var fix = @"
+namespace A.B.C.D
+{
+    public class Test
+    {
+        public Test() { }
+        
+        public static void UnusedParamMethod() { }
+    }
+}
+
+namespace E
+{
+    class CallerClass
+    {
+        public void Caller()
+        {
+            var test = new A.B.C.D.Test();
+            A.B.C.D.Test.UnusedParamMethod();
+        }
+    }
+}
+";
+            VerifyCSharpFix(code, fix);
+        }
+
+        [Fact]
+        public void IndexerNoFix_CSharp()
+        {
+            var code = @"
+class C
+{
+    public int this[int i]
+    {
+        get { return 0; }
+        set { }
+    }
+}
+";
+            VerifyCSharpFix(code, code);
+        }
+
+        [Fact]
+        public void PropertyNoFix_CSharp()
+        {
+            var code = @"
+class C
+{
+    public int Property
+    {
+        get { return 0; }
+        set { }
+    }
+}
+";
+            VerifyCSharpFix(code, code);
+        }
+
+        [Fact]
+        public void CalculationsInParameter_CSharp()
+        {
+            var code = @"
+class C
+{
+    void M() { }
+    
+    int N(int x) => x;
+    
+    void Caller()
+    {
+        M();
+    }
+}
+";
+
+            VerifyCSharpFix(code, code);
+        }
+
+        [Fact]
+        public void Conversion_CSharp()
+        {
+            var code = @"
+class C
+{
+    public static explicit operator int(C value) => 0;
+
+    public void M1(double d) { }
+
+    public void M2(int i) { }
+
+    public void M3(int x) { }
+
+    public void Caller()
+    {
+        int i = 0;
+        M1(i);
+        double d = 0;
+        M2((int)d);
+        var instance = new C();
+        M3((int)instance);
+    }
+}
+";
+            var fix = @"
+class C
+{
+    public static explicit operator int(C value) => 0;
+
+    public void M1() { }
+
+    public void M2() { }
+
+    public void M3() { }
+
+    public void Caller()
+    {
+        int i = 0;
+        M1();
+        double d = 0;
+        M2();
+        var instance = new C();
+        M3();
+    }
+}
+";
+            VerifyCSharpFix(code, fix, allowNewCompilerDiagnostics: true);
+        }
+
+        [Fact]
+        public void ExtensionMethod_CSharp()
+        {
+            var code = @"
+static class C
+{
+    static void ExtensionMethod(this int i) { }
+    static void ExtensionMethod(this int i, int anotherParam) { }
+
+    static void Caller()
+    {
+        int i = 0;
+        i.ExtensionMethod();
+        i.ExtensionMethod(i);
+    }
+}
+";
+            var fix = @"
+static class C
+{
+    static void ExtensionMethod(this int i) { }
+    static void ExtensionMethod(this int i) { }
+
+    static void Caller()
+    {
+        int i = 0;
+        i.ExtensionMethod();
+        i.ExtensionMethod();
+    }
+}
+";
+            VerifyCSharpFix(code, fix, allowNewCompilerDiagnostics: true, validationMode: TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/22449")]
+        public void DictionaryConstructor_CSharp()
+        {
+            var code = @"
+using System.Collections.Generic;
+
+class Dict : Dictionary<int, MyValue>
+{
+    public void Add(int key, int a, int b)
+    {
+        var val = new MyValue();
+        val.A = a;
+        this.Add(key, val);
+    }
+    
+    public static Dict Create()
+    {
+        return new Dict()
+        {
+            {0, 1, 2}
+        };
+    }
+}
+
+class MyValue
+{
+    public int A;
+}
+";
+
+            var fix = @"
+using System.Collections.Generic;
+
+class Dict : Dictionary<int, MyValue>
+{
+    public void Add(int key, int a)
+    {
+        var val = new MyValue();
+        val.A = a;
+        this.Add(key, val);
+    }
+    
+    public static Dict Create()
+    {
+        return new Dict()
+        {
+            {0, 1}
+        };
+    }
+}
+
+class MyValue
+{
+    public int A;
+}
+";
+            VerifyCSharpFix(code, fix);
+        }
+
+        [Fact]
+        public void BaseScenario_Basic()
+        {
+            var code = @"
+Class C
+    Public Property Property1 As Integer
+
+    Public Field1 As Integer
+
+    Public Sub New(param As Integer)
+    End Sub
+
+    Public Sub UnusedParamMethod(param As Integer)
+    End Sub
+
+    Public Shared Sub UnusedParamStaticMethod(param1 As Integer)
+    End Sub
+
+    Public Sub UnusedDefaultParamMethod(Optional defaultParam As Integer = 1)
+    End Sub
+
+    Public Sub UnusedParamsArrayParamMethod(ParamArray paramsArr As Integer())
+    End Sub
+
+    Public Sub MultipleUnusedParamsMethod(param1 As Integer, param2 As Integer)
+    End Sub
+
+    Private Sub UnusedRefParamMethod(ByRef param1 As Integer)
+    End Sub
+
+    Public Sub UnusedErrorTypeParamMethod(param1 As UndefinedType) ' error BC30002: Type 'UndefinedType' is not defined.
+    End Sub
+
+    Public Sub Caller()
+        Dim c = New C(0)
+        UnusedParamMethod(Property1)
+        Dim b As Integer = 0
+        UnusedParamMethod(b)
+        UnusedParamStaticMethod(1 + 1)
+        UnusedDefaultParamMethod(Field1)
+        UnusedParamsArrayParamMethod(New Integer() {})
+        MultipleUnusedParamsMethod(0, 1)
+        Dim a As Integer = 0
+        UnusedRefParamMethod(a)
+    End Sub
+End Class
+";
+            var fix = @"
+Class C
+    Public Property Property1 As Integer
+
+    Public Field1 As Integer
+
+    Public Sub New()
+    End Sub
+
+    Public Sub UnusedParamMethod()
+    End Sub
+
+    Public Shared Sub UnusedParamStaticMethod()
+    End Sub
+
+    Public Sub UnusedDefaultParamMethod()
+    End Sub
+
+    Public Sub UnusedParamsArrayParamMethod()
+    End Sub
+
+    Public Sub MultipleUnusedParamsMethod()
+    End Sub
+
+    Private Sub UnusedRefParamMethod()
+    End Sub
+
+    Public Sub UnusedErrorTypeParamMethod() ' error BC30002: Type 'UndefinedType' is not defined.
+    End Sub
+
+    Public Sub Caller()
+        Dim c = New C()
+        UnusedParamMethod()
+        Dim b As Integer = 0
+        UnusedParamMethod()
+        UnusedParamStaticMethod()
+        UnusedDefaultParamMethod()
+        UnusedParamsArrayParamMethod()
+        MultipleUnusedParamsMethod()
+        Dim a As Integer = 0
+        UnusedRefParamMethod()
+    End Sub
+End Class
+";
+            VerifyBasicFix(code, fix, allowNewCompilerDiagnostics: true, validationMode: TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void ExternalFileScenario_Basic()
+        {
+            var code = @"
+Class C
+    Public Shared Sub UnusedParamStaticMethod(param1 As Integer)
+    End Sub
+End Class
+
+Class D
+    Public Sub Caller()
+        C.UnusedParamStaticMethod(0)
+        E.M(0)
+    End Sub
+End Class
+";
+            var fix = @"
+Class C
+    Public Shared Sub UnusedParamStaticMethod()
+    End Sub
+End Class
+
+Class D
+    Public Sub Caller()
+        C.UnusedParamStaticMethod()
+        E.M()
+    End Sub
+End Class
+";
+
+            var anotherCode = @"
+Class E
+    Public Shared Sub M(param1 As Integer)
+    End Sub
+End Class
+";
+            var anotherCodeFix = @"
+Class E
+    Public Shared Sub M()
+    End Sub
+End Class
+";
+            VerifyBasicFix(new[] { code, anotherCode }, new[] { fix, anotherCodeFix });
+        }
+
+        [Fact]
+        public void NamedParams_Basic()
+        {
+            var code = @"
+Class C
+    Public Function UnusedParamMethod(param1 As Integer, param2 As Integer) As Integer
+        Return param1
+    End Function
+
+    Public Sub Caller()
+        UnusedParamMethod(param2:=0, param1:=1)
+    End Sub
+End Class
+";
+            var fix = @"
+Class C
+    Public Function UnusedParamMethod(param1 As Integer) As Integer
+        Return param1
+    End Function
+
+    Public Sub Caller()
+        UnusedParamMethod(param1:=1)
+    End Sub
+End Class
+";
+            VerifyBasicFix(code, fix);
+        }
+
+        [Fact]
+        public void MultipleNamespaces_Basic()
+        {
+            var code = @"
+Namespace A.B.C.D
+    Public Class Test
+        Public Sub New(param1 As Integer)
+        End Sub
+
+        Public Shared Sub UnusedParamMethod(param1 As Integer)
+        End Sub
+    End Class
+End Namespace
+
+Namespace E
+    Class CallerClass
+        Public Sub Caller()
+            Dim test = New A.B.C.D.Test(0)
+            A.B.C.D.Test.UnusedParamMethod(0)
+        End Sub
+    End Class
+End Namespace
+";
+            var fix = @"
+Namespace A.B.C.D
+    Public Class Test
+        Public Sub New()
+        End Sub
+
+        Public Shared Sub UnusedParamMethod()
+        End Sub
+    End Class
+End Namespace
+
+Namespace E
+    Class CallerClass
+        Public Sub Caller()
+            Dim test = New A.B.C.D.Test()
+            A.B.C.D.Test.UnusedParamMethod()
+        End Sub
+    End Class
+End Namespace
+";
+            VerifyBasicFix(code, fix);
+        }
+
+        [Fact]
+        public void CalculationsInParameter_Basic()
+        {
+            var code = @"
+Class C
+    Sub M(x As Integer)
+    End Sub
+
+    Function N(x As Integer) As Integer
+        Return x
+    End Function
+
+    Sub Caller()
+        M(N(0))
+    End Sub
+End Class
+";
+
+            var fix = @"
+Class C
+    Sub M()
+    End Sub
+
+    Function N(x As Integer) As Integer
+        Return x
+    End Function
+
+    Sub Caller()
+        M()
+    End Sub
+End Class
+";
+            VerifyBasicFix(code, fix);
+        }
+
+        [Fact]
+        public void IndexerNoFix_Basic()
+        {
+            var code = @"
+Class C
+    Public Property Item(i As Integer) As Integer
+        Get
+            Return 0
+        End Get
+
+        Set
+        End Set
+    End Property
+End Class
+";
+
+            VerifyBasicFix(code, code);
+        }
+
+        [Fact]
+        public void PropertyNoFix_Basic()
+        {
+            var code = @"
+Class C
+    Public Property Property1 As Integer
+        Get
+            Return 0
+        End Get
+
+        Set
+        End Set
+    End Property
+End Class
+";
+
+            VerifyBasicFix(code, code);
+        }
+
+        [Fact]
+        public void Conversion_Basic()
+        {
+            var code = @"
+Class C
+    Public Shared Narrowing Operator CType(value As C) As Integer
+        Return 0
+    End Operator
+
+    Public Sub M1(d As Double)
+    End Sub
+
+    Public Sub M2(i As Integer)
+    End Sub
+
+    Public Sub M3(x As Integer)
+    End Sub
+
+    Public Sub Caller()
+        Dim i As Integer = 0
+        M1(i)
+        Dim d As Double = 0
+        M2(CInt(d))
+        Dim instance = New C()
+        M3(CType(instance, Integer))
+    End Sub
+End Class
+";
+            var fix = @"
+Class C
+    Public Shared Narrowing Operator CType(value As C) As Integer
+        Return 0
+    End Operator
+
+    Public Sub M1()
+    End Sub
+
+    Public Sub M2()
+    End Sub
+
+    Public Sub M3()
+    End Sub
+
+    Public Sub Caller()
+        Dim i As Integer = 0
+        M1()
+        Dim d As Double = 0
+        M2()
+        Dim instance = New C()
+        M3()
+    End Sub
+End Class
+";
+            VerifyBasicFix(code, fix, allowNewCompilerDiagnostics: true);
+        }
+
+        [Fact]
+        public void ExtensionMethod_Basic()
+        {
+            var code = @"
+Imports System.Runtime.CompilerServices
+
+Module D
+    <Extension()> 
+    Public Sub ExtensionMethod(s As String)
+    End Sub
+
+    <Extension()> 
+    Public Sub ExtensionMethod(s As String, i As Integer)
+    End Sub
+
+    Sub Caller()
+        Dim s as String
+        s.ExtensionMethod()
+        s.ExtensionMethod(0)
+    End Sub
+End Module
+";
+            var fix = @"
+Imports System.Runtime.CompilerServices
+
+Module D
+    <Extension()> 
+    Public Sub ExtensionMethod(s As String)
+    End Sub
+
+    <Extension()> 
+    Public Sub ExtensionMethod(s As String)
+    End Sub
+
+    Sub Caller()
+        Dim s as String
+        s.ExtensionMethod()
+        s.ExtensionMethod()
+    End Sub
+End Module
+";
+            VerifyBasicFix(code, fix, allowNewCompilerDiagnostics: true, validationMode: TestValidationMode.AllowCompileErrors);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.Fixer.cs
@@ -333,38 +333,6 @@ namespace E
         }
 
         [Fact]
-        public void IndexerNoFix_CSharp()
-        {
-            var code = @"
-class C
-{
-    public int this[int i]
-    {
-        get { return 0; }
-        set { }
-    }
-}
-";
-            VerifyCSharpFix(code, code);
-        }
-
-        [Fact]
-        public void PropertyNoFix_CSharp()
-        {
-            var code = @"
-class C
-{
-    public int Property
-    {
-        get { return 0; }
-        set { }
-    }
-}
-";
-            VerifyCSharpFix(code, code);
-        }
-
-        [Fact]
         public void CalculationsInParameter_CSharp()
         {
             var code = @"
@@ -380,7 +348,6 @@ class C
     }
 }
 ";
-
             VerifyCSharpFix(code, code);
         }
 
@@ -773,44 +740,6 @@ Class C
 End Class
 ";
             VerifyBasicFix(code, fix);
-        }
-
-        [Fact]
-        public void IndexerNoFix_Basic()
-        {
-            var code = @"
-Class C
-    Public Property Item(i As Integer) As Integer
-        Get
-            Return 0
-        End Get
-
-        Set
-        End Set
-    End Property
-End Class
-";
-
-            VerifyBasicFix(code, code);
-        }
-
-        [Fact]
-        public void PropertyNoFix_Basic()
-        {
-            var code = @"
-Class C
-    Public Property Property1 As Integer
-        Get
-            Return 0
-        End Get
-
-        Set
-        End Set
-    End Property
-End Class
-";
-
-            VerifyBasicFix(code, code);
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -665,15 +665,82 @@ Public Class C1
 End Class");
         }
 
-        #endregion
-
-        #region Unit tests for analyzer diagnostic(s)
-
         [Fact]
-        [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
-        public void CSharp_DiagnosticForSimpleCasesTest()
+        public void NoDiagnosticsForIndexer()
         {
             VerifyCSharp(@"
+class C
+{
+    public int this[int i]
+    {
+        get { return 0; }
+        set { }
+    }
+}
+");
+   
+        VerifyBasic(@"
+Class C
+    Public Property Item(i As Integer) As Integer
+        Get
+            Return 0
+        End Get
+
+        Set
+        End Set
+    End Property
+End Class
+");
+    }
+
+    [Fact]
+    public void NoDiagnosticsForPropertySetter()
+    {
+        VerifyCSharp(@"
+class C
+{
+    public int Property
+    {
+        get { return 0; }
+        set { }
+    }
+}
+");
+
+        VerifyBasic(@"
+Class C
+    Public Property Property1 As Integer
+        Get
+            Return 0
+        End Get
+
+        Set
+        End Set
+    End Property
+End Class
+");
+    }
+        [Fact]
+        public void NoDiagnosticsForFirstParameterOfExtensionMethod()
+        {
+            VerifyCSharp(@"
+static class C
+{
+    static void ExtensionMethod(this int i) { }
+    static int ExtensionMethod(this int i, int anotherParam) { return anotherParam; }
+}
+");
+    }
+
+    #endregion
+
+    #region Unit tests for analyzer diagnostic(s)
+
+    [Fact]
+    [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
+    public void CSharp_DiagnosticForSimpleCasesTest()
+    {
+        VerifyCSharp(@"
 using System;
 
 class C
@@ -780,6 +847,19 @@ End Class
       GetBasicUnusedParameterResultAt(21, 44, "param1", "UnusedRefParamMethod"),
       // Test0.vb(24,43): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
       GetBasicUnusedParameterResultAt(24, 43, "param1", "UnusedErrorTypeParamMethod"));
+    }
+
+        [Fact]
+        public void DiagnosticsForNonFirstParameterOfExtensionMethod()
+        {
+            VerifyCSharp(@"
+static class C
+{
+    static void ExtensionMethod(this int i, int anotherParam) { }
+}
+",
+    // Test0.cs(4,49): warning CA1801: Parameter anotherParam of method ExtensionMethod is never used. Remove the parameter or use it in the method body.
+    GetCSharpUnusedParameterResultAt(4, 49, "anotherParam", "ExtensionMethod"));
         }
 
         #endregion

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/Maintainability/BasicReviewUnusedParameters.Fixer.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/Maintainability/BasicReviewUnusedParameters.Fixer.vb
@@ -3,6 +3,7 @@
 Imports System.Composition
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeQuality.Analyzers.Maintainability
 
 Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability
@@ -13,5 +14,13 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability
     Public NotInheritable Class BasicReviewUnusedParametersFixer
         Inherits ReviewUnusedParametersFixer
 
+        Protected Overrides Function GetParameterNode(node As SyntaxNode) As SyntaxNode
+            Return node.Parent
+        End Function
+
+        Protected Overrides Function CanContinuouslyLeadToObjectCreationOrInvocation(node As SyntaxNode) As Boolean
+            Dim kind = node.Kind()
+            Return kind = SyntaxKind.QualifiedName OrElse kind = SyntaxKind.IdentifierName OrElse kind = SyntaxKind.SimpleMemberAccessExpression
+        End Function
     End Class
 End Namespace

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/Maintainability/BasicReviewUnusedParameters.Fixer.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/Maintainability/BasicReviewUnusedParameters.Fixer.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability
     Public NotInheritable Class BasicReviewUnusedParametersFixer
         Inherits ReviewUnusedParametersFixer
 
-        Protected Overrides Function GetParameterNode(node As SyntaxNode) As SyntaxNode
+        Protected Overrides Function GetParameterDeclarationNode(node As SyntaxNode) As SyntaxNode
             Return node.Parent
         End Function
 


### PR DESCRIPTION
Fixes #459

The current version performs all the fixes: safe and unsafe.

```
    void M1(int x) { }
    int M2(int x) => x;
    void Caller1()
    {
        M1(M2(0));
    }
```
would be fixed.