### PR TITLE
Rewrite UseGenericEventHandlerInstancesAnalyzer to match CA1003 and C…

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/ApiDesignGuidelines/CSharpUseGenericEventHandlerInstances.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/ApiDesignGuidelines/CSharpUseGenericEventHandlerInstances.cs
@@ -10,40 +10,12 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class CSharpUseGenericEventHandlerInstancesAnalyzer : UseGenericEventHandlerInstancesAnalyzer
     {
-        protected override SymbolAnalyzer GetAnalyzer(
-            Compilation compilation,
-            INamedTypeSymbol eventHandler,
-            INamedTypeSymbol genericEventHandler,
-            INamedTypeSymbol eventArgs,
-            INamedTypeSymbol comSourceInterfacesAttribute)
+        protected override bool IsAssignableTo(Compilation compilation, ITypeSymbol fromSymbol, ITypeSymbol toSymbol)
         {
-            return new CSharpSymbolAnalyzer(compilation, eventHandler, genericEventHandler, eventArgs, comSourceInterfacesAttribute);
-        }
-
-        private sealed class CSharpSymbolAnalyzer : SymbolAnalyzer
-        {
-            public CSharpSymbolAnalyzer(
-                Compilation compilation,
-                INamedTypeSymbol eventHandler,
-                INamedTypeSymbol genericEventHandler,
-                INamedTypeSymbol eventArgs,
-                INamedTypeSymbol comSourceInterfacesAttribute)
-                : base(compilation, eventHandler, genericEventHandler, eventArgs, comSourceInterfacesAttribute)
-            {
-            }
-
-            protected override bool IsViolatingEventHandler(INamedTypeSymbol type)
-            {
-                return !IsValidLibraryEventHandlerInstance(type);
-            }
-
-            protected override bool IsAssignableTo(Compilation compilation, ITypeSymbol fromSymbol, ITypeSymbol toSymbol)
-            {
-                return
-                    fromSymbol != null &&
-                    toSymbol != null &&
-                    ((CSharpCompilation)compilation).ClassifyConversion(fromSymbol, toSymbol).IsImplicit;
-            }
+            return
+                fromSymbol != null &&
+                toSymbol != null &&
+                ((CSharpCompilation)compilation).ClassifyConversion(fromSymbol, toSymbol).IsImplicit;
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -186,14 +186,23 @@
   <data name="UseGenericEventHandlerInstancesTitle" xml:space="preserve">
     <value>Use generic event handler instances</value>
   </data>
-  <data name="UseGenericEventHandlerInstancesDescription" xml:space="preserve">
+  <data name="UseGenericEventHandlerInstancesForDelegateMessage" xml:space="preserve">
+    <value>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</value>
+  </data>
+  <data name="UseGenericEventHandlerInstancesForDelegateDescription" xml:space="preserve">
     <value>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</value>
   </data>
-  <data name="UseGenericEventHandlerInstancesMessageVB" xml:space="preserve">
-    <value>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</value>
+  <data name="UseGenericEventHandlerInstancesForEventMessage" xml:space="preserve">
+    <value>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</value>
   </data>
-  <data name="UseGenericEventHandlerInstancesMessageDefault" xml:space="preserve">
-    <value>Remove {0} and replace its usage with EventHandler&lt;T&gt;</value>
+  <data name="UseGenericEventHandlerInstancesForEventDescription" xml:space="preserve">
+    <value>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</value>
+  </data>
+  <data name="UseGenericEventHandlerInstancesForEvent2Message" xml:space="preserve">
+    <value>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</value>
+  </data>
+  <data name="UseGenericEventHandlerInstancesForEvent2Description" xml:space="preserve">
+    <value>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</value>
   </data>
   <data name="EnumsShouldHaveZeroValueTitle" xml:space="preserve">
     <value>Enums should have zero value</value>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseGenericEventHandlerInstances.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseGenericEventHandlerInstances.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     INamedTypeSymbol comSourceInterfacesAttribute = WellKnownTypes.ComSourceInterfaceAttribute(context.Compilation);
                     bool ContainingTypeHasComSourceInterfacesAttribute(IEventSymbol eventSymbol) =>
                         comSourceInterfacesAttribute != null &&
-                        eventSymbol.ContainingType.GetAttributes().FirstOrDefault(a => a.AttributeClass == comSourceInterfacesAttribute) != null;
+                        eventSymbol.ContainingType.GetAttributes().Any(a => a.AttributeClass == comSourceInterfacesAttribute);
 
                     context.RegisterSymbolAction(symbolContext =>
                     {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseGenericEventHandlerInstances.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseGenericEventHandlerInstances.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
@@ -12,35 +14,61 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
     /// CA1003: Use generic event handler instances
+    /// CA1009: A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.
     /// 
     /// Recommends that event handlers use <see cref="System.EventHandler{TEventArgs}"/>
     /// </summary>
+    /// <remarks>
+    /// NOTE: Legacy FxCop reports CA1009 for delegate type that handles a public or protected event and does not have the correct signature, return type, or parameter names.
+    ///       This rule recommends fixing the signature to use a valid non-generic event handler.
+    ///       We do not report CA1009, but instead report CA1003 and recommend using a generic event handler.
+    /// </remarks>
     public abstract class UseGenericEventHandlerInstancesAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA1003";
         private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesTitle), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
-        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesMessageDefault), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
-        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageForDelegate = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesForDelegateMessage), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescriptionForDelegate = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesForDelegateDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageForEvent = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesForEventMessage), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescriptionForEvent = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesForEventDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessageForEvent2 = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesForEvent2Message), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescriptionForEvent2 = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesForEvent2Description), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
 
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+        internal static DiagnosticDescriptor RuleForDelegates = new DiagnosticDescriptor(
             RuleId,
             s_localizableTitle,
-            s_localizableMessage,
+            s_localizableMessageForDelegate,
             DiagnosticCategory.Design,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
             isEnabledByDefault: false,
-            description: s_localizableDescription,
-            helpLinkUri: "http://msdn.microsoft.com/library/ms182178.aspx",
+            description: s_localizableDescriptionForDelegate,
+            helpLinkUri: "https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1003-use-generic-event-handler-instances",
             customTags: WellKnownDiagnosticTags.Telemetry);
 
-        protected abstract SymbolAnalyzer GetAnalyzer(
-            Compilation compilation,
-            INamedTypeSymbol eventHandler,
-            INamedTypeSymbol genericEventHandler,
-            INamedTypeSymbol eventArgs,
-            INamedTypeSymbol comSourceInterfacesAttribute);
+        internal static DiagnosticDescriptor RuleForEvents = new DiagnosticDescriptor(
+            RuleId,
+            s_localizableTitle,
+            s_localizableMessageForEvent,
+            DiagnosticCategory.Design,
+            DiagnosticHelpers.DefaultDiagnosticSeverity,
+            isEnabledByDefault: false,
+            description: s_localizableDescriptionForEvent,
+            helpLinkUri: "https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1003-use-generic-event-handler-instances",
+            customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        internal static DiagnosticDescriptor RuleForEvents2 = new DiagnosticDescriptor(
+            RuleId,
+            s_localizableTitle,
+            s_localizableMessageForEvent2,
+            DiagnosticCategory.Design,
+            DiagnosticHelpers.DefaultDiagnosticSeverity,
+            isEnabledByDefault: false,
+            description: s_localizableDescriptionForEvent2,
+            helpLinkUri: "https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1003-use-generic-event-handler-instances",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RuleForDelegates, RuleForEvents, RuleForEvents2);
+        protected abstract bool IsAssignableTo(Compilation compilation, ITypeSymbol fromSymbol, ITypeSymbol toSymbol);
 
         public override void Initialize(AnalysisContext analysisContext)
         {
@@ -50,118 +78,92 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.RegisterCompilationStartAction(
                 (context) =>
                 {
-                    INamedTypeSymbol eventHandler = WellKnownTypes.EventHandler(context.Compilation);
-                    if (eventHandler == null)
-                    {
-                        return;
-                    }
-
-                    INamedTypeSymbol genericEventHandler = WellKnownTypes.GenericEventHandler(context.Compilation);
-                    if (genericEventHandler == null)
-                    {
-                        return;
-                    }
-
                     INamedTypeSymbol eventArgs = WellKnownTypes.EventArgs(context.Compilation);
                     if (eventArgs == null)
                     {
                         return;
                     }
 
-                    INamedTypeSymbol comSourceInterfacesAttribute = WellKnownTypes.ComSourceInterfaceAttribute(context.Compilation);
-                    if (comSourceInterfacesAttribute == null)
+                    // Only analyze compilations that have a generic event handler defined.
+                    if (WellKnownTypes.GenericEventHandler(context.Compilation) == null)
                     {
                         return;
                     }
 
-                    context.RegisterSymbolAction(GetAnalyzer(context.Compilation, eventHandler, genericEventHandler, eventArgs, comSourceInterfacesAttribute).AnalyzeSymbol, SymbolKind.Event);
-                });
-        }
+                    bool IsDelegateTypeWithInvokeMethod(INamedTypeSymbol namedType) =>
+                        namedType.TypeKind == TypeKind.Delegate && namedType.DelegateInvokeMethod != null;
 
-        protected abstract class SymbolAnalyzer
-        {
-            private readonly Compilation _compilation;
-            private readonly INamedTypeSymbol _eventHandler;
-            private readonly INamedTypeSymbol _genericEventHandler;
-            private readonly INamedTypeSymbol _eventArgs;
-            private readonly INamedTypeSymbol _comSourceInterfacesAttribute;
-
-            public SymbolAnalyzer(
-                Compilation compilation,
-                INamedTypeSymbol eventHandler,
-                INamedTypeSymbol genericEventHandler,
-                INamedTypeSymbol eventArgs,
-                INamedTypeSymbol comSourceInterfacesAttribute)
-            {
-                _compilation = compilation;
-                _eventHandler = eventHandler;
-                _genericEventHandler = genericEventHandler;
-                _eventArgs = eventArgs;
-                _comSourceInterfacesAttribute = comSourceInterfacesAttribute;
-            }
-
-            public void AnalyzeSymbol(SymbolAnalysisContext context)
-            {
-                var eventSymbol = (IEventSymbol)context.Symbol;
-                if (eventSymbol != null)
-                {
-                    if (eventSymbol.Type is INamedTypeSymbol eventType &&
-                        eventSymbol.IsExternallyVisible() &&
-                        !eventSymbol.IsOverride &&
-                        !eventSymbol.IsImplementationOfAnyInterfaceMember() &&
-                        !HasComSourceInterfacesAttribute(eventSymbol.ContainingType) &&
-                        IsViolatingEventHandler(eventType))
+                    bool IsEventArgsParameter(IParameterSymbol parameter)
                     {
-                        context.ReportDiagnostic(eventSymbol.CreateDiagnostic(Rule));
+                        var type = parameter.Type;
+                        if (IsAssignableTo(context.Compilation, type, eventArgs))
+                        {
+                            return true;
+                        }
+
+                        // FxCop compat: Struct with name ending with "EventArgs" are allowed.
+                        if (type.IsValueType)
+                        {
+                            return type.Name.EndsWith("EventArgs", StringComparison.Ordinal);
+                        }
+
+                        return false;
                     }
-                }
-            }
 
-            protected abstract bool IsViolatingEventHandler(INamedTypeSymbol type);
+                    bool IsValidNonGenericEventHandler(IMethodSymbol delegateInvokeMethod)
+                    {
+                        Debug.Assert(delegateInvokeMethod != null);
 
-            protected abstract bool IsAssignableTo(Compilation compilation, ITypeSymbol fromSymbol, ITypeSymbol toSymbol);
+                        return delegateInvokeMethod.ReturnsVoid &&
+                            delegateInvokeMethod.Parameters.Length == 2 &&
+                            delegateInvokeMethod.Parameters[0].Type.SpecialType == SpecialType.System_Object &&
+                            IsEventArgsParameter(delegateInvokeMethod.Parameters[1]);
+                    }
 
-            protected bool IsValidLibraryEventHandlerInstance(INamedTypeSymbol type)
-            {
-                if (type == _eventHandler)
-                {
-                    return true;
-                }
+                    context.RegisterSymbolAction(symbolContext =>
+                    {
+                        var namedType = (INamedTypeSymbol)symbolContext.Symbol;
+                        if (namedType.IsExternallyVisible() &&
+                            IsDelegateTypeWithInvokeMethod(namedType) &&
+                            IsValidNonGenericEventHandler(namedType.DelegateInvokeMethod))
+                        {
+                            // CA1003: Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs
+                            symbolContext.ReportDiagnostic(namedType.CreateDiagnostic(RuleForDelegates, namedType.Name));
+                        }
+                    }, SymbolKind.NamedType);
 
-                if (IsGenericEventHandlerInstance(type) &&
-                    IsEventArgs(type.TypeArguments[0]))
-                {
-                    return true;
-                }
+                    INamedTypeSymbol comSourceInterfacesAttribute = WellKnownTypes.ComSourceInterfaceAttribute(context.Compilation);
+                    bool ContainingTypeHasComSourceInterfacesAttribute(IEventSymbol eventSymbol) =>
+                        comSourceInterfacesAttribute != null &&
+                        eventSymbol.ContainingType.GetAttributes().FirstOrDefault(a => a.AttributeClass == comSourceInterfacesAttribute) != null;
 
-                return false;
-            }
+                    context.RegisterSymbolAction(symbolContext =>
+                    {
+                        // NOTE: Legacy FxCop reports CA1009 for delegate type that handles a public or protected event and does not have the correct signature, return type, or parameter names.
+                        //       which recommends fixing the signature to use a valid non-generic event handler.
+                        //       We do not report CA1009, but instead report CA1003 and recommend using a generic event handler.
+                        var eventSymbol = (IEventSymbol)symbolContext.Symbol;
+                        if (eventSymbol.IsExternallyVisible() &&
+                            !eventSymbol.IsOverride &&
+                            !eventSymbol.IsImplementationOfAnyInterfaceMember() &&
+                            !ContainingTypeHasComSourceInterfacesAttribute(eventSymbol) &&
+                            eventSymbol.Type is INamedTypeSymbol eventType &&
+                            IsDelegateTypeWithInvokeMethod(eventType))
+                        {
+                            if (eventType.IsImplicitlyDeclared)
+                            {
+                                // CA1003: Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).
+                                symbolContext.ReportDiagnostic(eventSymbol.CreateDiagnostic(RuleForEvents2, eventSymbol.Name));
+                            }
+                            else if (!IsValidNonGenericEventHandler(eventType.DelegateInvokeMethod))
+                            {
+                                // CA1003: Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs
+                                symbolContext.ReportDiagnostic(eventSymbol.CreateDiagnostic(RuleForEvents, eventSymbol.Name, eventType.ToDisplayString()));
+                            }
 
-            protected bool IsGenericEventHandlerInstance(INamedTypeSymbol type)
-            {
-                return type.OriginalDefinition.Equals(_genericEventHandler) &&
-                    type.TypeArguments.Length == 1;
-            }
-
-            protected bool IsEventArgs(ITypeSymbol type)
-            {
-                if (IsAssignableTo(_compilation, type, _eventArgs))
-                {
-                    return true;
-                }
-
-                if (type.IsValueType)
-                {
-                    return type.Name.EndsWith("EventArgs", StringComparison.Ordinal);
-                }
-
-                return false;
-            }
-
-            private bool HasComSourceInterfacesAttribute(INamedTypeSymbol symbol)
-            {
-                return symbol.GetAttributes().FirstOrDefault(a => a.AttributeClass == _comSourceInterfacesAttribute) != null;
-            }
+                        }
+                    }, SymbolKind.Event);
+                });
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
@@ -117,21 +117,6 @@
         <target state="translated">Použijte obecné instance obslužné rutiny události.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">Typ obsahuje delegáta, který vrací hodnotu void, jehož podpis obsahuje dva parametry (prvním je objekt a druhým je typ, který se dá přiřadit k EventArgs), přičemž cílem obsahujícího sestavení je Microsoft .NET Framework 2.0.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic generuje delegáty EventHandler pro události, které používají následující vzor: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Explicitním definováním typu události (například Event MyEvent As EventHandler(Of MyEventArgs)) změňte událost definující EventHandler {0} tak, aby používala EventHandler&lt;T&gt; .</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">Odeberte {0} a nahraďte jeho použití za EventHandler&lt;T&gt;.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">Výčty mají mít nulovou hodnotu.</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">Neskrývejte metody základní třídy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
@@ -117,21 +117,6 @@
         <target state="translated">Generische Ereignishandlerinstanzen verwenden</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">Ein Typ enthält einen Delegaten, der "void" zurückgibt und dessen Signatur zwei Parameter enthält (als ersten ein Objekt und als zweiten einen Typ, der EventArgs zugeordnet werden kann), und die enthaltene Assembly ist auf Microsoft .NET Framework 2.0 ausgerichtet.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic generiert EventHandler-Delegate für Ereignisse, die das folgende Muster verwenden: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Ändern Sie das Ereignis, das den EventHandler "{0}" verwendet, so um, dass der EventHandler&lt;T&gt; verwendet wird. Hierzu muss der Ereignistyp explizit definiert werden. Beispiel: Event MyEvent As EventHandler(Of MyEventArgs).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">Entfernen Sie "{0}", und ersetzen Sie die Verwendung durch "EventHandler&lt;T&gt;".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">Enumerationen müssen einen Wert von null aufweisen.</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">Basisklassenmethoden nicht verdecken</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
@@ -117,21 +117,6 @@
         <target state="translated">Usar instancias genéricas del controlador de eventos</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">Un tipo contiene un delegado que devuelve void, cuya signatura contiene dos parámetros (el primero un objeto y el segundo un tipo asignable a EventArgs) y el ensamblado contenedor está destinado a Microsoft .NET Framework 2.0.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic genera delegados EventHandler para los eventos que usan el patrón siguiente: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Cambie el evento que define EventHandler {0} para que use EventHandler&lt;T&gt; mediante la definición del tipo de evento de forma explícita. Por ejemplo: Event MyEvent As EventHandler(Of MyEventArgs).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">Quite {0} y reemplace el uso por EventHandler&lt;T&gt;</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">Las enumeraciones deben tener un valor igual a cero</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">No ocultar métodos de clases base</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
@@ -117,21 +117,6 @@
         <target state="translated">Utiliser les instances du gestionnaire d'événements génériques</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">Un type contient un délégué qui retourne void, dont la signature contient deux paramètres (le premier est un objet et le second est un type pouvant être assigné à EventArgs), et l'assembly conteneur cible Microsoft .NET Framework 2.0.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic génère les délégués EventHandler pour les événements qui utilisent le modèle suivant : Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Changez l'événement qui définit EventHandler {0} pour utiliser EventHandler&lt;T&gt; en définissant explicitement le type d'événement, par exemple Event MyEvent As EventHandler(Of MyEventArgs).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">Supprimer {0} et remplacer son utilisation par EventHandler&lt;T&gt;</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">Les enums doivent avoir la valeur zéro</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">Ne pas masquer les méthodes de classe de base</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
@@ -117,21 +117,6 @@
         <target state="translated">Usare istanze del gestore dell'evento generico</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">Un tipo contiene un delegato che restituisce void, la cui firma contiene due parametri (il primo è un oggetto e il secondo è un tipo assegnabile a EventArgs) e l'assembly che lo contiene è destinato a Microsoft .NET Framework 2.0.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic genera delegati di EventHandler per gli eventi che usano il criterio seguente: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Modificare l'evento che definisce l'elemento EventHandler {0} in modo da usare EventHandler&lt;T&gt; definendo il tipo di evento in modo esplicito, ad esempio Event MyEvent As EventHandler(Of MyEventArgs).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">Rimuovere {0} e sostituirne l'utilizzo con EventHandler&lt;T&gt;</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">Le enumerazioni devono avere valore zero</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">Non nascondere i metodi della classe di base</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
@@ -117,21 +117,6 @@
         <target state="translated">汎用イベント ハンドラーのインスタンスを使用します</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">型に void を返すデリゲートが含まれており、デリゲートのシグネチャに 2 つのパラメーター (1 つはオブジェクト、もう 1 つは EventArgs に割り当て可能な型) が含まれ、包含アセンブリの対象が .NET Framework 2.0 です。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">次のパターンを使用するイベントに対して、Visual Basic は EventHandler デリゲートを生成します: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs)。EventHandler&lt;T&gt; を使用するために、イベント型を明示的に定義して、EventHandler {0} を定義するイベントを変更します。例: Event MyEvent As EventHandler(Of MyEventArgs)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">{0} を削除し、その使用を EventHandler&lt;T&gt; で置き換えます</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">列挙型は 0 値を含んでいなければなりません</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">基底クラス メソッドを非表示にしません</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
@@ -117,21 +117,6 @@
         <target state="translated">제네릭 이벤트 처리기 인스턴스를 사용하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">형식이 void를 반환하는 대리자를 포함하며 이 형식의 시그니처는 매개 변수 2개(개체 및 EventArgs에 할당할 수 있는 형식) 및 포함하는 어셈블리 대상 Microsoft .NET Framework 2.0을 포함합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic은 Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs) 패턴을 사용하는 이벤트에 대해 EventHandler 대리자를 생성합니다. Event MyEvent As EventHandler(Of MyEventArgs)와 같이 이벤트 형식을 명시적으로 정의하여 EventHandler&lt;T&gt;를 사용하도록 EventHandler {0}을(를) 정의하는 이벤트를 변경하세요.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">{0}을(를) 제거하고 EventHandler&lt;T&gt;로 바꿔 사용하세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">열거형에는 0 값이 있어야 합니다.</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">기본 클래스 메서드를 숨기지 마세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
@@ -117,21 +117,6 @@
         <target state="translated">Używaj ogólnych wystąpień procedur obsługi zdarzeń</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">Typ zawiera delegata zwracającego typ void, którego sygnatura zawiera dwa parametry (pierwszy jest obiektem, a drugi typem, który można przypisać do typu EventArgs), a zawierający zestaw jest przeznaczony dla programu Microsoft .NET Framework 2.0.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Język Visual Basic generuje delegatów EventHandler dla zdarzeń używających następującego wzorca: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Zmień zdarzenie definiujące element EventHandler {0}, tak aby użyć elementu EventHandler&lt;T&gt;, definiując jawnie typ zdarzenia, np. Event MyEvent As EventHandler(Of MyEventArgs).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">Usuń element {0} i zmień sposób jego użycia na EventHandler&lt;T&gt;</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">Wyliczenia powinny mieć wartość zero</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">Nie ukrywaj metod klasy podstawowej</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
@@ -117,21 +117,6 @@
         <target state="translated">Usar instâncias do manipulador de eventos genéricos</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">Um tipo contém um delegado que retorna void, cuja assinatura contém dois parâmetros (o primeiro é um objeto e o segundo é um tipo atribuível a EventArgs) e o assembly recipiente é direcionado para o Microsoft .NET Framework 2.0.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">O Visual Basic gera delegados EventHandler para eventos que usam o seguinte padrão: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Altere o evento que define EventHandler {0} para usar EventHandler&lt;T&gt; definindo o tipo de evento explicitamente, ex.: Event MyEvent As EventHandler(Of MyEventArgs).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">Remova {0} e substitua seu uso por EventHandler&lt;T&gt;</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">Enums devem ter valor zero</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">Não ocultar métodos de classe base</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
@@ -117,21 +117,6 @@
         <target state="translated">Используйте экземпляры обработчика универсальных событий</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">Тип содержит делегат, возвращающий значение void, сигнатура которого содержит два параметра (первый является объектом, а второй — типом, назначаемым для EventArgs), а содержащая сборка ориентирована на платформу Microsoft .NET Framework 2.0.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic создает делегаты EventHandler для событий, использующих следующий шаблон: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Измените событие, определяющее EventHandler {0}, так, чтобы использовать EventHandler&lt;T&gt;, явно определив тип события, т. е. Event MyEvent As EventHandler(Of MyEventArgs).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">Удалите {0}, заменив на EventHandler&lt;T&gt;</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">Перечисления должны иметь нулевое значение</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">Не скрывайте методы базовых классов</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
@@ -117,21 +117,6 @@
         <target state="translated">Genel olay işleyicisi örnekleri kullanın</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">Bir tür, void döndüren ve imzası iki parametre (ilki bir nesne, ikincisi EventArgs’a atanabilen bir tür) içeriyor ve bunu içeren bütünleştirilmiş kod Microsoft .NET Framework?2.0 sürümünü hedefliyor.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic, şu deseni kullanan olaylar için EventHandler temsilcileri oluşturur: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Olay türünü açık bir şekilde belirterek (örneğin, Event MyEvent As EventHandler(Of MyEventArgs)), {0} EventHandler'ın EventHandler&lt;T&gt; kullanmasını tanımlayan olayı değiştirin.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">{0} öğesini kaldırın ve kullanımını EventHandler&lt;T&gt; ile değiştirin</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">Sabit listelerinin sıfır değeri olmalıdır</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">Temel sınıf yöntemlerini gizlemeyin</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
@@ -117,21 +117,6 @@
         <target state="translated">使用泛型事件处理程序实例</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">类型包含返回 void 的委托，其签名包含两个参数(第一个参数为对象，第二个参数为分配给 EventArgs 的类型)，且包含程序集的目标为 Microsoft .NET Framework 2.0。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic 为使用以下模式的事件生成 EventHandler 委托: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs)。可以通过显式定义事件类型(例如，Event MyEvent As EventHandler(Of MyEventArgs))来更改定义 EventHandler {0} 的事件以使用 EventHandler&lt;T&gt;。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">删除 {0}，改用 EventHandler&lt;T&gt;</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">枚举应具有零值</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">不要隐藏基类方法</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
@@ -117,21 +117,6 @@
         <target state="translated">使用泛型事件處理常式執行個體</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesDescription">
-        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
-        <target state="translated">類型包含傳回 void 的委派，其簽章包含兩個參數 (第一個參數是物件，第二個參數則是可指派給 EventArgs 的類型)，而內含的組件則以 Microsoft .NET Framework 2.0 為目標。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageVB">
-        <source>Visual Basic generates EventHandler delegates for events that use the following pattern: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs). Change the event that defines EventHandler {0} to use EventHandler&lt;T&gt; by defining the event type explicitly, e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
-        <target state="translated">Visual Basic 會為使用下列模式的事件產生 EventHandler 委派: Event MyEvent(ByVal Sender As Object, ByVal e as MyEventArgs)。利用明確地定義事件類型，可將定義 EventHandler {0} 的事件變更為使用 EventHandler&lt;T&gt;，例如 Event MyEvent As EventHandler(Of MyEventArgs)。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UseGenericEventHandlerInstancesMessageDefault">
-        <source>Remove {0} and replace its usage with EventHandler&lt;T&gt;</source>
-        <target state="translated">移除 {0} 並以 EventHandler&lt;T&gt; 取代其用法</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueTitle">
         <source>Enums should have zero value</source>
         <target state="translated">列舉應要零值</target>
@@ -1480,6 +1465,36 @@
       <trans-unit id="DoNotHideBaseClassMethodsTitle">
         <source>Do not hide base class methods</source>
         <target state="translated">請勿隱藏基底類別方法</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateMessage">
+        <source>Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Remove '{0}' and replace its usage with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForDelegateDescription">
+        <source>A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventMessage">
+        <source>Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</source>
+        <target state="new">Change the event '{0}' to replace the type '{1}' with a generic EventHandler, for e.g. EventHandler&lt;T&gt;, where T is a valid EventArgs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEventDescription">
+        <source>A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</source>
+        <target state="new">A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Message">
+        <source>Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</source>
+        <target state="new">Change the event '{0}' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseGenericEventHandlerInstancesForEvent2Description">
+        <source>A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</source>
+        <target state="new">A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseGenericEventHandlerInstancesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseGenericEventHandlerInstancesTests.cs
@@ -61,7 +61,8 @@ public class C
     public event System.EventHandler<BadArgs> E2;
 }
 ",
-                GetCA1003CSharpResultAt(13, 47));
+            // Test0.cs(13,47): warning CA1003: Change the event 'E2' to replace the type 'System.EventHandler<BadArgs>' with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(13, 47, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents, "E2", "System.EventHandler<BadArgs>"));
         }
 
         [Fact]
@@ -79,7 +80,8 @@ Public Class C
     Public Event E2 As System.EventHandler(Of BadArgs)
 End Class
 ",
-                GetCA1003BasicResultAt(10, 18));
+            // Test0.vb(10,18): warning CA1003: Change the event 'E2' to replace the type 'System.EventHandler(Of BadArgs)' with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetBasicResultAt(10, 18, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents, "E2", "System.EventHandler(Of BadArgs)"));
         }
 
         [Fact]
@@ -92,14 +94,22 @@ Public Class C
     Public Event E3(sender As Object)
     Public Event E4(sender As Object, args As Integer)
 End Class
-");
+",
+            // Test0.vb(3,18): warning CA1003: Change the event 'E1' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).
+            GetBasicResultAt(3, 18, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents2, "E1"),
+            // Test0.vb(4,18): warning CA1003: Change the event 'E2' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).
+            GetBasicResultAt(4, 18, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents2, "E2"),
+            // Test0.vb(5,18): warning CA1003: Change the event 'E3' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).
+            GetBasicResultAt(5, 18, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents2, "E3"),
+            // Test0.vb(6,18): warning CA1003: Change the event 'E4' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).
+            GetBasicResultAt(6, 18, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents2, "E4"));
         }
 
         [Fact]
-        public void TestNonPublicEvent()
+        public void TestNonPublicEventAndNonPublicDelegate()
         {
             VerifyCSharp(@"
-public delegate void BadEventHandler(object senderId, System.EventArgs e);
+internal delegate void BadEventHandler(object senderId, System.EventArgs e);
 
 public class EventsClass
 {
@@ -109,16 +119,29 @@ public class EventsClass
         }
 
         [Fact]
-        public void TestPublicEventInNonPublicType()
+        public void TestNonPublicEventButPublicDelegate()
         {
             VerifyCSharp(@"
-using System;
+public delegate void BadEventHandler(object senderId, System.EventArgs e);
 
-public delegate void BadEventHandler(object senderId, EventArgs e);
-
-internal class EventsClass
+public class EventsClass
 {
-    public event BadEventHandler E;
+    internal event BadEventHandler E;
+}
+",
+            // Test0.cs(2,22): warning CA1003: Remove 'BadEventHandler' and replace its usage with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(2, 22, UseGenericEventHandlerInstancesAnalyzer.RuleForDelegates, "BadEventHandler"));
+        }
+
+        [Fact]
+        public void TestNonPublicEventAndPublicInvalidDelegate()
+        {
+            VerifyCSharp(@"
+public delegate void BadEventHandler(object senderId);
+
+public class EventsClass
+{
+    internal event BadEventHandler E;
 }
 ");
         }
@@ -154,7 +177,8 @@ public class EventsClassExplicit : ITest
     }
 }
 ",
-                GetCA1003CSharpResultAt(8, 27));
+            // Test0.cs(4,22): warning CA1003: Remove 'BadEventHandler' and replace its usage with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(4, 22, UseGenericEventHandlerInstancesAnalyzer.RuleForDelegates, "BadEventHandler"));
         }
 
         [Fact]
@@ -173,7 +197,8 @@ public class D : C
     public override event BadHandler E;
 }
 ",
-                GetCA1003CSharpResultAt(6, 37));
+            // Test0.cs(6,37): warning CA1003: Change the event 'E' to replace the type 'BadHandler' with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(6, 37, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents, "E", "BadHandler"));
         }
 
         [Fact]
@@ -212,12 +237,18 @@ public class C
     public event EventHandler<int> E6;
 }
 ",
-                GetCA1003CSharpResultAt(12, 30),
-                GetCA1003CSharpResultAt(13, 30),
-                GetCA1003CSharpResultAt(14, 30),
-                GetCA1003CSharpResultAt(15, 30),
-                GetCA1003CSharpResultAt(16, 30),
-                GetCA1003CSharpResultAt(17, 36));
+            // Test0.cs(8,22): warning CA1003: Remove 'BadHandler5' and replace its usage with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(8, 22, UseGenericEventHandlerInstancesAnalyzer.RuleForDelegates, "BadHandler5"),
+            // Test0.cs(12,30): warning CA1003: Change the event 'E1' to replace the type 'BadHandler1' with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(12, 30, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents, "E1", "BadHandler1"),
+            // Test0.cs(13,30): warning CA1003: Change the event 'E2' to replace the type 'BadHandler2' with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(13, 30, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents, "E2", "BadHandler2"),
+            // Test0.cs(14,30): warning CA1003: Change the event 'E3' to replace the type 'BadHandler3' with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(14, 30, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents, "E3", "BadHandler3"),
+            // Test0.cs(15,30): warning CA1003: Change the event 'E4' to replace the type 'BadHandler4' with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(15, 30, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents, "E4", "BadHandler4"),
+            // Test0.cs(17,36): warning CA1003: Change the event 'E6' to replace the type 'System.EventHandler<int>' with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetCSharpResultAt(17, 36, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents, "E6", "System.EventHandler<int>"));
         }
 
         [Fact]
@@ -235,19 +266,12 @@ End Class
 Public Structure MyEventArgs
 End Structure
 ",
-                GetCA1003BasicResultAt(5, 18),
-                GetCA1003BasicResultAt(6, 18),
-                GetCA1003BasicResultAt(7, 18));
-        }
-
-        private static DiagnosticResult GetCA1003BasicResultAt(int line, int col)
-        {
-            return GetBasicResultAt(line, col, UseGenericEventHandlerInstancesAnalyzer.RuleId, MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesMessageDefault);
-        }
-
-        private static DiagnosticResult GetCA1003CSharpResultAt(int line, int col)
-        {
-            return GetCSharpResultAt(line, col, UseGenericEventHandlerInstancesAnalyzer.RuleId, MicrosoftApiDesignGuidelinesAnalyzersResources.UseGenericEventHandlerInstancesMessageDefault);
+            // Test0.vb(2,21): warning CA1003: Remove 'BadHandler' and replace its usage with a generic EventHandler, for e.g. EventHandler<T>, where T is a valid EventArgs
+            GetBasicResultAt(2, 21, UseGenericEventHandlerInstancesAnalyzer.RuleForDelegates, "BadHandler"),
+            // Test0.vb(6,18): warning CA1003: Change the event 'E2' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).
+            GetBasicResultAt(6, 18, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents2, "E2"),
+            // Test0.vb(7,18): warning CA1003: Change the event 'E3' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).
+            GetBasicResultAt(7, 18, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents2, "E3"));
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/ApiDesignGuidelines/BasicUseGenericEventHandlerInstances.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/ApiDesignGuidelines/BasicUseGenericEventHandlerInstances.vb
@@ -12,56 +12,8 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines
     Public Class BasicUseGenericEventHandlerInstancesAnalyzer
         Inherits UseGenericEventHandlerInstancesAnalyzer
 
-        Protected Overrides Function GetAnalyzer(
-            compilation As Compilation,
-            eventHandler As INamedTypeSymbol,
-            genericEventHandler As INamedTypeSymbol,
-            eventArgs As INamedTypeSymbol,
-            comSourceInterfacesAttribute As INamedTypeSymbol) As SymbolAnalyzer
-
-            Return New BasicSymbolAnalyzer(compilation, eventHandler, genericEventHandler, eventArgs, comSourceInterfacesAttribute)
+        Protected Overrides Function IsAssignableTo(compilation As Compilation, fromSymbol As ITypeSymbol, toSymbol As ITypeSymbol) As Boolean
+            Return fromSymbol IsNot Nothing AndAlso toSymbol IsNot Nothing AndAlso DirectCast(compilation, VisualBasicCompilation).ClassifyConversion(fromSymbol, toSymbol).IsWidening
         End Function
-
-        Private NotInheritable Class BasicSymbolAnalyzer
-            Inherits SymbolAnalyzer
-
-            Public Sub New(
-                compilation As Compilation,
-                eventHandler As INamedTypeSymbol,
-                genericEventHandler As INamedTypeSymbol,
-                eventArgs As INamedTypeSymbol,
-                comSourceInterfacesAttribute As INamedTypeSymbol)
-
-                MyBase.New(compilation, eventHandler, genericEventHandler, eventArgs, comSourceInterfacesAttribute)
-            End Sub
-
-            Protected Overrides Function IsViolatingEventHandler(type As INamedTypeSymbol) As Boolean
-                Return IsGenericEventHandlerInstance(type) AndAlso Not IsEventArgs(type.TypeArguments(0)) OrElse
-                    IsEventHandler(type) AndAlso Not IsValidLibraryEventHandlerInstance(type)
-            End Function
-
-            Protected Overrides Function IsAssignableTo(compilation As Compilation, fromSymbol As ITypeSymbol, toSymbol As ITypeSymbol) As Boolean
-                Return fromSymbol IsNot Nothing AndAlso toSymbol IsNot Nothing AndAlso DirectCast(compilation, VisualBasicCompilation).ClassifyConversion(fromSymbol, toSymbol).IsWidening
-            End Function
-
-            Private Function IsEventHandler(type As ITypeSymbol) As Boolean
-                Dim delegateInvokeMethod = GetDelegateInvokeMethod(type)
-                If delegateInvokeMethod Is Nothing Then
-                    Return False
-                End If
-
-                Dim parameters = delegateInvokeMethod.Parameters
-                Return delegateInvokeMethod.ReturnsVoid AndAlso
-                    parameters.Length = 2 AndAlso
-                    parameters(0).Type.SpecialType = SpecialType.System_Object AndAlso
-                    IsEventArgs(parameters(1).Type)
-            End Function
-
-            Private Shared Function GetDelegateInvokeMethod(type As ITypeSymbol) As IMethodSymbol
-                Return If(type.TypeKind = TypeKind.Delegate,
-                    type.GetMembers(WellKnownMemberNames.DelegateInvokeName).OfType(Of IMethodSymbol)().FirstOrDefault(),
-                    Nothing)
-            End Function
-        End Class
     End Class
 End Namespace

--- a/src/Utilities/WellKnownTypes.cs
+++ b/src/Utilities/WellKnownTypes.cs
@@ -226,11 +226,6 @@ namespace Analyzer.Utilities
             return compilation.GetTypeByMetadataName("System.Runtime.InteropServices.ComSourceInterfacesAttribute");
         }
 
-        public static INamedTypeSymbol EventHandler(Compilation compilation)
-        {
-            return compilation.GetTypeByMetadataName("System.EventHandler");
-        }
-
         public static INamedTypeSymbol GenericEventHandler(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.EventHandler`1");


### PR DESCRIPTION
…A1009 legacy FxCop implementation

This analyzer was originally written to merge CA1003 (use generic event handlers) and CA1009 (fix signature of non-generic event handlers) into a single analyzer aimed at recommending users to use generic event handlers. However, the implementation was incorrectly merged to only analyze and report issues on event symbols, while the original FxCop reported CA1003 for externally visible delegates and CA1009 for externally visible events. This PR changes the analyzer so we have two separate symbols actions tackling delegate and event cases respectively. The logic for both these actions match the legacy FxCop implementations (and the public documentation), but instead of reporting CA1009, whose recommendation would trigger CA1003, we report CA1003 (use generic event handlers) in both cases, but have different messages to clarify the issue.

Fixes #1509