### PR TITLE
Correctly detect serializable types from metadata using reflection

### DIFF
--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
@@ -264,34 +266,20 @@ namespace Microsoft.NetFramework.Analyzers
                         return true;
 
                     default:
-                        return IsPrimitiveType(type) ||
-                            type.SpecialType == SpecialType.System_String ||
-                            type.SpecialType == SpecialType.System_Decimal ||
-                            type.GetAttributes()
-                                .Any(a => a.AttributeClass.Equals(_serializableAttributeTypeSymbol));
-                }
-            }
+                        if (type.GetAttributes().Any(a => a.AttributeClass.Equals(_serializableAttributeTypeSymbol)))
+                        {
+                            return true;
+                        }
 
-            private static bool IsPrimitiveType(ITypeSymbol type)
-            {
-                switch (type.SpecialType)
-                {
-                    case SpecialType.System_Boolean:
-                    case SpecialType.System_Byte:
-                    case SpecialType.System_Char:
-                    case SpecialType.System_Double:
-                    case SpecialType.System_Int16:
-                    case SpecialType.System_Int32:
-                    case SpecialType.System_Int64:
-                    case SpecialType.System_UInt16:
-                    case SpecialType.System_UInt32:
-                    case SpecialType.System_UInt64:
-                    case SpecialType.System_IntPtr:
-                    case SpecialType.System_UIntPtr:
-                    case SpecialType.System_SByte:
-                    case SpecialType.System_Single:
-                        return true;
-                    default:
+                        // Workaround for https://github.com/dotnet/roslyn/issues/3898
+                        var isSerializableMetadataProperty = type.GetType().GetRuntimeProperties().FirstOrDefault(p => p.Name.Equals("IsSerializable", StringComparison.Ordinal));
+                        if (isSerializableMetadataProperty != null &&
+                            isSerializableMetadataProperty.GetValue(type) is bool isSerializable &&
+                            isSerializable)
+                        {
+                            return true;
+                        }
+
                         return false;
                 }
             }

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -272,15 +272,10 @@ namespace Microsoft.NetFramework.Analyzers
                         }
 
                         // Workaround for https://github.com/dotnet/roslyn/issues/3898
-                        var isSerializableMetadataProperty = type.GetType().GetRuntimeProperties().FirstOrDefault(p => p.Name.Equals("IsSerializable", StringComparison.Ordinal));
-                        if (isSerializableMetadataProperty != null &&
-                            isSerializableMetadataProperty.GetValue(type) is bool isSerializable &&
-                            isSerializable)
-                        {
-                            return true;
-                        }
-
-                        return false;
+                        return type.GetType().GetRuntimeProperties().Any(
+                            p => p.Name.Equals("IsSerializable", StringComparison.Ordinal) &&
+                                p.GetValue(type) is bool isSerializable &&
+                                isSerializable);
                 }
             }
         }

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
@@ -457,6 +457,48 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
                 End Class");
         }
 
+        [Fact, WorkItem(1510, "https://github.com/dotnet/roslyn-analyzers/issues/1510")]
+        public void CA2235WithDateTimeType()
+        {
+            VerifyCSharp(@"
+                using System;
+
+                [Serializable]
+                internal class CA2235WithDateTimeField
+                {
+                    public DateTime s1;
+                }");
+
+            VerifyBasic(@"
+                Imports System
+
+                <Serializable>
+                Friend Class CA2235WithDateTimeField
+                    Public s1 As DateTime
+                End Class");
+        }
+
+        [Fact, WorkItem(1510, "https://github.com/dotnet/roslyn-analyzers/issues/1510")]
+        public void CA2235WithNullableType()
+        {
+            VerifyCSharp(@"
+                using System;
+
+                [Serializable]
+                internal class CA2235WithNullableField
+                {
+                    public long? s1;
+                }");
+
+            VerifyBasic(@"
+                Imports System
+
+                <Serializable>
+                Friend Class CA2235WithNullableField
+                    Public s1 As Long?
+                End Class");
+        }
+
         [Fact]
         public void CA2235WithSpecialSerializableTypeFields()
         {


### PR DESCRIPTION
https://github.com/dotnet/roslyn/issues/3898 prevents the existing attribute based detection code to work for large number of cases. This PR adds a workaround to use reflection to read this property. Once the Roslyn issue is fixed, this code must be removed.

Fixes #1510