### PR TITLE
Workaround for Roslyn bug in SyntaxGenerator.NameOfExpression in nameof fixer

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/Maintainability/CSharpUseNameofInPlaceOfString.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/Maintainability/CSharpUseNameofInPlaceOfString.Fixer.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeQuality.Analyzers.Maintainability;
+
+namespace Microsoft.CodeQuality.CSharp.Analyzers.Maintainability
+{
+    /// <summary>
+    /// CA1507: Use nameof to express symbol names
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    public sealed class CSharpUseNameofInPlaceOfStringFixer : UseNameOfInPlaceOfStringFixer
+    {
+        protected override SyntaxNode GetNameOfExpression(SyntaxGenerator generator, string identifierNameArgument)
+        {
+            // Workaround for https://github.com/dotnet/roslyn/issues/24212
+            // Once the above Roslyn bug is fixed, we can remove this override and make UseNameOfInPlaceOfStringFixer language agnostic.
+            string nameofString = SyntaxFacts.GetText(SyntaxKind.NameOfKeyword);
+            SyntaxToken nameofIdentifierToken = SyntaxFactory.Identifier(leading: default(SyntaxTriviaList), contextualKind: SyntaxKind.NameOfKeyword,
+                text: nameofString, valueText: nameofString, trailing: default(SyntaxTriviaList));
+            var nameofIdentifierNode = SyntaxFactory.IdentifierName(nameofIdentifierToken);
+            var nameofArgumentNode = SyntaxFactory.IdentifierName(identifierNameArgument);
+            return generator.InvocationExpression(expression: nameofIdentifierNode, arguments: nameofArgumentNode);
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/UseNameofInPlaceOfString.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/UseNameofInPlaceOfString.Fixer.cs
@@ -14,10 +14,9 @@ using Microsoft.CodeAnalysis.Editing;
 namespace Microsoft.CodeQuality.Analyzers.Maintainability
 {
     /// <summary>
-    /// CA1507 Use nameof to express symbol names
+    /// CA1507: Use nameof to express symbol names
     /// </summary>
-    [ExportCodeFixProvider(LanguageNames.VisualBasic, LanguageNames.CSharp), Shared]
-    public class UseNameOfInPlaceOfStringFixer : CodeFixProvider
+    public abstract class UseNameOfInPlaceOfStringFixer : CodeFixProvider
     {
         public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(UseNameofInPlaceOfStringAnalyzer.RuleId);
 
@@ -26,6 +25,9 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers'
             return WellKnownFixAllProviders.BatchFixer;
         }
+
+        protected virtual SyntaxNode GetNameOfExpression(SyntaxGenerator generator, string identifierNameArgument) =>
+            generator.NameOfExpression(generator.IdentifierName(identifierNameArgument));
 
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -52,7 +54,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
             var trailingTrivia = nodeToReplace.GetTrailingTrivia();
             var leadingTrivia = nodeToReplace.GetLeadingTrivia();
-            var nameOfExpression = generator.NameOfExpression(generator.IdentifierName(stringText))
+            SyntaxNode nameOfExpression = GetNameOfExpression(generator, stringText)
                 .WithTrailingTrivia(trailingTrivia)
                 .WithLeadingTrivia(leadingTrivia);
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.Fixer.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 {
-    public class UseNameOfInPlaceOfStringTests : CodeFixTestBase
+    public class UseNameOfInPlaceOfStringFixerTests : CodeFixTestBase
     {
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
@@ -24,12 +24,12 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 
         protected override CodeFixProvider GetBasicCodeFixProvider()
         {
-                return new UseNameOfInPlaceOfStringFixer();
+                return new BasicUseNameofInPlaceOfStringFixer();
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
-                return new UseNameOfInPlaceOfStringFixer();
+                return new CSharpUseNameofInPlaceOfStringFixer();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ class C
     {
         throw new ArgumentNullException(nameof(x));
     }
-}", allowNewCompilerDiagnostics: true, validationMode: TestValidationMode.AllowCompileErrors );
+}");
         }
 
         [Fact]
@@ -75,7 +75,7 @@ class C
     {
         throw new ArgumentNullException(/*Leading*/nameof(x)/*Trailing*/);
     }
-}", allowNewCompilerDiagnostics: true, validationMode: TestValidationMode.AllowCompileErrors);
+}");
         }
 
         [Fact]
@@ -98,7 +98,7 @@ class C
     {
         throw new ArgumentException(""Somemessage"", /*Leading*/nameof(x)/*Trailing*/);
     }
-}", allowNewCompilerDiagnostics: true, validationMode: TestValidationMode.AllowCompileErrors);
+}");
         }
 
         [Fact]
@@ -119,7 +119,7 @@ Module Mod1
     Sub f(s As String)
         Throw New ArgumentNullException(NameOf(s))
     End Sub
-End Module", allowNewCompilerDiagnostics: true, validationMode: TestValidationMode.AllowCompileErrors);
+End Module");
         }
 
         [Fact]
@@ -175,7 +175,7 @@ public class Person : INotifyPropertyChanged
             handler(this, new PropertyChangedEventArgs(propertyName));
         }
     }
-}", allowNewCompilerDiagnostics: true, validationMode: TestValidationMode.AllowCompileErrors);
+}");
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/Maintainability/BasicUseNameofInPlaceOfString.Fixer.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/Maintainability/BasicUseNameofInPlaceOfString.Fixer.vb
@@ -1,0 +1,16 @@
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeQuality.Analyzers.Maintainability
+
+Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability
+    ''' <summary>
+    ''' CA1507: Use nameof to express symbol names
+    ''' </summary>
+    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
+    Public NotInheritable Class BasicUseNameofInPlaceOfStringFixer
+        Inherits UseNameOfInPlaceOfStringFixer
+    End Class
+End Namespace


### PR DESCRIPTION
This PR adds a workaround for https://github.com/dotnet/roslyn/issues/24212
Once the above Roslyn bug is fixed, we should revert the product changes made in this PR.
Fixes #1364