### PR TITLE
Ca1801 false positives

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -108,7 +108,7 @@ End Class
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/8884")]
+        [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
         public void NoDiagnosticDelegateTest2_CSharp()
         {
@@ -125,7 +125,7 @@ public class NeatCode
             a();
         });
     }
-");
+}");
         }
 
         [Fact]
@@ -146,7 +146,7 @@ End Class
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/8884")]
+        [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
         public void NoDiagnosticUsingTest_CSharp()
         {
@@ -166,7 +166,7 @@ class C
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/8884")]
+        [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
         public void NoDiagnosticUsingTest_VB()
         {
@@ -183,7 +183,7 @@ End Class
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/8884")]
+        [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
         public void NoDiagnosticLinqTest_CSharp()
         {
@@ -205,7 +205,7 @@ class C
         }
 
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/8884")]
+        [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
         public void NoDiagnosticLinqTest_VB()
         {
@@ -490,7 +490,7 @@ public class C3
 }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19917"), WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
+        [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
         public void NoDiagnosticForMethodsUsedAsDelegatesBasic()
         {
             VerifyBasic(@"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -732,6 +732,30 @@ static class C
 ");
     }
 
+        [Fact]
+        public void NoDiagnosticsForSingleStatementMethodsWithDefaultParameters()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public void Foo(string bar, string baz = null)
+    {
+        throw new NotImplementedException();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+Public Class C
+    Public Sub Test(bar As String, Optional baz As String = Nothing)
+        Throw New NotImplementedException()
+    End Sub
+End Class");
+        }
+
     #endregion
 
     #region Unit tests for analyzer diagnostic(s)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/1545.  Previously we were assuming that we would only ever be interested in scenarios with only 1 top-level operation block, which misses parameter initializers.

I also unskipped CA1801 tests that had closed bugs attached.