### PR TITLE
Implement PointsToAnalysis to track locations of all symbols and ins…

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAbstractValue.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
 {
     /// <summary>
-    /// Abstract null value for symbol/operation tracked by <see cref="NullAnalysis"/>.
+    /// Abstract null value for <see cref="AnalysisEntity"/>/<see cref="IOperation"/> tracked by <see cref="NullAnalysis"/>.
     /// </summary>
     internal enum NullAbstractValue
     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullAbstractValueDomain.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
 {
-    using NullAnalysisData = IDictionary<ISymbol, NullAbstractValue>;
+    using NullAnalysisData = IDictionary<AnalysisEntity, NullAbstractValue>;
 
     internal partial class NullAnalysis : ForwardDataFlowAnalysis<NullAnalysisData, NullBlockAnalysisResult, NullAbstractValue>
     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullBlockAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullBlockAnalysisResult.cs
@@ -6,22 +6,22 @@ using Microsoft.CodeAnalysis.Operations.ControlFlow;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
 {
-    using NullAnalysisData = IDictionary<ISymbol, NullAbstractValue>;
+    using NullAnalysisData = IDictionary<AnalysisEntity, NullAbstractValue>;
 
     /// <summary>
     /// Result from execution of <see cref="NullAnalysis"/> on a basic block.
-    /// It store null values for symbols at the start and end of the basic block.
+    /// It store null values for each <see cref="AnalysisEntity"/> at the start and end of the basic block.
     /// </summary>
     internal class NullBlockAnalysisResult : AbstractBlockAnalysisResult<NullAnalysisData, NullAbstractValue>
     {
         public NullBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<NullAnalysisData> blockAnalysisData)
             : base (basicBlock)
         {
-            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<ISymbol, NullAbstractValue>.Empty;
-            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<ISymbol, NullAbstractValue>.Empty;
+            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, NullAbstractValue>.Empty;
+            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, NullAbstractValue>.Empty;
         }
 
-        public ImmutableDictionary<ISymbol, NullAbstractValue> InputData { get; }
-        public ImmutableDictionary<ISymbol, NullAbstractValue> OutputData { get; }
+        public ImmutableDictionary<AnalysisEntity, NullAbstractValue> InputData { get; }
+        public ImmutableDictionary<AnalysisEntity, NullAbstractValue> OutputData { get; }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
+{
+    /// <summary>
+    /// Abstract points to value for an <see cref="AnalysisEntity"/>/<see cref="IOperation"/> tracked by <see cref="PointsToAnalysis"/>.
+    /// It contains the set of possible <see cref="AbstractLocation"/>s that the entity or the operation can point to and the <see cref="Kind"/> of the location(s).
+    /// </summary>
+    internal class PointsToAbstractValue: IEquatable<PointsToAbstractValue>
+    {
+        public static PointsToAbstractValue Undefined = new PointsToAbstractValue(PointsToAbstractValueKind.Undefined);
+        public static PointsToAbstractValue NoLocation = new PointsToAbstractValue(PointsToAbstractValueKind.NoLocation);
+        public static PointsToAbstractValue Unknown = new PointsToAbstractValue(PointsToAbstractValueKind.Unknown);
+        
+        private PointsToAbstractValue(ImmutableHashSet<AbstractLocation> locations, PointsToAbstractValueKind kind)
+        {
+            Locations = locations;
+            Kind = kind;
+        }
+
+        private PointsToAbstractValue(PointsToAbstractValueKind kind)
+            : this(ImmutableHashSet<AbstractLocation>.Empty, kind)
+        {
+            Debug.Assert(kind != PointsToAbstractValueKind.Known);
+        }
+
+        public PointsToAbstractValue(AbstractLocation location)
+            : this(ImmutableHashSet.Create(location))
+        {
+        }
+
+        public PointsToAbstractValue(ImmutableHashSet<AbstractLocation> locations)
+            : this(locations, PointsToAbstractValueKind.Known)
+        {
+            Debug.Assert(locations.Count > 0);            
+        }
+
+        public ImmutableHashSet<AbstractLocation> Locations { get; }
+        public PointsToAbstractValueKind Kind { get; }
+
+        public static bool operator ==(PointsToAbstractValue value1, PointsToAbstractValue value2)
+        {
+            if ((object)value1 == null)
+            {
+                return (object)value2 == null;
+            }
+
+            return value1.Equals(value2);
+        }
+
+        public static bool operator !=(PointsToAbstractValue value1, PointsToAbstractValue value2)
+        {
+            return !(value1 == value2);
+        }
+
+        public bool Equals(PointsToAbstractValue other)
+        {
+            return other != null &&
+                Kind == other.Kind &&
+                Locations.SetEquals(other.Locations);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as PointsToAbstractValue);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = HashUtilities.Combine(Kind.GetHashCode(), Locations.Count.GetHashCode());
+            foreach (var location in Locations)
+            {
+                hashCode = HashUtilities.Combine(location.GetHashCode(), hashCode);
+            }
+
+            return hashCode;
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 {
     /// <summary>
-    /// Abstract points to value for an <see cref="AnalysisEntity"/>/<see cref="IOperation"/> tracked by <see cref="PointsToAnalysis"/>.
+    /// Abstract PointsTo value for an <see cref="AnalysisEntity"/>/<see cref="IOperation"/> tracked by <see cref="PointsToAnalysis"/>.
     /// It contains the set of possible <see cref="AbstractLocation"/>s that the entity or the operation can point to and the <see cref="Kind"/> of the location(s).
     /// </summary>
     internal class PointsToAbstractValue: IEquatable<PointsToAbstractValue>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValueKind.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValueKind.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
+{
+    /// <summary>
+    /// Kind for the <see cref="PointsToAbstractValue"/>.
+    /// </summary>
+    internal enum PointsToAbstractValueKind
+    {
+        /// <summary>
+        /// Undefined value.
+        /// </summary>
+        Undefined,
+
+        /// <summary>
+        /// Points to one or more known possible locations.
+        /// </summary>
+        Known,
+
+        /// <summary>
+        /// Indicates no tracked location (for e.g. literals, constants, etc.).
+        /// </summary>
+        NoLocation,
+
+        /// <summary>
+        /// Points to unknown set of locations.
+        /// </summary>
+        Unknown,
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
+{
+    using PointsToAnalysisData = IDictionary<AnalysisEntity, PointsToAbstractValue>;
+
+    internal partial class PointsToAnalysis : ForwardDataFlowAnalysis<PointsToAnalysisData, PointsToBlockAnalysisResult, PointsToAbstractValue>
+    {
+        /// <summary>
+        /// Abstract value domain for <see cref="PointsToAnalysis"/> to merge and compare <see cref="PointsToAbstractValue"/> values.
+        /// </summary>
+        private class PointsToAbstractValueDomain : AbstractDomain<PointsToAbstractValue>
+        {
+            public static PointsToAbstractValueDomain Default = new PointsToAbstractValueDomain();
+            private readonly SetAbstractDomain<AbstractLocation> _locationsDomain = new SetAbstractDomain<AbstractLocation>();
+
+            private PointsToAbstractValueDomain() { }
+
+            public override PointsToAbstractValue Bottom => PointsToAbstractValue.Undefined;
+
+            public override int Compare(PointsToAbstractValue oldValue, PointsToAbstractValue newValue)
+            {
+                if (oldValue == null)
+                {
+                    return newValue == null ? 0 : -1;
+                }
+                else if (newValue == null)
+                {
+                    return 1;
+                }
+
+                if (ReferenceEquals(oldValue, newValue))
+                {
+                    return 0;
+                }
+
+                if (oldValue.Kind == newValue.Kind)
+                {
+                    return _locationsDomain.Compare(oldValue.Locations, newValue.Locations);
+                }
+                else if (oldValue.Kind < newValue.Kind)
+                {
+                    return -1;
+                }
+                else
+                {
+                    return 1;
+                }
+            }
+
+            public override PointsToAbstractValue Merge(PointsToAbstractValue value1, PointsToAbstractValue value2)
+            {
+                if (value1 == null)
+                {
+                    return value2;
+                }
+                else if (value2 == null)
+                {
+                    return value1;
+                }
+                else if(value1.Kind == PointsToAbstractValueKind.Undefined || value1.Kind == PointsToAbstractValueKind.NoLocation)
+                {
+                    return value2;
+                }
+                else if (value2.Kind == PointsToAbstractValueKind.Undefined || value2.Kind == PointsToAbstractValueKind.NoLocation)
+                {
+                    return value1;
+                }
+                else if (value1.Kind == PointsToAbstractValueKind.Unknown || value2.Kind == PointsToAbstractValueKind.Unknown)
+                {
+                    return PointsToAbstractValue.Unknown;
+                }
+
+                Debug.Assert(value1.Kind == PointsToAbstractValueKind.Known && value2.Kind == PointsToAbstractValueKind.Known);
+                return new PointsToAbstractValue(_locationsDomain.Merge(value1.Locations, value2.Locations));
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -1,0 +1,323 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Analyzer.Utilities.Extensions;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
+{
+    using Microsoft.CodeAnalysis.Operations.ControlFlow;
+    using PointsToAnalysisData = IDictionary<AnalysisEntity, PointsToAbstractValue>;
+
+    internal partial class PointsToAnalysis : ForwardDataFlowAnalysis<PointsToAnalysisData, PointsToBlockAnalysisResult, PointsToAbstractValue>
+    {
+        /// <summary>
+        /// Operation visitor to flow the points to values across a given statement in a basic block.
+        /// </summary>
+        private sealed class PointsToDataFlowOperationVisitor : DataFlowOperationVisitor<PointsToAnalysisData, PointsToAbstractValue>
+        {
+            public PointsToDataFlowOperationVisitor(
+                AbstractDomain<PointsToAbstractValue> valueDomain,
+                INamedTypeSymbol containingTypeSymbol,
+                DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt)
+                : base(valueDomain, containingTypeSymbol, nullAnalysisResultOpt: nullAnalysisResultOpt, pointsToAnalysisResultOpt: null)
+            {
+            }
+
+            protected override PointsToAbstractValue UnknownOrMayBeValue => PointsToAbstractValue.Unknown;
+            protected override bool HasPointsToAnalysisResult => true;
+
+            protected override bool HasAbstractValue(AnalysisEntity analysisEntity) =>
+                CurrentAnalysisData.ContainsKey(analysisEntity);
+
+            public override PointsToAnalysisData Flow(IOperation statement, BasicBlock block, PointsToAnalysisData input)
+            {
+                if (input != null)
+                {
+                    // Always set the points to value for the "this" or "Me" instance.
+                    input[AnalysisEntityFactory.ThisOrMeInstance] = ThisOrMePointsToAbstractValue;
+                }
+
+                return base.Flow(statement, block, input);
+            }
+
+            protected override PointsToAbstractValue GetAbstractValue(AnalysisEntity analysisEntity)
+            {
+                if (analysisEntity.Type.HasValueCopySemantics())
+                {
+                    return PointsToAbstractValue.NoLocation;
+                }
+
+                if (!CurrentAnalysisData.TryGetValue(analysisEntity, out var value))
+                {
+                    value = analysisEntity.SymbolOpt?.Kind == SymbolKind.Local ?
+                        PointsToAbstractValue.Undefined :
+                        UnknownOrMayBeValue;
+                }
+
+                return value;
+            }
+
+            protected override PointsToAbstractValue GetPointsToAbstractValue(IOperation operation)
+            {
+                return base.GetCachedAbstractValue(operation);
+            }
+
+            protected override PointsToAbstractValue GetAbstractDefaultValue(ITypeSymbol type)
+                => PointsToAbstractValue.NoLocation;
+
+            protected override void SetAbstractValue(AnalysisEntity analysisEntity, PointsToAbstractValue value)
+            {
+                if (!analysisEntity.Type.HasValueCopySemantics())
+                {
+                    CurrentAnalysisData[analysisEntity] = value;
+                }
+            }
+
+            protected override void ResetCurrentAnalysisData(PointsToAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);
+
+            protected override PointsToAbstractValue ComputeAnalysisValueForReferenceOperation(IOperation operation, PointsToAbstractValue defaultValue)
+            {
+                if (!operation.Type.HasValueCopySemantics() &&
+                    AnalysisEntityFactory.TryCreate(operation, out AnalysisEntity analysisEntity))
+                {
+                    if (!HasAbstractValue(analysisEntity))
+                    {
+                        var value = new PointsToAbstractValue(AbstractLocation.CreateAllocationLocation(operation, operation.Type));
+                        SetAbstractValue(analysisEntity, value);
+                        return value;
+                    }
+
+                    return GetAbstractValue(analysisEntity);
+                }
+                else
+                {
+                    Debug.Assert(!operation.Type.HasValueCopySemantics() || defaultValue == PointsToAbstractValue.NoLocation);
+                    return defaultValue;
+                }
+            }
+
+            #region Visitor methods
+
+            public override PointsToAbstractValue DefaultVisit(IOperation operation, object argument)
+            {
+                var value = base.DefaultVisit(operation, argument);
+
+                // Constants, operations with NullAbstractValue.Null and operations with value copy semantics (value type and strings)
+                // do not point to any location.
+                if (operation.ConstantValue.HasValue ||
+                    GetNullAbstractValue(operation) == NullAnalysis.NullAbstractValue.Null ||
+                    (operation.Type != null && operation.Type.HasValueCopySemantics()))
+                {
+                    return PointsToAbstractValue.NoLocation;
+                }
+
+                return UnknownOrMayBeValue;
+            }
+
+            public override PointsToAbstractValue VisitAwait(IAwaitOperation operation, object argument)
+            {
+                var _ = base.VisitAwait(operation, argument);
+                return PointsToAbstractValue.Unknown;
+            }
+
+            public override PointsToAbstractValue VisitNameOf(INameOfOperation operation, object argument)
+            {
+                var _ = base.VisitNameOf(operation, argument);
+                return PointsToAbstractValue.NoLocation;
+            }
+
+            public override PointsToAbstractValue VisitIsType(IIsTypeOperation operation, object argument)
+            {
+                var _ = base.VisitIsType(operation, argument);
+                return PointsToAbstractValue.NoLocation;
+            }
+
+            public override PointsToAbstractValue VisitInstanceReference(IInstanceReferenceOperation operation, object argument)
+            {
+                var _ = base.VisitInstanceReference(operation, argument);
+                IOperation currentInstanceOperation = operation.GetInstance();
+                return currentInstanceOperation != null ?
+                    GetCachedAbstractValue(currentInstanceOperation) :
+                    ThisOrMePointsToAbstractValue;
+            }
+
+            private PointsToAbstractValue VisitTypeCreationWithArgumentsAndInitializer(IEnumerable<IOperation> arguments, IObjectOrCollectionInitializerOperation initializer, IOperation operation, object argument)
+            {
+                AbstractLocation location = AbstractLocation.CreateAllocationLocation(operation, operation.Type);
+                var pointsToAbstractValue = new PointsToAbstractValue(location);
+                CacheAbstractValue(operation, pointsToAbstractValue);
+
+                var unusedArray = VisitArray(arguments, argument);
+                var initializerValue = Visit(initializer, argument);
+                Debug.Assert(initializer == null || initializerValue == pointsToAbstractValue);
+                return pointsToAbstractValue;
+            }
+
+            public override PointsToAbstractValue VisitObjectCreation(IObjectCreationOperation operation, object argument)
+            {
+                return VisitTypeCreationWithArgumentsAndInitializer(operation.Arguments, operation.Initializer, operation, argument);
+            }
+
+            public override PointsToAbstractValue VisitDynamicObjectCreation(IDynamicObjectCreationOperation operation, object argument)
+            {
+                return VisitTypeCreationWithArgumentsAndInitializer(operation.Arguments, operation.Initializer, operation, argument);
+            }
+
+            public override PointsToAbstractValue VisitAnonymousObjectCreation(IAnonymousObjectCreationOperation operation, object argument)
+            {
+                AbstractLocation location = AbstractLocation.CreateAllocationLocation(operation, operation.Type);
+                var pointsToAbstractValue = new PointsToAbstractValue(location);
+                CacheAbstractValue(operation, pointsToAbstractValue);
+
+                var _ = VisitArray(operation.Initializers, argument);
+                return pointsToAbstractValue;
+            }
+
+            public override PointsToAbstractValue VisitDelegateCreation(IDelegateCreationOperation operation, object argument)
+            {
+                var _ = base.VisitDelegateCreation(operation, argument);
+                AbstractLocation location = AbstractLocation.CreateAllocationLocation(operation, operation.Type);
+                return new PointsToAbstractValue(location);
+            }
+
+            public override PointsToAbstractValue VisitTypeParameterObjectCreation(ITypeParameterObjectCreationOperation operation, object argument)
+            {
+                var arguments = ImmutableArray<IOperation>.Empty;
+                return VisitTypeCreationWithArgumentsAndInitializer(arguments, operation.Initializer, operation, argument);
+            }
+
+            public override PointsToAbstractValue VisitMemberInitializer(IMemberInitializerOperation operation, object argument)
+            {
+                if (operation.InitializedMember is IMemberReferenceOperation memberReference)
+                {
+                    IOperation objectCreation = operation.GetCreation();
+                    PointsToAbstractValue objectCreationLocation = GetCachedAbstractValue(objectCreation);
+                    Debug.Assert(objectCreationLocation.Kind == PointsToAbstractValueKind.Known);
+                    Debug.Assert(objectCreationLocation.Locations.Count == 1);
+
+                    PointsToAbstractValue memberInstanceLocation = new PointsToAbstractValue(AbstractLocation.CreateAllocationLocation(operation, memberReference.Type));
+                    CacheAbstractValue(operation, memberInstanceLocation);
+                    CacheAbstractValue(operation.Initializer, memberInstanceLocation);
+
+                    var unusedInitializedMemberValue = Visit(memberReference, argument);
+                    var initializerValue = Visit(operation.Initializer, argument);
+                    Debug.Assert(operation.Initializer == null || initializerValue == memberInstanceLocation);
+                    SetAbstractValueForAssignment(memberReference, operation, memberInstanceLocation);
+
+                    return memberInstanceLocation;
+                }
+
+                var _ = base.Visit(operation, argument);
+                return PointsToAbstractValue.NoLocation;
+            }
+
+            public override PointsToAbstractValue VisitObjectOrCollectionInitializer(IObjectOrCollectionInitializerOperation operation, object argument)
+            {
+                var _ = base.VisitObjectOrCollectionInitializer(operation, argument);
+
+                // We should have created and created a new points to value for the associated creation operation.
+                return GetCachedAbstractValue(operation.Parent);
+            }
+
+            public override PointsToAbstractValue VisitArrayInitializer(IArrayInitializerOperation operation, object argument)
+            {
+                var _ = base.VisitArrayInitializer(operation, argument);
+
+                // We should have created and created a new points to value for the associated array creation operation.
+                return GetCachedAbstractValue((IArrayCreationOperation)operation.Parent);
+            }
+
+            public override PointsToAbstractValue VisitArrayCreation(IArrayCreationOperation operation, object argument)
+            {
+                var pointsToAbstractValue = new PointsToAbstractValue(AbstractLocation.CreateAllocationLocation(operation, operation.Type));
+                CacheAbstractValue(operation, pointsToAbstractValue);
+
+                var unusedDimensionsValue = VisitArray(operation.DimensionSizes, argument);
+                var initializerValue = Visit(operation.Initializer, argument);
+                Debug.Assert(operation.Initializer == null || initializerValue == pointsToAbstractValue);
+                return pointsToAbstractValue;
+            }
+
+            public override PointsToAbstractValue VisitParameterReference(IParameterReferenceOperation operation, object argument)
+            {
+                // Create a dummy points to value for each reference type parameter.
+                if (!operation.Type.HasValueCopySemantics())
+                {
+                    var result = AnalysisEntityFactory.TryCreateForSymbolDeclaration(operation.Parameter, out AnalysisEntity analysisEntity);
+                    Debug.Assert(result);
+                    if (!HasAbstractValue(analysisEntity))
+                    {
+                        var value = new PointsToAbstractValue(AbstractLocation.CreateAllocationLocation(operation, operation.Parameter.Type));
+                        SetAbstractValue(analysisEntity, value);
+                        return value;
+                    }
+
+                    return GetAbstractValue(analysisEntity);
+                }
+                else
+                {
+                    return PointsToAbstractValue.NoLocation;
+                }
+            }
+
+            public override PointsToAbstractValue VisitIsPattern(IIsPatternOperation operation, object argument)
+            {
+                // TODO: Handle patterns
+                return base.VisitIsPattern(operation, argument);
+            }
+
+            public override PointsToAbstractValue VisitDeclarationPattern(IDeclarationPatternOperation operation, object argument)
+            {
+                // TODO: Handle patterns
+                return base.VisitDeclarationPattern(operation, argument);
+            }
+
+            public override PointsToAbstractValue VisitInterpolatedString(IInterpolatedStringOperation operation, object argument)
+            {
+                var _ = base.VisitInterpolatedString(operation, argument);
+                return PointsToAbstractValue.NoLocation;
+            }
+
+            public override PointsToAbstractValue VisitBinaryOperator(IBinaryOperation operation, object argument)
+            {
+                var _ = base.VisitBinaryOperator(operation, argument);
+                return PointsToAbstractValue.Unknown;
+            }
+
+            public override PointsToAbstractValue VisitSizeOf(ISizeOfOperation operation, object argument)
+            {
+                var _ = base.VisitSizeOf(operation, argument);
+                return PointsToAbstractValue.NoLocation;
+            }
+
+            public override PointsToAbstractValue VisitTypeOf(ITypeOfOperation operation, object argument)
+            {
+                var _ = base.VisitTypeOf(operation, argument);
+                return PointsToAbstractValue.NoLocation;
+            }
+
+            public override PointsToAbstractValue VisitThrow(IThrowOperation operation, object argument)
+            {
+                var _ = base.VisitThrow(operation, argument);
+                return PointsToAbstractValue.NoLocation;
+            }
+
+            public override PointsToAbstractValue VisitTuple(ITupleOperation operation, object argument)
+            {
+                // TODO: Handle tuples.
+                return base.VisitTuple(operation, argument);
+            }
+
+            public override PointsToAbstractValue VisitReturn(IReturnOperation operation, object argument)
+            {
+                var _ = base.VisitReturn(operation, argument);
+                return PointsToAbstractValue.NoLocation;
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
     internal partial class PointsToAnalysis : ForwardDataFlowAnalysis<PointsToAnalysisData, PointsToBlockAnalysisResult, PointsToAbstractValue>
     {
         /// <summary>
-        /// Operation visitor to flow the points to values across a given statement in a basic block.
+        /// Operation visitor to flow the PointsTo values across a given statement in a basic block.
         /// </summary>
         private sealed class PointsToDataFlowOperationVisitor : DataFlowOperationVisitor<PointsToAnalysisData, PointsToAbstractValue>
         {
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             {
                 if (input != null)
                 {
-                    // Always set the points to value for the "this" or "Me" instance.
+                    // Always set the PointsTo value for the "this" or "Me" instance.
                     input[AnalysisEntityFactory.ThisOrMeInstance] = ThisOrMePointsToAbstractValue;
                 }
 
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             {
                 var _ = base.VisitObjectOrCollectionInitializer(operation, argument);
 
-                // We should have created and created a new points to value for the associated creation operation.
+                // We should have created a new PointsTo value for the associated creation operation.
                 return GetCachedAbstractValue(operation.Parent);
             }
 
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             {
                 var _ = base.VisitArrayInitializer(operation, argument);
 
-                // We should have created and created a new points to value for the associated array creation operation.
+                // We should have created a new PointsTo value for the associated array creation operation.
                 return GetCachedAbstractValue((IArrayCreationOperation)operation.Parent);
             }
 
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 
             public override PointsToAbstractValue VisitParameterReference(IParameterReferenceOperation operation, object argument)
             {
-                // Create a dummy points to value for each reference type parameter.
+                // Create a dummy PointsTo value for each reference type parameter.
                 if (!operation.Type.HasValueCopySemantics())
                 {
                     var result = AnalysisEntityFactory.TryCreateForSymbolDeclaration(operation.Parameter, out AnalysisEntity analysisEntity);
@@ -266,12 +266,14 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             public override PointsToAbstractValue VisitIsPattern(IIsPatternOperation operation, object argument)
             {
                 // TODO: Handle patterns
+                // https://github.com/dotnet/roslyn-analyzers/issues/1571
                 return base.VisitIsPattern(operation, argument);
             }
 
             public override PointsToAbstractValue VisitDeclarationPattern(IDeclarationPatternOperation operation, object argument)
             {
                 // TODO: Handle patterns
+                // https://github.com/dotnet/roslyn-analyzers/issues/1571
                 return base.VisitDeclarationPattern(operation, argument);
             }
 
@@ -308,13 +310,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             public override PointsToAbstractValue VisitTuple(ITupleOperation operation, object argument)
             {
                 // TODO: Handle tuples.
+                // https://github.com/dotnet/roslyn-analyzers/issues/1571
                 return base.VisitTuple(operation, argument);
-            }
-
-            public override PointsToAbstractValue VisitReturn(IReturnOperation operation, object argument)
-            {
-                var _ = base.VisitReturn(operation, argument);
-                return PointsToAbstractValue.NoLocation;
             }
 
             #endregion

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
+{
+    using PointsToAnalysisData = IDictionary<AnalysisEntity, PointsToAbstractValue>;
+    using PointsToAnalysisDomain = MapAbstractDomain<AnalysisEntity, PointsToAbstractValue>;
+
+    /// <summary>
+    /// Dataflow analysis to track locations pointed to by <see cref="AnalysisEntity"/> and <see cref="IOperation"/> instances.
+    /// </summary>
+    internal partial class PointsToAnalysis : ForwardDataFlowAnalysis<PointsToAnalysisData, PointsToBlockAnalysisResult, PointsToAbstractValue>
+    {
+        private PointsToAnalysis(PointsToAnalysisDomain analysisDomain, PointsToDataFlowOperationVisitor operationVisitor)
+            : base(analysisDomain, operationVisitor)
+        {
+        }
+
+        public static DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> GetOrComputeResult(
+            ControlFlowGraph cfg,
+            INamedTypeSymbol containingTypeSymbol,
+            DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
+        {
+            var analysisDomain = new PointsToAnalysisDomain(PointsToAbstractValueDomain.Default);
+            var operationVisitor = new PointsToDataFlowOperationVisitor(PointsToAbstractValueDomain.Default, containingTypeSymbol, nullAnalysisResultOpt);
+            var pointsToAnalysis = new PointsToAnalysis(analysisDomain, operationVisitor);
+            return pointsToAnalysis.GetOrComputeResultCore(cfg);
+        }
+
+        internal override PointsToBlockAnalysisResult ToResult(BasicBlock basicBlock, DataFlowAnalysisInfo<PointsToAnalysisData> blockAnalysisData) => new PointsToBlockAnalysisResult(basicBlock, blockAnalysisData);
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToBlockAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToBlockAnalysisResult.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
+{
+    using PointsToAnalysisData = IDictionary<AnalysisEntity, PointsToAbstractValue>;
+
+    /// <summary>
+    /// Result from execution of <see cref="PointsToAnalysis"/> on a basic block.
+    /// It store points to values for each <see cref="AnalysisEntity"/> at the start and end of the basic block.
+    /// </summary>
+    internal class PointsToBlockAnalysisResult : AbstractBlockAnalysisResult<PointsToAnalysisData, PointsToAbstractValue>
+    {
+        public PointsToBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<PointsToAnalysisData> blockAnalysisData)
+            : base (basicBlock)
+        {
+            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, PointsToAbstractValue>.Empty;
+            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, PointsToAbstractValue>.Empty;
+        }
+
+        public ImmutableDictionary<AnalysisEntity, PointsToAbstractValue> InputData { get; }
+        public ImmutableDictionary<AnalysisEntity, PointsToAbstractValue> OutputData { get; }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToBlockAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToBlockAnalysisResult.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 
     /// <summary>
     /// Result from execution of <see cref="PointsToAnalysis"/> on a basic block.
-    /// It store points to values for each <see cref="AnalysisEntity"/> at the start and end of the basic block.
+    /// It stores the PointsTo value for each <see cref="AnalysisEntity"/> at the start and end of the basic block.
     /// </summary>
     internal class PointsToBlockAnalysisResult : AbstractBlockAnalysisResult<PointsToAnalysisData, PointsToAbstractValue>
     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContainsNonLiteralState.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContainsNonLiteralState.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 {
     /// <summary>
-    /// String state for presence of non-literal values for symbol/operation tracked by <see cref="StringContentAnalysis"/>.
+    /// String state for presence of non-literal values for <see cref="AnalysisEntity"/>/<see cref="IOperation"/> tracked by <see cref="StringContentAnalysis"/>.
     /// </summary>
     internal enum StringContainsNonLiteralState
     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAbstractValue.cs
@@ -9,7 +9,7 @@ using Analyzer.Utilities;
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 {
     /// <summary>
-    /// Abstract string content data value for symbol/operation tracked by <see cref="StringContentAnalysis"/>.
+    /// Abstract string content data value for <see cref="AnalysisEntity"/>/<see cref="IOperation"/> tracked by <see cref="StringContentAnalysis"/>.
     /// </summary>
     internal partial class StringContentAbstractValue : IEquatable<StringContentAbstractValue>
     {
@@ -70,6 +70,21 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
         public override bool Equals(object obj)
         {
             return Equals(obj as StringContentAbstractValue);
+        }
+
+        public static bool operator ==(StringContentAbstractValue value1, StringContentAbstractValue value2)
+        {
+            if ((object)value1 == null)
+            {
+                return (object)value2 == null;
+            }
+
+            return value1.Equals(value2);
+        }
+
+        public static bool operator !=(StringContentAbstractValue value1, StringContentAbstractValue value2)
+        {
+            return !(value1 == value2);
         }
 
         public bool Equals(StringContentAbstractValue other)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentAbstractDomain.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 {
-    using StringContentAnalysisData = IDictionary<ISymbol, StringContentAbstractValue>;
+    using StringContentAnalysisData = IDictionary<AnalysisEntity, StringContentAbstractValue>;
 
     internal partial class StringContentAnalysis : ForwardDataFlowAnalysis<StringContentAnalysisData, StringContentBlockAnalysisResult, StringContentAbstractValue>
     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentBlockAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentBlockAnalysisResult.cs
@@ -6,23 +6,23 @@ using Microsoft.CodeAnalysis.Operations.ControlFlow;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 {
-    using StringContentAnalysisData = IDictionary<ISymbol, StringContentAbstractValue>;
+    using StringContentAnalysisData = IDictionary<AnalysisEntity, StringContentAbstractValue>;
 
     /// <summary>
     /// Result from execution of <see cref="StringContentAnalysis"/> on a basic block.
-    /// It stores string content values for symbols at the start and end of the basic block.
+    /// It stores string content values for each <see cref="AnalysisEntity"/> at the start and end of the basic block.
     /// </summary>
     internal class StringContentBlockAnalysisResult : AbstractBlockAnalysisResult<StringContentAnalysisData, StringContentAbstractValue>
     {
         public StringContentBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<StringContentAnalysisData> blockAnalysisData)
             : base(basicBlock)
         {
-            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<ISymbol, StringContentAbstractValue>.Empty;
-            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<ISymbol, StringContentAbstractValue>.Empty;
+            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, StringContentAbstractValue>.Empty;
+            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, StringContentAbstractValue>.Empty;
         }
 
-        public ImmutableDictionary<ISymbol, StringContentAbstractValue> InputData { get; }
+        public ImmutableDictionary<AnalysisEntity, StringContentAbstractValue> InputData { get; }
 
-        public ImmutableDictionary<ISymbol, StringContentAbstractValue> OutputData { get; }
+        public ImmutableDictionary<AnalysisEntity, StringContentAbstractValue> OutputData { get; }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    internal abstract partial class AbstractIndex
+    {
+        private sealed class ConstantValueIndex : AbstractIndex
+        {
+            public ConstantValueIndex(uint index)
+            {
+                Index = index;
+            }
+
+            public uint Index { get; }
+
+            public override bool Equals(AbstractIndex other)
+            {
+                return other is ConstantValueIndex otherIndex &&
+                    Index == otherIndex.Index;
+            }
+
+            public override int GetHashCode()
+            {
+                return HashUtilities.Combine(Index.GetHashCode(), nameof(ConstantValueIndex).GetHashCode());
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Analyzer.Utilities;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    internal abstract partial class AbstractIndex
+    {
+        private sealed class OperationBasedIndex : AbstractIndex
+        {
+            public OperationBasedIndex(IOperation operation)
+            {
+                Debug.Assert(operation != null);
+                Operation = operation;
+            }
+
+            public IOperation Operation { get; }
+
+            public override bool Equals(AbstractIndex other)
+            {
+                return other is OperationBasedIndex otherIndex &&
+                    Operation.Equals(otherIndex.Operation);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashUtilities.Combine(Operation.GetHashCode(), nameof(OperationBasedIndex).GetHashCode());
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    internal abstract partial class AbstractIndex
+    {
+        private sealed class AnalysisEntityBasedIndex : AbstractIndex
+        {
+            public AnalysisEntityBasedIndex(AnalysisEntity analysisEntity)
+            {
+                AnalysisEntity = analysisEntity;
+            }
+
+            public AnalysisEntity AnalysisEntity { get; }
+
+            public override bool Equals(AbstractIndex other)
+            {
+                return other is AnalysisEntityBasedIndex otherIndex &&
+                    AnalysisEntity.Equals(otherIndex.AnalysisEntity);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashUtilities.Combine(AnalysisEntity.GetHashCode(), nameof(AnalysisEntityBasedIndex).GetHashCode());
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    /// <summary>
+    /// Represents an abstract index into a location.
+    /// It is used by an <see cref="AnalysisEntity"/> for operations such as an <see cref="IArrayElementReferenceOperation"/>, index access <see cref="IPropertyReferenceOperation"/>, etc.
+    /// </summary>
+    internal abstract partial class AbstractIndex : IEquatable<AbstractIndex>
+    {
+        public static AbstractIndex Create(uint index) => new ConstantValueIndex(index);
+        public static AbstractIndex Create(AnalysisEntity analysisEntity) => new AnalysisEntityBasedIndex(analysisEntity);
+        public static AbstractIndex Create(IOperation operation) => new OperationBasedIndex(operation);
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AbstractIndex);
+        }
+
+        public static bool operator ==(AbstractIndex value1, AbstractIndex value2)
+        {
+            if ((object)value1 == null)
+            {
+                return (object)value2 == null;
+            }
+
+            return value1.Equals(value2);
+        }
+
+        public static bool operator !=(AbstractIndex value1, AbstractIndex value2)
+        {
+            return !(value1 == value2);
+        }
+
+        public abstract bool Equals(AbstractIndex other);
+
+        public override abstract int GetHashCode();
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    /// <summary>
+    /// <para>
+    /// Represents an abstract analysis location.
+    /// This is may be used to represent a location where an <see cref="AnalysisEntity"/> resides, i.e. <see cref="AnalysisEntity.InstanceLocation"/> or
+    /// a location that is pointed to by a reference type variable, and tracked with <see cref="PointsToAnalysis.PointsToAnalysis"/>.
+    /// </para>
+    /// <para>
+    /// An analysis location can be created for one of the following cases:
+    ///     1. An allocation or an object creation operation (<see cref="CreateAllocationLocation(IOperation, ITypeSymbol)"/>).
+    ///     2. Location for the implicit 'this' or 'Me' instance being analyzed (<see cref="CreateThisOrMeLocation(INamedTypeSymbol)"/>).
+    ///     3. Location created for certain symbols which do not have a declaration in executable code, i.e. no <see cref="IOperation"/> for declaration (such as parameter symbols, member symbols, etc. - <see cref="CreateSymbolLocation(ISymbol)"/>).
+    /// </para>
+    /// </summary>
+    internal sealed class AbstractLocation : IEquatable<AbstractLocation>
+    {
+        private AbstractLocation(IOperation creationOpt, ISymbol symbolOpt, ITypeSymbol locationType)
+        {
+            Debug.Assert(creationOpt != null ^ symbolOpt != null);
+            Debug.Assert(locationType != null);
+
+            CreationOpt = creationOpt;
+            SymbolOpt = symbolOpt;
+            LocationType = locationType;
+        }
+
+        public static AbstractLocation CreateAllocationLocation(IOperation creation, ITypeSymbol locationType) => new AbstractLocation(creation, symbolOpt: null, locationType: locationType);
+        public static AbstractLocation CreateThisOrMeLocation(INamedTypeSymbol namedTypeSymbol) => new AbstractLocation(creationOpt: null, symbolOpt: namedTypeSymbol, locationType: namedTypeSymbol);
+        public static AbstractLocation CreateSymbolLocation(ISymbol symbol) => new AbstractLocation(creationOpt: null, symbolOpt: symbol, locationType: symbol.GetMemerOrLocalOrParameterType());
+
+        public IOperation CreationOpt { get; }
+        public ISymbol SymbolOpt { get; }
+        public ITypeSymbol LocationType { get; }
+        
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AbstractLocation);
+        }
+
+        public static bool operator ==(AbstractLocation value1, AbstractLocation value2)
+        {
+            if ((object)value1 == null)
+            {
+                return (object)value2 == null;
+            }
+
+            return value1.Equals(value2);
+        }
+
+        public static bool operator !=(AbstractLocation value1, AbstractLocation value2)
+        {
+            return !(value1 == value2);
+        }
+
+        public bool Equals(AbstractLocation other)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return other != null &&
+                CreationOpt == other.CreationOpt &&
+                SymbolOpt == other.SymbolOpt &&
+                LocationType == other.LocationType;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashUtilities.Combine(CreationOpt?.GetHashCode() ?? 0,
+                HashUtilities.Combine(SymbolOpt?.GetHashCode() ?? 0, LocationType.GetHashCode()));
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -1,0 +1,197 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    /// <summary>
+    /// <para>
+    /// Primary entity for which analysis data is tracked by <see cref="DataFlowAnalysis"/>.
+    /// </para>
+    /// <para>
+    /// The entity is based on one or more of the following:
+    ///     1. An <see cref="ISymbol"/>.
+    ///     2. One or more <see cref="AbstractIndex"/> indices to index into the parent key.
+    ///     3. "this" or "Me" instance.
+    ///     4. An allocation or an object creation.
+    /// </para>
+    /// <para>
+    /// Each entity has:
+    ///     1. An associated non-null <see cref="Type"/> and
+    ///     2. A non-null <see cref="InstanceLocation"/> indicating the abstract location at which the entity is located and
+    ///     3. An optional parent key if this key has the same <see cref="InstanceLocation"/> as the parent (i.e. parent is a value type).
+    /// </para>
+    /// </summary>
+    internal sealed class AnalysisEntity : IEquatable<AnalysisEntity>
+    {
+        private AnalysisEntity(ISymbol symbolOpt, ImmutableArray<AbstractIndex> indices, PointsToAbstractValue location, ITypeSymbol type, AnalysisEntity parentOpt)
+        {
+            Debug.Assert(!indices.IsDefault);
+            Debug.Assert(symbolOpt != null || !indices.IsEmpty);
+            Debug.Assert(location != null);
+            Debug.Assert(type != null);
+            Debug.Assert(parentOpt == null || parentOpt.Type.HasValueCopySemantics());
+
+            SymbolOpt = symbolOpt;
+            Indices = indices;
+            InstanceLocation = location;
+            Type = type;
+            ParentOpt = parentOpt;
+        }
+
+        private AnalysisEntity(IInstanceReferenceOperation instanceReferenceOperation, PointsToAbstractValue location)
+        {
+            Debug.Assert(instanceReferenceOperation != null);
+            Debug.Assert(location != null);
+
+            InstanceReferenceOperationSyntaxOpt = instanceReferenceOperation.Syntax;
+            InstanceLocation = location;
+            Type = instanceReferenceOperation.Type;
+            Indices = ImmutableArray<AbstractIndex>.Empty;
+        }
+
+        private AnalysisEntity(INamedTypeSymbol typeSymbol, PointsToAbstractValue location)
+        {
+            Debug.Assert(typeSymbol != null);
+            Debug.Assert(location != null);
+
+            SymbolOpt = typeSymbol;
+            InstanceLocation = location;
+            Type = typeSymbol;
+            Indices = ImmutableArray<AbstractIndex>.Empty;
+        }
+
+        public static AnalysisEntity Create(ISymbol symbolOpt, ImmutableArray<AbstractIndex> indices,
+            ITypeSymbol type, PointsToAbstractValue instanceLocation, AnalysisEntity parentOpt)
+        {
+            Debug.Assert(symbolOpt != null || !indices.IsEmpty);
+            Debug.Assert(instanceLocation != null);
+            Debug.Assert(type != null);
+            Debug.Assert(parentOpt == null || parentOpt.InstanceLocation == instanceLocation);
+
+            return new AnalysisEntity(symbolOpt, indices, instanceLocation, type, parentOpt);
+        }
+
+        public static AnalysisEntity Create(IInstanceReferenceOperation instanceReferenceOperation, PointsToAbstractValue instanceLocation)
+        {
+            Debug.Assert(instanceReferenceOperation != null);
+            Debug.Assert(instanceLocation != null);
+
+            return new AnalysisEntity(instanceReferenceOperation, instanceLocation);
+        }
+
+        public static AnalysisEntity CreateThisOrMeInstance(INamedTypeSymbol typeSymbol, PointsToAbstractValue instanceLocation)
+        {
+            Debug.Assert(typeSymbol != null);
+            Debug.Assert(instanceLocation != null);
+            Debug.Assert(instanceLocation.Locations.Count == 1);
+            Debug.Assert(instanceLocation.Locations.Single().CreationOpt == null);
+            Debug.Assert(instanceLocation.Locations.Single().SymbolOpt == typeSymbol);
+
+            return new AnalysisEntity(typeSymbol, instanceLocation);
+        }
+
+        public bool IsChildOrInstanceMember
+        {
+            get
+            {
+                bool result;
+                if (SymbolOpt != null)
+                {
+                    result = SymbolOpt.Kind != SymbolKind.Parameter &&
+                        SymbolOpt.Kind != SymbolKind.Local &&
+                        !SymbolOpt.IsStatic;
+                }
+                else if (Indices.Length > 0)
+                {
+                    result = true;
+                }
+                else
+                {
+                    result = false;
+                }
+
+                Debug.Assert(ParentOpt == null || result);
+                return result;
+            }
+        }
+
+        public ISymbol SymbolOpt { get; }
+        public ImmutableArray<AbstractIndex> Indices { get; }
+        public SyntaxNode InstanceReferenceOperationSyntaxOpt { get; }
+        public PointsToAbstractValue InstanceLocation { get; }
+        public ITypeSymbol Type { get; }
+        public AnalysisEntity ParentOpt { get; }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AnalysisEntity);
+        }
+
+        public static bool operator ==(AnalysisEntity value1, AnalysisEntity value2)
+        {
+            if ((object)value1 == null)
+            {
+                return (object)value2 == null;
+            }
+
+            return value1.Equals(value2);
+        }
+
+        public static bool operator !=(AnalysisEntity value1, AnalysisEntity value2)
+        {
+            return !(value1 == value2);
+        }
+
+        public bool Equals(AnalysisEntity other)
+        {
+            return other != null &&
+                SymbolOpt == other.SymbolOpt &&
+                InstanceReferenceOperationSyntaxOpt == other.InstanceReferenceOperationSyntaxOpt &&
+                Indices.SequenceEqual(other.Indices) &&
+                InstanceLocation == other.InstanceLocation &&
+                Type.Equals(other.Type) &&
+                ParentOpt == other.ParentOpt;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = HashUtilities.Combine(SymbolOpt?.GetHashCode() ?? 0,
+                HashUtilities.Combine(InstanceReferenceOperationSyntaxOpt?.GetHashCode() ?? 0,
+                HashUtilities.Combine(InstanceLocation.GetHashCode(),
+                HashUtilities.Combine(Type.GetHashCode(),
+                HashUtilities.Combine(ParentOpt?.GetHashCode() ?? 0, Indices.Length.GetHashCode())))));
+
+            foreach (AbstractIndex index in Indices)
+            {
+                hashCode = HashUtilities.Combine(index.GetHashCode(), hashCode);
+            }
+
+            return hashCode;
+        }
+
+        public bool HasAncestorOrSelf(AnalysisEntity ancestor)
+        {
+            Debug.Assert(ancestor != null);
+
+            AnalysisEntity current = this;
+            do
+            {
+                if (current == ancestor)
+                {
+                    return true;
+                }
+
+                current = current.ParentOpt;
+            } while (current != null);
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -1,0 +1,332 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    /// <summary>
+    /// Factory to create <see cref="AnalysisEntity"/> objects for operations, symbol declarations, etc.
+    /// This factory also tracks analysis entities that share the same instance location (e.g. value type members).
+    /// </summary>
+    internal sealed class AnalysisEntityFactory
+    {
+        private readonly ImmutableDictionary<PointsToAbstractValue, ImmutableHashSet<AnalysisEntity>.Builder>.Builder _analysisEntitiesPerInstance;
+        private readonly Dictionary<IOperation, AnalysisEntity> _analysisEntityMap;
+        private readonly Dictionary<ISymbol, PointsToAbstractValue> _instanceLocationsForSymbols;
+        private readonly Func<IOperation, PointsToAbstractValue> _getPointsToAbstractValueOpt;
+        
+        public AnalysisEntityFactory(
+            Func<IOperation, PointsToAbstractValue> getPointsToAbstractValueOpt, INamedTypeSymbol containingTypeSymbol)
+        {
+            _getPointsToAbstractValueOpt = getPointsToAbstractValueOpt;
+            _analysisEntitiesPerInstance = ImmutableDictionary.CreateBuilder<PointsToAbstractValue, ImmutableHashSet<AnalysisEntity>.Builder>();
+            _analysisEntityMap = new Dictionary<IOperation, AnalysisEntity>();
+            _instanceLocationsForSymbols = new Dictionary<ISymbol, PointsToAbstractValue>();
+
+            var thisOrMeInstanceLocation = AbstractLocation.CreateThisOrMeLocation(containingTypeSymbol);
+            var instanceLocation = new PointsToAbstractValue(thisOrMeInstanceLocation);
+            ThisOrMeInstance = AnalysisEntity.CreateThisOrMeInstance(containingTypeSymbol, instanceLocation);
+            AddToMap(instanceLocation, ThisOrMeInstance);
+        }
+
+        public AnalysisEntity ThisOrMeInstance { get; }
+
+        private ImmutableArray<AbstractIndex> CreateAbstractIndices<T>(ImmutableArray<T> indices)
+            where T : IOperation
+        {
+            if (indices.Length > 0)
+            {
+                var builder = ImmutableArray.CreateBuilder<AbstractIndex>();
+                foreach (var index in indices)
+                {
+                    builder.Add(CreateAbstractIndex(index));
+                }
+
+                return builder.ToImmutable();
+            }
+
+            return ImmutableArray<AbstractIndex>.Empty;
+        }
+
+        private AbstractIndex CreateAbstractIndex(IOperation operation)
+        {
+            if (operation.ConstantValue.HasValue && operation.ConstantValue.Value is int index)
+            {
+                return AbstractIndex.Create((uint)index);
+            }
+            else if (TryCreate(operation, out AnalysisEntity analysisEntity))
+            {
+                return AbstractIndex.Create(analysisEntity);
+            }
+            else
+            {
+                return AbstractIndex.Create(operation);
+            }
+        }
+
+        public bool TryCreate(IOperation operation, out AnalysisEntity analysisEntity)
+        {
+            if (_analysisEntityMap.TryGetValue(operation, out analysisEntity))
+            {
+                return analysisEntity != null;
+            }
+
+            analysisEntity = null;
+            ISymbol symbolOpt = null;
+            ImmutableArray<AbstractIndex> indices = ImmutableArray<AbstractIndex>.Empty;
+            IOperation instanceOpt = null;
+            switch (operation)
+            {
+                case ILocalReferenceOperation localReference:
+                    symbolOpt = localReference.Local;
+                    break;
+
+                case IParameterReferenceOperation parameterReference:
+                    symbolOpt = parameterReference.Parameter;
+                    break;
+
+                case IMemberReferenceOperation memberReference:
+                    instanceOpt = memberReference.Instance;
+                    GetSymbolAndIndicesForMemberReference(memberReference, ref symbolOpt, ref indices);
+                    
+                    // Workaround for https://github.com/dotnet/roslyn/issues/22736 (IPropertyReferenceExpressions in IAnonymousObjectCreationExpression are missing a receiver).
+                    if (instanceOpt == null &&
+                        symbolOpt != null &&
+                        memberReference is IPropertyReferenceOperation propertyReference)
+                    {
+                        instanceOpt = propertyReference.GetAnonymousObjectCreation();
+                    }
+
+                    break;
+
+                case IArrayElementReferenceOperation arrayElementReference:
+                    instanceOpt = arrayElementReference.ArrayReference;
+                    indices = CreateAbstractIndices(arrayElementReference.Indices);
+                    break;
+
+                case IDynamicIndexerAccessOperation dynamicIndexerAccess:
+                    instanceOpt = dynamicIndexerAccess.Operation;
+                    indices = CreateAbstractIndices(dynamicIndexerAccess.Arguments);
+                    break;
+
+                case IConditionalAccessInstanceOperation conditionalAccessInstance:
+                    IConditionalAccessOperation conditionalAccess = conditionalAccessInstance.GetConditionalAccess();
+                    instanceOpt = conditionalAccess.Operation;
+                    if (conditionalAccessInstance.Parent is IMemberReferenceOperation memberReferenceParent)
+                    {
+                        GetSymbolAndIndicesForMemberReference(memberReferenceParent, ref symbolOpt, ref indices);
+                    }
+                    break;
+
+                case IInstanceReferenceOperation instanceReference:
+                    instanceOpt = instanceReference.GetInstance();
+                    if (instanceOpt == null)
+                    {
+                        // Reference to this or base instance.
+                        analysisEntity = ThisOrMeInstance;
+                    }
+                    else
+                    {
+                        var instanceLocation = _getPointsToAbstractValueOpt(instanceReference);
+                        analysisEntity = AnalysisEntity.Create(instanceReference, instanceLocation);
+                        AddToMap(instanceLocation, analysisEntity);
+                    }
+                    break;
+
+                case IInvocationOperation invocation:
+                    symbolOpt = invocation.TargetMethod;
+                    instanceOpt = invocation.Instance;
+                    break;
+
+                case IConversionOperation conversion:
+                    return TryCreate(conversion.Operand, out analysisEntity);
+
+                case IParenthesizedOperation parenthesized:
+                    return TryCreate(parenthesized.Operand, out analysisEntity);
+
+                default:
+                    break;
+            }
+
+            if (symbolOpt != null || !indices.IsEmpty)
+            {
+                TryCreate(symbolOpt, indices, operation.Type, instanceOpt, out analysisEntity);
+            }
+
+            _analysisEntityMap[operation] = analysisEntity;
+            return analysisEntity != null;
+        }
+
+        private void GetSymbolAndIndicesForMemberReference(IMemberReferenceOperation memberReference, ref ISymbol symbolOpt, ref ImmutableArray<AbstractIndex> indices)
+        {
+            switch (memberReference)
+            {
+                case IFieldReferenceOperation fieldReference:
+                    symbolOpt = fieldReference.Member;
+                    break;
+
+                case IEventReferenceOperation eventReference:
+                    symbolOpt = eventReference.Member;
+                    break;
+
+                case IPropertyReferenceOperation propertyReference:
+                    // We are only tracking:
+                    // 1) Indexers
+                    // 2) Read-only properties.
+                    // 3) Properties with a backing field (auto-generated properties)
+                    if (propertyReference.Arguments.Length > 0 ||
+                        propertyReference.Property.IsReadOnly ||
+                        propertyReference.Property.IsPropertyWithBackingField())
+                    {
+                        symbolOpt = propertyReference.Property;
+                        indices = propertyReference.Arguments.Length > 0 ?
+                            CreateAbstractIndices(propertyReference.Arguments.Select(a => a.Value).ToImmutableArray()) :
+                            ImmutableArray<AbstractIndex>.Empty;
+                    }
+                    break;
+            }
+        }
+
+        public bool TryCreateForSymbolDeclaration(ISymbol symbol, out AnalysisEntity analysisEntity)
+        {
+            Debug.Assert(symbol != null);
+            Debug.Assert(symbol.Kind == SymbolKind.Local || symbol.Kind == SymbolKind.Parameter || symbol.Kind == SymbolKind.Field || symbol.Kind == SymbolKind.Property);
+
+            var indices = ImmutableArray<AbstractIndex>.Empty;
+            IOperation instance = null;
+            var type = symbol.GetMemerOrLocalOrParameterType();
+            Debug.Assert(type != null);
+
+            return TryCreate(symbol, indices, type, instance, out analysisEntity);
+        }
+
+        public bool TryCreateForElementInitializer(IOperation instance, ImmutableArray<AbstractIndex> indices, ITypeSymbol elementType, out AnalysisEntity analysisEntity)
+        {
+            Debug.Assert(instance != null);
+            Debug.Assert(!indices.IsEmpty);
+            Debug.Assert(elementType != null);
+
+            ISymbol symbol = null;
+            return TryCreate(symbol, indices, elementType, instance, out analysisEntity);
+        }
+
+        private bool TryCreate(ISymbol symbolOpt, ImmutableArray<AbstractIndex> indices,
+            ITypeSymbol type, IOperation instanceOpt, out AnalysisEntity symbolWithLocationinfo)
+        {
+            Debug.Assert(symbolOpt != null || !indices.IsEmpty);
+            Debug.Assert(type != null);
+
+            symbolWithLocationinfo = null;
+
+            // Only analyze member symbols if we have points to analysis result.
+            if (_getPointsToAbstractValueOpt == null &&
+                symbolOpt?.Kind != SymbolKind.Local &&
+                symbolOpt?.Kind != SymbolKind.Parameter)
+            {
+                return false;
+            }
+
+            PointsToAbstractValue instanceLocationOpt = null;
+            AnalysisEntity parentOpt = null;
+            if (instanceOpt?.Type != null)
+            {
+                if (instanceOpt.Type.HasValueCopySemantics())
+                {
+                    if (TryCreate(instanceOpt, out parentOpt))
+                    {
+                        instanceLocationOpt = parentOpt.InstanceLocation;
+                    }
+                    else
+                    {
+                        // For value type allocations, we store the points to location.
+                        var instancePointsToValue = _getPointsToAbstractValueOpt(instanceOpt);
+                        if (instancePointsToValue.Kind != PointsToAbstractValueKind.NoLocation)
+                        {
+                            instanceLocationOpt = instancePointsToValue;
+                        }
+                    }
+                }
+                else
+                {
+                    instanceLocationOpt = _getPointsToAbstractValueOpt(instanceOpt);
+                }
+            }
+
+            symbolWithLocationinfo = Create(symbolOpt, indices, type, instanceLocationOpt, parentOpt);
+            return true;
+        }
+
+        private PointsToAbstractValue EnsureLocation(PointsToAbstractValue instanceLocationOpt, ISymbol symbolOpt, AnalysisEntity parentOpt, ITypeSymbol type)
+        {
+            if (instanceLocationOpt == null && symbolOpt != null)
+            {
+                Debug.Assert(symbolOpt.Kind == SymbolKind.Local || symbolOpt.Kind == SymbolKind.Parameter || symbolOpt.IsStatic);
+
+                if (!_instanceLocationsForSymbols.TryGetValue(symbolOpt, out instanceLocationOpt))
+                {
+                    if (parentOpt != null)
+                    {
+                        instanceLocationOpt = parentOpt.InstanceLocation;
+                    }
+                    else
+                    {
+                        var location = AbstractLocation.CreateSymbolLocation(symbolOpt);
+                        instanceLocationOpt = new PointsToAbstractValue(location);
+                    }
+
+                    _instanceLocationsForSymbols.Add(symbolOpt, instanceLocationOpt);
+                }
+            }
+
+            return instanceLocationOpt;
+        }
+
+        private AnalysisEntity Create(ISymbol symbolOpt, ImmutableArray<AbstractIndex> indices, ITypeSymbol type, PointsToAbstractValue instanceLocationOpt, AnalysisEntity parentOpt)
+        {
+            instanceLocationOpt = EnsureLocation(instanceLocationOpt, symbolOpt, parentOpt, type);
+            Debug.Assert(instanceLocationOpt != null);
+            var analysisEntity = AnalysisEntity.Create(symbolOpt, indices, type, instanceLocationOpt, parentOpt);
+            AddToMap(instanceLocationOpt, analysisEntity);
+            return analysisEntity;
+        }
+
+        private void AddToMap(PointsToAbstractValue instanceLocation, AnalysisEntity analysisEntity)
+        {
+            Debug.Assert(instanceLocation != null);
+            if (!_analysisEntitiesPerInstance.TryGetValue(instanceLocation, out var builder))
+            {
+                builder = ImmutableHashSet.CreateBuilder<AnalysisEntity>();
+            }
+
+            builder.Add(analysisEntity);
+            _analysisEntitiesPerInstance[instanceLocation] = builder;
+        }
+
+        public AnalysisEntity CreateWithNewInstanceRoot(AnalysisEntity analysisEntity, AnalysisEntity newRootInstance)
+        {
+            if (analysisEntity.InstanceLocation == newRootInstance.InstanceLocation)
+            {
+                return analysisEntity;
+            }
+
+            if (analysisEntity.ParentOpt == null)
+            {
+                return newRootInstance;
+            }
+
+            AnalysisEntity parentOpt = CreateWithNewInstanceRoot(analysisEntity.ParentOpt, newRootInstance);
+            return Create(analysisEntity.SymbolOpt, analysisEntity.Indices, analysisEntity.Type, newRootInstance.InstanceLocation, parentOpt);
+        }
+
+        public ImmutableHashSet<AnalysisEntity> GetAnalysisEntitiesCreatedFromInstance(PointsToAbstractValue instance)
+            => _analysisEntitiesPerInstance.TryGetValue(instance, out ImmutableHashSet<AnalysisEntity>.Builder builder) && builder != null ?
+                builder.ToImmutable() :
+                ImmutableHashSet<AnalysisEntity>.Empty;
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             return true;
         }
 
-        private PointsToAbstractValue EnsureLocation(PointsToAbstractValue instanceLocationOpt, ISymbol symbolOpt, AnalysisEntity parentOpt, ITypeSymbol type)
+        private PointsToAbstractValue EnsureLocation(PointsToAbstractValue instanceLocationOpt, ISymbol symbolOpt, AnalysisEntity parentOpt)
         {
             if (instanceLocationOpt == null && symbolOpt != null)
             {
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
 
         private AnalysisEntity Create(ISymbol symbolOpt, ImmutableArray<AbstractIndex> indices, ITypeSymbol type, PointsToAbstractValue instanceLocationOpt, AnalysisEntity parentOpt)
         {
-            instanceLocationOpt = EnsureLocation(instanceLocationOpt, symbolOpt, parentOpt, type);
+            instanceLocationOpt = EnsureLocation(instanceLocationOpt, symbolOpt, parentOpt);
             Debug.Assert(instanceLocationOpt != null);
             var analysisEntity = AnalysisEntity.Create(symbolOpt, indices, type, instanceLocationOpt, parentOpt);
             AddToMap(instanceLocationOpt, analysisEntity);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -217,12 +217,12 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         }
 
         private bool TryCreate(ISymbol symbolOpt, ImmutableArray<AbstractIndex> indices,
-            ITypeSymbol type, IOperation instanceOpt, out AnalysisEntity symbolWithLocationinfo)
+            ITypeSymbol type, IOperation instanceOpt, out AnalysisEntity analysisEntity)
         {
             Debug.Assert(symbolOpt != null || !indices.IsEmpty);
             Debug.Assert(type != null);
 
-            symbolWithLocationinfo = null;
+            analysisEntity = null;
 
             // Only analyze member symbols if we have points to analysis result.
             if (_getPointsToAbstractValueOpt == null &&
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 }
             }
 
-            symbolWithLocationinfo = Create(symbolOpt, indices, type, instanceLocationOpt, parentOpt);
+            analysisEntity = Create(symbolOpt, indices, type, instanceLocationOpt, parentOpt);
             return true;
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
 {
     /// <summary>
     /// Subtype for all dataflow analyses on a control flow graph.
-    /// It performs a worklist based approach to flow abstract data values for symbols/operations across the basic blocks until a fix point is reached.
+    /// It performs a worklist based approach to flow abstract data values for <see cref="AnalysisEntity"/>/<see cref="IOperation"/> across the basic blocks until a fix point is reached.
     /// </summary>
     internal abstract class DataFlowAnalysis<TAnalysisData, TAnalysisResult, TAbstractAnalysisValue>
         where TAnalysisData : class

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -5,8 +5,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis.Operations.ControlFlow;
 using Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow
 {
@@ -16,31 +18,84 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     internal abstract class DataFlowOperationVisitor<TAnalysisData, TAbstractAnalysisValue> : OperationVisitor<object, TAbstractAnalysisValue>
     {
         private readonly DataFlowAnalysisResult<NullBlockAnalysisResult, NullAbstractValue> _nullAnalysisResultOpt;
+        private readonly DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> _pointsToAnalysisResultOpt;
         private readonly ImmutableDictionary<IOperation, TAbstractAnalysisValue>.Builder _valueCacheBuilder;
+        private readonly List<IArgumentOperation> _pendingArgumentsToReset;
 
         private int _recursionDepth;
 
-        protected AbstractDomain<TAbstractAnalysisValue> ValueDomain { get; }
         protected abstract TAbstractAnalysisValue UnknownOrMayBeValue { get; }
-
-        protected abstract void SetAbstractValue(ISymbol symbol, TAbstractAnalysisValue value);
-        protected abstract TAbstractAnalysisValue GetAbstractValue(ISymbol symbol);
+        protected abstract void SetAbstractValue(AnalysisEntity analysisEntity, TAbstractAnalysisValue value);
+        protected abstract TAbstractAnalysisValue GetAbstractValue(AnalysisEntity analysisEntity);
+        protected abstract bool HasAbstractValue(AnalysisEntity analysisEntity);
         protected abstract TAbstractAnalysisValue GetAbstractDefaultValue(ITypeSymbol type);
         protected abstract void ResetCurrentAnalysisData(TAnalysisData newAnalysisDataOpt = default(TAnalysisData));
+        protected virtual bool HasPointsToAnalysisResult => _pointsToAnalysisResultOpt != null;
+
+        protected AbstractDomain<TAbstractAnalysisValue> ValueDomain { get; }
         protected TAnalysisData CurrentAnalysisData { get; private set; }
         protected BasicBlock CurrentBasicBlock { get; private set; }
         protected IOperation CurrentStatement { get; private set; }
-
-        protected DataFlowOperationVisitor(AbstractDomain<TAbstractAnalysisValue> valueDomain, DataFlowAnalysisResult<NullBlockAnalysisResult, NullAbstractValue> nullAnalysisResultOpt)
+        protected PointsToAbstractValue ThisOrMePointsToAbstractValue { get; }
+        protected AnalysisEntityFactory AnalysisEntityFactory { get; }
+        
+        protected DataFlowOperationVisitor(
+            AbstractDomain<TAbstractAnalysisValue> valueDomain,
+            INamedTypeSymbol containingTypeSymbol,
+            DataFlowAnalysisResult<NullBlockAnalysisResult, NullAbstractValue> nullAnalysisResultOpt,
+            DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResultOpt)
         {
             ValueDomain = valueDomain;
             _nullAnalysisResultOpt = nullAnalysisResultOpt;
+            _pointsToAnalysisResultOpt = pointsToAnalysisResultOpt;
             _valueCacheBuilder = ImmutableDictionary.CreateBuilder<IOperation, TAbstractAnalysisValue>();
+            _pendingArgumentsToReset = new List<IArgumentOperation>();
+            ThisOrMePointsToAbstractValue = GetThisOrMeInstancePointsToValue(containingTypeSymbol);
+            AnalysisEntityFactory = new AnalysisEntityFactory(
+                HasPointsToAnalysisResult ? GetPointsToAbstractValue : (Func<IOperation, PointsToAbstractValue>)null,
+                containingTypeSymbol);
         }
+
+        private static PointsToAbstractValue GetThisOrMeInstancePointsToValue(INamedTypeSymbol containingTypeSymbol)
+        {
+            if (!containingTypeSymbol.HasValueCopySemantics())
+            {
+                var thisOrMeLocation = AbstractLocation.CreateThisOrMeLocation(containingTypeSymbol);
+                return new PointsToAbstractValue(thisOrMeLocation);
+            }
+            else
+            {
+                return PointsToAbstractValue.NoLocation;
+            }
+        }
+
+        /// <summary>
+        /// Primary method that flows analysis data through the given statement.
+        /// </summary>
+        public virtual TAnalysisData Flow(IOperation statement, BasicBlock block, TAnalysisData input)
+        {
+            CurrentStatement = statement;
+            CurrentBasicBlock = block;
+            CurrentAnalysisData = input;
+            Visit(statement, null);
+
+#if DEBUG
+            // Ensure that we visited and cached values for all operation descendants.
+            foreach (var operation in statement.DescendantsAndSelf())
+            {
+                // GetState will throw an InvalidOperationException if the visitor did not visit the operation or cache it's abstract value.
+                var _ = GetCachedAbstractValue(operation);
+            }
+#endif
+
+            return CurrentAnalysisData;
+        }
+
+        #region Helper methods to get or cache analysis data for visited operations.
 
         public ImmutableDictionary<IOperation, TAbstractAnalysisValue> GetStateMap() => _valueCacheBuilder.ToImmutable();
 
-        public TAbstractAnalysisValue GetState(IOperation operation)
+        public TAbstractAnalysisValue GetCachedAbstractValue(IOperation operation)
         {
             if (operation == null)
             {
@@ -56,7 +111,17 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             return state;
         }
 
-        protected NullAbstractValue GetNullState(IOperation operation)
+        protected void CacheAbstractValue(IOperation operation, TAbstractAnalysisValue value)
+        {
+            if (operation == null)
+            {
+                throw new ArgumentNullException(nameof(operation));
+            }
+
+            _valueCacheBuilder[operation] = value;
+        }
+
+        protected virtual NullAbstractValue GetNullAbstractValue(IOperation operation)
         {
             if (_nullAnalysisResultOpt == null)
             {
@@ -68,24 +133,267 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             }
         }
 
-        public TAnalysisData Flow(IOperation statement, BasicBlock block, TAnalysisData input)
+        protected virtual PointsToAbstractValue GetPointsToAbstractValue(IOperation operation)
         {
-            CurrentStatement = statement;
-            CurrentBasicBlock = block;
-            CurrentAnalysisData = input;
-            Visit(statement, null);
-
-#if DEBUG
-            // Ensure that we visited and cached values for all operation descendants.
-            foreach (var operation in statement.DescendantsAndSelf())
+            if (_pointsToAnalysisResultOpt == null)
             {
-                // GetState will throw an InvalidOperationException if the visitor did not visit the operation or cache it's abstract value.
-                var _ = GetState(operation);
+                return PointsToAbstractValue.Unknown;
             }
-#endif
-
-            return CurrentAnalysisData;
+            else
+            {
+                return _pointsToAnalysisResultOpt[operation];
+            }
         }
+
+        #endregion region
+
+        protected virtual TAbstractAnalysisValue ComputeAnalysisValueForReferenceOperation(IOperation operation, TAbstractAnalysisValue defaultValue)
+        {
+            if (AnalysisEntityFactory.TryCreate(operation, out AnalysisEntity analysisEntity))
+            {
+                if (!HasAbstractValue(analysisEntity))
+                {
+                    SetAbstractValue(analysisEntity, defaultValue);
+                }
+
+                return GetAbstractValue(analysisEntity);
+            }
+            else
+            {
+                return defaultValue;
+            }
+        }
+
+        /// <summary>
+        /// Helper method to reset analysis data for analysis entities.
+        /// If <paramref name="newAnalysisDataOpt"/> is null, all the analysis values in <paramref name="currentAnalysisDataOpt"/> are set to <see cref="UnknownOrMayBeValue"/>.
+        /// Otherwise, all the key-value paris in <paramref name="newAnalysisDataOpt"/> are transfered to <paramref name="currentAnalysisDataOpt"/> and keys in <paramref name="currentAnalysisDataOpt"/> which
+        /// are not present in <paramref name="newAnalysisDataOpt"/> are set to <see cref="UnknownOrMayBeValue"/>.
+        /// </summary>
+        /// <param name="currentAnalysisDataOpt"></param>
+        /// <param name="newAnalysisDataOpt"></param>
+        protected void ResetAnalysisData(IDictionary<AnalysisEntity, TAbstractAnalysisValue> currentAnalysisDataOpt, IDictionary<AnalysisEntity, TAbstractAnalysisValue> newAnalysisDataOpt)
+        {
+            // Reset the current analysis data, while ensuring that we don't violate the monotonicity, i.e. we cannot remove any existing key from currentAnalysisData.
+            if (newAnalysisDataOpt == null)
+            {
+                // Just set the values for existing keys to UnknownOrMayBeValue.
+                foreach (var key in currentAnalysisDataOpt?.Keys.ToArray())
+                {
+                    SetAbstractValue(key, UnknownOrMayBeValue);
+                }
+            }
+            else
+            {
+                // Merge the values from current and new analysis data.
+                var keys = currentAnalysisDataOpt?.Keys.Concat(newAnalysisDataOpt.Keys).ToArray();
+                foreach (var key in keys)
+                {
+                    var value1 = currentAnalysisDataOpt != null && currentAnalysisDataOpt.TryGetValue(key, out var currentValue) ? currentValue : ValueDomain.Bottom;
+                    var value2 = newAnalysisDataOpt.TryGetValue(key, out var newValue) ? newValue : ValueDomain.Bottom;
+                    var mergedValue = ValueDomain.Merge(value1, value2);
+                    SetAbstractValue(key, mergedValue);
+                }
+            }
+        }
+
+        #region Helper methods to handle initialization/assignment operations
+        private void SetAbstractValueForSymbolDeclaration(ISymbol symbol, IOperation initializer, TAbstractAnalysisValue initializerValue)
+        {
+            if (AnalysisEntityFactory.TryCreateForSymbolDeclaration(symbol, out AnalysisEntity analysisEntity))
+            {
+                SetAbstractValueForAssignment(analysisEntity, initializer, initializerValue);
+            }
+        }
+
+        private void SetAbstractValueForElementInitializer(IOperation instance, ImmutableArray<AbstractIndex> indices, ITypeSymbol elementType, IOperation initializer, TAbstractAnalysisValue value)
+        {
+            if (AnalysisEntityFactory.TryCreateForElementInitializer(instance, indices, elementType, out AnalysisEntity analysisEntity))
+            {
+                SetAbstractValueForAssignment(analysisEntity, initializer, value);
+            }
+        }
+
+        protected void SetAbstractValueForAssignment(IOperation target, IOperation assignedValueOperation, TAbstractAnalysisValue assignedValue)
+        {
+            if (AnalysisEntityFactory.TryCreate(target, out AnalysisEntity targetAnalysisEntity))
+            {
+                SetAbstractValueForAssignment(targetAnalysisEntity, assignedValueOperation, assignedValue);
+            }
+        }
+
+        protected void SetAbstractValueForAssignment(AnalysisEntity targetAnalysisEntity, IOperation assignedValueOperation, TAbstractAnalysisValue assignedValue)
+        {
+            // Value type and string type assignment has copy semantics.
+            if (HasPointsToAnalysisResult &&
+                targetAnalysisEntity.Type.HasValueCopySemantics())
+            {
+                if (HasAbstractValue(targetAnalysisEntity))
+                {
+                    // Reset the analysis values for analysis entities within the target instance.
+                    ResetValueTypeInstanceAnalysisData(targetAnalysisEntity);
+                }
+
+                // Transfer the values of symbols from the assigned instance to the analysis entities in the target instance.
+                TransferValueTypeInstanceAnalysisDataForAssignment(targetAnalysisEntity, assignedValueOperation);
+            }
+
+            SetAbstractValue(targetAnalysisEntity, assignedValue);
+        }
+
+        #endregion
+
+        #region Helper methods for reseting/transfer instance analysis data when PointsTo analysis results are available
+
+        /// <summary>
+        /// Reset all the instance analysis data if <see cref="HasPointsToAnalysisResult"/> is true.
+        /// If we are using or performing points to analysis, certain operations can invalidate all the analysis data off the containing instance.
+        /// </summary>
+        private void ResetInstanceAnalysisData(IOperation operation)
+        {
+            if (operation == null || !HasPointsToAnalysisResult)
+            {
+                return;
+            }
+
+            if (operation.Type.HasValueCopySemantics())
+            {
+                if (AnalysisEntityFactory.TryCreate(operation, out AnalysisEntity analysisEntity))
+                {
+                    ResetValueTypeInstanceAnalysisData(analysisEntity);
+                }
+            }
+            else
+            {
+                ResetReferenceTypeInstanceAnalysisData(operation);
+            }
+        }
+
+        /// <summary>
+        /// Resets all the analysis data for all <see cref="AnalysisEntity"/> instances that share the same <see cref="AnalysisEntity.InstanceLocation"/>
+        /// as the given <paramref name="analysisEntity"/>.
+        /// </summary>
+        /// <param name="analysisEntity"></param>
+        private void ResetValueTypeInstanceAnalysisData(AnalysisEntity analysisEntity)
+        {
+            Debug.Assert(HasPointsToAnalysisResult);
+            Debug.Assert(analysisEntity.Type.HasValueCopySemantics());
+
+            IEnumerable<AnalysisEntity> dependantAnalysisEntities = GetChildAnalysisEntities(analysisEntity);
+            ResetInstanceAnalysisDataCore(dependantAnalysisEntities);
+        }
+
+        /// <summary>
+        /// Resets all the analysis data for all <see cref="AnalysisEntity"/> instances that share the same <see cref="AnalysisEntity.InstanceLocation"/>
+        /// as pointed to by given reference type <paramref name="operation"/>.
+        /// </summary>
+        /// <param name="operation"></param>
+        private void ResetReferenceTypeInstanceAnalysisData(IOperation operation)
+        {
+            Debug.Assert(HasPointsToAnalysisResult);
+            Debug.Assert(!operation.Type.HasValueCopySemantics());
+
+            var pointsToValue = GetPointsToAbstractValue(operation);
+            if (pointsToValue.Kind != PointsToAbstractValueKind.Known)
+            {
+                return;
+            }
+
+            IEnumerable<AnalysisEntity> dependantAnalysisEntities = GetChildAnalysisEntities(pointsToValue);
+            ResetInstanceAnalysisDataCore(dependantAnalysisEntities);
+        }
+
+        /// <summary>
+        /// Resets the analysis data for the given <paramref name="dependantAnalysisEntities"/>.
+        /// </summary>
+        /// <param name="dependantAnalysisEntities"></param>
+        private void ResetInstanceAnalysisDataCore(IEnumerable<AnalysisEntity> dependantAnalysisEntities)
+        {
+            foreach (var dependentAnalysisEntity in dependantAnalysisEntities)
+            {
+                // Reset value.
+                SetAbstractValue(dependentAnalysisEntity, UnknownOrMayBeValue);
+            }
+        }
+
+        /// <summary>
+        /// Resets the analysis data for an object instance passed around as an <see cref="IArgumentOperation"/>.
+        /// </summary>
+        private void ResetInstanceAnalysisDataForArgument(IArgumentOperation operation)
+        {
+            // For reference types passed as arguments, 
+            // reset all analysis data for the instance members as the content might change for them.
+            if (HasPointsToAnalysisResult &&
+                !operation.Value.Type.HasValueCopySemantics())
+            {
+                ResetReferenceTypeInstanceAnalysisData(operation.Value);
+            }
+
+            // Handle ref/out arguments as escapes.
+            if (operation.Parameter.RefKind != RefKind.None)
+            {
+                SetAbstractValueForAssignment(operation.Value, operation.Value, UnknownOrMayBeValue);
+            }
+        }
+
+        /// <summary>
+        /// Transfers the analysis data rooted from <paramref name="assignedValueOperation"/> to <paramref name="targetAnalysisEntity"/>, for a value type assignment operation.
+        /// This involves transfer of data for of all <see cref="AnalysisEntity"/> instances that share the same <see cref="AnalysisEntity.InstanceLocation"/> as the valueAnalysisEntity for the <paramref name="assignedValueOperation"/>
+        /// to all <see cref="AnalysisEntity"/> instances that share the same <see cref="AnalysisEntity.InstanceLocation"/> as <paramref name="targetAnalysisEntity"/>.
+        /// </summary>
+        private void TransferValueTypeInstanceAnalysisDataForAssignment(AnalysisEntity targetAnalysisEntity, IOperation assignedValueOperation)
+        {
+            Debug.Assert(HasPointsToAnalysisResult);
+            Debug.Assert(targetAnalysisEntity.Type.HasValueCopySemantics());
+
+            IEnumerable<AnalysisEntity> dependentAnalysisEntities;
+            if (AnalysisEntityFactory.TryCreate(assignedValueOperation, out AnalysisEntity valueAnalysisEntity))
+            {
+                dependentAnalysisEntities = GetChildAnalysisEntities(valueAnalysisEntity);
+            }
+            else
+            {
+                // For allocations.
+                PointsToAbstractValue newValueLocation = GetPointsToAbstractValue(assignedValueOperation);
+                if (newValueLocation.Kind == PointsToAbstractValueKind.NoLocation)
+                {
+                    return;
+                }
+
+                dependentAnalysisEntities = GetChildAnalysisEntities(newValueLocation);
+            }
+
+            foreach (AnalysisEntity dependentInstance in dependentAnalysisEntities)
+            {
+                // Clone the dependent instance but with with target as the root.
+                AnalysisEntity newAnalysisEntity = AnalysisEntityFactory.CreateWithNewInstanceRoot(dependentInstance, targetAnalysisEntity);
+                var dependentValue = GetAbstractValue(dependentInstance);
+                SetAbstractValue(newAnalysisEntity, dependentValue);
+            }
+        }
+
+        private IEnumerable<AnalysisEntity> GetChildAnalysisEntities(AnalysisEntity analysisEntity)
+        {
+            IEnumerable<AnalysisEntity> dependentAnalysisEntities = GetChildAnalysisEntities(analysisEntity.InstanceLocation);
+            if (analysisEntity.Type.HasValueCopySemantics())
+            {
+                dependentAnalysisEntities = dependentAnalysisEntities.Where(info => info.HasAncestorOrSelf(analysisEntity));
+            }
+
+            return dependentAnalysisEntities;
+        }
+
+        private IEnumerable<AnalysisEntity> GetChildAnalysisEntities(PointsToAbstractValue instanceLocationOpt)
+        {
+            // We are interested only in dependent child/member infos, not the root info.
+            return instanceLocationOpt != null ?
+                AnalysisEntityFactory.GetAnalysisEntitiesCreatedFromInstance(instanceLocationOpt).Where(info => info.IsChildOrInstanceMember) :
+                ImmutableHashSet<AnalysisEntity>.Empty;
+        }
+
+        #endregion
+
+        #region Visitor methods
 
         internal TAbstractAnalysisValue VisitArray(IEnumerable<IOperation> operations, object argument)
         {
@@ -109,7 +417,18 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             if (operation != null)
             {
                 var value = VisitCore(operation, argument);
-                _valueCacheBuilder[operation] = value;
+                CacheAbstractValue(operation, value);
+
+                if (_pendingArgumentsToReset.Any(arg => arg.Parent == operation))
+                {
+                    var pendingArguments = _pendingArgumentsToReset.Where(arg => arg.Parent == operation).ToImmutableArray();
+                    foreach (IArgumentOperation argumentOperation in pendingArguments)
+                    {
+                        ResetInstanceAnalysisDataForArgument(argumentOperation);
+                        _pendingArgumentsToReset.Remove(argumentOperation);
+                    }
+                }
+
                 return value;
             }
 
@@ -153,32 +472,124 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         protected virtual TAbstractAnalysisValue VisitAssignmentOperation(IAssignmentOperation operation, object argument)
         {
             TAbstractAnalysisValue _ = Visit(operation.Target, argument);
-            TAbstractAnalysisValue value = Visit(operation.Value, argument);
-            SetAbstractValueForAssignment(operation.Target, value);
+            TAbstractAnalysisValue assignedValue = Visit(operation.Value, argument);
+            SetAbstractValueForAssignment(operation.Target, operation.Value, assignedValue);
 
-            return value;
+            return assignedValue;
         }
 
-        protected void SetAbstractValueForAssignment(IOperation target, TAbstractAnalysisValue value)
+        public override TAbstractAnalysisValue VisitMemberInitializer(IMemberInitializerOperation operation, object argument)
         {
-            if (target is ILocalReferenceOperation localReference)
+            TAbstractAnalysisValue _ = Visit(operation.InitializedMember, argument);
+            TAbstractAnalysisValue assignedValue = Visit(operation.Initializer, argument);
+            SetAbstractValueForAssignment(operation.InitializedMember, operation.Initializer, assignedValue);
+            return assignedValue;
+        }
+
+        public override TAbstractAnalysisValue VisitObjectOrCollectionInitializer(IObjectOrCollectionInitializerOperation operation, object argument)
+        {
+            // Special handling for collection initializers as we need to track indices.
+            uint collectionElementInitializerIndex = 0;
+            foreach (var elementInitializer in operation.Initializers)
             {
-                SetAbstractValue(localReference.Local, value);
+                if (elementInitializer is ICollectionElementInitializerOperation collectionElementInitializer)
+                {
+                    var _ = Visit(elementInitializer, argument: collectionElementInitializerIndex);
+                    collectionElementInitializerIndex += (uint)collectionElementInitializer.Arguments.Length;
+                }
+                else
+                {
+                    var _ = Visit(elementInitializer, argument);
+                }
             }
-            else if (target is IParameterReferenceOperation parameterReference)
+
+            return UnknownOrMayBeValue;
+        }
+
+        public override TAbstractAnalysisValue VisitCollectionElementInitializer(ICollectionElementInitializerOperation operation, object argument)
+        {
+            var objectCreation = operation.GetAncestor<IObjectCreationOperation>(OperationKind.ObjectCreation);
+            ITypeSymbol collectionElementType = operation.AddMethod?.Parameters.FirstOrDefault()?.Type;
+            if (collectionElementType != null)
             {
-                SetAbstractValue(parameterReference.Parameter, value);
+                var index = (uint)argument;
+                for (int i = 0; i < operation.Arguments.Length; i++, index++)
+                {
+                    AbstractIndex abstractIndex = AbstractIndex.Create(index);
+                    IOperation elementInitializer = operation.Arguments[i];
+                    TAbstractAnalysisValue argumentValue = Visit(elementInitializer, argument: null);
+                    SetAbstractValueForElementInitializer(objectCreation, ImmutableArray.Create(abstractIndex), collectionElementType, elementInitializer, argumentValue);
+                }
             }
+            else
+            {
+                var _ = base.VisitCollectionElementInitializer(operation, argument: null);
+            }
+
+            return UnknownOrMayBeValue;
+        }
+
+        public override TAbstractAnalysisValue VisitArrayInitializer(IArrayInitializerOperation operation, object argument)
+        {
+            var arrayCreation = (IArrayCreationOperation)operation.Parent;
+            var elementType = ((IArrayTypeSymbol)arrayCreation.Type).ElementType;
+            for (int index = 0; index < operation.ElementValues.Length; index++)
+            {
+                AbstractIndex abstractIndex = AbstractIndex.Create((uint)index);
+                IOperation elementInitializer = operation.ElementValues[index];
+                TAbstractAnalysisValue initializerValue = Visit(elementInitializer, argument);
+                SetAbstractValueForElementInitializer(arrayCreation, ImmutableArray.Create(abstractIndex), elementType, elementInitializer, initializerValue);
+            }
+
+            return UnknownOrMayBeValue;
         }
 
         public override TAbstractAnalysisValue VisitLocalReference(ILocalReferenceOperation operation, object argument)
         {
-            return GetAbstractValue(operation.Local);
+            var value = base.VisitLocalReference(operation, argument);
+            return ComputeAnalysisValueForReferenceOperation(operation, value);
         }
 
         public override TAbstractAnalysisValue VisitParameterReference(IParameterReferenceOperation operation, object argument)
         {
-            return GetAbstractValue(operation.Parameter);
+            var value = base.VisitParameterReference(operation, argument);
+            return ComputeAnalysisValueForReferenceOperation(operation, value);
+        }
+
+        public override TAbstractAnalysisValue VisitArrayElementReference(IArrayElementReferenceOperation operation, object argument)
+        {
+            var value = base.VisitArrayElementReference(operation, argument);
+            return ComputeAnalysisValueForReferenceOperation(operation, value);
+        }
+
+        public override TAbstractAnalysisValue VisitDynamicMemberReference(IDynamicMemberReferenceOperation operation, object argument)
+        {
+            var value = base.VisitDynamicMemberReference(operation, argument);
+            return ComputeAnalysisValueForReferenceOperation(operation, value);
+        }
+
+        public override TAbstractAnalysisValue VisitEventReference(IEventReferenceOperation operation, object argument)
+        {
+            var value = base.VisitEventReference(operation, argument);
+            return ComputeAnalysisValueForReferenceOperation(operation, value);
+        }
+
+        public override TAbstractAnalysisValue VisitFieldReference(IFieldReferenceOperation operation, object argument)
+        {
+            var value = base.VisitFieldReference(operation, argument);
+            return ComputeAnalysisValueForReferenceOperation(operation, value);
+        }
+
+        public override TAbstractAnalysisValue VisitMethodReference(IMethodReferenceOperation operation, object argument)
+        {
+            var value = base.VisitMethodReference(operation, argument);
+            return ComputeAnalysisValueForReferenceOperation(operation, value);
+        }
+
+        public override TAbstractAnalysisValue VisitPropertyReference(IPropertyReferenceOperation operation, object argument)
+        {
+            var value = base.VisitPropertyReference(operation, argument);
+            return ComputeAnalysisValueForReferenceOperation(operation, value);
         }
 
         public override TAbstractAnalysisValue VisitDefaultValue(IDefaultValueOperation operation, object argument)
@@ -190,7 +601,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         {
             var leftValue = Visit(operation.Value, argument);
             var rightValue = Visit(operation.WhenNull, argument);
-            var leftNullValue = GetNullState(operation.Value);
+            var leftNullValue = GetNullAbstractValue(operation.Value);
             switch (leftNullValue)
             {
                 case NullAbstractValue.Null:
@@ -208,7 +619,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         {
             var leftValue = Visit(operation.Operation, argument);
             var whenNullValue = Visit(operation.WhenNotNull, argument);
-            var leftNullValue = GetNullState(operation.Operation);
+            var leftNullValue = GetNullAbstractValue(operation.Operation);
             switch (leftNullValue)
             {
                 case NullAbstractValue.Null:
@@ -223,12 +634,18 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             }
         }
 
+        public override TAbstractAnalysisValue VisitConditionalAccessInstance(IConditionalAccessInstanceOperation operation, object argument)
+        {
+            IConditionalAccessOperation conditionalAccess = operation.GetConditionalAccess();
+            return GetCachedAbstractValue(conditionalAccess.Operation);
+        }
+
         public override TAbstractAnalysisValue VisitConditional(IConditionalOperation operation, object argument)
         {
             var _ = Visit(operation.Condition, argument);
             var whenTrue = Visit(operation.WhenTrue, argument);
             var whenFalse = Visit(operation.WhenFalse, argument);
-
+            
             if (operation.Condition.ConstantValue.HasValue &&
                 operation.Condition.ConstantValue.Value is bool condition)
             {
@@ -254,38 +671,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         public override TAbstractAnalysisValue VisitArgument(IArgumentOperation operation, object argument)
         {
             var value = Visit(operation.Value, argument);
-
-            // Handle ref/out arguments as escapes.
-            if (operation.Parameter.RefKind != RefKind.None)
-            {
-                ISymbol symbol;
-                switch (operation.Value)
-                {
-                    case ILocalReferenceOperation localReference:
-                        symbol = localReference.Local;
-                        break;
-
-                    case IParameterReferenceOperation parameterReference:
-                        symbol = parameterReference.Parameter;
-                        break;
-
-                    case IMemberReferenceOperation memberReference:
-                        symbol = memberReference.Member;
-                        break;
-
-                    default:
-                        symbol = null;
-                        break;
-                }
-
-                if (symbol != null)
-                {
-                    SetAbstractValue(symbol, UnknownOrMayBeValue);
-                }
-
-                return UnknownOrMayBeValue;
-            }
-
+            _pendingArgumentsToReset.Add(operation);
             return value;
         }
 
@@ -315,7 +701,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         protected virtual TAbstractAnalysisValue VisitSymbolInitializer(ISymbolInitializerOperation operation, ISymbol initializedSymbol, object argument)
         {
             var value = Visit(operation.Value, argument);
-            SetAbstractValue(initializedSymbol, value);
+            SetAbstractValueForSymbolDeclaration(initializedSymbol, operation.Value, value);
             return value;
         }
 
@@ -324,7 +710,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             var value = Visit(operation.Value, argument);
             foreach (var initializedSymbol in initializedSymbols)
             {
-                SetAbstractValue(initializedSymbol, value);
+                SetAbstractValueForSymbolDeclaration(initializedSymbol, operation.Value, value);
             }
 
             return value;
@@ -339,7 +725,10 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             if (initializer == null)
             {
                 value = ValueDomain.Bottom;
-                SetAbstractValue(operation.Symbol, value);
+                if (AnalysisEntityFactory.TryCreateForSymbolDeclaration(operation.Symbol, out AnalysisEntity analysisEntity))
+                {
+                    SetAbstractValue(analysisEntity, value);
+                }
             }
 
             return value;
@@ -377,17 +766,26 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
 
         public sealed override TAbstractAnalysisValue VisitInvocation(IInvocationOperation operation, object argument)
         {
+            TAbstractAnalysisValue value;
             switch (operation.TargetMethod.MethodKind)
             {
                 case MethodKind.LambdaMethod:
                 case MethodKind.LocalFunction:
                 case MethodKind.DelegateInvoke:
                     // Invocation of a lambda or local function.
-                    return VisitInvocation_LambdaOrDelegateOrLocalFunction(operation, argument);
+                    value = VisitInvocation_LambdaOrDelegateOrLocalFunction(operation, argument);
+                    break;
 
                 default:
-                    return VisitInvocation_NonLambdaOrDelegateOrLocalFunction(operation, argument);
+                    value = VisitInvocation_NonLambdaOrDelegateOrLocalFunction(operation, argument);
+                    break;
             }
+
+            // Invocation might invalidate all the analysis data on the invoked instance.
+            // Conservatively reset all the instance analysis data.
+            ResetInstanceAnalysisData(operation.Instance);
+
+            return value;
         }
 
         public virtual TAbstractAnalysisValue VisitInvocation_NonLambdaOrDelegateOrLocalFunction(IInvocationOperation operation, object argument)
@@ -407,29 +805,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             return value;
         }
 
-        protected void ResetAnalysisData(IDictionary<ISymbol, TAbstractAnalysisValue> currentAnalysisData, IDictionary<ISymbol, TAbstractAnalysisValue> newAnalysisDataOpt)
-        {
-            // Reset the current analysis data, while ensuring that we don't violate the monotonicity, i.e. we cannot remove any existing key from currentAnalysisData.
-            if (newAnalysisDataOpt == null)
-            {
-                // Just set the values for existing keys to UnknownOrMayBeValue.
-                foreach (var key in currentAnalysisData.Keys.ToArray())
-                {
-                    SetAbstractValue(key, UnknownOrMayBeValue);
-                }
-            }
-            else
-            {
-                // Merge the values from current and new analysis data.
-                var keys = currentAnalysisData.Keys.Concat(newAnalysisDataOpt.Keys).ToArray();
-                foreach (var key in keys)
-                {
-                    var value1 = currentAnalysisData.TryGetValue(key, out var currentValue) ? currentValue : ValueDomain.Bottom;
-                    var value2 = newAnalysisDataOpt.TryGetValue(key, out var newValue) ? newValue : ValueDomain.Bottom;
-                    var mergedValue = ValueDomain.Merge(value1, value2);
-                    SetAbstractValue(key, mergedValue);
-                }
-            }
-        }
+#endregion
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/ReviewSqlQueriesForSecurityVulnerabilities.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/ReviewSqlQueriesForSecurityVulnerabilities.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Operations.ControlFlow;
 using Microsoft.CodeAnalysis.Operations.DataFlow;
 using Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis;
 
 namespace Microsoft.CodeQuality.Analyzers.Exp.Maintainability
@@ -213,8 +214,9 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Maintainability
                 if (topmostBlock != null)
                 {
                     var cfg = ControlFlowGraph.Create(topmostBlock);
-                    var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg);
-                    var stringContentResult = StringContentAnalysis.GetOrComputeResult(cfg, nullAnalysisResult);
+                    var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType);
+                    var pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType, nullAnalysisResult);
+                    var stringContentResult = StringContentAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType, nullAnalysisResult, pointsToAnalysisResult);
                     StringContentAbstractValue value = stringContentResult[argumentValue];
                     if (value.NonLiteralState == StringContainsNonLiteralState.No)
                     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
@@ -1020,7 +1020,7 @@ End Module",
             GetBasicResultAt(142, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
-        [Fact(Skip = "TODO: Readonly Field Analysis")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1569")]
         public void FlowAnalysis_ConditionalAccess_Constant_NoDiagnostic()
         {
             VerifyCSharp($@"
@@ -1116,7 +1116,7 @@ class Test
         c = new Adapter1(str, str);
 
         a.X = """";
-        str = a?.X;     // Need PointsTo analysis to detect constant, NYI
+        str = a?.X;
         c = new Adapter1(str, str);
 
         a.X = param;
@@ -1131,7 +1131,6 @@ class Test
 ",
         GetCSharpResultAt(103, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
         GetCSharpResultAt(107, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
-        GetCSharpResultAt(111, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
         GetCSharpResultAt(115, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
             VerifyBasic($@"
@@ -1158,7 +1157,7 @@ Module Test
         c = New Adapter1(str, str)
 
         a.X = """"
-        str = a?.X                  ' Need PointsTo analysis to detect constant, NYI
+        str = a?.X
         c = New Adapter1(str, str)
 
         a.X = param
@@ -1172,11 +1171,10 @@ Module Test
 End Module",
             GetBasicResultAt(138, 18, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"),
             GetBasicResultAt(142, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"),
-            GetBasicResultAt(146, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"),
             GetBasicResultAt(150, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
-        [Fact(Skip = "TODO:File Bug")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
         public void FlowAnalysis_WhileLoop_NonConstant_Diagnostic()
         {
             VerifyCSharp($@"
@@ -1226,7 +1224,7 @@ End Module",
             GetBasicResultAt(135, 22, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
-        [Fact(Skip = "TODO:File Bug")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
         public void FlowAnalysis_ForLoop_NonConstant_Diagnostic()
         {
             VerifyCSharp($@"
@@ -1276,7 +1274,7 @@ End Module",
             GetBasicResultAt(135, 22, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
-        [Fact(Skip = "TODO:File Bug")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
         public void FlowAnalysis_ForEachLoop_NonConstant_Diagnostic()
         {
             VerifyCSharp($@"
@@ -1326,7 +1324,7 @@ End Module",
             GetBasicResultAt(135, 22, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
-        [Fact(Skip = "TODO:File Bug")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
         public void FlowAnalysis_Conditional_Constant_NoDiagnostic()
         {
             VerifyCSharp($@"
@@ -1846,6 +1844,3434 @@ Module Test
 End Module",
             // Currently we generate a diagnostic as we do not analyze lambda invocations and pessimistically assume it invalidates all saved state.
             GetBasicResultAt(141, 18, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsToAnalysis_CopySemanticsForString_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    public string Field;
+    void M1(Test t, string param)
+    {{
+        t.Field = """";
+        string str = t.Field;
+        t.Field = param; // This should not affect location/value of 'str'.
+        Command c = new Command1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Test
+    Public Field As String
+    Sub M1(t As Test, param As String)
+        t.Field = """"
+        Dim str As String = t.Field
+        t.Field = param ' This should not affect location/value of 'str'.
+        Dim c As New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceTypeCopy_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    public string Field;
+    void M1(Test t)
+    {{
+        t.Field = """";
+        Test t2 = t;
+        string str = t2.Field;
+        Command c = new Command1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Test
+    Public Field As String
+    Sub M1(t As Test)
+        t.Field = """"
+        Dim t2 As Test = t
+        Dim str As String = t2.Field
+        Dim c As New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueTypeCopy_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct Test
+{{
+    public string Field;
+    void M1(Test t)
+    {{
+        t.Field = """";
+        Test t2 = t;
+        string str = t2.Field;
+        Command c = new Command1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure Test
+    Public Field As String
+    Sub M1(t As Test)
+        t.Field = """"
+        Dim t2 As Test = t
+        Dim str As String = t2.Field
+        Dim c As New Command1(str, str)
+    End Sub
+End Structure");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceTypeNestingCopy_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(Test t, string param)
+    {{
+        t.a.Field = """";
+        Test t2 = t;
+        string str = t2.a.Field;
+        Command c = new Command1(str, str);
+
+        str = param;
+        A a = t.a;
+        str = a.Field;
+        c = new Command1(str, str);
+ 
+        t.a.Field = param;
+        a = t.a;
+        A b = a;
+        t2.a.Field = """";
+        str = b.Field;
+        c = new Command1(str, str);
+ 
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+End Class
+
+Class Test
+    Public a As A
+    Sub M1(t As Test, param As String)
+        t.a.Field = """"
+        Dim t2 As Test = t
+        Dim str As String = t2.a.Field
+        Dim c As New Command1(str, str)
+
+        str = param
+        Dim a As A = t.a
+        str = a.Field
+        c = New Command1(str, str)
+ 
+        t.a.Field = param
+        a = t.a
+        Dim b As A = a
+        t2.a.Field = """"
+        str = b.Field
+        c = New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueTypeNestingCopy_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(Test t, string param)
+    {{
+        t.a.Field = """";
+        Test t2 = t;
+        string str = t2.a.Field;
+        Command c = new Command1(str, str);
+
+        str = param;
+        A a = t.a;
+        str = a.Field;
+        c = new Command1(str, str);
+ 
+        t.a.Field = param;
+        a = t.a;
+        A b = a;
+        t2.a.Field = """";  // 't2.a' and 'b' point to different value type objects.
+        str = b.Field;
+        c = new Command1(str, str);
+    }}
+}}
+",
+        // Test0.cs(118,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+        GetCSharpResultAt(118, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+End Structure
+
+Class Test
+    Public a As A
+    Sub M1(t As Test, param As String)
+        t.a.Field = """"
+        Dim t2 As Test = t
+        Dim str As String = t2.a.Field
+        Dim c As New Command1(str, str)
+
+        str = param
+        Dim a As A = t.a
+        str = a.Field
+        c = New Command1(str, str)
+ 
+        t.a.Field = param
+        a = t.a
+        Dim b As A = a
+        t2.a.Field = """"       ' 't2.a' and 'b' point to different value type objects.
+        str = b.Field
+        c = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(153,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(153, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+
+        public void FlowAnalysis_PointsTo_ValueTypeNestingCopy_02_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(Test t, string param)
+    {{
+        t.a.Field = """";
+        Test t2 = new Test();
+        t = t2;             // This should clear out all the data about 't'
+        string str = t.a.Field;
+        Command c = new Command1(str, str);
+
+        t.a.Field = """";
+        A a = new A() {{ Field = param }};
+        t2 = new Test(){{ a = a }};
+        t = t2;             // This should clear out all the data about 't'
+        str = t.a.Field;
+        c = new Command1(str, str);
+    }}
+}}
+",
+        // Test0.cs(107,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+        GetCSharpResultAt(107, 21, "Command1.Command1(string cmd, string parameter2)", "M1"),
+        // Test0.cs(114,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+        GetCSharpResultAt(114, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+End Structure
+
+Class Test
+    Public a As A
+    Sub M1(t As Test, param As String) 
+        t.a.Field = """"
+        Dim t2 As New Test()
+        t = t2             ' This should clear out all the data about 't'
+        Dim str As String = t.a.Field
+        Dim c As New Command1(str, str)
+
+        t.a.Field = """"
+        Dim a As New A() With {{ .Field = param }}
+        t2 = New Test() With {{ .a = a }}
+        t = t2             ' This should clear out all the data about 't'
+        str = t.a.Field
+        c = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(142,18): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(142, 18, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(149,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(149, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceTypeAllocationAndInitializer_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(Test t, string param)
+    {{
+        t = new Test();
+        string str = t.a.Field;         // Unknown value.
+        Command c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(105,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(105, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+    Public Field2 As String
+End Class
+
+Class Test
+
+    Public a As A
+
+    Private Sub M1(ByVal t As Test, ByVal param As String)
+        t = New Test()
+        Dim str As String = t.a.Field       ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(143,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(143, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceTypeAllocationAndInitializer_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(Test t, string param)
+    {{
+        A b = new A();
+        b.Field = """";
+        t = new Test() {{ a = b }};
+        string str = t.a.Field;                 //  'a' and 'b' point to same object.
+        Command c = new Command1(str, str);
+ 
+        str = param;
+        t = new Test() {{ a = {{ Field = """" }} }};
+        str = t.a.Field;
+        c = new Command1(str, str); 
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+    Public Field2 As String
+End Class
+
+Class Test
+
+    Public a As A
+
+    Private Sub M1(ByVal t As Test, ByVal param As String)
+        Dim b As A = New A()
+        b.Field = """"
+        t = New Test() With {{.a = b}}
+        Dim str As String = t.a.Field
+        Dim c As Command = New Command1(str, str)
+
+        str = param
+        t = New Test() With {{.a = New A() With {{.Field = """", .Field2 = .Field}} }}
+        str = t.a.Field2
+        c = New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(Test t, string param)
+    {{
+        t = new Test();
+        string str = t.a.Field;         // Unknown value.
+        Command c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(105,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(105, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+    Public Field2 As String
+End Structure
+
+Class Test
+
+    Public a As A
+
+    Private Sub M1(ByVal t As Test, ByVal param As String)
+        t = New Test()
+        Dim str As String = t.a.Field       ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(143,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(143, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(Test t, string param)
+    {{
+        A b = new A();
+        b.Field = """";
+        t = new Test() {{ a = b }};
+        string str = t.a.Field;                 //  'a' and 'b' have the same value.
+        Command c = new Command1(str, str);
+ 
+        t.a.Field = param;
+        str = param;
+        t = new Test() {{ a = {{ Field = """" }} }};
+        str = t.a.Field;
+        c = new Command1(str, str); 
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+    Public Field2 As String
+End Structure
+
+Class Test
+
+    Public a As A
+
+    Private Sub M1(ByVal t As Test, ByVal param As String)
+        Dim b As A = New A()
+        b.Field = """"
+        t = New Test() With {{.a = b}}
+        Dim str As String = t.a.Field
+        Dim c As Command = New Command1(str, str)
+
+        str = param
+        t = New Test() With {{.a = New A() With {{.Field = """", .Field2 = .Field}} }}
+        str = t.a.Field2
+        c = New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_02_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+struct Test
+{{
+    public A a;
+    void M1(Test t, string param)
+    {{
+        A b = new A();
+        b.Field = """";
+        t = new Test() {{ a = b }};
+        Test t2 = t;
+        string str = t2.a.Field;                 //  'a' and 'b' have the same value.
+        Command1 c = new Command1(str, str);
+ 
+        t.a.Field = param;
+        str = param;
+        t = new Test() {{ a = {{ Field = """" }} }};
+        t2 = t;
+        str = t2.a.Field;
+        c = new Command1(str, str); 
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+    Public Field2 As String
+End Structure
+
+Structure Test
+
+    Public a As A
+
+    Private Sub M1(ByVal t As Test, ByVal param As String)
+        Dim b As A = New A()
+        b.Field = """"
+        t = New Test() With {{.a = b}}
+        Dim t2 As Test = t
+        Dim str As String = t2.a.Field
+        Dim c As Command = New Command1(str, str)
+
+        str = param
+        t = New Test() With {{.a = New A() With {{.Field = """", .Field2 = .Field}} }}
+        t2 = t
+        str = t2.a.Field2
+        c = New Command1(str, str)
+    End Sub
+End Structure");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceTypeCollectionInitializer_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(string param)
+    {{
+        var list = new System.Collections.Generic.List<string>() {{ """", param }};
+        string str = list[1];
+        Command c = new Command1(str, str);
+
+        var list2 = new System.Collections.Generic.List<Test>() {{
+            new Test() {{ a = {{ Field = """" }} }},
+            new Test() {{ a = {{ Field = param }} }}
+        }};
+        str = list2[1].a.Field;
+        c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(105,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(105, 21, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(112,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(112, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+    Public Field2 As String
+End Class
+
+Class Test
+
+    Public a As A
+
+    Private Sub M1(ByVal param As String)
+        Dim list = New System.Collections.Generic.List(Of String) From {{"""", param}}
+        Dim str As String = list(1)
+        Dim c As Command = New Command1(str, str)
+
+        Dim list2 = New System.Collections.Generic.List(Of Test) From {{
+            New Test() With {{ .a = New A() With {{ .Field = """", .Field2 = .Field }} }},
+            New Test() With {{ .a = New A() With {{ .Field = param, .Field2 = .Field }} }}
+        }}
+
+        str = list2(1).a.Field2
+        c = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(143,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(143, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(151,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(151, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1570")]
+        public void FlowAnalysis_PointsTo_ReferenceTypeCollectionInitializer_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(string param)
+    {{
+        var list = new System.Collections.Generic.List<string>() {{ """", param }};
+        string str = list[0];
+        Command c = new Command1(str, str);
+
+        var list2 = new System.Collections.Generic.List<Test>() {{
+            new Test() {{ a = {{ Field = """" }} }},
+            new Test() {{ a = {{ Field = param }} }}
+        }};
+        str = list2[0].a.Field;
+        c = new Command1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+    Public Field2 As String
+End Class
+
+Class Test
+
+    Public a As A
+
+    Private Sub M1(ByVal param As String)
+        Dim list = New System.Collections.Generic.List(Of String) From {{"""", param}}
+        Dim str As String = list(1)
+        Dim c As Command = New Command1(str, str)
+
+        Dim list2 = New System.Collections.Generic.List(Of Test) From {{
+            New Test() With {{ .a = New A() With {{ .Field = """", .Field2 = .Field }} }},
+            New Test() With {{ .a = New A() With {{ .Field = param, .Field2 = .Field }} }}
+        }}
+
+        str = list2(1).a.Field2
+        c = New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_DynamicObjectCreation_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    public Test(int i)
+    {{
+    }}
+    public Test(string s)
+    {{
+    }}
+
+    void M1(Test t, string param, dynamic d)
+    {{
+        t = new Test(d);
+        string str = t.a.Field;         // Unknown value.
+        Command c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(112,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(112, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_DynamicObjectCreation_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    public Test(int i)
+    {{
+    }}
+    public Test(string s)
+    {{
+    }}
+
+    void M1(Test t, string param, dynamic d)
+    {{
+        A b = new A();
+        b.Field = """";
+        t = new Test(d) {{ a = b }};
+        string str = t.a.Field;                 //  'a' and 'b' point to same object.
+        Command c = new Command1(str, str);
+ 
+        str = param;
+        t = new Test(d) {{ a = {{ Field = """" }} }};
+        str = t.a.Field;
+        c = new Command1(str, str); 
+    }}
+}}
+");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_AnonymousObjectCreation_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        var t = new {{ Field = """", Field2 = param }};
+        string str = t.Field2;                  // Unknown value.
+        Command c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(99,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(99, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Test
+    Private Sub M1(ByVal param As String)
+        Dim t As New With {{Key .Field1 = """", .Field2 = param }}
+        Dim str As String = t.Field2       ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(135,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(135, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1568")]
+        public void FlowAnalysis_PointsTo_AnonymousObjectCreation_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        var t = new {{ Field = """", Field2 = param }};
+        var t2 = new {{ Field = param, Field2 = """" }};
+
+        string str = t.Field;
+        Command c = new Command1(str, str);
+ 
+        str = param;
+        t = t2;
+        str = t.Field2 + t2.Field2;
+        c = new Command1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Test
+    Private Sub M1(ByVal param As String)
+        Dim t As New With {{Key .Field1 = """", .Field2 = .Field1 }}
+        Dim t2 As New With {{Key .Field1 = param, .Field2 = """" }}
+
+        Dim str As String = t.Field2
+        Dim c As Command = New Command1(str, str)
+ 
+        str = param
+        t = t2
+        str = t.Field2 + t2.Field2
+        c = New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived__Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Base
+{{
+    public string Field;
+}}
+class Derived : Base
+{{
+}}
+
+class Test
+{{
+    public Base B;
+    void M1(string param)
+    {{
+        Test t = new Test();
+        Derived d = new Derived();
+        d.Field = param;
+        t.B = new Base();
+        t.B.Field = """";
+        t.B = d;                    // t.B now points to d
+        string str = t.B.Field;     // d.Field has unknown value.
+        Command c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(113,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(113, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Base
+    Public Field As String
+End Class
+
+Class Derived
+    Inherits Base
+End Class
+
+Class Test
+    Public b As Base
+
+    Private Sub M1(ByVal param As String)
+        Dim t As New Test()
+        Dim d As New Derived()
+        d.Field = param
+        t.B = New Base()
+        t.B.Field = """"
+        t.B = d                             ' t.B now points to d
+        Dim str As String = t.B.Field       ' d.Field has unknown value.
+        Dim c As Command = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(150,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(150, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Base
+{{
+    public string Field;
+}}
+class Derived : Base
+{{
+}}
+
+class Test
+{{
+    public Base B;
+    void M1(string param)
+    {{
+        Test t = new Test();
+        Derived d = new Derived();
+        d.Field = """";
+        t.B = new Base();
+        t.B.Field = param;
+        t.B = d;                    // t.B now points to d
+        string str = t.B.Field;     // d.Field is empty string.
+        Command c = new Command1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Base
+    Public Field As String
+End Class
+
+Class Derived
+    Inherits Base
+End Class
+
+Class Test
+    Public b As Base
+
+    Private Sub M1(ByVal param As String)
+        Dim t As New Test()
+        Dim d As New Derived()
+        d.Field = """"
+        t.B = New Base()
+        t.B.Field = param
+        t.B = d                             ' t.B now points to d
+        Dim str As String = t.B.Field       ' d.Field is empty string.
+        Dim c As Command = New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
+        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Base
+{{
+    public string Field;
+}}
+class Derived : Base
+{{
+}}
+
+class Test
+{{
+    public Base B;
+    void M1(string param)
+    {{
+        Test t = new Test();
+        t.B = new Base();
+        t.B.Field = param;
+        if (param != null)
+        {{
+            Derived d = new Derived();
+            d.Field = param;
+            t.B = d;                    // t.B now points to d
+        }}
+        else 
+        {{
+            Base b = new Base();
+            b.Field = """";
+            t.B = b;                    // t.B now points to b       
+        }}
+        
+        string str = t.B.Field;         // t.B now points to either b or d, but d.Field could be an unknown value (param) in one code path.
+        Command c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(123,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(123, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Base
+    Public Field As String
+End Class
+
+Class Derived
+    Inherits Base
+End Class
+
+Class Test
+    Public b As Base
+
+    Private Sub M1(ByVal param As String)
+        Dim t As New Test()
+        t.B = New Base()
+        t.B.Field = param
+        If param IsNot Nothing Then
+            Dim d As New Derived()
+            d.Field = param
+            t.B = d                             ' t.B now points to d
+        Else
+            Dim b As New Base()
+            b.Field = """"
+            t.B = b                             ' t.B now points to b
+        End If
+        Dim str As String = t.B.Field           ' t.B now points to either b or d, but d.Field could be an unknown value (param) in one code path.
+        Dim c As Command = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(156,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(156, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
+        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_02_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Base
+{{
+    public string Field;
+}}
+class Derived : Base
+{{
+}}
+
+class Test
+{{
+    public Base B;
+    void M1(string param, string param2)
+    {{
+        Test t = new Test();
+        t.B = new Base();
+        t.B.Field = param;
+        if (param != null)
+        {{
+            Derived d = new Derived();
+            d.Field = """";
+            t.B = d;                    // t.B now points to d
+            if (param2 != null)
+            {{
+                d.Field = param;        // t.B.Field is unknown in this code path.
+            }}
+        }}
+        else 
+        {{
+            Base b = new Base();
+            b.Field = """";
+            t.B = b;                    // t.B now points to b       
+        }}
+        
+        string str = t.B.Field;         // t.B now points to either b or d, but d.Field could be an unknown value (param) in one code path.
+        Command c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(127,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(127, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Base
+    Public Field As String
+End Class
+
+Class Derived
+    Inherits Base
+End Class
+
+Class Test
+    Public b As Base
+
+    Private Sub M1(ByVal param As String, ByVal param2 As String)
+        Dim t As New Test()
+        t.B = New Base()
+        t.B.Field = param
+        If param IsNot Nothing Then
+            Dim d As New Derived()
+            d.Field = """"
+            t.B = d                             ' t.B now points to d
+            If param2 IsNot Nothing Then
+                d.Field = param                 ' t.B.Field is unknown in this code path.
+            End If
+        Else
+            Dim b As New Base()
+            b.Field = """"
+            t.B = b                             ' t.B now points to b
+        End If
+        Dim str As String = t.B.Field           ' t.B now points to either b or d, but d.Field could be an unknown value (param) in one code path.
+        Dim c As Command = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(159,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(159, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Base
+{{
+    public string Field;
+}}
+class Derived : Base
+{{
+}}
+
+class Test
+{{
+    public Base B;
+    void M1(string param)
+    {{
+        Test t = new Test();
+        t.B = new Base();
+        t.B.Field = param;
+        if (param != null)
+        {{
+            Derived d = new Derived();
+            d.Field = """";
+            t.B = d;                    // t.B now points to d
+        }}
+        else
+        {{
+            Base b = new Base();
+            b.Field = """";
+            t.B = b;                    // t.B now points to b       
+        }}
+        
+        string str = t.B.Field;         // t.B now points to either b or d, both of which have .Field = """"
+        Command c = new Command1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Base
+    Public Field As String
+End Class
+
+Class Derived
+    Inherits Base
+End Class
+
+Class Test
+    Public b As Base
+
+    Private Sub M1(ByVal param As String)
+        Dim t As New Test()
+        t.B = New Base()
+        t.B.Field = param
+        If param IsNot Nothing Then
+            Dim d As New Derived()
+            d.Field = """"
+            t.B = d                             ' t.B now points to d
+        Else
+            Dim b As New Base()
+            b.Field = """"
+            t.B = b                             ' t.B now points to b
+        End If
+        Dim str As String = t.B.Field           ' t.B now points to either b or d, both of which have .Field = """"
+        Dim c As Command = New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceType_ThisInstanceReference_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        string str = this.a.Field;         // Unknown value.
+        Command c = new Command1(str, str);
+
+        str = this.Field;           // Unknown value.
+        c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(106,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(106, 21, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(109,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(109, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+    Public Field2 As String
+End Class
+
+Class Test
+
+    Public a As A
+    Public Field As String
+
+    Private Sub M1(ByVal param As String)
+        Dim str As String = Me.a.Field       ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+
+        str = Me.Field                       ' Unknown value.
+        c = New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(143,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(143, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(146,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(146, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceType_ThisInstanceReference_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        A b = new A();
+        b.Field = """";
+        this.a = b;
+        string str = this.a.Field;
+        Command1 c = new Command1(str, str);
+
+        str = param;
+        this.a = new A() {{ Field = """" }};
+        str = this.a.Field;
+        c = new Command1(str, str);
+ 
+        str = param;
+        Field = """";
+        str = this.Field;
+        c = new Command1(str, str);
+     }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+    Public Field2 As String
+End Class
+
+Class Test
+
+    Public a As A
+    Public Field As String
+    Public Field2 As String
+ 
+    Private Sub M1(ByVal param As String)
+        Dim b As A = New A()
+        b.Field = """"
+        Me.a  = b
+        Dim str As String = a.Field
+        Dim c As New Command1(str, str)
+
+        str = param
+        Me.a = New A() With {{.Field = """", .Field2 = .Field}}
+        str = a.Field2
+        c = New Command1(str, str)
+
+        str = param
+        Me.Field = """"
+        Field2 = Field
+        str = Me.Field2
+        c = New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueType_ThisInstanceReference_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+struct Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        string str = this.a.Field;         // Unknown value.
+        Command c = new Command1(str, str);
+
+        str = this.Field;           // Unknown value.
+        c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(106,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(106, 21, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(109,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(109, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+    Public Field2 As String
+End Structure
+
+Structure Test
+
+    Public a As A
+    Public Field As String
+
+    Private Sub M1(ByVal param As String)
+        Dim str As String = Me.a.Field       ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+
+        str = Me.Field                       ' Unknown value.
+        c = New Command1(str, str)
+    End Sub
+End Structure",
+            // Test0.vb(143,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(143, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(146,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(146, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueType_ThisInstanceReference_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+struct Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        A b = new A();
+        b.Field = """";
+        this.a = b;
+        string str = this.a.Field;
+        Command1 c = new Command1(str, str);
+
+        str = param;
+        this.a = new A() {{ Field = """" }};
+        str = this.a.Field;
+        c = new Command1(str, str);
+ 
+        str = param;
+        Field = """";
+        str = this.Field;
+        c = new Command1(str, str);
+     }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+    Public Field2 As String
+End Structure
+
+Structure Test
+
+    Public a As A
+    Public Field As String
+    Public Field2 As String
+ 
+    Private Sub M1(ByVal param As String)
+        Dim b As A = New A()
+        b.Field = """"
+        Me.a  = b
+        Dim str As String = a.Field
+        Dim c As New Command1(str, str)
+
+        str = param
+        Me.a = New A() With {{.Field = """", .Field2 = .Field}}
+        str = a.Field2
+        c = New Command1(str, str)
+
+        str = param
+        Me.Field = """"
+        Field2 = Field
+        str = Me.Field2
+        c = New Command1(str, str)
+    End Sub
+End Structure");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceType_InvocationInstanceReceiver_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        this.a.Field = """";
+        this.M2();
+        string str = this.a.Field;         // Unknown value.
+        Command c = new Command1(str, str);
+
+        Test t = new Test();
+        t.Field = """";
+        t.M2();
+        str = t.Field;                     // Unknown value.
+        c = new Command1(str, str);
+    }}
+    
+    public void M2()
+    {{
+    }}
+}}
+",
+            // Test0.cs(108,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(108, 21, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(114,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(114, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+End Class
+
+Class Test
+
+    Public a As A
+    Public Field As String
+
+    Private Sub M1(ByVal param As String)
+        Me.a.Field = """"
+        Me.M2()
+        Dim str As String = Me.a.Field       ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+
+        Dim t As New Test()
+        t.Field = """"
+        t.M2()
+        str = Me.Field                       ' Unknown value.
+        c = New Command1(str, str)
+    End Sub
+
+    Public Sub M2()
+    End Sub
+End Class",
+            // Test0.vb(144,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(144, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(150,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(150, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueType_InvocationInstanceReceiver_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+struct Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        this.a.Field = """";
+        this.M2();
+        string str = this.a.Field;         // Unknown value.
+        Command c = new Command1(str, str);
+
+        Test t = new Test();
+        t.Field = """";
+        t.M2();
+        str = t.Field;                     // Unknown value.
+        c = new Command1(str, str);
+    }}
+    
+    public void M2()
+    {{
+    }}
+}}
+",
+            // Test0.cs(108,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(108, 21, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(114,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(114, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+End Structure
+
+Structure Test
+
+    Public a As A
+    Public Field As String
+
+    Private Sub M1(ByVal param As String)
+        Me.a.Field = """"
+        Me.M2()
+        Dim str As String = Me.a.Field       ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+
+        Dim t As New Test()
+        t.Field = """"
+        t.M2()
+        str = Me.Field                       ' Unknown value.
+        c = New Command1(str, str)
+    End Sub
+
+    Public Sub M2()
+    End Sub
+End Structure",
+            // Test0.vb(144,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(144, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(150,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(150, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceType_Argument_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        Test t = new Test();
+        t.Field = """";
+        M2(t);
+        string str = t.Field;               // Unknown value.
+        Command c = new Command1(str, str);
+
+        t.a.Field = """";
+        this.M2(t);
+        str = t.a.Field;                    // Unknown value.
+        c = new Command1(str, str);
+
+        t.a.Field = """";
+        this.M3(ref t);
+        str = t.a.Field;                    // Unknown value.
+        c = new Command1(str, str);
+    }}
+    
+    public void M2(Test t)
+    {{
+    }}
+    
+    public void M3(ref Test t)
+    {{
+    }}
+}}
+",
+            // Test0.cs(109,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(109, 21, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(114,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(114, 13, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(119,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(119, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+End Class
+
+Class Test
+
+    Public a As A
+    Public Field As String
+
+    Private Sub M1(ByVal param As String)
+        Dim t As New Test()
+        t.Field = """"
+        M2(t)
+        Dim str As String = t.Field                       ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+
+        t.a.Field = """"
+        Me.M2(t)
+        str = t.a.Field                                   ' Unknown value.
+        c = New Command1(str, str)
+
+        t.a.Field = """"
+        Me.M3(t)
+        str = t.a.Field                                   ' Unknown value.
+        c = New Command1(str, str)
+    End Sub
+
+    Public Sub M2(t As Test)
+    End Sub
+
+    Public Sub M3(ByRef t as Test)
+    End Sub
+End Class",
+            // Test0.vb(145,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(145, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(150,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(150, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(155,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(155, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceType_ThisArgument_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        Test t = new Test();
+        this.a.Field = """";
+        t.M2(this);
+        string str = a.Field;               // Unknown value.
+        Command c = new Command1(str, str);
+
+        this.Field = """";
+        t.M2(this);
+        str = Field;                        // Unknown value.
+        c = new Command1(str, str);
+    }}
+    
+    public void M2(Test t)
+    {{
+    }}
+}}
+",
+            // Test0.cs(109,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(109, 21, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(114,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(114, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+End Class
+
+Class Test
+
+    Public a As A
+    Public Field As String
+
+    Private Sub M1(ByVal param As String)
+        Dim t as New Test()
+        Me.a.Field = """"
+        t.M2(Me)
+        Dim str As String = a.Field                        ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+        
+        Me.Field = """"
+        t.M2(Me)
+        str = Field                                        ' Unknown value.
+        c = New Command1(str, str)
+    End Sub
+
+    Public Sub M2(t As Test)
+    End Sub
+End Class",
+            // Test0.vb(145,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(145, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(150,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(150, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueType_Argument_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+struct Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        Test t = new Test();
+        t.Field = """";
+        M2(t);                              // Passing by value cannot change contents of a value type.
+        string str = t.Field;
+        Command c = new Command1(str, str);
+
+        t.a.Field = """";
+        this.M2(t);                         // Passing by value cannot change contents of a value type.
+        str = t.a.Field;
+        c = new Command1(str, str);
+    }}
+    
+    public void M2(Test t)
+    {{
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+End Structure
+
+Structure Test
+
+    Public a As A
+    Public Field As String
+
+    Private Sub M1(ByVal param As String)
+        Dim t As New Test()
+        t.Field = """"
+        M2(t)                                             ' Passing by value cannot change contents of a value type.
+        Dim str As String = t.Field
+        Dim c As Command = New Command1(str, str)
+
+        t.a.Field = """"
+        Me.M2(t)                                          ' Passing by value cannot change contents of a value type.
+        str = t.a.Field
+        c = New Command1(str, str)
+    End Sub
+
+    Public Sub M2(t As Test)
+    End Sub
+
+    Public Sub M3(ByRef t as Test)
+    End Sub
+End Structure");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueType_Argument_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+struct Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        Test t = new Test();
+        t.a.Field = """";
+        this.M2(ref t);
+        string str = t.a.Field;                    // Passing by ref can change contents of a value type.
+        Command c = new Command1(str, str);
+    }}
+    
+    public void M2(ref Test t)
+    {{
+    }}
+}}
+",
+            // Test0.cs(109,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(109, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+End Structure
+
+Structure Test
+
+    Public a As A
+    Public Field As String
+
+    Private Sub M1(ByVal param As String)
+        Dim t As New Test()
+        t.a.Field = """"
+        Me.M2(t)                                          ' Passing by ref can change contents of a value type.
+        Dim str As String = t.a.Field
+        Dim c As Command = New Command1(str, str)
+    End Sub
+
+    Public Sub M2(ByRef t as Test)
+    End Sub
+End Structure",
+            // Test0.vb(145,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(145, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ValueType_ThisArgument_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string Field;
+}}
+
+struct Test
+{{
+    public A a;
+    public string Field;
+
+    void M1(string param)
+    {{
+        Test t = new Test();
+        this.a.Field = """";
+        t.M2(this);                              // Passing by value cannot change contents of a value type.
+        string str = a.Field;
+        Command c = new Command1(str, str);
+
+        this.Field = """";
+        t.M2(this);                              // Passing by value cannot change contents of a value type.
+        str = Field;
+        c = new Command1(str, str);
+    }}
+    
+    public void M2(Test t)
+    {{
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public Field As String
+End Structure
+
+Structure Test
+
+    Public a As A
+    Public Field As String
+
+    Private Sub M1(ByVal param As String)
+        Dim t as New Test()
+        Me.a.Field = """"
+        t.M2(Me)
+        Dim str As String = a.Field                        ' Unknown value.
+        Dim c As Command = New Command1(str, str)
+        
+        Me.Field = """"
+        t.M2(Me)
+        str = Field                                        ' Unknown value.
+        c = New Command1(str, str)
+    End Sub
+
+    Public Sub M2(t As Test)
+    End Sub
+End Structure");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ConstantArrayElement_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string[] strArray)
+    {{
+        strArray[0] = """";
+        string str = strArray[0];
+        Adapter c = new Adapter1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(strArray As String())
+        strArray(0) = """"
+        Dim str As String = strArray(0)
+        Dim c As New Adapter1(str, str)
+    End Sub
+End Module");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_NonConstantArrayElement_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string[] strArray, string param)
+    {{
+        strArray[0] = param;
+        string str = strArray[0];
+        Adapter c = new Adapter1(str, str);
+    }}
+}}
+",
+            // Test0.cs(99,21): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(99, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(strArray As String(), param As String)
+        strArray(0) = param
+        Dim str As String = strArray(0)
+        Dim c As New Adapter1(str, str)
+    End Sub
+End Module",
+            // Test0.vb(135,18): warning CA2100: Review if the query string passed to 'Sub Adapter1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(135, 18, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ArrayInitializer_ConstantArrayElement_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        string[] strArray = new string[] {{ """", param }} ;
+        string str = strArray[0];
+        Adapter c = new Adapter1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String)
+        Dim strArray As String() = New String() {{ """", param }}
+        Dim str As String = strArray(0)
+        Dim c As New Adapter1(str, str)
+    End Sub
+End Module");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ArrayInitializer_NonConstantArrayElement_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        string[] strArray = new string[] {{ """", param }} ;
+        string str = strArray[1];
+        Adapter c = new Adapter1(str, str);
+    }}
+}}
+",
+            GetCSharpResultAt(99, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String)
+        Dim strArray As String() = New String() {{ """", param }}
+        Dim str As String = strArray(1)
+        Dim c As New Adapter1(str, str)
+    End Sub
+End Module",
+            GetBasicResultAt(135, 18, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ConstantArrayElement_ArrayFieldInReferenceType_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string[] StringArrayA;
+}}
+
+class Test
+{{
+    public A a;
+    public string[] StringArray;
+
+    void M1(Test t, string[] strArray1, string[] strArray2, string[] strArray3)
+    {{
+        t.StringArray = strArray1;
+        strArray1[0] = """";
+        string str = t.StringArray[0];
+        Adapter c = new Adapter1(str, str);
+
+        strArray2[1] = """";
+        t.StringArray = strArray2;
+        str = t.StringArray[1];
+        c = new Adapter1(str, str);
+
+        strArray3[1000] = """";
+        t.a.StringArrayA = strArray3;
+        Test t2 = t;
+        str = t2.a.StringArrayA[1000];
+        c = new Adapter1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public StringArrayA As String()
+End Class
+
+Class Test
+    Public a As A
+    Public StringArray As String()
+
+    Sub M1(t As Test, strArray1 As String(), strArray2 As String(), strArray3 As String())
+        t.StringArray = strArray1
+        strArray1(0) = """"
+        Dim str As String = t.StringArray(0)
+        Dim c As New Adapter1(str, str)
+
+        strArray2(1) = """"
+        t.StringArray = strArray2
+        str = t.StringArray(1)
+        c = New Adapter1(str, str)
+
+        strArray3(1000) = """"
+        t.a.StringArrayA = strArray3
+        Dim t2 As Test = t
+        str = t2.a.StringArrayA(1000)
+        c = New Adapter1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_NonConstantArrayElement_ArrayFieldInReferenceType_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string[] StringArrayA;
+}}
+
+class Test
+{{
+    public A a;
+    public string[] StringArray;
+
+    void M1(Test t, string[] strArray1, string[] strArray2, string[] strArray3, string param)
+    {{
+        t.StringArray = strArray1;
+        string str = t.StringArray[1];
+        Adapter c = new Adapter1(str, str);
+
+        strArray2[1] = """";
+        t.StringArray = strArray2;
+        strArray2[1] = param;
+        str = t.StringArray[1];
+        c = new Adapter1(str, str);
+
+        strArray3[1000] = """";
+        t.a.StringArrayA = strArray3;
+        Test t2 = t;
+        string[] strArray4 = strArray3;
+        strArray4[1000] = param;
+        str = t2.a.StringArrayA[1000];
+        c = new Adapter1(str, str);
+    }}
+}}
+",
+            // Test0.cs(107,21): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(107, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(113,13): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(113, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(121,13): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(121, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public StringArrayA As String()
+End Class
+
+Class Test
+    Public a As A
+    Public StringArray As String()
+
+    Sub M1(t As Test, strArray1 As String(), strArray2 As String(), strArray3 As String(), param As String)
+        t.StringArray = strArray1
+        Dim str As String = t.StringArray(0)
+        Dim c As New Adapter1(str, str)
+
+        strArray2(1) = """"
+        t.StringArray = strArray2
+        strArray2(1) = param
+        str = t.StringArray(1)
+        c = New Adapter1(str, str)
+
+        strArray3(1000) = """"
+        t.a.StringArrayA = strArray3
+        Dim t2 As Test = t
+        Dim strArray4 As String() = strArray3
+        strArray4(1000) = param
+        str = t2.a.StringArrayA(1000)
+        c = New Adapter1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(142,18): warning CA2100: Review if the query string passed to 'Sub Adapter1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(142, 18, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(148,13): warning CA2100: Review if the query string passed to 'Sub Adapter1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(148, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(156,13): warning CA2100: Review if the query string passed to 'Sub Adapter1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(156, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ConstantArrayElement_ArrayFieldInValueType_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string[] StringArrayA;
+}}
+
+struct Test
+{{
+    public A a;
+    public string[] StringArray;
+
+    void M1(Test t, string[] strArray1, string[] strArray2, string[] strArray3)
+    {{
+        t.StringArray = strArray1;
+        strArray1[0] = """";
+        string str = t.StringArray[0];
+        Adapter c = new Adapter1(str, str);
+
+        strArray2[1] = """";
+        t.StringArray = strArray2;
+        str = t.StringArray[1];
+        c = new Adapter1(str, str);
+
+        strArray3[1000] = """";
+        t.a.StringArrayA = strArray3;
+        Test t2 = t;
+        str = t2.a.StringArrayA[1000];
+        c = new Adapter1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public StringArrayA As String()
+End Structure
+
+Structure Test
+    Public a As A
+    Public StringArray As String()
+
+    Sub M1(t As Test, strArray1 As String(), strArray2 As String(), strArray3 As String())
+        t.StringArray = strArray1
+        strArray1(0) = """"
+        Dim str As String = t.StringArray(0)
+        Dim c As New Adapter1(str, str)
+
+        strArray2(1) = """"
+        t.StringArray = strArray2
+        str = t.StringArray(1)
+        c = New Adapter1(str, str)
+
+        strArray3(1000) = """"
+        t.a.StringArrayA = strArray3
+        Dim t2 As Test = t
+        str = t2.a.StringArrayA(1000)
+        c = New Adapter1(str, str)
+    End Sub
+End Structure");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_NonConstantArrayElement_ArrayFieldInValueType_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+struct A
+{{
+    public string[] StringArrayA;
+}}
+
+struct Test
+{{
+    public A a;
+    public string[] StringArray;
+
+    void M1(Test t, string[] strArray1, string[] strArray2, string[] strArray3, string param)
+    {{
+        t.StringArray = strArray1;
+        string str = t.StringArray[1];
+        Adapter c = new Adapter1(str, str);
+
+        strArray2[1] = """";
+        t.StringArray = strArray2;
+        strArray2[1] = param;
+        str = t.StringArray[1];
+        c = new Adapter1(str, str);
+
+        strArray3[1000] = """";
+        t.a.StringArrayA = strArray3;
+        Test t2 = t;
+        string[] strArray4 = strArray3;
+        strArray4[1000] = param;
+        str = t2.a.StringArrayA[1000];
+        c = new Adapter1(str, str);
+    }}
+}}
+",
+            // Test0.cs(107,21): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(107, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(113,13): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(113, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(121,13): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(121, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Structure A
+    Public StringArrayA As String()
+End Structure
+
+Structure Test
+    Public a As A
+    Public StringArray As String()
+
+    Sub M1(t As Test, strArray1 As String(), strArray2 As String(), strArray3 As String(), param As String)
+        t.StringArray = strArray1
+        Dim str As String = t.StringArray(0)
+        Dim c As New Adapter1(str, str)
+
+        strArray2(1) = """"
+        t.StringArray = strArray2
+        strArray2(1) = param
+        str = t.StringArray(1)
+        c = New Adapter1(str, str)
+
+        strArray3(1000) = """"
+        t.a.StringArrayA = strArray3
+        Dim t2 As Test = t
+        Dim strArray4 As String() = strArray3
+        strArray4(1000) = param
+        str = t2.a.StringArrayA(1000)
+        c = New Adapter1(str, str)
+    End Sub
+End Structure",
+            // Test0.vb(142,18): warning CA2100: Review if the query string passed to 'Sub Adapter1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(142, 18, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(148,13): warning CA2100: Review if the query string passed to 'Sub Adapter1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(148, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(156,13): warning CA2100: Review if the query string passed to 'Sub Adapter1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(156, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ConstantArrayElement_IndexerFieldInReferenceType_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    private string[] _stringArray;
+    public string this[int i]
+    {{
+        get => _stringArray[i];
+        set => _stringArray[i] = value;
+    }}
+
+}}
+
+class Test
+{{
+    public A a;
+
+    private string[] _stringArray;
+    public string this[int i]
+    {{
+        get => _stringArray[i];
+        set => _stringArray[i] = value;
+    }}
+
+    void M1(Test t, string[] strArray1)
+    {{
+        strArray1[0] = """";
+        t[0] = strArray1[0];
+        string str = t[0];
+        Adapter c = new Adapter1(str, str);
+
+        A a = new A();
+        t.a = a;
+        Test t2 = t;
+        a[1000] = """";
+        str = t2.a[1000];
+        c = new Adapter1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Private _stringArray As String()
+    Public Property StringArray(i As Integer) As String
+        Get
+            Return _stringArray(i)
+        End Get
+        Set(value As String)
+            _stringArray(i) = value
+        End Set
+    End Property
+End Class
+
+Class Test
+    Public a As A
+    
+    Private _stringArray As String()
+    Public Property StringArray(i As Integer) As String
+        Get
+            Return _stringArray(i)
+        End Get
+        Set(value As String)
+            _stringArray(i) = value
+        End Set
+    End Property
+
+    Sub M1(t As Test, strArray1 As String())
+        strArray1(0) = """"
+        t.StringArray(0) = strArray1(0)
+        Dim str As String = t.StringArray(0)
+        Dim c As New Adapter1(str, str)
+
+        Dim a As new A()
+        t.a = a
+        Dim t2 As Test = t
+        a.StringArray(1000) = """"
+        str = t2.a.StringArray(1000)
+        c = New Adapter1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_NonConstantArrayElement_IndexerFieldInReferenceType_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Adapter1 : Adapter
+{{
+    public Adapter1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    private string[] _stringArray;
+    public string this[int i]
+    {{
+        get => _stringArray[i];
+        set => _stringArray[i] = value;
+    }}
+
+}}
+
+class Test
+{{
+    public A a;
+
+    private string[] _stringArray;
+    public string this[int i]
+    {{
+        get => _stringArray[i];
+        set => _stringArray[i] = value;
+    }}
+
+    void M1(Test t, string[] strArray1, string param)
+    {{
+        t[0] = """";
+        string str = t[1];
+        Adapter c = new Adapter1(str, str);
+
+        A a = new A();
+        t.a = a;
+        Test t2 = t;
+        a[1000] = param;
+        str = t2.a[1000];
+        c = new Adapter1(str, str);
+    }}
+}}
+",
+            // Test0.cs(119,21): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(119, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(126,13): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(126, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Adapter1
+    Inherits Adapter
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Private _stringArray As String()
+    Public Property StringArray(i As Integer) As String
+        Get
+            Return _stringArray(i)
+        End Get
+        Set(value As String)
+            _stringArray(i) = value
+        End Set
+    End Property
+End Class
+
+Class Test
+    Public a As A
+    
+    Private _stringArray As String()
+    Public Property StringArray(i As Integer) As String
+        Get
+            Return _stringArray(i)
+        End Get
+        Set(value As String)
+            _stringArray(i) = value
+        End Set
+    End Property
+
+    Sub M1(t As Test, strArray1 As String(), param As String)
+        t.StringArray(0) = """"
+        Dim str As String = t.StringArray(1)
+        Dim c As New Adapter1(str, str)
+
+        Dim a As new A()
+        t.a = a
+        Dim t2 As Test = t
+        a.StringArray(1000) = param
+        str = t2.a.StringArray(1000)
+        c = New Adapter1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(159,18): warning CA2100: Review if the query string passed to 'Sub Adapter1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(159, 18, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(166,13): warning CA2100: Review if the query string passed to 'Sub Adapter1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(166, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceTypeArray_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(string param)
+    {{
+        A b = new A() {{ Field = """" }};
+        A c = new A() {{ Field = param }};
+        Test t = new Test() {{ a = c }};
+        Test[] testArray = new Test[] {{ new Test() {{ a = b }}, t }};
+        string str = testArray[1].a.Field;         // testArray[1].a points to c.
+        Command cmd = new Command1(str, str);
+
+        b.Field = param;
+        str = testArray[0].a.Field;         // testArray[0].a points to b.
+        cmd = new Command1(str, str);        
+    }}
+}}
+",
+            // Test0.cs(108,23): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(108, 23, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(112,15): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(112, 15, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+End Class
+
+Class Test
+    Public a As A
+
+    Private Sub M1(ByVal param As String)
+        Dim b As A = New A() With {{.Field = """"}}
+        Dim c As A = New A() With {{.Field = param}}
+        Dim t As Test = New Test() With {{.a = c}}
+        Dim testArray As Test() = New Test() {{New Test() With {{.a = b}}, t}}
+        Dim str As String = testArray(1).a.Field         ' testArray[1].a points to c.
+        Dim cmd As Command = New Command1(str, str)
+
+        b.Field = param
+        str = testArray(0).a.Field         ' testArray[0].a points to b.
+        cmd = New Command1(str, str)
+    End Sub
+End Class
+",
+            // Test0.vb(144,30): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(144, 30, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(148,15): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(148, 15, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_ReferenceTypeArray_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class A
+{{
+    public string Field;
+}}
+
+class Test
+{{
+    public A a;
+    void M1(string param)
+    {{
+        A b = new A() {{ Field = """" }};
+        A c = new A() {{ Field = param }};
+        Test t = new Test() {{ a = c }};
+        Test[] testArray = new Test[] {{ new Test() {{ a = b }}, t }};
+        string str = testArray[0].a.Field;         // testArray[0].a points to b.
+        Command cmd = new Command1(str, str);
+
+        c.Field = b.Field;
+        str = testArray[1].a.Field;         // testArray[1].a points to c.
+        cmd = new Command1(str, str);        
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class A
+    Public Field As String
+End Class
+
+Class Test
+    Public a As A
+
+    Private Sub M1(ByVal param As String)
+        Dim b As A = New A() With {{.Field = """"}}
+        Dim c As A = New A() With {{.Field = param}}
+        Dim t As Test = New Test() With {{.a = c}}
+        Dim testArray As Test() = New Test() {{New Test() With {{.a = b}}, t}}
+        Dim str As String = testArray(0).a.Field         ' testArray[0].a points to b.
+        Dim cmd As Command = New Command1(str, str)
+
+        c.Field = b.Field
+        str = testArray(1).a.Field         ' testArray[1].a points to c.
+        cmd = New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_AutoGeneratedProperty_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    public string AutoGeneratedProperty {{ get; set; }}
+
+    void M1()
+    {{
+        AutoGeneratedProperty = """";
+        string str = AutoGeneratedProperty;
+        Command c = new Command1(str, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Test
+    Public Property AutoGeneratedProperty As String
+    Sub M1()
+        AutoGeneratedProperty = """"
+        Dim str As String = AutoGeneratedProperty
+        Dim c As New Command1(str, str)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void FlowAnalysis_PointsTo_CustomProperty_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    string _value;
+    string _value2;
+    public string MyProperty {{ get => _value; set => _value = value + _value2; }}
+
+    void M1(string param)
+    {{
+        _value2 = param;
+        MyProperty = """";
+        string str = MyProperty;
+        Command c = new Command1(str, str);
+    }}
+}}
+",
+            // Test0.cs(104,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(104, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Test
+    Private _value, _value2 As String
+    Public Property MyProperty As String
+        Get
+            Return _value
+        End Get
+        Set(value As String)
+            _value = value + _value2
+        End Set
+    End Property
+
+    Sub M1(param As String)
+        _value2 = param
+        MyProperty = """"
+        Dim str As String = MyProperty
+        Dim c As New Command1(str, str)
+    End Sub
+End Class",
+            // Test0.vb(146,18): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(146, 18, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
     }
 }

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -185,9 +186,12 @@ namespace Analyzer.Utilities.Extensions
         }
 
         /// <summary>
-        /// Gets the first ancestor of this operation with the specified OperationKind. Returns null if there is no ancestor of the given kind.
+        /// Gets the first ancestor of this operation with:
+        ///  1. Specified OperationKind
+        ///  2. If <paramref name="predicateOpt"/> is non-null, it succeeds for the ancestor.
+        /// Returns null if there is no such ancestor.
         /// </summary>
-        public static TOperation GetAncestor<TOperation>(this IOperation root, OperationKind ancestorKind) where TOperation : IOperation
+        public static TOperation GetAncestor<TOperation>(this IOperation root, OperationKind ancestorKind, Func<TOperation, bool> predicateOpt = null) where TOperation : IOperation
         {
             if (root == null)
             {
@@ -202,12 +206,97 @@ namespace Analyzer.Utilities.Extensions
 
             if (ancestor != null)
             {
+                if (predicateOpt != null && !predicateOpt((TOperation)ancestor))
+                {
+                    return GetAncestor(ancestor, ancestorKind, predicateOpt);
+                }
                 return (TOperation)ancestor;
             }
             else
             {
                 return default(TOperation);
             }
+        }
+
+        public static IConditionalAccessOperation GetConditionalAccess(this IConditionalAccessInstanceOperation operation)
+        {
+            Func<IConditionalAccessOperation, bool> predicate = c => c.Operation.Syntax == operation.Syntax;
+            return operation.GetAncestor(OperationKind.ConditionalAccess, predicate);
+        }
+
+        /// <summary>
+        /// Gets the operation for the object being created that is being referenced by <paramref name="operation"/>.
+        /// If the operation is referencing an implicit or an explicit this/base/Me/MyBase/MyClass instance, then we return "null".
+        /// </summary>
+        public static IOperation GetInstance(this IInstanceReferenceOperation operation)
+        {
+            // VB object initializer allows accessing the members of the object being created with "." operator.
+            // The syntax of such an IInstanceReferenceOperation points to the object being created.
+            // Check for such an  IObjectCreationOperation or IAnonymousObjectCreationOperation with matching syntax.
+            // For example, instance reference for members ".Field1" and ".Field2" in "New C() With { .Field1 = 0, .Field2 = .Field1 }".
+            Func<IObjectCreationOperation, bool> isObjectCreation = creation => creation.Syntax == operation.Syntax;
+            var objectCreation = operation.GetAncestor(OperationKind.ObjectCreation, isObjectCreation);
+            if (objectCreation != null)
+            {
+                return objectCreation;
+            }
+
+            Func<IAnonymousObjectCreationOperation, bool> isAnonymousObjectCreation = creation => creation.Syntax == operation.Syntax;
+            var anonymousObjectCreation = operation.GetAncestor(OperationKind.AnonymousObjectCreation, isAnonymousObjectCreation);
+            if (anonymousObjectCreation != null)
+            {
+                return anonymousObjectCreation;
+            }
+
+            // IInstanceReferenceOperation on left of an IMemberInitializerOperation refers to the ancestor IObjectCreationOperation/IAnonymousObjectCreationOperation/IMemberInitializerOperation.
+            // For example, implicit instance reference for member initializer "AnotherType" in "new C() { AnotherType = { IntField = 0 } };", where "AnotherType" is a member of named type kind.
+            IMemberInitializerOperation parentMemberInitializer = operation.GetAncestor<IMemberInitializerOperation>(OperationKind.MemberInitializer);
+            if (parentMemberInitializer != null &&
+                parentMemberInitializer.InitializedMember.DescendantsAndSelf().Contains(operation))
+            {
+                return parentMemberInitializer.GetCreation();
+            }
+
+            // IInstanceReferenceOperation on left of an ISimpleAssignmentOperation with an IObjectOrCollectionInitializerOperation parent refers to the parenting IObjectCreationOperation/IAnonymousObjectCreationOperation/IMemberInitializerOperation.
+            // For example, implicit instance reference for "IntField" in "new C() { IntField = 0 };".
+            ISimpleAssignmentOperation parentSimpleAssignmentInitialier = operation.GetAncestor<ISimpleAssignmentOperation>(OperationKind.SimpleAssignment);
+            if (parentSimpleAssignmentInitialier != null &&
+                parentSimpleAssignmentInitialier.Parent is IObjectOrCollectionInitializerOperation &&
+                parentSimpleAssignmentInitialier.Target.DescendantsAndSelf().Contains(operation))
+            {
+                return parentSimpleAssignmentInitialier.Parent.Parent;
+            }
+
+            // For all cases, IInstanceReferenceOperation refers to the implicit or explicit this/base/Me/MyBase/MyClass reference.
+            // We return null for such cases.
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the object creation or anonymous object creation for the given member initializer.
+        /// </summary>
+        public static IOperation GetCreation(this IMemberInitializerOperation operation)
+        {
+            Debug.Assert(operation.Parent is IObjectOrCollectionInitializerOperation);
+            return operation.Parent.Parent;
+        }
+
+        /// <summary>
+        /// Workaround for https://github.com/dotnet/roslyn/issues/22736 (IPropertyReferenceExpressions in IAnonymousObjectCreationExpression are missing a receiver).
+        /// Gets the instance for the anonymous object being created that is being referenced by <paramref name="operation"/>.
+        /// Otherwise, returns null
+        /// </summary>
+        public static IAnonymousObjectCreationOperation GetAnonymousObjectCreation(this IPropertyReferenceOperation operation)
+        {
+            if (operation.Instance == null &&
+                operation.Property.ContainingType.IsAnonymousType)
+            {
+                var declarationSyntax = operation.Property.ContainingType.DeclaringSyntaxReferences[0].GetSyntax();
+                Func<IAnonymousObjectCreationOperation, bool> predicate = a => a.Syntax == declarationSyntax;
+                return operation.GetAncestor(OperationKind.AnonymousObjectCreation, predicate);
+            }
+
+            return null;
         }
     }
 }

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -67,6 +67,12 @@ namespace Analyzer.Utilities.Extensions
             return (symbol as IPropertySymbol)?.IsIndexer == true;
         }
 
+        public static bool IsPropertyWithBackingField(this ISymbol symbol)
+        {
+            return symbol is IPropertySymbol propertySymbol &&
+                propertySymbol.ContainingType.GetMembers().OfType<IFieldSymbol>().Any(f => f.IsImplicitlyDeclared && f.AssociatedSymbol == symbol);
+        }
+
         public static bool IsUserDefinedOperator(this ISymbol symbol)
         {
             return (symbol as IMethodSymbol)?.MethodKind == MethodKind.UserDefinedOperator;
@@ -393,6 +399,33 @@ namespace Analyzer.Utilities.Extensions
             }
 
             return false;
+        }
+
+        public static ITypeSymbol GetMemerOrLocalOrParameterType(this ISymbol symbol)
+        {
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Event:
+                    return ((IEventSymbol)symbol).Type;
+
+                case SymbolKind.Field:
+                    return ((IFieldSymbol)symbol).Type;
+
+                case SymbolKind.Method:
+                    return ((IMethodSymbol)symbol).ReturnType;
+
+                case SymbolKind.Property:
+                    return ((IPropertySymbol)symbol).Type;
+
+                case SymbolKind.Local:
+                    return ((ILocalSymbol)symbol).Type;
+
+                case SymbolKind.Parameter:
+                    return ((IParameterSymbol)symbol).Type;
+
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/src/Utilities/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Extensions/ITypeSymbolExtensions.cs
@@ -135,6 +135,9 @@ namespace Analyzer.Utilities.Extensions
             return false;
         }
 
+        public static bool HasValueCopySemantics(this ITypeSymbol typeSymbol)
+            => typeSymbol.IsValueType || typeSymbol.SpecialType == SpecialType.System_String;
+
         public static Accessibility DetermineMinimalAccessibility(this ITypeSymbol typeSymbol)
         {
             return typeSymbol.Accept(MinimalAccessibilityVisitor.Instance);


### PR DESCRIPTION
…tances and arrays. Primary changes are:

1. Change all the analyses to track values for `AnalysisEntity` instances instead of `ISymbol`. An analysis entity is essentially a symbol (or an allocation or an indexed location) which also has an associated `InstanceLocation` where the entity resides. So for example, each local and parameter symbol with have a single unique `AnalysisEntity` instance, while each member symbol(fields/properties/events/methods) will have separate `AnalysisEntity` instances for every instance within which it is contained.

2. Add support for `PointsToAnalysis`, which tracks the locations that can be pointed to by analysis entities and operations. Note that this points to location is different from the `InstanceLocation` mentioned above, which indicate the location at which an analysis entity _resides_. On the other hand, PointsToAnalysis tracks the location that is _pointed to_ by reference types and allocation operations. Constants and value types always have a value of `PointsToAbstractValue.NoLocation`, indicating that they cannot point to any location.

3. Improve precision of `StringContentsAnalysis` used by DFA rule `CA2100` (Review SQL queries for security vulnerabilities) by using the points to analysis result. This analysis can now track string values of members of named types and arrays. Note that were very minimal changes to `StringContentsAnalysis` in this PR, as the base `DataFlowOperationVisitor` tracks using and manipulating the points to analysis data. This should enable future analyses to consume the points to analysis result to improve precision, without having to write any complex code to handle points to analysis data.

4. Write new unit tests for `CA2100` for precision added by the underlying points to analysis.