### PR TITLE
Handle loops and if-else statements and fix a bug in merge algorithm

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullAbstractValueDomain.cs
@@ -11,13 +11,15 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
         /// <summary>
         /// Abstract value domain for <see cref="NullAnalysis"/> to merge and compare <see cref="NullAbstractValue"/> values.
         /// </summary>
-        private class NullAbstractValueDomain : AbstractDomain<NullAbstractValue>
+        private class NullAbstractValueDomain : AbstractValueDomain<NullAbstractValue>
         {
             public static NullAbstractValueDomain Default = new NullAbstractValueDomain();
 
             private NullAbstractValueDomain() { }
 
             public override NullAbstractValue Bottom => NullAbstractValue.Undefined;
+
+            public override NullAbstractValue UnknownOrMayBeValue => NullAbstractValue.MaybeNull;
 
             public override int Compare(NullAbstractValue oldValue, NullAbstractValue newValue)
             {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
@@ -14,23 +14,20 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
         private sealed class NullDataFlowOperationVisitor : DataFlowOperationVisitor<NullAnalysisData, NullAbstractValue>
         {
             public NullDataFlowOperationVisitor(
-                AbstractDomain<NullAbstractValue> valueDomain,
+                NullAbstractValueDomain valueDomain,
                 INamedTypeSymbol containingTypeSymbol,
                 DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt)
                 : base(valueDomain, containingTypeSymbol, nullAnalysisResultOpt: null, pointsToAnalysisResultOpt: pointsToAnalysisResultOpt)
             {
             }
 
-            protected override NullAbstractValue UnknownOrMayBeValue => NullAbstractValue.MaybeNull;
+            protected override IEnumerable<AnalysisEntity> TrackedEntities => CurrentAnalysisData.Keys;
 
-            protected override void SetAbstractValue(AnalysisEntity analysisEntity, NullAbstractValue value) =>
-                CurrentAnalysisData[analysisEntity] = value;
+            protected override void SetAbstractValue(AnalysisEntity analysisEntity, NullAbstractValue value) => CurrentAnalysisData[analysisEntity] = value;
 
-            protected override bool HasAbstractValue(AnalysisEntity analysisEntity) =>
-                CurrentAnalysisData.ContainsKey(analysisEntity);
+            protected override bool HasAbstractValue(AnalysisEntity analysisEntity) => CurrentAnalysisData.ContainsKey(analysisEntity);
 
-            protected override NullAbstractValue GetAbstractValue(AnalysisEntity analysisEntity) =>
-                CurrentAnalysisData.TryGetValue(analysisEntity, out var value) ? value : UnknownOrMayBeValue;
+            protected override NullAbstractValue GetAbstractValue(AnalysisEntity analysisEntity) => CurrentAnalysisData.TryGetValue(analysisEntity, out var value) ? value : ValueDomain.UnknownOrMayBeValue;
 
             protected override NullAbstractValue GetAbstractDefaultValue(ITypeSymbol type)
             {
@@ -43,6 +40,17 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
             }
 
             protected override void ResetCurrentAnalysisData(NullAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);
+
+            // TODO: Remove these temporary methods once we move to compiler's CFG
+            // https://github.com/dotnet/roslyn-analyzers/issues/1567
+            #region Temporary methods to workaround lack of *real* CFG
+            protected override NullAnalysisData MergeAnalysisData(NullAnalysisData value1, NullAnalysisData value2)
+                => NullAnalysisDomainInstance.Merge(value1, value2);
+            protected override NullAnalysisData GetClonedAnalysisData()
+                => GetClonedAnalysisData(CurrentAnalysisData);
+            protected override bool Equals(NullAnalysisData value1, NullAnalysisData value2)
+                => EqualsHelper(value1, value2);
+            #endregion
 
             #region Visitor methods
             public override NullAbstractValue DefaultVisit(IOperation operation, object argument)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.cs
@@ -6,13 +6,14 @@ using Microsoft.CodeAnalysis.Operations.ControlFlow;
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
 {
     using NullAnalysisData = IDictionary<AnalysisEntity, NullAbstractValue>;
-    using NullAnalysisDomain = MapAbstractDomain<AnalysisEntity, NullAbstractValue>;
+    using NullAnalysisDomain = AnalysisEntityMapAbstractDomain<NullAbstractValue>;
 
     /// <summary>
     /// Dataflow analysis to track null-ness of <see cref="AnalysisEntity"/>/<see cref="IOperation"/> instances.
     /// </summary>
     internal partial class NullAnalysis : ForwardDataFlowAnalysis<NullAnalysisData, NullBlockAnalysisResult, NullAbstractValue>
     {
+        public static readonly NullAnalysisDomain NullAnalysisDomainInstance = new NullAnalysisDomain(NullAbstractValueDomain.Default);
         private NullAnalysis(NullAnalysisDomain analysisDomain, NullDataFlowOperationVisitor operationVisitor)
             : base(analysisDomain, operationVisitor)
         {
@@ -23,9 +24,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
             INamedTypeSymbol containingTypeSymbol,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt = null)
         {
-            var analysisDomain = new NullAnalysisDomain(NullAbstractValueDomain.Default);
             var operationVisitor = new NullDataFlowOperationVisitor(NullAbstractValueDomain.Default, containingTypeSymbol, pointsToAnalysisResultOpt);
-            var nullAnalysis = new NullAnalysis(analysisDomain, operationVisitor);
+            var nullAnalysis = new NullAnalysis(NullAnalysisDomainInstance, operationVisitor);
             return nullAnalysis.GetOrComputeResultCore(cfg);
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
         /// <summary>
         /// Abstract value domain for <see cref="PointsToAnalysis"/> to merge and compare <see cref="PointsToAbstractValue"/> values.
         /// </summary>
-        private class PointsToAbstractValueDomain : AbstractDomain<PointsToAbstractValue>
+        private class PointsToAbstractValueDomain : AbstractValueDomain<PointsToAbstractValue>
         {
             public static PointsToAbstractValueDomain Default = new PointsToAbstractValueDomain();
             private readonly SetAbstractDomain<AbstractLocation> _locationsDomain = new SetAbstractDomain<AbstractLocation>();
@@ -21,6 +21,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             private PointsToAbstractValueDomain() { }
 
             public override PointsToAbstractValue Bottom => PointsToAbstractValue.Undefined;
+
+            public override PointsToAbstractValue UnknownOrMayBeValue => PointsToAbstractValue.Unknown;
 
             public override int Compare(PointsToAbstractValue oldValue, PointsToAbstractValue newValue)
             {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -6,13 +6,16 @@ using Microsoft.CodeAnalysis.Operations.ControlFlow;
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 {
     using PointsToAnalysisData = IDictionary<AnalysisEntity, PointsToAbstractValue>;
-    using PointsToAnalysisDomain = MapAbstractDomain<AnalysisEntity, PointsToAbstractValue>;
+    using PointsToAnalysisDomain = AnalysisEntityMapAbstractDomain<PointsToAbstractValue>;
 
     /// <summary>
     /// Dataflow analysis to track locations pointed to by <see cref="AnalysisEntity"/> and <see cref="IOperation"/> instances.
     /// </summary>
     internal partial class PointsToAnalysis : ForwardDataFlowAnalysis<PointsToAnalysisData, PointsToBlockAnalysisResult, PointsToAbstractValue>
     {
+        public static readonly PointsToAnalysisDomain PointsToAnalysisDomainInstance = new PointsToAnalysisDomain(PointsToAbstractValueDomain.Default);
+        public static readonly AbstractValueDomain<PointsToAbstractValue> PointsToAbstractValueDomainInstance = PointsToAbstractValueDomain.Default;
+
         private PointsToAnalysis(PointsToAnalysisDomain analysisDomain, PointsToDataFlowOperationVisitor operationVisitor)
             : base(analysisDomain, operationVisitor)
         {
@@ -23,9 +26,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             INamedTypeSymbol containingTypeSymbol,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
         {
-            var analysisDomain = new PointsToAnalysisDomain(PointsToAbstractValueDomain.Default);
             var operationVisitor = new PointsToDataFlowOperationVisitor(PointsToAbstractValueDomain.Default, containingTypeSymbol, nullAnalysisResultOpt);
-            var pointsToAnalysis = new PointsToAnalysis(analysisDomain, operationVisitor);
+            var pointsToAnalysis = new PointsToAnalysis(PointsToAnalysisDomainInstance, operationVisitor);
             return pointsToAnalysis.GetOrComputeResultCore(cfg);
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentAbstractDomain.cs
@@ -11,13 +11,15 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
         /// <summary>
         /// Abstract value domain for <see cref="StringContentAnalysis"/> to merge and compare <see cref="StringContentAbstractValue"/> values.
         /// </summary>
-        private sealed class StringContentAbstractValueDomain : AbstractDomain<StringContentAbstractValue>
+        private sealed class StringContentAbstractValueDomain : AbstractValueDomain<StringContentAbstractValue>
         {
             public static StringContentAbstractValueDomain Default = new StringContentAbstractValueDomain();
 
             private StringContentAbstractValueDomain() { }
 
             public override StringContentAbstractValue Bottom => StringContentAbstractValue.UndefinedState;
+
+            public override StringContentAbstractValue UnknownOrMayBeValue => StringContentAbstractValue.MayBeContainsNonLiteralState;
 
             public override int Compare(StringContentAbstractValue oldValue, StringContentAbstractValue newValue)
             {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
         private sealed class StringContentDataFlowOperationVisitor : DataFlowOperationVisitor<StringContentAnalysisData, StringContentAbstractValue>
         {
             public StringContentDataFlowOperationVisitor(
-                AbstractDomain<StringContentAbstractValue> valueDomain,
+                StringContentAbstractValueDomain valueDomain,
                 INamedTypeSymbol containingTypeSymbol,
                 DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt,
                 DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt)
@@ -25,20 +25,28 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
             {
             }
 
-            protected override StringContentAbstractValue UnknownOrMayBeValue => StringContentAbstractValue.MayBeContainsNonLiteralState;
-            protected override void SetAbstractValue(AnalysisEntity analysisEntity, StringContentAbstractValue value)
-                => CurrentAnalysisData[analysisEntity] = value;
+            protected override IEnumerable<AnalysisEntity> TrackedEntities => CurrentAnalysisData.Keys;
 
-            protected override bool HasAbstractValue(AnalysisEntity analysisEntity) =>
-                CurrentAnalysisData.ContainsKey(analysisEntity);
+            protected override void SetAbstractValue(AnalysisEntity analysisEntity, StringContentAbstractValue value) => CurrentAnalysisData[analysisEntity] = value;
 
-            protected override StringContentAbstractValue GetAbstractValue(AnalysisEntity analysisEntity) =>
-                CurrentAnalysisData.TryGetValue(analysisEntity, out var value) ? value : UnknownOrMayBeValue;
+            protected override bool HasAbstractValue(AnalysisEntity analysisEntity) => CurrentAnalysisData.ContainsKey(analysisEntity);
 
-            protected override StringContentAbstractValue GetAbstractDefaultValue(ITypeSymbol type) =>
-                StringContentAbstractValue.DoesNotContainNonLiteralState;
+            protected override StringContentAbstractValue GetAbstractValue(AnalysisEntity analysisEntity) => CurrentAnalysisData.TryGetValue(analysisEntity, out var value) ? value : ValueDomain.UnknownOrMayBeValue;
+
+            protected override StringContentAbstractValue GetAbstractDefaultValue(ITypeSymbol type) => StringContentAbstractValue.DoesNotContainNonLiteralState;
 
             protected override void ResetCurrentAnalysisData(StringContentAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);
+
+            // TODO: Remove these temporary methods once we move to compiler's CFG
+            // https://github.com/dotnet/roslyn-analyzers/issues/1567
+            #region Temporary methods to workaround lack of *real* CFG
+            protected override StringContentAnalysisData MergeAnalysisData(StringContentAnalysisData value1, StringContentAnalysisData value2)
+                => StringContentAnalysisDomainInstance.Merge(value1, value2);
+            protected override StringContentAnalysisData GetClonedAnalysisData()
+                => GetClonedAnalysisData(CurrentAnalysisData);
+            protected override bool Equals(StringContentAnalysisData value1, StringContentAnalysisData value2)
+                => EqualsHelper(value1, value2);
+            #endregion
 
             #region Visitor methods
             public override StringContentAbstractValue DefaultVisit(IOperation operation, object argument)
@@ -61,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
                     }
                 }
 
-                return UnknownOrMayBeValue;
+                return ValueDomain.UnknownOrMayBeValue;
             }
 
             public override StringContentAbstractValue VisitBinaryOperator(IBinaryOperation operation, object argument)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.cs
@@ -6,14 +6,14 @@ using Microsoft.CodeAnalysis.Operations.ControlFlow;
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 {
     using StringContentAnalysisData = IDictionary<AnalysisEntity, StringContentAbstractValue>;
-    using StringContentAnalysisDomain = MapAbstractDomain<AnalysisEntity, StringContentAbstractValue>;
+    using StringContentAnalysisDomain = AnalysisEntityMapAbstractDomain<StringContentAbstractValue>;
 
     /// <summary>
     /// Dataflow analysis to track string content of <see cref="AnalysisEntity"/>/<see cref="IOperation"/>.
     /// </summary>
     internal partial class StringContentAnalysis : ForwardDataFlowAnalysis<StringContentAnalysisData, StringContentBlockAnalysisResult, StringContentAbstractValue>
     {
-        private static readonly StringContentAnalysisDomain s_StringContentAnalysisDomain = new StringContentAnalysisDomain(StringContentAbstractValueDomain.Default);
+        public static readonly StringContentAnalysisDomain StringContentAnalysisDomainInstance = new StringContentAnalysisDomain(StringContentAbstractValueDomain.Default);
 
         private StringContentAnalysis(StringContentAnalysisDomain analysisDomain, StringContentDataFlowOperationVisitor operationVisitor)
             : base(analysisDomain, operationVisitor)
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt = null)
         {
             var operationVisitor = new StringContentDataFlowOperationVisitor(StringContentAbstractValueDomain.Default, containingTypeSymbol, nullAnalysisResultOpt, pointsToAnalysisResultOpt);
-            var nullAnalysis = new StringContentAnalysis(s_StringContentAnalysisDomain, operationVisitor);
+            var nullAnalysis = new StringContentAnalysis(StringContentAnalysisDomainInstance, operationVisitor);
             return nullAnalysis.GetOrComputeResultCore(cfg);
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractValueDomain.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    /// <summary>
+    /// Abstract value domain for a <see cref="DataFlowAnalysis"/> to merge and compare values.
+    /// </summary>
+    internal abstract class AbstractValueDomain<T> : AbstractDomain<T>
+    {
+        /// <summary>
+        /// Returns the major Unknown or MayBe top value of the domain.
+        /// </summary>
+        public abstract T UnknownOrMayBeValue { get; }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     /// </summary>
     internal sealed class AnalysisEntityFactory
     {
-        private readonly ImmutableDictionary<PointsToAbstractValue, ImmutableHashSet<AnalysisEntity>.Builder>.Builder _analysisEntitiesPerInstance;
         private readonly Dictionary<IOperation, AnalysisEntity> _analysisEntityMap;
         private readonly Dictionary<ISymbol, PointsToAbstractValue> _instanceLocationsForSymbols;
         private readonly Func<IOperation, PointsToAbstractValue> _getPointsToAbstractValueOpt;
@@ -25,14 +24,12 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             Func<IOperation, PointsToAbstractValue> getPointsToAbstractValueOpt, INamedTypeSymbol containingTypeSymbol)
         {
             _getPointsToAbstractValueOpt = getPointsToAbstractValueOpt;
-            _analysisEntitiesPerInstance = ImmutableDictionary.CreateBuilder<PointsToAbstractValue, ImmutableHashSet<AnalysisEntity>.Builder>();
             _analysisEntityMap = new Dictionary<IOperation, AnalysisEntity>();
             _instanceLocationsForSymbols = new Dictionary<ISymbol, PointsToAbstractValue>();
 
             var thisOrMeInstanceLocation = AbstractLocation.CreateThisOrMeLocation(containingTypeSymbol);
             var instanceLocation = new PointsToAbstractValue(thisOrMeInstanceLocation);
             ThisOrMeInstance = AnalysisEntity.CreateThisOrMeInstance(containingTypeSymbol, instanceLocation);
-            AddToMap(instanceLocation, ThisOrMeInstance);
         }
 
         public AnalysisEntity ThisOrMeInstance { get; }
@@ -135,7 +132,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                     {
                         var instanceLocation = _getPointsToAbstractValueOpt(instanceReference);
                         analysisEntity = AnalysisEntity.Create(instanceReference, instanceLocation);
-                        AddToMap(instanceLocation, analysisEntity);
                     }
                     break;
 
@@ -292,20 +288,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             instanceLocationOpt = EnsureLocation(instanceLocationOpt, symbolOpt, parentOpt);
             Debug.Assert(instanceLocationOpt != null);
             var analysisEntity = AnalysisEntity.Create(symbolOpt, indices, type, instanceLocationOpt, parentOpt);
-            AddToMap(instanceLocationOpt, analysisEntity);
             return analysisEntity;
-        }
-
-        private void AddToMap(PointsToAbstractValue instanceLocation, AnalysisEntity analysisEntity)
-        {
-            Debug.Assert(instanceLocation != null);
-            if (!_analysisEntitiesPerInstance.TryGetValue(instanceLocation, out var builder))
-            {
-                builder = ImmutableHashSet.CreateBuilder<AnalysisEntity>();
-            }
-
-            builder.Add(analysisEntity);
-            _analysisEntitiesPerInstance[instanceLocation] = builder;
         }
 
         public AnalysisEntity CreateWithNewInstanceRoot(AnalysisEntity analysisEntity, AnalysisEntity newRootInstance)
@@ -323,10 +306,5 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             AnalysisEntity parentOpt = CreateWithNewInstanceRoot(analysisEntity.ParentOpt, newRootInstance);
             return Create(analysisEntity.SymbolOpt, analysisEntity.Indices, analysisEntity.Type, newRootInstance.InstanceLocation, parentOpt);
         }
-
-        public ImmutableHashSet<AnalysisEntity> GetAnalysisEntitiesCreatedFromInstance(PointsToAbstractValue instance)
-            => _analysisEntitiesPerInstance.TryGetValue(instance, out ImmutableHashSet<AnalysisEntity>.Builder builder) && builder != null ?
-                builder.ToImmutable() :
-                ImmutableHashSet<AnalysisEntity>.Empty;
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    /// <summary>
+    /// An abstract domain implementation for analyses that store dictionary typed data.
+    /// </summary>
+    internal class AnalysisEntityMapAbstractDomain<TValue> : MapAbstractDomain<AnalysisEntity, TValue>
+    {
+        public AnalysisEntityMapAbstractDomain(AbstractValueDomain<TValue> valueDomain)
+            : base(valueDomain)
+        {
+        }
+
+        protected override IDictionary<AnalysisEntity, TValue> MergeCore(IDictionary<AnalysisEntity, TValue> map1, IDictionary<AnalysisEntity, TValue> map2)
+        {
+            Debug.Assert(map1 != null);
+            Debug.Assert(map2 != null);
+
+            var resultMap = new Dictionary<AnalysisEntity, TValue>();
+            foreach (var entry1 in map1)
+            {
+                AnalysisEntity key1 = entry1.Key;
+                TValue value1 = entry1.Value;
+                var equivalentKeys2 = map2.Keys.Where(key => key.EqualsIgnoringInstanceLocation(key1));
+                if (!equivalentKeys2.Any())
+                {
+                    resultMap.Add(key1, ValueDomain.UnknownOrMayBeValue);
+                    continue;
+                }
+
+                foreach (AnalysisEntity key2 in equivalentKeys2)
+                {
+                    TValue value2 = map2[key2];
+                    TValue mergedValue = ValueDomain.Merge(value1, value2);
+                    if (key1.InstanceLocation.Equals(key2.InstanceLocation))
+                    {
+                        resultMap[key1] = mergedValue;
+                    }
+                    else
+                    {
+                        AnalysisEntity mergedKey = key1.WithMergedInstanceLocation(key2);
+                        if (resultMap.TryGetValue(mergedKey, out var existingValue))
+                        {
+                            mergedValue = ValueDomain.Merge(mergedValue, existingValue);
+                        }
+
+                        resultMap[mergedKey] = mergedValue;
+                    }
+                }
+            }
+
+            foreach (var key2 in map2.Keys)
+            {
+                if (!resultMap.ContainsKey(key2))
+                {
+                    resultMap.Add(key2, ValueDomain.UnknownOrMayBeValue);
+                }
+            }
+
+            return resultMap;
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
@@ -1174,7 +1174,7 @@ End Module",
             GetBasicResultAt(150, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
+        [Fact]
         public void FlowAnalysis_WhileLoop_NonConstant_Diagnostic()
         {
             VerifyCSharp($@"
@@ -1224,7 +1224,7 @@ End Module",
             GetBasicResultAt(135, 22, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
+        [Fact]
         public void FlowAnalysis_ForLoop_NonConstant_Diagnostic()
         {
             VerifyCSharp($@"
@@ -1274,7 +1274,7 @@ End Module",
             GetBasicResultAt(135, 22, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
+        [Fact]
         public void FlowAnalysis_ForEachLoop_NonConstant_Diagnostic()
         {
             VerifyCSharp($@"
@@ -3063,7 +3063,7 @@ Class Test
 End Class");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
+        [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_Diagnostic()
         {
             VerifyCSharp($@"
@@ -3155,7 +3155,7 @@ End Class",
             GetBasicResultAt(156, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1567")]
+        [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_02_Diagnostic()
         {
             VerifyCSharp($@"


### PR DESCRIPTION
Addresses #1567

Add temporary code to DataFlowOperationVisitor to handle flow analysis for loops and if-else statements. This code will be removed once we move to compiler's CFG, which would have lowered all IOperations for these constructs. #1567 will be kept active to track this code removal.
Enabling skipped tests for if-else statement identified a bug in the merge algorithm for merging analysis data in presence of points to analysis, which has now been fixed.