### PR TITLE
Implement CA2213 (DisposableFieldsShouldBeDisposed)

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/DisposeAnalysisHelper.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/DisposeAnalysisHelper.cs
@@ -1,0 +1,212 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp
+{
+    /// <summary>
+    /// Helper for <see cref="DisposeAnalysis"/>.
+    /// </summary>
+    internal class DisposeAnalysisHelper
+    {
+        private static readonly string[] s_disposeOwnershipTransferLikelyTypes = new string[]
+            {
+                "System.IO.Stream",
+                "System.IO.TextReader",
+                "System.IO.TextWriter",
+                "System.Resources.IResourceReader",
+            };
+        private static readonly ConditionalWeakTable<Compilation, DisposeAnalysisHelper> s_DisposeHelperCache =
+            new ConditionalWeakTable<Compilation, DisposeAnalysisHelper>();
+        private static readonly ConditionalWeakTable<Compilation, DisposeAnalysisHelper>.CreateValueCallback s_DisposeHelperCacheCallback =
+            new ConditionalWeakTable<Compilation, DisposeAnalysisHelper>.CreateValueCallback(compilation => new DisposeAnalysisHelper(compilation));
+
+        private static ImmutableHashSet<OperationKind> s_DisposableCreationKinds => ImmutableHashSet.Create(
+            OperationKind.ObjectCreation,
+            OperationKind.TypeParameterObjectCreation,
+            OperationKind.DynamicObjectCreation,
+            OperationKind.Invocation);
+
+        public INamedTypeSymbol IDisposable { get; }
+        private readonly INamedTypeSymbol _iCollection;
+        private readonly INamedTypeSymbol _genericICollection;
+        private readonly ImmutableHashSet<INamedTypeSymbol> _disposeOwnershipTransferLikelyTypes;
+        private ConcurrentDictionary<INamedTypeSymbol, ImmutableHashSet<IFieldSymbol>> _lazyDisposableFieldsMap;
+
+        private DisposeAnalysisHelper(Compilation compilation)
+        {
+            IDisposable = WellKnownTypes.IDisposable(compilation);
+            if (IDisposable != null)
+            {
+                _iCollection = WellKnownTypes.ICollection(compilation);
+                _genericICollection = WellKnownTypes.GenericICollection(compilation);
+                _disposeOwnershipTransferLikelyTypes = GetDisposeOwnershipTransferLikelyTypes(compilation);
+            }
+        }
+
+        private static ImmutableHashSet<INamedTypeSymbol> GetDisposeOwnershipTransferLikelyTypes(Compilation compilation)
+        {
+            var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>();
+            foreach (var typeName in s_disposeOwnershipTransferLikelyTypes)
+            {
+                INamedTypeSymbol typeSymbol = compilation.GetTypeByMetadataName(typeName);
+                if (typeSymbol != null)
+                {
+                    builder.Add(typeSymbol);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private void EnsureDisposableFieldsMap()
+        {
+            if (_lazyDisposableFieldsMap == null)
+            {
+                Interlocked.CompareExchange(ref _lazyDisposableFieldsMap, new ConcurrentDictionary<INamedTypeSymbol, ImmutableHashSet<IFieldSymbol>>(), null);
+            }
+        }
+
+        public static bool TryGetOrCreate(Compilation compilation, out DisposeAnalysisHelper disposeHelper)
+        {
+            disposeHelper = s_DisposeHelperCache.GetValue(compilation, s_DisposeHelperCacheCallback);
+            if (disposeHelper.IDisposable == null)
+            {
+                disposeHelper = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        public bool TryGetOrComputeResult(
+            ImmutableArray<IOperation> operationBlocks,
+            IMethodSymbol containingMethod,
+            out ControlFlowGraph cfg,
+            out DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult)
+        {
+            return TryGetOrComputeResult(operationBlocks, containingMethod, out cfg, out disposeAnalysisResult, out var _);
+        }
+
+        public bool TryGetOrComputeResult(
+            ImmutableArray<IOperation> operationBlocks,
+            IMethodSymbol containingMethod,
+            out ControlFlowGraph cfg,
+            out DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult,
+            out DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult)
+        {
+            return TryGetOrComputeResult(operationBlocks, containingMethod, out cfg, out disposeAnalysisResult, out pointsToAnalysisResult, out var _);
+        }
+
+        public bool TryGetOrComputeResult(
+            ImmutableArray<IOperation> operationBlocks,
+            IMethodSymbol containingMethod,
+            out ControlFlowGraph cfg,
+            out DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult,
+            out DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult,
+            out ImmutableDictionary<IFieldSymbol, PointsToAbstractValue> trackedInstanceFieldPointsToMap)
+        {
+            foreach (var operationRoot in operationBlocks)
+            {
+                IBlockOperation topmostBlock = operationRoot.GetTopmostParentBlock();
+                if (topmostBlock != null)
+                {
+                    cfg = ControlFlowGraph.Create(topmostBlock);
+                    var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType);
+                    pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType, nullAnalysisResult);
+                    disposeAnalysisResult = DisposeAnalysis.GetOrComputeResult(cfg, IDisposable, _iCollection,
+                        _genericICollection, _disposeOwnershipTransferLikelyTypes, containingMethod.ContainingType, pointsToAnalysisResult,
+                        out trackedInstanceFieldPointsToMap, nullAnalysisResult);
+                    return true;
+                }
+            }
+
+            cfg = null;
+            disposeAnalysisResult = null;
+            pointsToAnalysisResult = null;
+            trackedInstanceFieldPointsToMap = null;
+            return false;
+        }
+
+        private bool HasDisposableOwnershipTransferForParameter(IMethodSymbol containingMethod) =>
+            containingMethod.MethodKind == MethodKind.Constructor &&
+            containingMethod.Parameters.Length == 1 &&
+            _disposeOwnershipTransferLikelyTypes.Contains(containingMethod.Parameters[0].Type);
+
+        public bool HasAnyDisposableCreationDescendant(ImmutableArray<IOperation> operationBlocks, IMethodSymbol containingMethod)
+        {
+            foreach (var operationBlock in operationBlocks)
+            {
+                foreach (var descendant in operationBlock.DescendantsAndSelf())
+                {
+                    if (s_DisposableCreationKinds.Contains(descendant.Kind) &&
+                        descendant.Type.IsDisposable(IDisposable))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return HasDisposableOwnershipTransferForParameter(containingMethod);
+        }
+
+        public ImmutableHashSet<IFieldSymbol> GetDisposableFields(INamedTypeSymbol namedType)
+        {
+            EnsureDisposableFieldsMap();
+            if (_lazyDisposableFieldsMap.TryGetValue(namedType, out ImmutableHashSet<IFieldSymbol> disposableFields))
+            {
+                return disposableFields;
+            }
+
+            if (!namedType.IsDisposable(IDisposable))
+            {
+                disposableFields = ImmutableHashSet<IFieldSymbol>.Empty;
+            }
+            else
+            {
+                disposableFields = namedType.GetMembers().OfType<IFieldSymbol>().Where(f => f.Type.IsDisposable(IDisposable)).ToImmutableHashSet();
+            }
+
+            return _lazyDisposableFieldsMap.GetOrAdd(namedType, disposableFields);
+        }
+
+        /// <summary>
+        /// Returns true if the given <paramref name="location"/> was created for an allocation in the <paramref name="containingMethod"/>
+        /// or represents a location created for a constructor parameter whose type indicates dispose ownership transfer.
+        /// </summary>
+        public bool IsDisposableCreationOrDisposeOwnershipTransfer(AbstractLocation location, IMethodSymbol containingMethod)
+        {
+            if (location.CreationOpt == null)
+            {
+                return false;
+            }
+
+            if (s_DisposableCreationKinds.Contains(location.CreationOpt.Kind))
+            {
+                return true;
+            }
+
+            if (location.CreationOpt.Kind == OperationKind.ParameterReference)
+            {
+                return HasDisposableOwnershipTransferForParameter(containingMethod);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/DisposeAnalysisHelper.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/DisposeAnalysisHelper.cs
@@ -110,12 +110,14 @@ namespace Microsoft.CodeQuality.Analyzers.Exp
             out DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult,
             out DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult)
         {
-            return TryGetOrComputeResult(operationBlocks, containingMethod, out cfg, out disposeAnalysisResult, out pointsToAnalysisResult, out var _);
+            return TryGetOrComputeResult(operationBlocks, containingMethod, trackInstanceFields: false,
+                cfg: out cfg, disposeAnalysisResult: out disposeAnalysisResult, pointsToAnalysisResult: out pointsToAnalysisResult, trackedInstanceFieldPointsToMap: out var _);
         }
 
         public bool TryGetOrComputeResult(
             ImmutableArray<IOperation> operationBlocks,
             IMethodSymbol containingMethod,
+            bool trackInstanceFields,
             out ControlFlowGraph cfg,
             out DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult,
             out DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult,
@@ -131,7 +133,7 @@ namespace Microsoft.CodeQuality.Analyzers.Exp
                     pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType, nullAnalysisResult);
                     disposeAnalysisResult = DisposeAnalysis.GetOrComputeResult(cfg, IDisposable, _iCollection,
                         _genericICollection, _disposeOwnershipTransferLikelyTypes, containingMethod.ContainingType, pointsToAnalysisResult,
-                        out trackedInstanceFieldPointsToMap, nullAnalysisResult);
+                        trackInstanceFields, out trackedInstanceFieldPointsToMap, nullAnalysisResult);
                     return true;
                 }
             }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeAbstractValueDomain.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
 
                 if (oldValue.Kind == newValue.Kind)
                 {
-                    return _disposingOperationsDomain.Compare(oldValue.DisposingOperations, newValue.DisposingOperations);
+                    return _disposingOperationsDomain.Compare(oldValue.DisposingOrEscapingOperations, newValue.DisposingOrEscapingOperations);
                 }
                 else if (oldValue.Kind < newValue.Kind)
                 {
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
                     DisposeAbstractValueKind.Disposed :
                     DisposeAbstractValueKind.MaybeDisposed;
 
-                var mergedDisposingOperations = _disposingOperationsDomain.Merge(value1.DisposingOperations, value2.DisposingOperations);
+                var mergedDisposingOperations = _disposingOperationsDomain.Merge(value1.DisposingOrEscapingOperations, value2.DisposingOrEscapingOperations);
                 if (mergedDisposingOperations.IsEmpty)
                 {
                     Debug.Assert(kind == DisposeAbstractValueKind.MaybeDisposed);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
                 var value = base.VisitUsing(operation, argument);
                 if (operation.Resources is IVariableDeclarationGroupOperation varDeclGroup)
                 {
-                    var variablerInitializers = varDeclGroup.Declarations.SelectMany(declaration => declaration.Declarators).Select(declarator => declarator.GetVariableInitializer()).WhereNotNull();
+                    var variablerInitializers = varDeclGroup.Declarations.SelectMany(declaration => declaration.Declarators).Select(declarator => declarator.GetVariableInitializer()?.Value).WhereNotNull();
                     foreach (var disposedInstance in variablerInitializers)
                     {
                         HandleDisposingOperation(operation, disposedInstance);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
@@ -31,15 +31,50 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
         {
+            return GetOrComputeResultCore(cfg, iDisposable, iCollection, genericICollection,
+                disposeOwnershipTransferLikelyTypes, containingTypeSymbol, pointsToAnalysisResult,
+                nullAnalysisResultOpt, trackInstanceFields: false, trackedInstanceFieldPointsToMap: out var _);
+        }
+
+        public static DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> GetOrComputeResult(
+            ControlFlowGraph cfg,
+            INamedTypeSymbol iDisposable,
+            INamedTypeSymbol iCollection,
+            INamedTypeSymbol genericICollection,
+            ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
+            INamedTypeSymbol containingTypeSymbol,
+            DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
+            out ImmutableDictionary<IFieldSymbol, PointsToAnalysis.PointsToAbstractValue> trackedInstanceFieldPointsToMap,
+            DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
+        {
+            return GetOrComputeResultCore(cfg, iDisposable, iCollection, genericICollection,
+                disposeOwnershipTransferLikelyTypes, containingTypeSymbol, pointsToAnalysisResult,
+                nullAnalysisResultOpt, trackInstanceFields: true, trackedInstanceFieldPointsToMap: out trackedInstanceFieldPointsToMap);
+        }
+
+        private static DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> GetOrComputeResultCore(
+            ControlFlowGraph cfg,
+            INamedTypeSymbol iDisposable,
+            INamedTypeSymbol iCollection,
+            INamedTypeSymbol genericICollection,
+            ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
+            INamedTypeSymbol containingTypeSymbol,
+            DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
+            DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt,
+            bool trackInstanceFields,
+            out ImmutableDictionary<IFieldSymbol, PointsToAnalysis.PointsToAbstractValue> trackedInstanceFieldPointsToMap)
+        {
             Debug.Assert(cfg != null);
             Debug.Assert(iDisposable != null);
             Debug.Assert(containingTypeSymbol != null);
             Debug.Assert(pointsToAnalysisResult != null);
 
             var operationVisitor = new DisposeDataFlowOperationVisitor(iDisposable, iCollection, genericICollection,
-                disposeOwnershipTransferLikelyTypes, DisposeAbstractValueDomain.Default, containingTypeSymbol, pointsToAnalysisResult, nullAnalysisResultOpt);
+                disposeOwnershipTransferLikelyTypes, DisposeAbstractValueDomain.Default, containingTypeSymbol, trackInstanceFields, pointsToAnalysisResult, nullAnalysisResultOpt);
             var disposeAnalysis = new DisposeAnalysis(DisposeAnalysisDomainInstance, operationVisitor);
-            return disposeAnalysis.GetOrComputeResultCore(cfg);
+            var result = disposeAnalysis.GetOrComputeResultCore(cfg);
+            trackedInstanceFieldPointsToMap = trackInstanceFields ? operationVisitor.TrackedInstanceFieldPointsToMap : null;
+            return result;
         }
 
         internal override DisposeBlockAnalysisResult ToResult(BasicBlock basicBlock, DataFlowAnalysisInfo<IDictionary<AbstractLocation, DisposeAbstractValue>> blockAnalysisData) => new DisposeBlockAnalysisResult(basicBlock, blockAnalysisData);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
@@ -44,12 +44,13 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
             ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
             INamedTypeSymbol containingTypeSymbol,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
+            bool trackInstanceFields,
             out ImmutableDictionary<IFieldSymbol, PointsToAnalysis.PointsToAbstractValue> trackedInstanceFieldPointsToMap,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
         {
             return GetOrComputeResultCore(cfg, iDisposable, iCollection, genericICollection,
                 disposeOwnershipTransferLikelyTypes, containingTypeSymbol, pointsToAnalysisResult,
-                nullAnalysisResultOpt, trackInstanceFields: true, trackedInstanceFieldPointsToMap: out trackedInstanceFieldPointsToMap);
+                nullAnalysisResultOpt, trackInstanceFields, out trackedInstanceFieldPointsToMap);
         }
 
         private static DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> GetOrComputeResultCore(

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocationDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocationDataFlowOperationVisitor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             AbstractValueDomain<TAbstractAnalysisValue> valueDomain,
             INamedTypeSymbol containingTypeSymbol,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt,
-            DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt)
+            DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResultOpt)
             : base(valueDomain, containingTypeSymbol, nullAnalysisResultOpt, pointsToAnalysisResultOpt)
         {
         }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             else
             {
                 // Merge the values from current and new analysis data.
-                var keys = currentAnalysisDataOpt?.Keys.Concat(newAnalysisDataOpt.Keys).ToImmutableArray();
+                var keys = currentAnalysisDataOpt?.Keys.Concat(newAnalysisDataOpt.Keys).ToImmutableHashSet();
                 foreach (var key in keys)
                 {
                     var value1 = currentAnalysisDataOpt != null && currentAnalysisDataOpt.TryGetValue(key, out var currentValue) ? currentValue : ValueDomain.Bottom;

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Reliability/DisposeObjectsBeforeLosingScope.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Reliability/DisposeObjectsBeforeLosingScope.cs
@@ -63,10 +63,13 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Reliability
                         {
                             AbstractLocation location = kvp.Key;
                             DisposeAbstractValue disposeValue = kvp.Value;
+                            if (disposeValue.Kind == DisposeAbstractValueKind.NotDisposable)
+                            {
+                                continue;
+                            }
+
                             if (disposeValue.Kind == DisposeAbstractValueKind.NotDisposed ||
-                                ((disposeValue.Kind == DisposeAbstractValueKind.Disposed ||
-                                  disposeValue.Kind == DisposeAbstractValueKind.MaybeDisposed) &&
-                                 disposeValue.DisposingOrEscapingOperations.Count > 0 &&
+                                (disposeValue.DisposingOrEscapingOperations.Count > 0 &&
                                  disposeValue.DisposingOrEscapingOperations.All(d => d.IsInsideCatchClause())))
                             {
                                 Debug.Assert(location.CreationOpt != null);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Reliability/DisposeObjectsBeforeLosingScope.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Reliability/DisposeObjectsBeforeLosingScope.cs
@@ -11,8 +11,6 @@ using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Operations.ControlFlow;
 using Microsoft.CodeAnalysis.Operations.DataFlow;
 using Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis;
-using Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis;
-using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
 
 namespace Microsoft.CodeQuality.Analyzers.Exp.Reliability
 {
@@ -20,14 +18,6 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Reliability
     public sealed class DisposeObjectsBeforeLosingScope : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA2000";
-
-        private static readonly string[] s_disposeOwnershipTransferLikelyTypes = new string[]
-            {
-                "System.IO.Stream",
-                "System.IO.TextReader",
-                "System.IO.TextWriter",
-                "System.Resources.IResourceReader",
-            };
 
         private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftReliabilityAnalyzersResources.DisposeObjectsBeforeLosingScopeTitle), MicrosoftReliabilityAnalyzersResources.ResourceManager, typeof(MicrosoftReliabilityAnalyzersResources));
         private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftReliabilityAnalyzersResources.DisposeObjectsBeforeLosingScopeMessage), MicrosoftReliabilityAnalyzersResources.ResourceManager, typeof(MicrosoftReliabilityAnalyzersResources));
@@ -51,91 +41,46 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Reliability
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.RegisterCompilationStartAction(compilationContext =>
             {
-                var iDisposable = WellKnownTypes.IDisposable(compilationContext.Compilation);
-                if (iDisposable == null)
+                if (!DisposeAnalysisHelper.TryGetOrCreate(compilationContext.Compilation, out DisposeAnalysisHelper disposeAnalysisHelper))
                 {
                     return;
                 }
 
-                var iCollection = WellKnownTypes.ICollection(compilationContext.Compilation);
-                var genericICollection = WellKnownTypes.GenericICollection(compilationContext.Compilation);
-                var disposeOwnershipTransferLikelyTypes = GetDisposeOwnershipTransferLikelyTypes(compilationContext.Compilation);
-                compilationContext.RegisterOperationBlockStartAction(operationBlockStartContext =>
+                compilationContext.RegisterOperationBlockAction(operationBlockContext =>
                 {
-                    bool hasDisposableCreation = false;
-                    operationBlockStartContext.RegisterOperationAction(operationContext =>
+                    if (!(operationBlockContext.OwningSymbol is IMethodSymbol containingMethod) ||
+                        !disposeAnalysisHelper.HasAnyDisposableCreationDescendant(operationBlockContext.OperationBlocks, containingMethod))
                     {
-                        if (!hasDisposableCreation &&
-                            operationContext.Operation.Type.IsDisposable(iDisposable))
-                        {
-                            hasDisposableCreation = true;
-                        }
-                    },
-                    OperationKind.ObjectCreation,
-                    OperationKind.TypeParameterObjectCreation,
-                    OperationKind.DynamicObjectCreation,
-                    OperationKind.Invocation);
+                        return;
+                    }
 
-                    operationBlockStartContext.RegisterOperationBlockEndAction(operationBlockEndContext =>
+                    ControlFlowGraph cfg;
+                    DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult;
+                    if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockContext.OperationBlocks, containingMethod, out cfg, out disposeAnalysisResult))
                     {
-                        if (!hasDisposableCreation ||
-                            !(operationBlockEndContext.OwningSymbol is IMethodSymbol containingMethod))
+                        ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[cfg.Exit].InputData;
+                        foreach (var kvp in disposeDataAtExit)
                         {
-                            return;
-                        }
-
-                        foreach (var operationRoot in operationBlockEndContext.OperationBlocks)
-                        {
-                            IBlockOperation topmostBlock = operationRoot.GetTopmostParentBlock();
-                            if (topmostBlock != null)
+                            AbstractLocation location = kvp.Key;
+                            DisposeAbstractValue disposeValue = kvp.Value;
+                            if (disposeValue.Kind == DisposeAbstractValueKind.NotDisposed ||
+                                ((disposeValue.Kind == DisposeAbstractValueKind.Disposed ||
+                                  disposeValue.Kind == DisposeAbstractValueKind.MaybeDisposed) &&
+                                 disposeValue.DisposingOrEscapingOperations.Count > 0 &&
+                                 disposeValue.DisposingOrEscapingOperations.All(d => d.IsInsideCatchClause())))
                             {
-                                var cfg = ControlFlowGraph.Create(topmostBlock);
-                                var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType);
-                                var pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType, nullAnalysisResult);
-                                var disposeAnalysisResult = DisposeAnalysis.GetOrComputeResult(cfg, iDisposable, iCollection,
-                                    genericICollection, disposeOwnershipTransferLikelyTypes, containingMethod.ContainingType, pointsToAnalysisResult, nullAnalysisResult);
-                                ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[cfg.Exit].InputData;
-                                foreach (var kvp in disposeDataAtExit)
-                                {
-                                    AbstractLocation location = kvp.Key;
-                                    DisposeAbstractValue disposeValue = kvp.Value;
-                                    if (disposeValue.Kind == DisposeAbstractValueKind.NotDisposed ||
-                                        ((disposeValue.Kind == DisposeAbstractValueKind.Disposed ||
-                                          disposeValue.Kind == DisposeAbstractValueKind.MaybeDisposed) &&
-                                         disposeValue.DisposingOperations.Count > 0 &&
-                                         disposeValue.DisposingOperations.All(d => d.IsInsideCatchClause())))
-                                    {
-                                        Debug.Assert(location.CreationOpt != null);
+                                Debug.Assert(location.CreationOpt != null);
 
-                                        // CA2000: In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.
-                                        var arg1 = containingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                                        var arg2 = location.CreationOpt.Syntax.ToString();
-                                        var diagnostic = location.CreationOpt.Syntax.CreateDiagnostic(Rule, arg1, arg2);
-                                        operationBlockEndContext.ReportDiagnostic(diagnostic);
-                                    }
-                                }
-
-                                break;
+                                // CA2000: In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.
+                                var arg1 = containingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                                var arg2 = location.CreationOpt.Syntax.ToString();
+                                var diagnostic = location.CreationOpt.Syntax.CreateDiagnostic(Rule, arg1, arg2);
+                                operationBlockContext.ReportDiagnostic(diagnostic);
                             }
                         }
-                    });
+                    }
                 });
             });
-        }
-
-        private static ImmutableHashSet<INamedTypeSymbol> GetDisposeOwnershipTransferLikelyTypes(Compilation compilation)
-        {
-            var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>();
-            foreach (var typeName in s_disposeOwnershipTransferLikelyTypes)
-            {
-                INamedTypeSymbol typeSymbol = compilation.GetTypeByMetadataName(typeName);
-                if (typeSymbol != null)
-                {
-                    builder.Add(typeSymbol);
-                }
-            }
-
-            return builder.ToImmutable();
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
@@ -142,7 +142,8 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
                             DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult;
                             DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult;
                             ImmutableDictionary<IFieldSymbol, PointsToAbstractValue> trackedInstanceFieldPointsToMap;
-                            if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext.OperationBlocks, containingMethod, out cfg, out disposeAnalysisResult, out pointsToAnalysisResult, out trackedInstanceFieldPointsToMap))
+                            if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext.OperationBlocks, containingMethod, trackInstanceFields: true,
+                                cfg: out cfg, disposeAnalysisResult: out disposeAnalysisResult, pointsToAnalysisResult: out pointsToAnalysisResult, trackedInstanceFieldPointsToMap: out trackedInstanceFieldPointsToMap))
                             {
                                 foreach (var fieldWithPointsToValue in trackedInstanceFieldPointsToMap)
                                 {
@@ -174,43 +175,6 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
                                         }
                                     }
                                 }
-
-                            //    operationBlockStartContext.RegisterOperationAction(operationContext =>
-                            //    {
-                            //        var invocation = (IInvocationOperation)operationContext.Operation;
-                            //        if (invocation.TargetMethod.GetDisposeMethodKind(operationContext.Compilation) != DisposeMethodKind.None)
-                            //        {
-                            //            if (invocation.Instance != null)
-                            //            {
-                            //                IFieldReferenceOperation fieldReference = null;
-                            //                switch (invocation.Instance.Kind)
-                            //                {
-                            //                    case OperationKind.FieldReference:
-                            //                        fieldReference = (IFieldReferenceOperation)invocation.Instance;
-                            //                        break;
-
-                            //                    case OperationKind.ConditionalAccessInstance:
-                            //                        var conditionalAccessInstance = (IConditionalAccessInstanceOperation)invocation.Instance;
-                            //                        IConditionalAccessOperation conditionalAccess = conditionalAccessInstance.GetConditionalAccess();
-                            //                        if (conditionalAccess.Operation.Kind == OperationKind.FieldReference)
-                            //                        {
-                            //                            fieldReference = (IFieldReferenceOperation)conditionalAccess.Operation;
-                            //                        }
-                            //                        break;
-                            //                }
-
-                            //                IFieldSymbol field = fieldReference?.Field;
-                            //                if (field != null &&
-                            //                    disposableFields.Contains(field) &&
-                            //                    !field.IsStatic &&
-                            //                    fieldReference.Instance?.Kind == OperationKind.InstanceReference)
-                            //                {
-                            //                    addOrUpdateFieldDisposedValue(field, /*disposed*/true);
-                            //                }
-                            //            }
-                            //        }
-                            //    },
-                            //OperationKind.Invocation);
                             }
                         }
                     }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
                 }
 
                 var fieldDisposeValueMap = new ConcurrentDictionary<IFieldSymbol, /*disposed*/bool>();
-                Action<IFieldSymbol, bool> addOrUpdateFieldDisposedValue = (field, disposed) =>
+                void addOrUpdateFieldDisposedValue(IFieldSymbol field, bool disposed)
                 {
                     Debug.Assert(!field.IsStatic);
                     Debug.Assert(field.Type.IsDisposable(disposeAnalysisHelper.IDisposable));
@@ -69,7 +69,7 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
                         if (!field.IsStatic &&
                             disposeAnalysisHelper.GetDisposableFields(field.ContainingType).Contains(field))
                         {
-                            addOrUpdateFieldDisposedValue(field, /*disposed*/false);
+                            addOrUpdateFieldDisposedValue(field, disposed: false);
                         }
                     }
                 },
@@ -122,7 +122,7 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
                                     {
                                         if (disposeAnalysisHelper.IsDisposableCreationOrDisposeOwnershipTransfer(location, containingMethod))
                                         {
-                                            addOrUpdateFieldDisposedValue(field, /*disposed*/false);
+                                            addOrUpdateFieldDisposedValue(field, disposed: false);
                                             break;
                                         }
                                     }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
@@ -1,0 +1,239 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class DisposableFieldsShouldBeDisposed : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA2213";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftUsageAnalyzersResources.DisposableFieldsShouldBeDisposedTitle), MicrosoftUsageAnalyzersResources.ResourceManager, typeof(MicrosoftUsageAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftUsageAnalyzersResources.DisposableFieldsShouldBeDisposedMessage), MicrosoftUsageAnalyzersResources.ResourceManager, typeof(MicrosoftUsageAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftUsageAnalyzersResources.DisposableFieldsShouldBeDisposedDescription), MicrosoftUsageAnalyzersResources.ResourceManager, typeof(MicrosoftUsageAnalyzersResources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
+                                                                             s_localizableTitle,
+                                                                             s_localizableMessage,
+                                                                             DiagnosticCategory.Usage,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             description: s_localizableDescription,
+                                                                             helpLinkUri: "https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2213-disposable-fields-should-be-disposed",
+                                                                             customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                if (!DisposeAnalysisHelper.TryGetOrCreate(compilationContext.Compilation, out DisposeAnalysisHelper disposeAnalysisHelper))
+                {
+                    return;
+                }
+
+                var fieldDisposeValueMap = new ConcurrentDictionary<IFieldSymbol, /*disposed*/bool>();
+                Action<IFieldSymbol, bool> addOrUpdateFieldDisposedValue = (field, disposed) =>
+                {
+                    Debug.Assert(!field.IsStatic);
+                    Debug.Assert(field.Type.IsDisposable(disposeAnalysisHelper.IDisposable));
+
+                    fieldDisposeValueMap.AddOrUpdate(field,
+                        addValue: disposed,
+                        updateValueFactory: (f, currentValue) => currentValue || disposed);
+                };
+
+                // Disposable fields with initializer at declaration must be disposed.
+                compilationContext.RegisterOperationAction(operationContext =>
+                {
+                    var initializedFields = ((IFieldInitializerOperation)operationContext.Operation).InitializedFields;
+                    foreach (var field in initializedFields)
+                    {
+                        if (!field.IsStatic &&
+                            disposeAnalysisHelper.GetDisposableFields(field.ContainingType).Contains(field))
+                        {
+                            addOrUpdateFieldDisposedValue(field, /*disposed*/false);
+                        }
+                    }
+                },
+                OperationKind.FieldInitializer);
+
+                // Instance fields initialized in constructor/method body with a locally created disposable object must be disposed.
+                compilationContext.RegisterOperationBlockStartAction(operationBlockStartContext =>
+                {
+                    if (!(operationBlockStartContext.OwningSymbol is IMethodSymbol containingMethod))
+                    {
+                        return;
+                    }
+
+                    if (disposeAnalysisHelper.HasAnyDisposableCreationDescendant(operationBlockStartContext.OperationBlocks, containingMethod))
+                    {
+                        ControlFlowGraph cfg;
+                        DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult;
+                        DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult;
+                        if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext.OperationBlocks, containingMethod, out cfg, out disposeAnalysisResult, out pointsToAnalysisResult))
+                        {
+                            Debug.Assert(cfg != null);
+                            Debug.Assert(disposeAnalysisResult != null);
+                            Debug.Assert(pointsToAnalysisResult != null);
+
+                            operationBlockStartContext.RegisterOperationAction(operationContext =>
+                            {
+                                var fieldReference = (IFieldReferenceOperation)operationContext.Operation;
+                                var field = fieldReference.Field;
+
+                                // Only track instance fields on the current instance.
+                                if (field.IsStatic || fieldReference.Instance?.Kind != OperationKind.InstanceReference)
+                                {
+                                    return;
+                                }
+
+                                // Check if this is a Disposable field that is not currently being tracked.
+                                if (fieldDisposeValueMap.ContainsKey(field) ||
+                                    !disposeAnalysisHelper.GetDisposableFields(field.ContainingType).Contains(field))
+                                {
+                                    return;
+                                }
+
+                                // We have a field reference for a disposable field.
+                                // Check if it is being assigned a locally created disposable object.
+                                if (fieldReference.Parent is ISimpleAssignmentOperation simpleAssignmentOperation &&
+                                    simpleAssignmentOperation.Target == fieldReference)
+                                {
+                                    PointsToAbstractValue assignedPointsToValue = pointsToAnalysisResult[simpleAssignmentOperation.Value];
+                                    foreach (var location in assignedPointsToValue.Locations)
+                                    {
+                                        if (disposeAnalysisHelper.IsDisposableCreationOrDisposeOwnershipTransfer(location, containingMethod))
+                                        {
+                                            addOrUpdateFieldDisposedValue(field, /*disposed*/false);
+                                            break;
+                                        }
+                                    }
+                                }
+                            },
+                            OperationKind.FieldReference);
+                        }
+                    }
+
+                    // Mark fields disposed in Dispose method(s).
+                    if (containingMethod.GetDisposeMethodKind(operationBlockStartContext.Compilation) != DisposeMethodKind.None)
+                    {
+                        var disposableFields = disposeAnalysisHelper.GetDisposableFields(containingMethod.ContainingType);
+                        if (!disposableFields.IsEmpty)
+                        {
+                            ControlFlowGraph cfg;
+                            DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult;
+                            DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult;
+                            ImmutableDictionary<IFieldSymbol, PointsToAbstractValue> trackedInstanceFieldPointsToMap;
+                            if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext.OperationBlocks, containingMethod, out cfg, out disposeAnalysisResult, out pointsToAnalysisResult, out trackedInstanceFieldPointsToMap))
+                            {
+                                foreach (var fieldWithPointsToValue in trackedInstanceFieldPointsToMap)
+                                {
+                                    IFieldSymbol field = fieldWithPointsToValue.Key;
+                                    PointsToAbstractValue pointsToValue = fieldWithPointsToValue.Value;
+
+                                    Debug.Assert(field.Type.IsDisposable(disposeAnalysisHelper.IDisposable));
+                                    ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[cfg.Exit].InputData;
+                                    var disposed = false;
+                                    foreach (var location in pointsToValue.Locations)
+                                    {
+                                        if (disposeDataAtExit.TryGetValue(location, out DisposeAbstractValue disposeValue))
+                                        {
+                                            switch (disposeValue.Kind)
+                                            {
+                                                // For MaybeDisposed, conservatively mark the field as disposed as we don't support path sensitive analysis.
+                                                case DisposeAbstractValueKind.MaybeDisposed:
+                                                case DisposeAbstractValueKind.Disposed:
+                                                    disposed = true;
+                                                    addOrUpdateFieldDisposedValue(field, disposed);
+                                                    break;
+
+                                            }
+                                        }
+
+                                        if (disposed)
+                                        {
+                                            break;
+                                        }
+                                    }
+                                }
+
+                            //    operationBlockStartContext.RegisterOperationAction(operationContext =>
+                            //    {
+                            //        var invocation = (IInvocationOperation)operationContext.Operation;
+                            //        if (invocation.TargetMethod.GetDisposeMethodKind(operationContext.Compilation) != DisposeMethodKind.None)
+                            //        {
+                            //            if (invocation.Instance != null)
+                            //            {
+                            //                IFieldReferenceOperation fieldReference = null;
+                            //                switch (invocation.Instance.Kind)
+                            //                {
+                            //                    case OperationKind.FieldReference:
+                            //                        fieldReference = (IFieldReferenceOperation)invocation.Instance;
+                            //                        break;
+
+                            //                    case OperationKind.ConditionalAccessInstance:
+                            //                        var conditionalAccessInstance = (IConditionalAccessInstanceOperation)invocation.Instance;
+                            //                        IConditionalAccessOperation conditionalAccess = conditionalAccessInstance.GetConditionalAccess();
+                            //                        if (conditionalAccess.Operation.Kind == OperationKind.FieldReference)
+                            //                        {
+                            //                            fieldReference = (IFieldReferenceOperation)conditionalAccess.Operation;
+                            //                        }
+                            //                        break;
+                            //                }
+
+                            //                IFieldSymbol field = fieldReference?.Field;
+                            //                if (field != null &&
+                            //                    disposableFields.Contains(field) &&
+                            //                    !field.IsStatic &&
+                            //                    fieldReference.Instance?.Kind == OperationKind.InstanceReference)
+                            //                {
+                            //                    addOrUpdateFieldDisposedValue(field, /*disposed*/true);
+                            //                }
+                            //            }
+                            //        }
+                            //    },
+                            //OperationKind.Invocation);
+                            }
+                        }
+                    }
+                });
+
+                compilationContext.RegisterCompilationEndAction(compilationEndContext =>
+                {
+                    foreach (var kvp in fieldDisposeValueMap)
+                    {
+                        IFieldSymbol field = kvp.Key;
+                        bool disposed = kvp.Value;
+                        if (!disposed)
+                        {
+                            // '{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.
+                            var arg1 = field.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                            var arg2 = field.Name;
+                            var arg3 = field.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                            var diagnostic = field.CreateDiagnostic(Rule, arg1, arg2, arg3);
+                            compilationEndContext.ReportDiagnostic(diagnostic);
+                        }
+                    }
+                });
+            });
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/MicrosoftUsageAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/MicrosoftUsageAnalyzersResources.resx
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DisposableFieldsShouldBeDisposedDescription" xml:space="preserve">
+    <value>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</value>
+  </data>
+  <data name="DisposableFieldsShouldBeDisposedMessage" xml:space="preserve">
+    <value>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</value>
+  </data>
+  <data name="DisposableFieldsShouldBeDisposedTitle" xml:space="preserve">
+    <value>Disposable fields should be disposed</value>
+  </data>
+</root>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.cs.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.de.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.es.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.fr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.it.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ja.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ko.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.pl.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.pt-BR.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ru.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.tr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.zh-Hans.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.zh-Hant.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../MicrosoftUsageAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DisposableFieldsShouldBeDisposedDescription">
+        <source>A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</source>
+        <target state="new">A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedTitle">
+        <source>Disposable fields should be disposed</source>
+        <target state="new">Disposable fields should be disposed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
+        <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposableFieldsShouldBeDisposedTests.cs
@@ -1,0 +1,2055 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeQuality.Analyzers.Exp.Usage;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Usage
+{
+    public partial class DisposableFieldsShouldBeDisposedTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new DisposableFieldsShouldBeDisposed();
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new DisposableFieldsShouldBeDisposed();
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, string containingType, string field, string fieldType) =>
+            GetCSharpResultAt(line, column, DisposableFieldsShouldBeDisposed.Rule, containingType, field, fieldType);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, string containingType, string field, string fieldType) =>
+            GetBasicResultAt(line, column, DisposableFieldsShouldBeDisposed.Rule, containingType, field, fieldType);
+
+        [Fact]
+        public void DisposableAllocationInConstructor_AssignedDirectly_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private readonly A a;
+    public B()
+    {
+        a = new A();
+    }
+
+    public void Dispose()
+    {
+        a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private ReadOnly a As A
+    Sub New()
+        a = New A()
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocationInConstructor_AssignedDirectly_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private readonly A a;
+    public B()
+    {
+        a = new A();
+    }
+
+    public void Dispose()
+    {
+    }
+}
+",
+            // Test0.cs(14,24): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetCSharpResultAt(14, 24, "B", "a", "A"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private ReadOnly a As A
+    Sub New()
+        a = New A()
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class",
+            // Test0.vb(14,22): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetBasicResultAt(14, 22, "B", "a", "A"));
+        }
+
+        [Fact]
+        public void DisposableAllocationInMethod_AssignedDirectly_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public void SomeMethod()
+    {
+        a = new A();
+    }
+
+    public void Dispose()
+    {
+        a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub SomeMethod()
+        a = New A()
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocationInMethod_AssignedDirectly_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public void SomeMethod()
+    {
+        a = new A();
+    }
+
+    public void Dispose()
+    {
+    }
+}
+",
+            // Test0.cs(14,15): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetCSharpResultAt(14, 15, "B", "a", "A"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub SomeMethod()
+        a = New A()
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class",
+            // Test0.vb(14,13): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetBasicResultAt(14, 13, "B", "a", "A"));
+        }
+
+        [Fact]
+        public void DisposableAllocationInFieldInitializer_AssignedDirectly_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    private readonly A a2 = new A();
+    
+    public void Dispose()
+    {
+        a.Dispose();
+        a2.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+    Private ReadOnly a2 As New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+        a2.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocationInFieldInitializer_AssignedDirectly_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    private readonly A a2 = new A();
+    
+    public void Dispose()
+    {
+    }
+}
+",
+            // Test0.cs(14,15): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetCSharpResultAt(14, 15, "B", "a", "A"),
+            // Test0.cs(15,24): warning CA2213: 'B' contains field 'a2' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetCSharpResultAt(15, 24, "B", "a2", "A"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+    Private ReadOnly a2 As New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class",
+            // Test0.vb(14,13): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetBasicResultAt(14, 13, "B", "a", "A"),
+            // Test0.vb(15,22): warning CA2213: 'B' contains field 'a2' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetBasicResultAt(15, 22, "B", "a2", "A"));
+        }
+
+        [Fact]
+        public void StaticField_NotDisposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private static A a = new A();
+    private static readonly A a2 = new A();
+
+    public void Dispose()
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private Shared a As A = New A()
+    Private Shared ReadOnly a2 As New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedThroughLocal_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public void SomeMethod()
+    {
+        var l = new A();
+        a = l;
+    }
+
+    public void Dispose()
+    {
+        a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub SomeMethod()
+        Dim l = New A()
+        a = l
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedThroughLocal_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public void SomeMethod()
+    {
+        var l = new A();
+        a = l;
+    }
+
+    public void Dispose()
+    {
+    }
+}
+",
+            // Test0.cs(14,15): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetCSharpResultAt(14, 15, "B", "a", "A"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub SomeMethod()
+        Dim l = New A()
+        a = l
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class",
+            // Test0.vb(14,13): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetBasicResultAt(14, 13, "B", "a", "A"));
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedThroughParameter_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public B(A p)
+    {
+        p = new A();
+        a = p;
+    }
+
+    public void Dispose()
+    {
+        a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub New(p As A)
+        p = New A()
+        a = p
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedThroughParameter_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public B(A p)
+    {
+        p = new A();
+        a = p;
+    }
+
+    public void Dispose()
+    {
+    }
+}
+",
+            // Test0.cs(14,15): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetCSharpResultAt(14, 15, "B", "a", "A"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub New(p As A)
+        p = New A()
+        a = p
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class",
+            // Test0.vb(14,13): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Dispose or Close on this field.
+            GetBasicResultAt(14, 13, "B", "a", "A"));
+        }
+
+        [Fact]
+        public void DisposableSymbolWithoutAllocation_AssignedThroughParameter_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public B(A p)
+    {
+        a = p;
+    }
+
+    public void Dispose()
+    {
+        a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub New(p As A)
+        a = p
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableSymbolWithoutAllocation_AssignedThroughParameter_NotDisposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public B(A p)
+    {
+        a = p;
+    }
+
+    public void Dispose()
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub New(p As A)
+        a = p
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedThroughInstanceInvocation_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public B()
+    {
+        a = GetA();
+    }
+
+    private A GetA() => new A();
+
+    public void Dispose()
+    {
+        a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub New()
+        a = GetA()
+    End Sub
+
+    Private Function GetA() As A
+        Return New A()
+    End Function
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedThroughInstanceInvocation_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public B()
+    {
+        a = GetA();
+    }
+
+    private A GetA() => new A();
+
+    public void Dispose()
+    {
+    }
+}
+",
+            // Test0.cs(14,15): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetCSharpResultAt(14, 15, "B", "a", "A"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub New()
+        a = GetA()
+    End Sub
+
+    Private Function GetA() As A
+        Return New A()
+    End Function
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class",
+            // Test0.vb(14,13): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetBasicResultAt(14, 13, "B", "a", "A"));
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedThroughStaticCreateInvocation_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public B()
+    {
+        a = Create();
+    }
+
+    private static A Create() => new A();
+
+    public void Dispose()
+    {
+        a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub New()
+        a = Create()
+    End Sub
+
+    Private Shared Function Create() As A
+        Return New A()
+    End Function
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedThroughStaticCreateInvocation_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    public B()
+    {
+        a = Create();
+    }
+
+    private static A Create() => new A();
+
+    public void Dispose()
+    {
+    }
+}
+",
+            // Test0.cs(14,15): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetCSharpResultAt(14, 15, "B", "a", "A"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Sub New()
+        a = Create()
+    End Sub
+
+    Private Shared Function Create() As A
+        Return New A()
+    End Function
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class",
+            // Test0.vb(14,13): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetBasicResultAt(14, 13, "B", "a", "A"));
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedInDifferentType_DisposedInContainingType_NoDiagnostic()
+        {
+            // We don't track disposable field assignments in different type.
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    public A a;
+    public void Dispose()
+    {
+        a.Dispose();
+    }
+}
+
+class WrapperB
+{
+    private B b;
+    public void Create()
+    {
+        b.a = new A();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Public a As A
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+    End Sub
+End Class
+
+Class WrapperB
+    Dim b As B
+    Public Sub Create()
+        b.a = new A()
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedInDifferentType_DisposedInDifferentNonDisposableType_NoDiagnostic()
+        {
+            // We don't track disposable field assignments in different type.
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    public A a;
+    public void Dispose()
+    {
+    }
+}
+
+class WrapperB
+{
+    private B b;
+
+    public void Create()
+    {
+        b.a = new A();
+    }
+
+    public void Dispose()
+    {
+        b.a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Public a As A
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class WrapperB
+    Dim b As B
+
+    Public Sub Create()
+        b.a = new A()
+    End Sub
+
+    Public Sub Dispose()
+        b.a.Dispose()
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedInDifferentType_NotDisposed_NoDiagnostic()
+        {
+            // We don't track disposable field assignments in different type.
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    public A a;
+    public void Dispose()
+    {
+    }
+}
+
+class Test
+{
+    public void M(B b)
+    {
+        b.a = new A();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Public a As A
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class Test
+    Public Sub M(b As B)
+        b.a = new A()
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void DisposableOwnershipTransferSpecialCases_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.IO;
+using System.Resources;
+
+class A : IDisposable
+{
+    private Stream s;
+    private TextReader tr;
+    private TextWriter tw;
+    private IResourceReader rr;
+
+    public A(Stream s)
+    {
+        this.s = s;
+    }
+
+    public A(TextReader tr)
+    {
+        this.tr = tr;
+    }
+
+    public A(TextWriter tw)
+    {
+        this.tw = tw;
+    }
+
+    public A(IResourceReader rr)
+    {
+        this.rr = rr;
+    }
+
+    public void Dispose()
+    {
+        if (s != null)
+        {
+            s.Dispose();
+        }
+
+        if (tr != null)
+        {
+            tr.Dispose();
+        }
+
+        if (tw != null)
+        {
+            tw.Dispose();
+        }
+
+        if (rr != null)
+        {
+            rr.Dispose();
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+Imports System.IO
+Imports System.Resources
+
+Class A
+    Implements IDisposable
+
+    Private s As Stream
+    Private tr As TextReader
+    Private tw As TextWriter
+    Private rr As IResourceReader
+
+    Public Sub New(ByVal s As Stream)
+        Me.s = s
+    End Sub
+
+    Public Sub New(ByVal tr As TextReader)
+        Me.tr = tr
+    End Sub
+
+    Public Sub New(ByVal tw As TextWriter)
+        Me.tw = tw
+    End Sub
+
+    Public Sub New(ByVal rr As IResourceReader)
+        Me.rr = rr
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        If s IsNot Nothing Then
+            s.Dispose()
+        End If
+
+        If tr IsNot Nothing Then
+            tr.Dispose()
+        End If
+
+        If tw IsNot Nothing Then
+            tw.Dispose()
+        End If
+
+        If rr IsNot Nothing Then
+            rr.Dispose()
+        End If
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void DisposableOwnershipTransferSpecialCases_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.IO;
+using System.Resources;
+
+class A : IDisposable
+{
+    private Stream s;
+    private TextReader tr;
+    private TextWriter tw;
+    private IResourceReader rr;
+
+    public A(Stream s)
+    {
+        this.s = s;
+    }
+
+    public A(TextReader tr)
+    {
+        this.tr = tr;
+    }
+
+    public A(TextWriter tw)
+    {
+        this.tw = tw;
+    }
+
+    public A(IResourceReader rr)
+    {
+        this.rr = rr;
+    }
+
+    public void Dispose()
+    {
+    }
+}
+",
+            // Test0.cs(8,20): warning CA2213: 'A' contains field 's' that is of IDisposable type 'Stream', but it is never disposed. Change the Dispose method on 'A' to call Close or Dispose on this field.
+            GetCSharpResultAt(8, 20, "A", "s", "Stream"),
+            // Test0.cs(9,24): warning CA2213: 'A' contains field 'tr' that is of IDisposable type 'TextReader', but it is never disposed. Change the Dispose method on 'A' to call Close or Dispose on this field.
+            GetCSharpResultAt(9, 24, "A", "tr", "TextReader"),
+            // Test0.cs(10,24): warning CA2213: 'A' contains field 'tw' that is of IDisposable type 'TextWriter', but it is never disposed. Change the Dispose method on 'A' to call Close or Dispose on this field.
+            GetCSharpResultAt(10, 24, "A", "tw", "TextWriter"),
+            // Test0.cs(11,29): warning CA2213: 'A' contains field 'rr' that is of IDisposable type 'IResourceReader', but it is never disposed. Change the Dispose method on 'A' to call Close or Dispose on this field.
+            GetCSharpResultAt(11, 29, "A", "rr", "IResourceReader"));
+
+            VerifyBasic(@"
+Imports System
+Imports System.IO
+Imports System.Resources
+
+Class A
+    Implements IDisposable
+
+    Private s As Stream
+    Private tr As TextReader
+    Private tw As TextWriter
+    Private rr As IResourceReader
+
+    Public Sub New(ByVal s As Stream)
+        Me.s = s
+    End Sub
+
+    Public Sub New(ByVal tr As TextReader)
+        Me.tr = tr
+    End Sub
+
+    Public Sub New(ByVal tw As TextWriter)
+        Me.tw = tw
+    End Sub
+
+    Public Sub New(ByVal rr As IResourceReader)
+        Me.rr = rr
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+",
+            // Test0.vb(9,13): warning CA2213: 'A' contains field 's' that is of IDisposable type 'Stream', but it is never disposed. Change the Dispose method on 'A' to call Close or Dispose on this field.
+            GetBasicResultAt(9, 13, "A", "s", "Stream"),
+            // Test0.vb(10,13): warning CA2213: 'A' contains field 'tr' that is of IDisposable type 'TextReader', but it is never disposed. Change the Dispose method on 'A' to call Close or Dispose on this field.
+            GetBasicResultAt(10, 13, "A", "tr", "TextReader"),
+            // Test0.vb(11,13): warning CA2213: 'A' contains field 'tw' that is of IDisposable type 'TextWriter', but it is never disposed. Change the Dispose method on 'A' to call Close or Dispose on this field.
+            GetBasicResultAt(11, 13, "A", "tw", "TextWriter"),
+            // Test0.vb(12,13): warning CA2213: 'A' contains field 'rr' that is of IDisposable type 'IResourceReader', but it is never disposed. Change the Dispose method on 'A' to call Close or Dispose on this field.
+            GetBasicResultAt(12, 13, "A", "rr", "IResourceReader"));
+        }
+
+        [Fact]
+        public void DisposableAllocation_DisposedWithConditionalAccess_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    
+    public void Dispose()
+    {
+        a?.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a?.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedToLocal_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    
+    public void Dispose()
+    {
+        A l = a;
+        l.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Dim l = a
+        l.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AssignedToLocal_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    
+    public void Dispose()
+    {
+        A l = a;
+    }
+}
+",
+            // Test0.cs(14,15): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetCSharpResultAt(14, 15, "B", "a", "A"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Dim l = a
+    End Sub
+End Class",
+            // Test0.vb(14,13): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetBasicResultAt(14, 13, "B", "a", "A"));
+        }
+
+        [Fact]
+        public void DisposableAllocation_IfElseStatement_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    private A b;
+
+    public B(bool flag)
+    {
+        A l = new A();
+        if (flag)
+        {
+            a = l;
+        }
+        else
+        {
+            b = l;
+        }
+    }
+
+    public void Dispose()
+    {
+        A l = null;
+        if (a != null)
+        {
+            l = a;
+        }
+        else if (b != null)
+        {
+            l = b;
+        }
+
+        l.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Private b As A
+
+    Public Sub New(ByVal flag As Boolean)
+        Dim l As A = New A()
+        If flag Then
+            a = l
+        Else
+            b = l
+        End If
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Dim l As A = Nothing
+        If a IsNot Nothing Then
+            l = a
+        ElseIf b IsNot Nothing Then
+            l = b
+        End If
+        l.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_IfElseStatement_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a;
+    private A b;
+
+    public B(bool flag)
+    {
+        A l = new A();
+        if (flag)
+        {
+            a = l;
+        }
+        else
+        {
+            b = l;
+        }
+    }
+
+    public void Dispose()
+    {
+        A l = null;
+        if (a != null)
+        {
+            l = a;
+        }
+        else if (b != null)
+        {
+            l = b;
+        }
+    }
+}
+",
+            // Test0.cs(14,15): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetCSharpResultAt(14, 15, "B", "a", "A"),
+            // Test0.cs(15,15): warning CA2213: 'B' contains field 'b' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetCSharpResultAt(15, 15, "B", "b", "A"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A
+    Private b As A
+
+    Public Sub New(ByVal flag As Boolean)
+        Dim l As A = New A()
+        If flag Then
+            a = l
+        Else
+            b = l
+        End If
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Dim l As A = Nothing
+        If a IsNot Nothing Then
+            l = a
+        ElseIf b IsNot Nothing Then
+            l = b
+        End If
+    End Sub
+End Class",
+            // Test0.vb(14,13): warning CA2213: 'B' contains field 'a' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetBasicResultAt(14, 13, "B", "a", "A"),
+            // Test0.vb(15,13): warning CA2213: 'B' contains field 'b' that is of IDisposable type 'A', but it is never disposed. Change the Dispose method on 'B' to call Close or Dispose on this field.
+            GetBasicResultAt(15, 13, "B", "b", "A"));
+        }
+
+        [Fact]
+        public void DisposableAllocation_EscapedField_NotDisposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    
+    public void Dispose()
+    {
+        DisposeA(ref this.a);
+    }
+
+    private static void DisposeA(ref A a)
+    {
+        a.Dispose();
+        a = null;
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        DisposeA(a)
+    End Sub
+
+    Private Shared Sub DisposeA(ByRef a As A)
+        a.Dispose()
+        a = Nothing
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_DisposedWithDisposeBoolInvocation_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose(bool disposed)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    
+    public void Dispose()
+    {
+        a.Dispose(true);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Dispose(disposed As Boolean)
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose(True)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_DisposedInsideDisposeBool_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose(bool disposed)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    
+    public void Dispose()
+    {
+        Dispose(true);
+    }
+
+    public void Dispose(bool disposed)
+    {
+        a.Dispose(disposed);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Dispose(disposed As Boolean)
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Dispose(True)
+    End Sub
+
+    Public Sub Dispose(disposed As Boolean)
+        a.Dispose(disposed)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_DisposedWithDisposeCloseInvocation_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Close()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    
+    public void Dispose()
+    {
+        a.Close();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Close()
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Close()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_AllDisposedMethodsMixed_Disposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose(bool disposed)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Close()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    private A a2 = new A();
+    private A a3 = new A();
+    
+    public void Dispose()
+    {
+        a.Close();
+    }
+    
+    public void Dispose(bool disposed)
+    {
+        a2.Dispose();
+    }
+    
+    public void Close()
+    {
+        a3.Dispose(true);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Dispose(disposed As Boolean)
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Close()
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+    Private a2 As A = New A()
+    Private a3 As A = New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Close()
+    End Sub
+
+    Public Sub Dispose(disposed As Boolean)
+        a2.Dispose()
+    End Sub
+
+    Public Sub Close()
+        a3.Dispose(True)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void DisposableAllocation_DisposedInsideDisposeClose_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Close()
+    {
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    
+    public void Dispose()
+    {
+        Close();
+    }
+
+    public void Close()
+    {
+        a.Close();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Dispose(disposed As Boolean)
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Dispose(True)
+    End Sub
+
+    Public Sub Dispose(disposed As Boolean)
+        a.Dispose(disposed)
+    End Sub
+End Class");
+        }
+
+
+
+    }
+}

--- a/src/Utilities/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Extensions/ITypeSymbolExtensions.cs
@@ -110,10 +110,10 @@ namespace Analyzer.Utilities.Extensions
             => iDisposable != null && type.AllInterfaces.Contains(iDisposable);
 
         /// <summary>
-        /// Indicates if the given <paramref name="type"/> is a reference type that implements <paramref name="iDisposable"/>.
+        /// Indicates if the given <paramref name="type"/> is a reference type that implements <paramref name="iDisposable"/> or is <see cref="IDisposable"/> type itself.
         /// </summary>
         public static bool IsDisposable(this ITypeSymbol type, INamedTypeSymbol iDisposable)
-            => type.IsReferenceType && type.ImplementsIDisposable(iDisposable);
+            => type.IsReferenceType && (type == iDisposable || type.ImplementsIDisposable(iDisposable));
 
         public static IEnumerable<AttributeData> GetApplicableAttributes(this INamedTypeSymbol type)
         {


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2213-disposable-fields-should-be-disposed for the rule description.
FxCop implementation for this rule reported CA2213 only for those fields which were assigned a locally created disposable object within the containing type methods/initializers. This reduced noise for cases where the type did not own the dispose responsibility for certain disposable fields. We are matching this implementation and will need to get the docs updated accordingly (#1593)

TODO: #1594 (Improve CA2213 (DisposableFieldsShouldBeDisposed) to handle cases where fields are disposed by helper methods invoked by Dispose)

Fixes #695