### PR TITLE
Fix NRE for invalid code in NullDataFlowOperationVisitor

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
             {
                 var value = base.VisitAssignmentOperation(operation, argument);
 
-                if (operation.Target.Type.IsValueType)
+                if (operation.Target.Type?.IsValueType == true)
                 {
                     return NullAbstractValue.NotNull;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
@@ -4398,5 +4398,32 @@ Class Test
 End Class
 ");
         }
+
+        [Fact, WorkItem(1597, "https://github.com/dotnet/roslyn-analyzers/issues/1597")]
+        public void DisposableObjectInErrorCode_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class B : IDisposable
+{
+    public void Dispose()
+    {
+        A x = new A();
+        = x
+    }
+}
+", TestValidationMode.AllowCompileErrors,
+            // Test0.cs(16,15): warning CA2000: In method 'void B.Dispose()', call System.IDisposable.Dispose on object created by 'new A()' before all references to it are out of scope.
+            GetCSharpResultAt(16, 15, "void B.Dispose()", "new A()"));
+        }
     }
 }


### PR DESCRIPTION
Don't assume that target of an assigment operation always has non-null type. Verified the NRE repros for the added test before the fix.
Fixes #1597