### PR TITLE
Bunch of fixes for DFA rules/analyses issues found from dogfooding th…

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
 
             private void HandleDisposingOperation(IOperation disposingOperation, IOperation disposedInstance)
             {
-                if (!disposedInstance.Type.IsDisposable(_iDisposable))
+                if (disposedInstance.Type?.IsDisposable(_iDisposable) == false)
                 {
                     return;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -197,14 +197,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
                 HandlePossibleEscapingForAssignment(target, assignedValueOperation, assignedValueOperation);
             }
 
-            protected override void SetValueForParameterOnEntry(IParameterSymbol parameter, AnalysisEntity analysisEntity)
+            protected override void SetValueForParameterPointsToLocationOnEntry(IParameterSymbol parameter, PointsToAbstractValue pointsToAbstractValue)
             {
                 if (_disposeOwnershipTransferLikelyTypes.Contains(parameter.Type))
                 {
-                    if (TryGetPointsToAbstractValueAtCurrentBlockExit(analysisEntity, out PointsToAbstractValue pointsToAbstractValue))
-                    {
-                        SetAbstractValue(pointsToAbstractValue, DisposeAbstractValue.NotDisposed);
-                    }
+                    SetAbstractValue(pointsToAbstractValue, DisposeAbstractValue.NotDisposed);
                 }
             }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -217,6 +217,20 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
                 }
             }
 
+            protected override DisposeAbstractValue ComputeAnalysisValueForOutArgument(IArgumentOperation operation, DisposeAbstractValue defaultValue)
+            {
+                // Special case: don't flag "out" arguments for "bool TryGetXXX(..., out value)" invocations.
+                if (operation.Parent is IInvocationOperation invocation &&
+                    invocation.TargetMethod.ReturnType.SpecialType == SpecialType.System_Boolean &&
+                    invocation.TargetMethod.Name.StartsWith("TryGet", StringComparison.Ordinal) &&
+                    invocation.Arguments[invocation.Arguments.Length - 1] == operation)
+                {
+                    return DisposeAbstractValue.NotDisposable;
+                }
+
+                return base.ComputeAnalysisValueForOutArgument(operation, defaultValue);
+            }
+
             // TODO: Remove these temporary methods once we move to compiler's CFG
             // https://github.com/dotnet/roslyn-analyzers/issues/1567
             #region Temporary methods to workaround lack of *real* CFG

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
@@ -24,42 +24,42 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
         public static DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> GetOrComputeResult(
             ControlFlowGraph cfg,
             INamedTypeSymbol iDisposable,
-            INamedTypeSymbol iCollection,
-            INamedTypeSymbol genericICollection,
+            INamedTypeSymbol taskType,
+            ImmutableHashSet<INamedTypeSymbol> collectionTypes,
             ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
-            INamedTypeSymbol containingTypeSymbol,
+            ISymbol owningSymbol,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
         {
-            return GetOrComputeResultCore(cfg, iDisposable, iCollection, genericICollection,
-                disposeOwnershipTransferLikelyTypes, containingTypeSymbol, pointsToAnalysisResult,
+            return GetOrComputeResultCore(cfg, iDisposable, taskType, collectionTypes,
+                disposeOwnershipTransferLikelyTypes, owningSymbol, pointsToAnalysisResult,
                 nullAnalysisResultOpt, trackInstanceFields: false, trackedInstanceFieldPointsToMap: out var _);
         }
 
         public static DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> GetOrComputeResult(
             ControlFlowGraph cfg,
             INamedTypeSymbol iDisposable,
-            INamedTypeSymbol iCollection,
-            INamedTypeSymbol genericICollection,
+            INamedTypeSymbol taskType,
+            ImmutableHashSet<INamedTypeSymbol> collectionTypes,
             ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
-            INamedTypeSymbol containingTypeSymbol,
+            ISymbol owningSymbol,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
             bool trackInstanceFields,
             out ImmutableDictionary<IFieldSymbol, PointsToAnalysis.PointsToAbstractValue> trackedInstanceFieldPointsToMap,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
         {
-            return GetOrComputeResultCore(cfg, iDisposable, iCollection, genericICollection,
-                disposeOwnershipTransferLikelyTypes, containingTypeSymbol, pointsToAnalysisResult,
+            return GetOrComputeResultCore(cfg, iDisposable, taskType, collectionTypes,
+                disposeOwnershipTransferLikelyTypes, owningSymbol, pointsToAnalysisResult,
                 nullAnalysisResultOpt, trackInstanceFields, out trackedInstanceFieldPointsToMap);
         }
 
         private static DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> GetOrComputeResultCore(
             ControlFlowGraph cfg,
             INamedTypeSymbol iDisposable,
-            INamedTypeSymbol iCollection,
-            INamedTypeSymbol genericICollection,
+            INamedTypeSymbol taskType,
+            ImmutableHashSet<INamedTypeSymbol> collectionTypes,
             ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
-            INamedTypeSymbol containingTypeSymbol,
+            ISymbol owningSymbol,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt,
             bool trackInstanceFields,
@@ -67,11 +67,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
         {
             Debug.Assert(cfg != null);
             Debug.Assert(iDisposable != null);
-            Debug.Assert(containingTypeSymbol != null);
+            Debug.Assert(owningSymbol != null);
             Debug.Assert(pointsToAnalysisResult != null);
 
-            var operationVisitor = new DisposeDataFlowOperationVisitor(iDisposable, iCollection, genericICollection,
-                disposeOwnershipTransferLikelyTypes, DisposeAbstractValueDomain.Default, containingTypeSymbol, trackInstanceFields, pointsToAnalysisResult, nullAnalysisResultOpt);
+            var operationVisitor = new DisposeDataFlowOperationVisitor(iDisposable, taskType, collectionTypes,
+                disposeOwnershipTransferLikelyTypes, DisposeAbstractValueDomain.Default, owningSymbol, trackInstanceFields, pointsToAnalysisResult, nullAnalysisResultOpt);
             var disposeAnalysis = new DisposeAnalysis(DisposeAnalysisDomainInstance, operationVisitor);
             var result = disposeAnalysis.GetOrComputeResultCore(cfg);
             trackedInstanceFieldPointsToMap = trackInstanceFields ? operationVisitor.TrackedInstanceFieldPointsToMap : null;

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
@@ -15,9 +15,10 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
         {
             public NullDataFlowOperationVisitor(
                 NullAbstractValueDomain valueDomain,
-                INamedTypeSymbol containingTypeSymbol,
+                ISymbol owningSymbol,
+                bool pessimisticAnalysis,
                 DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt)
-                : base(valueDomain, containingTypeSymbol, nullAnalysisResultOpt: null, pointsToAnalysisResultOpt: pointsToAnalysisResultOpt)
+                : base(valueDomain, owningSymbol, pessimisticAnalysis, nullAnalysisResultOpt: null, pointsToAnalysisResultOpt: pointsToAnalysisResultOpt)
             {
             }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.cs
@@ -21,10 +21,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
 
         public static DataFlowAnalysisResult<NullBlockAnalysisResult, NullAbstractValue> GetOrComputeResult(
             ControlFlowGraph cfg,
-            INamedTypeSymbol containingTypeSymbol,
+            ISymbol owningSymbol,
+            bool pessimisticAnalysis = true,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt = null)
         {
-            var operationVisitor = new NullDataFlowOperationVisitor(NullAbstractValueDomain.Default, containingTypeSymbol, pointsToAnalysisResultOpt);
+            var operationVisitor = new NullDataFlowOperationVisitor(NullAbstractValueDomain.Default, owningSymbol, pessimisticAnalysis, pointsToAnalysisResultOpt);
             var nullAnalysis = new NullAnalysis(NullAnalysisDomainInstance, operationVisitor);
             return nullAnalysis.GetOrComputeResultCore(cfg);
         }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -85,6 +85,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 
             protected override void SetValueForParameterOnExit(IParameterSymbol parameter, AnalysisEntity analysisEntity)
             {
+                // Do not escape the PointsTo value for parameter at exit.
             }
 
             protected override void ResetCurrentAnalysisData(PointsToAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -20,9 +20,10 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
         {
             public PointsToDataFlowOperationVisitor(
                 PointsToAbstractValueDomain valueDomain,
-                INamedTypeSymbol containingTypeSymbol,
+                ISymbol owningSymbol,
+                bool pessimisticAnalysis,
                 DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt)
-                : base(valueDomain, containingTypeSymbol, nullAnalysisResultOpt: nullAnalysisResultOpt, pointsToAnalysisResultOpt: null)
+                : base(valueDomain, owningSymbol, pessimisticAnalysis, nullAnalysisResultOpt: nullAnalysisResultOpt, pointsToAnalysisResultOpt: null)
             {
             }
 
@@ -72,6 +73,20 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
                 }
             }
 
+            protected override void SetValueForParameterOnEntry(IParameterSymbol parameter, AnalysisEntity analysisEntity)
+            {
+                // Create a dummy PointsTo value for each reference type parameter.
+                if (!parameter.Type.HasValueCopySemantics())
+                {
+                    var value = new PointsToAbstractValue(AbstractLocation.CreateSymbolLocation(parameter));
+                    SetAbstractValue(analysisEntity, value);
+                }
+            }
+
+            protected override void SetValueForParameterOnExit(IParameterSymbol parameter, AnalysisEntity analysisEntity)
+            {
+            }
+
             protected override void ResetCurrentAnalysisData(PointsToAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);
 
             protected override PointsToAbstractValue ComputeAnalysisValueForReferenceOperation(IOperation operation, PointsToAbstractValue defaultValue)
@@ -94,6 +109,17 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
                     Debug.Assert(operation.Type == null || !operation.Type.HasValueCopySemantics() || defaultValue == PointsToAbstractValue.NoLocation);
                     return defaultValue;
                 }
+            }
+
+            protected override PointsToAbstractValue ComputeAnalysisValueForOutArgument(AnalysisEntity analysisEntity, IArgumentOperation operation, PointsToAbstractValue defaultValue)
+            {
+                if (analysisEntity.Type.HasValueCopySemantics())
+                {
+                    return PointsToAbstractValue.NoLocation;
+                }
+
+                var location = AbstractLocation.CreateAllocationLocation(operation, analysisEntity.Type);
+                return new PointsToAbstractValue(location);
             }
 
             // TODO: Remove these temporary methods once we move to compiler's CFG
@@ -247,28 +273,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
                 var initializerValue = Visit(operation.Initializer, argument);
                 Debug.Assert(operation.Initializer == null || initializerValue == pointsToAbstractValue);
                 return pointsToAbstractValue;
-            }
-
-            public override PointsToAbstractValue VisitParameterReference(IParameterReferenceOperation operation, object argument)
-            {
-                // Create a dummy PointsTo value for each reference type parameter.
-                if (!operation.Type.HasValueCopySemantics())
-                {
-                    var result = AnalysisEntityFactory.TryCreateForSymbolDeclaration(operation.Parameter, out AnalysisEntity analysisEntity);
-                    Debug.Assert(result);
-                    if (!HasAbstractValue(analysisEntity))
-                    {
-                        var value = new PointsToAbstractValue(AbstractLocation.CreateAllocationLocation(operation, operation.Parameter.Type));
-                        SetAbstractValue(analysisEntity, value);
-                        return value;
-                    }
-
-                    return GetAbstractValue(analysisEntity);
-                }
-                else
-                {
-                    return PointsToAbstractValue.NoLocation;
-                }
             }
 
             public override PointsToAbstractValue VisitIsPattern(IIsPatternOperation operation, object argument)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -23,10 +23,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 
         public static DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> GetOrComputeResult(
             ControlFlowGraph cfg,
-            INamedTypeSymbol containingTypeSymbol,
-            DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
+            ISymbol owningSymbol,
+            DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null,
+            bool pessimisticAnalysis = true)
         {
-            var operationVisitor = new PointsToDataFlowOperationVisitor(PointsToAbstractValueDomain.Default, containingTypeSymbol, nullAnalysisResultOpt);
+            var operationVisitor = new PointsToDataFlowOperationVisitor(PointsToAbstractValueDomain.Default, owningSymbol, pessimisticAnalysis, nullAnalysisResultOpt);
             var pointsToAnalysis = new PointsToAnalysis(PointsToAnalysisDomainInstance, operationVisitor);
             return pointsToAnalysis.GetOrComputeResultCore(cfg);
         }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
@@ -16,10 +16,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
         {
             public StringContentDataFlowOperationVisitor(
                 StringContentAbstractValueDomain valueDomain,
-                INamedTypeSymbol containingTypeSymbol,
+                ISymbol owningSymbol,
+                bool pessimisticAnalysis,
                 DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt,
                 DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt)
-                : base(valueDomain, containingTypeSymbol, nullAnalysisResultOpt, pointsToAnalysisResultOpt)
+                : base(valueDomain, owningSymbol, pessimisticAnalysis, nullAnalysisResultOpt, pointsToAnalysisResultOpt)
             {
             }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.cs
@@ -22,11 +22,12 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 
         public static DataFlowAnalysisResult<StringContentBlockAnalysisResult, StringContentAbstractValue> GetOrComputeResult(
             ControlFlowGraph cfg,
-            INamedTypeSymbol containingTypeSymbol,
+            ISymbol owningSymbol,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null,
-            DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt = null)
+            DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt = null,
+            bool pessimisticAnalsysis = true)
         {
-            var operationVisitor = new StringContentDataFlowOperationVisitor(StringContentAbstractValueDomain.Default, containingTypeSymbol, nullAnalysisResultOpt, pointsToAnalysisResultOpt);
+            var operationVisitor = new StringContentDataFlowOperationVisitor(StringContentAbstractValueDomain.Default, owningSymbol, pessimisticAnalsysis, nullAnalysisResultOpt, pointsToAnalysisResultOpt);
             var nullAnalysis = new StringContentAnalysis(StringContentAnalysisDomainInstance, operationVisitor);
             return nullAnalysis.GetOrComputeResultCore(cfg);
         }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocationDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocationDataFlowOperationVisitor.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
 using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow
@@ -13,11 +16,13 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     {
         protected AbstractLocationDataFlowOperationVisitor(
             AbstractValueDomain<TAbstractAnalysisValue> valueDomain,
-            INamedTypeSymbol containingTypeSymbol,
+            ISymbol owningSymbol,
+            bool pessimisticAnalysis,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt,
             DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResultOpt)
-            : base(valueDomain, containingTypeSymbol, nullAnalysisResultOpt, pointsToAnalysisResultOpt)
+            : base(valueDomain, owningSymbol, pessimisticAnalysis, nullAnalysisResultOpt, pointsToAnalysisResultOpt)
         {
+            Debug.Assert(pointsToAnalysisResultOpt != null);
         }
 
         protected abstract TAbstractAnalysisValue GetAbstractValue(AbstractLocation location);
@@ -57,10 +62,45 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             }
         }
 
-        protected virtual TAbstractAnalysisValue HandleInstanceCreation(IOperation operation, PointsToAbstractValue instanceLocation, TAbstractAnalysisValue defaultValue)
+        protected virtual TAbstractAnalysisValue HandleInstanceCreation(ITypeSymbol instanceType, PointsToAbstractValue instanceLocation, TAbstractAnalysisValue defaultValue)
         {
             SetAbstractValue(instanceLocation, defaultValue);
             return defaultValue;
+        }
+
+        protected override TAbstractAnalysisValue ComputeAnalysisValueForOutArgument(IArgumentOperation operation, TAbstractAnalysisValue defaultValue)
+        {
+            if (operation.Value.Type != null)
+            {
+                PointsToAbstractValue instanceLocation = GetPointsToAbstractValue(operation);
+                return HandleInstanceCreation(operation.Value.Type, instanceLocation, defaultValue);
+            }
+
+            return defaultValue;
+        }
+
+        protected override void SetValueForParameterOnEntry(IParameterSymbol parameter, AnalysisEntity analysisEntity)
+        {
+        }
+
+        protected override void SetValueForParameterOnExit(IParameterSymbol parameter, AnalysisEntity analysisEntity)
+        {
+            Debug.Assert(analysisEntity.SymbolOpt == parameter);
+            if (parameter.RefKind != RefKind.None)
+            {
+                if (TryGetPointsToAbstractValueAtCurrentBlockEntry(analysisEntity, out PointsToAbstractValue pointsToAbstractValue))
+                {
+                    SetValueForParameterPointsToLocationOnExit(parameter, pointsToAbstractValue);
+                }
+            }
+        }
+
+        protected virtual void SetValueForParameterPointsToLocationOnExit(IParameterSymbol parameter, PointsToAbstractValue pointsToAbstractValue)
+        {
+            foreach (var location in pointsToAbstractValue.Locations)
+            {
+                SetAbstractValue(pointsToAbstractValue, ValueDomain.UnknownOrMayBeValue);
+            }            
         }
 
         #region Visitor methods
@@ -69,42 +109,42 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         {
             var value = base.VisitObjectCreation(operation, argument);
             PointsToAbstractValue instanceLocation = GetPointsToAbstractValue(operation);
-            return HandleInstanceCreation(operation, instanceLocation, value);
+            return HandleInstanceCreation(operation.Type, instanceLocation, value);
         }
 
         public override TAbstractAnalysisValue VisitTypeParameterObjectCreation(ITypeParameterObjectCreationOperation operation, object argument)
         {
             var value = base.VisitTypeParameterObjectCreation(operation, argument);
             PointsToAbstractValue instanceLocation = GetPointsToAbstractValue(operation);
-            return HandleInstanceCreation(operation, instanceLocation, value);
+            return HandleInstanceCreation(operation.Type, instanceLocation, value);
         }
 
         public override TAbstractAnalysisValue VisitDynamicObjectCreation(IDynamicObjectCreationOperation operation, object argument)
         {
             var value = base.VisitDynamicObjectCreation(operation, argument);
             PointsToAbstractValue instanceLocation = GetPointsToAbstractValue(operation);
-            return HandleInstanceCreation(operation, instanceLocation, value);
+            return HandleInstanceCreation(operation.Type, instanceLocation, value);
         }
 
         public override TAbstractAnalysisValue VisitAnonymousObjectCreation(IAnonymousObjectCreationOperation operation, object argument)
         {
             var value = base.VisitAnonymousObjectCreation(operation, argument);
             PointsToAbstractValue instanceLocation = GetPointsToAbstractValue(operation);
-            return HandleInstanceCreation(operation, instanceLocation, value);
+            return HandleInstanceCreation(operation.Type, instanceLocation, value);
         }
 
         public override TAbstractAnalysisValue VisitArrayCreation(IArrayCreationOperation operation, object argument)
         {
             var value = base.VisitArrayCreation(operation, argument);
             PointsToAbstractValue instanceLocation = GetPointsToAbstractValue(operation);
-            return HandleInstanceCreation(operation, instanceLocation, value);
+            return HandleInstanceCreation(operation.Type, instanceLocation, value);
         }
 
         public override TAbstractAnalysisValue VisitDelegateCreation(IDelegateCreationOperation operation, object argument)
         {
             var value = base.VisitDelegateCreation(operation, argument);
             PointsToAbstractValue instanceLocation = GetPointsToAbstractValue(operation);
-            return HandleInstanceCreation(operation, instanceLocation, value);
+            return HandleInstanceCreation(operation.Type, instanceLocation, value);
         }
 
         #endregion

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocationDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocationDataFlowOperationVisitor.cs
@@ -79,8 +79,15 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             return defaultValue;
         }
 
+        protected abstract void SetValueForParameterPointsToLocationOnEntry(IParameterSymbol parameter, PointsToAbstractValue pointsToAbstractValue);
+        protected abstract void SetValueForParameterPointsToLocationOnExit(IParameterSymbol parameter, PointsToAbstractValue pointsToAbstractValue);
+
         protected override void SetValueForParameterOnEntry(IParameterSymbol parameter, AnalysisEntity analysisEntity)
         {
+            if (TryGetPointsToAbstractValueAtCurrentBlockExit(analysisEntity, out PointsToAbstractValue pointsToAbstractValue))
+            {
+                SetValueForParameterPointsToLocationOnEntry(parameter, pointsToAbstractValue);
+            }
         }
 
         protected override void SetValueForParameterOnExit(IParameterSymbol parameter, AnalysisEntity analysisEntity)
@@ -93,14 +100,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                     SetValueForParameterPointsToLocationOnExit(parameter, pointsToAbstractValue);
                 }
             }
-        }
-
-        protected virtual void SetValueForParameterPointsToLocationOnExit(IParameterSymbol parameter, PointsToAbstractValue pointsToAbstractValue)
-        {
-            foreach (var location in pointsToAbstractValue.Locations)
-            {
-                SetAbstractValue(pointsToAbstractValue, ValueDomain.UnknownOrMayBeValue);
-            }            
         }
 
         #region Visitor methods

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -146,6 +146,23 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 case IParenthesizedOperation parenthesized:
                     return TryCreate(parenthesized.Operand, out analysisEntity);
 
+                case IArgumentOperation argument:
+                    return TryCreate(argument.Value, out analysisEntity);
+
+                case IDeclarationExpressionOperation declarationExpression:
+                    switch (declarationExpression.Expression)
+                    {
+                        case ILocalReferenceOperation localReference:
+                            return TryCreateForSymbolDeclaration(localReference.Local, out analysisEntity);
+
+                        case ITupleOperation tupleOperation:
+                            // TODO handle tuple operations
+                            // https://github.com/dotnet/roslyn-analyzers/issues/1571
+                            break;
+                    }
+
+                    break;
+
                 default:
                     break;
             }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -51,6 +51,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                         {
                             mergedValue = ValueDomain.Merge(mergedValue, existingValue);
                         }
+                        else if (ReferenceEquals(mergedValue, ValueDomain.UnknownOrMayBeValue))
+                        {
+                            // Do no add a new key-value pair to the resultMap if the value is UnknownOrMayBeValue.
+                            continue;
+                        }
 
                         resultMap[mergedKey] = mergedValue;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Security/ReviewSqlQueriesForSecurityVulnerabilities.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Security/ReviewSqlQueriesForSecurityVulnerabilities.cs
@@ -213,9 +213,9 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Security
                 if (topmostBlock != null)
                 {
                     var cfg = ControlFlowGraph.Create(topmostBlock);
-                    var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType);
-                    var pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType, nullAnalysisResult);
-                    var stringContentResult = StringContentAnalysis.GetOrComputeResult(cfg, containingMethod.ContainingType, nullAnalysisResult, pointsToAnalysisResult);
+                    var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod);
+                    var pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod, nullAnalysisResult);
+                    var stringContentResult = StringContentAnalysis.GetOrComputeResult(cfg, containingMethod, nullAnalysisResult, pointsToAnalysisResult);
                     StringContentAbstractValue value = stringContentResult[argumentValue];
                     if (value.NonLiteralState == StringContainsNonLiteralState.No)
                     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
                     }
 
                     // Mark fields disposed in Dispose method(s).
-                    if (containingMethod.GetDisposeMethodKind(operationBlockStartContext.Compilation) != DisposeMethodKind.None)
+                    if (containingMethod.GetDisposeMethodKind(disposeAnalysisHelper.IDisposable) != DisposeMethodKind.None)
                     {
                         var disposableFields = disposeAnalysisHelper.GetDisposableFields(containingMethod.ContainingType);
                         if (!disposableFields.IsEmpty)
@@ -151,7 +151,7 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
                                     PointsToAbstractValue pointsToValue = fieldWithPointsToValue.Value;
 
                                     Debug.Assert(field.Type.IsDisposable(disposeAnalysisHelper.IDisposable));
-                                    ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[cfg.Exit].InputData;
+                                    ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[cfg.Exit].OutputData;
                                     var disposed = false;
                                     foreach (var location in pointsToValue.Locations)
                                     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
@@ -400,10 +400,10 @@ class A : IDisposable
 
 class Test
 {
-    //void M1(out A param)
-    //{
-    //    param = new A();
-    //}
+    void M1(out A param)
+    {
+        param = new A();
+    }
 
     void M2(out A param2)
     {
@@ -415,23 +415,23 @@ class Test
         param3 = new A();
     }
 
-    //void Method()
-    //{
-    //    A a;
-    //    M1(out a);
-    //    A local = a;
-    //    M1(out a);
+    void Method()
+    {
+        A a;
+        M1(out a);
+        A local = a;
+        M1(out a);
 
-    //    M1(out var a2);
+        M1(out var a2);
 
-    //    A a3;
-    //    M2(out a3);
+        A a3;
+        M2(out a3);
 
-    //    local.Dispose();
-    //    a.Dispose();
-    //    a2.Dispose();
-    //    a3.Dispose();
-    //}
+        local.Dispose();
+        a.Dispose();
+        a2.Dispose();
+        a3.Dispose();
+    }
 }
 ");
         }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
@@ -437,6 +437,37 @@ class Test
         }
 
         [Fact]
+        public void TryGetSpecialCase_OutDisposableArgument_NoDisposeCall_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Collections.Generic;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class MyCollection
+{
+    private readonly Dictionary<int, A> _map;
+    public MyCollection(Dictionary<int, A> map)
+    {
+        _map = map;
+    }
+
+    public bool ValueExists(int i)
+    {
+        return _map.TryGetValue(i, out var value);
+    }
+}
+");
+        }
+
+        [Fact]
         public void LocalWithMultipleDisposableAssignment_DisposeCallOnSome_Diagnostic()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
@@ -289,6 +289,154 @@ End Class",
         }
 
         [Fact]
+        public void OutAndRefParametersWithDisposableAssignment_NoDisposeCall_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class Test
+{
+    void M1(ref A a1, out A a2)
+    {
+        a1 = new A();
+        a2 = new A();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class Test
+    Sub M1(ByRef a As A)
+        a = New A()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void OutDisposableArgument_NoDisposeCall_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class Test
+{
+    void M1(out A param)
+    {
+        param = new A();
+    }
+
+    void M2(out A param2)
+    {
+        M3(out param2);
+    }
+
+    void M3(out A param3)
+    {
+        param3 = new A();
+    }
+
+    void Method()
+    {
+        A a;
+        M1(out a);
+        A local = a;
+        M1(out a);
+
+        M1(out var a2);
+
+        A a3;
+        M2(out a3);
+    }
+}
+",
+            // Test0.cs(32,12): warning CA2000: In method 'void Test.Method()', call System.IDisposable.Dispose on object created by 'out a' before all references to it are out of scope.
+            GetCSharpResultAt(32, 12, "void Test.Method()", "out a"),
+            // Test0.cs(34,12): warning CA2000: In method 'void Test.Method()', call System.IDisposable.Dispose on object created by 'out a' before all references to it are out of scope.
+            GetCSharpResultAt(34, 12, "void Test.Method()", "out a"),
+            // Test0.cs(36,12): warning CA2000: In method 'void Test.Method()', call System.IDisposable.Dispose on object created by 'out var a2' before all references to it are out of scope.
+            GetCSharpResultAt(36, 12, "void Test.Method()", "out var a2"),
+            // Test0.cs(39,12): warning CA2000: In method 'void Test.Method()', call System.IDisposable.Dispose on object created by 'out a3' before all references to it are out of scope.
+            GetCSharpResultAt(39, 12, "void Test.Method()", "out a3"));
+        }
+
+        [Fact]
+        public void OutDisposableArgument_DisposeCall_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class Test
+{
+    //void M1(out A param)
+    //{
+    //    param = new A();
+    //}
+
+    void M2(out A param2)
+    {
+        M3(out param2);
+    }
+
+    void M3(out A param3)
+    {
+        param3 = new A();
+    }
+
+    //void Method()
+    //{
+    //    A a;
+    //    M1(out a);
+    //    A local = a;
+    //    M1(out a);
+
+    //    M1(out var a2);
+
+    //    A a3;
+    //    M2(out a3);
+
+    //    local.Dispose();
+    //    a.Dispose();
+    //    a2.Dispose();
+    //    a3.Dispose();
+    //}
+}
+");
+        }
+
+        [Fact]
         public void LocalWithMultipleDisposableAssignment_DisposeCallOnSome_Diagnostic()
         {
             VerifyCSharp(@"
@@ -1113,6 +1261,120 @@ End Class");
         }
 
         [Fact]
+        public void CollectionAdd_IReadOnlyCollection_SpecialCases_ElementWithDisposableAssignment_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class MyReadOnlyCollection : IReadOnlyCollection<A>
+{
+    public void Add(A item)
+    {
+    }
+    
+    public int Count => throw new NotImplementedException();
+
+    public IEnumerator<A> GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class Test
+{
+    void M1()
+    {
+        var myReadOnlyCollection = new MyReadOnlyCollection();
+        myReadOnlyCollection.Add(new A());
+        A a = new A();
+        myReadOnlyCollection.Add(a);
+
+        var builder = ImmutableArray.CreateBuilder<A>();
+        builder.Add(new A());
+        A a2 = new A();
+        builder.Add(a2);
+
+        var bag = new ConcurrentBag<A>();
+        builder.Add(new A());
+        A a3 = new A();
+        builder.Add(a3);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+Imports System.Collections
+Imports System.Collections.Concurrent
+Imports System.Collections.Generic
+Imports System.Collections.Immutable
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class MyReadOnlyCollection
+    Implements IReadOnlyCollection(Of A)
+
+    Public Sub Add(ByVal item As A)
+    End Sub
+
+    Public ReadOnly Property Count As Integer Implements IReadOnlyCollection(Of A).Count
+        Get
+            Throw New NotImplementedException()
+        End Get
+    End Property
+
+    Public Function GetEnumerator() As IEnumerator(Of A) Implements IEnumerable(Of A).GetEnumerator
+        Throw New NotImplementedException()
+    End Function
+
+    Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException()
+    End Function
+End Class
+
+Class Test
+    Private Sub M1()
+        Dim myReadOnlyCollection = New MyReadOnlyCollection()
+        myReadOnlyCollection.Add(New A())
+        Dim a As A = New A()
+        myReadOnlyCollection.Add(a)
+
+        Dim builder = ImmutableArray.CreateBuilder(Of A)()
+        builder.Add(New A())
+        Dim a2 As A = New A()
+        builder.Add(a2)
+
+        Dim bag = New ConcurrentBag(Of A)()
+        builder.Add(New A())
+        Dim a3 As A = New A()
+        builder.Add(a3)
+    End Sub
+End Class");
+        }
+
+        [Fact]
         public void MemberInitializerWithDisposableAssignment_NoDiagnostic()
         {
             VerifyCSharp(@"
@@ -1399,7 +1661,7 @@ End Class");
         [Fact]
         public void LocalWithDisposableAssignment_ByRefEscape_NoDiagnostic()
         {
-            // Local/parameter passed by ref/out are escaped.
+            // Local/parameter passed by ref is escaped.
             VerifyCSharp(@"
 using System;
 
@@ -1448,6 +1710,41 @@ Class Test
         a = Nothing
     End Sub
 End Class");
+        }
+
+        [Fact]
+        public void LocalWithDisposableAssignment_OutRefKind_NotDisposed_Diagnostic()
+        {
+            // Local/parameter passed as out is not considered escaped.
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+class Test
+{
+    void M1()
+    {
+        A a = new A();
+        M2(out a);
+    }
+
+    void M2(out A a)
+    {
+        a = new A();
+    }
+}
+",
+            // Test0.cs(16,15): warning CA2000: In method 'void Test.M1()', call System.IDisposable.Dispose on object created by 'new A()' before all references to it are out of scope.
+            GetCSharpResultAt(16, 15, "void Test.M1()", "new A()"),
+            // Test0.cs(17,12): warning CA2000: In method 'void Test.M1()', call System.IDisposable.Dispose on object created by 'out a' before all references to it are out of scope.
+            GetCSharpResultAt(17, 12, "void Test.M1()", "out a"));
         }
 
         [Fact]
@@ -2721,6 +3018,65 @@ Class Test
 
     Public Iterator Function M4() As IEnumerable(Of A)
         Yield New A
+    End Function
+End Class");
+        }
+
+        [Fact]
+        public void ReturnStatement_02_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : I, IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+interface I
+{
+}
+
+class Test
+{
+    I M1()
+    {
+        return new A();
+    }
+
+    I M2()
+    {
+        return new A() as I;
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+Imports System.Collections.Generic
+
+Class A
+    Implements I, IDisposable
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Interface I
+End Interface
+
+Class Test
+
+    Private Function M1() As I
+        Return New A()
+    End Function
+
+    Private Function M2() As I
+        Return TryCast(New A(), I)
     End Function
 End Class");
         }
@@ -4521,6 +4877,46 @@ class Test
     }
 }
 ");
+        }
+
+        [Fact]
+        public void SystemThreadingTask_SpecialCase_NotDisposed_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.Threading.Tasks;
+
+public class A
+{
+    void M()
+    {
+        Task t = new Task(null);
+        M1(out var t2);
+    }
+
+    void M1(out Task<int> t)
+    {
+        t = null;
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+Imports System.Threading.Tasks
+Imports System.Runtime.InteropServices
+
+Public Class A
+
+    Private Sub M()
+        Dim t As Task = New Task(Nothing)
+        Dim t2 As Task = Nothing
+        M1(t2)
+    End Sub
+
+    Private Sub M1(<Out> ByRef t As Task(Of Integer))
+        t = Nothing
+    End Sub
+End Class");
         }
     }
 }

--- a/src/Utilities/WellKnownTypes.cs
+++ b/src/Utilities/WellKnownTypes.cs
@@ -16,6 +16,11 @@ namespace Analyzer.Utilities
             return compilation.GetTypeByMetadataName("System.Collections.Generic.ICollection`1");
         }
 
+        public static INamedTypeSymbol GenericIReadOnlyCollection(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Collections.Generic.IReadOnlyCollection`1");
+        }
+
         public static INamedTypeSymbol IEnumerable(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.Collections.IEnumerable");
@@ -119,6 +124,11 @@ namespace Analyzer.Utilities
         public static INamedTypeSymbol Thread(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.Threading.Thread");
+        }
+
+        public static INamedTypeSymbol Task(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
         }
 
         public static INamedTypeSymbol WebMethodAttribute(Compilation compilation)


### PR DESCRIPTION
…e rules on Roslyn.sln

1. Track out/ref parameters properly - we now handle them correctly by initializing parameter data values at CFG entry block and escaping the out/ref parameter values at CFG exit block.
2. Introduce concept of pessimistic/optimistic dataflow analysis. For example, invoking an instance method may likely invalidate all the instance field analysis state, i.e. reference type fields might be re-assigned to point to different objects in the called method. An optimistic points to analysis assumes that the points to values of instance fields don't change on invoking an instance method. A pessimistic points to analysis resets all the instance state and assumes the instance field might point to any object, hence has unknown state. For dispose analysis, we want to perform an optimistic points to analysis as we assume a disposable field is not likely to be re-assigned to a separate object in helper method invocations in Dispose. For string content analysis, we want to perform a pessimistic points to analysis to be conservative and avoid missing out true violations.
3. Fix issue with identifying collection add methods
4. Handle cases where we convert a disposable object to an interface that doesn't derive from IDisposable.
5. Handle cases where we are overriding a base method that is a dispose implementation.
6. Allow dispose ownership transfer to happen for any parameter in the parameter list, not just the first parameter (FxCop only allowed it for first parameter, but this produces lot of false positives).
7. Special case System.Threading.Tasks.Task to not track disposing it.
8. Performance optimization for Merge (8d5fcd079aaff24c1f072fb8a98f6d453ca137b2): Do no add a new key-value pair to the resultMap if the value is UnknownOrMayBeValue. This fixed the primary performance bottleneck on Roslyn.sln.