### PR TITLE
Couple more fixes to flow analysis for false positives on Roslyn.sln

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -194,6 +194,14 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
 
             protected override void SetAbstractValueForAssignment(IOperation target, IOperation assignedValueOperation, DisposeAbstractValue assignedValue)
             {
+                // Temporary workaround for missing dataflow support for tuples
+                // https://github.com/dotnet/roslyn-analyzers/issues/1571
+                if (assignedValueOperation?.Kind == OperationKind.Tuple)
+                {
+                    HandlePossibleEscapingOperation(escapingOperation: assignedValueOperation, escapedInstance: target);
+                    return;
+                }
+
                 HandlePossibleEscapingForAssignment(target, assignedValueOperation, assignedValueOperation);
             }
 
@@ -329,9 +337,9 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
                 return value;
             }
 
-            public override DisposeAbstractValue VisitReturn(IReturnOperation operation, object argument)
+            protected override DisposeAbstractValue VisitReturnCore(IReturnOperation operation, object argument)
             {
-                var value = base.VisitReturn(operation, argument);
+                var value = base.VisitReturnCore(operation, argument);
                 if (operation.ReturnedValue != null)
                 {
                     HandlePossibleEscapingOperation(operation, operation.ReturnedValue);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
 
             protected override void SetValueForParameterPointsToLocationOnExit(IParameterSymbol parameter, PointsToAbstractValue pointsToAbstractValue)
             {
-                if (pointsToAbstractValue.Kind == PointsToAbstractValueKind.Known &&
+                if (!pointsToAbstractValue.Locations.IsEmpty &&
                     parameter.Type.IsDisposable(_iDisposable))
                 {
                     SetAbstractValue(pointsToAbstractValue, ValueDomain.UnknownOrMayBeValue);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
@@ -254,9 +254,9 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
                 return NullAbstractValue.NotNull;
             }
 
-            public override NullAbstractValue VisitReturn(IReturnOperation operation, object argument)
+            protected override NullAbstractValue VisitReturnCore(IReturnOperation operation, object argument)
             {
-                var _ = base.VisitReturn(operation, argument);
+                var _ = base.VisitReturnCore(operation, argument);
                 return NullAbstractValue.NotNull;
             }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -17,8 +17,12 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
         public static PointsToAbstractValue NoLocation = new PointsToAbstractValue(PointsToAbstractValueKind.NoLocation);
         public static PointsToAbstractValue Unknown = new PointsToAbstractValue(PointsToAbstractValueKind.Unknown);
         
-        private PointsToAbstractValue(ImmutableHashSet<AbstractLocation> locations, PointsToAbstractValueKind kind)
+        public PointsToAbstractValue(ImmutableHashSet<AbstractLocation> locations, PointsToAbstractValueKind kind)
         {
+            Debug.Assert(kind != PointsToAbstractValueKind.Known || !locations.IsEmpty);
+            Debug.Assert(kind != PointsToAbstractValueKind.NoLocation || locations.IsEmpty);
+            Debug.Assert(kind != PointsToAbstractValueKind.Undefined || locations.IsEmpty);
+
             Locations = locations;
             Kind = kind;
         }
@@ -30,14 +34,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
         }
 
         public PointsToAbstractValue(AbstractLocation location)
-            : this(ImmutableHashSet.Create(location))
+            : this(ImmutableHashSet.Create(location), PointsToAbstractValueKind.Known)
         {
-        }
-
-        public PointsToAbstractValue(ImmutableHashSet<AbstractLocation> locations)
-            : this(locations, PointsToAbstractValueKind.Known)
-        {
-            Debug.Assert(locations.Count > 0);            
         }
 
         public ImmutableHashSet<AbstractLocation> Locations { get; }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
@@ -72,13 +72,19 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
                 {
                     return value1;
                 }
-                else if (value1.Kind == PointsToAbstractValueKind.Unknown || value2.Kind == PointsToAbstractValueKind.Unknown)
+
+                var kind = value1.Kind == PointsToAbstractValueKind.Known && value2.Kind == PointsToAbstractValueKind.Known ?
+                    PointsToAbstractValueKind.Known :
+                    PointsToAbstractValueKind.Unknown;
+
+                var mergedLocations = _locationsDomain.Merge(value1.Locations, value2.Locations);
+                if (mergedLocations.IsEmpty)
                 {
+                    Debug.Assert(kind == PointsToAbstractValueKind.Unknown);
                     return PointsToAbstractValue.Unknown;
                 }
 
-                Debug.Assert(value1.Kind == PointsToAbstractValueKind.Known && value2.Kind == PointsToAbstractValueKind.Known);
-                return new PointsToAbstractValue(_locationsDomain.Merge(value1.Locations, value2.Locations));
+                return new PointsToAbstractValue(mergedLocations, kind);
             }
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -320,13 +320,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
                 return PointsToAbstractValue.NoLocation;
             }
 
-            public override PointsToAbstractValue VisitTuple(ITupleOperation operation, object argument)
-            {
-                // TODO: Handle tuples.
-                // https://github.com/dotnet/roslyn-analyzers/issues/1571
-                return base.VisitTuple(operation, argument);
-            }
-
             private static PointsToAbstractValue VisitInvocationCommon(IOperation operation)
             {
                 if (!operation.Type.HasValueCopySemantics())

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             Debug.Assert(!operation.Type.HasValueCopySemantics());
 
             var pointsToValue = GetPointsToAbstractValue(operation);
-            if (pointsToValue.Kind != PointsToAbstractValueKind.Known)
+            if (pointsToValue.Locations.IsEmpty)
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis.Operations.ControlFlow;
 using Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis;
 using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                         }
                         else if (ReferenceEquals(mergedValue, ValueDomain.UnknownOrMayBeValue))
                         {
-                            // Do no add a new key-value pair to the resultMap if the value is UnknownOrMayBeValue.
+                            // PERF: Do not add a new key-value pair to the resultMap if the value is UnknownOrMayBeValue.
                             continue;
                         }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -73,6 +73,15 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 // Merge all the outputs to get the new input of the current block.
                 var input = AnalysisDomain.Merge(inputs);
 
+                // Temporary workaround due to lack of *real* CFG
+                // TODO: Remove the below if statement once we move to compiler's CFG
+                // https://github.com/dotnet/roslyn-analyzers/issues/1567
+                if (block.Kind == BasicBlockKind.Exit &&
+                    OperationVisitor.MergedAnalysisDataAtReturnStatements != null)
+                {
+                    input = AnalysisDomain.Merge(input, OperationVisitor.MergedAnalysisDataAtReturnStatements);
+                }
+                
                 // Compare the previous input with the new input.
                 var compare = AnalysisDomain.Compare(GetInput(resultBuilder[block]), input);
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -864,6 +864,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             // https://github.com/dotnet/roslyn-analyzers/issues/1571
             // Until the above is implemented, we pessimistically reset the current state of tuple elements.
             var value = base.VisitTuple(operation, argument);
+            CacheAbstractValue(operation, value);
             foreach (var element in operation.Elements)
             {
                 SetAbstractValueForAssignment(element, operation, ValueDomain.UnknownOrMayBeValue);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposableFieldsShouldBeDisposedTests.cs
@@ -1796,6 +1796,86 @@ End Class");
         }
 
         [Fact]
+        public void DisposableAllocation_OptimisticPointsToAnalysis_WithReturn_NoDiagnostic()
+        {
+            // Invoking an instance method may likely invalidate all the instance field analysis state, i.e.
+            // reference type fields might be re-assigned to point to different objects in the called method.
+            // An optimistic points to analysis assumes that the points to values of instance fields don't change on invoking an instance method.
+            // A pessimistic points to analysis resets all the instance state and assumes the instance field might point to any object, hence has unknown state.
+            // For dispose analysis, we want to perform an optimistic points to analysis as we assume a disposable field is not likely to be re-assigned to a separate object in helper method invocations in Dispose.
+
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+    public void PerformSomeCleanup()
+    {
+    }
+}
+
+class B : IDisposable
+{
+    private A a = new A();
+    public bool Disposed;
+    
+    public void Dispose()
+    {
+        if (Disposed)
+        {
+            return;
+        }
+
+        a.PerformSomeCleanup();
+        ClearMyState();
+        a.Dispose();
+    }
+
+    private void ClearMyState()
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub PerformSomeCleanup()
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private a As A = New A()
+    Public Disposed As Boolean
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        If Disposed Then
+            Return
+        End If
+
+        a.PerformSomeCleanup()
+        ClearMyState()
+        a.Dispose()
+    End Sub
+
+    Private Sub ClearMyState()
+    End Sub
+End Class");
+        }
+
+        [Fact]
         public void DisposableAllocation_DisposedinDisposeOverride_NoDiagnostic()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposableFieldsShouldBeDisposedTests.cs
@@ -1876,6 +1876,61 @@ End Class");
         }
 
         [Fact]
+        public void DisposableAllocation_IfStatementInDispose_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class Test : IDisposable
+{
+    private readonly A a = new A();
+    private bool cancelled;
+
+    public void Dispose()
+    {
+        if (cancelled)
+        {
+            a.GetType();
+        }
+
+        a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Public Class Test
+    Implements IDisposable
+    Private ReadOnly a As A = New A()
+    Private cancelled As Boolean
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        If cancelled Then
+            a.GetType()
+        End If
+        a.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
         public void DisposableAllocation_DisposedinDisposeOverride_NoDiagnostic()
         {
             VerifyCSharp(@"


### PR DESCRIPTION
1. Due to lack of a *real* CFG (#1567), we did not correctly merge analysis states from all return statements at CFG exit block. This change adds a temporary workaround to correctly track analysis state for methods with intermediate return statements.
2. Due to pending dataflow support for tuple operations (#1571), we need to pessimistically reset the analysis values for all tuple elements to ensure we do not report incorrect violations for dispose rules.