### PR TITLE
Fix performance regression for points to analysis from recent commit

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
@@ -12,9 +12,14 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
     /// </summary>
     internal sealed class DefaultPointsToValueGenerator
     {
-        private readonly ImmutableDictionary<AnalysisEntity, PointsToAbstractValue>.Builder _defaultPointsToValueMapBuilder
-            = ImmutableDictionary.CreateBuilder<AnalysisEntity, PointsToAbstractValue>();
+        private readonly ImmutableDictionary<AnalysisEntity, PointsToAbstractValue>.Builder _defaultPointsToValueMapBuilder;
         private ImmutableDictionary<AnalysisEntity, PointsToAbstractValue> _lazyDefaultPointsToValueMap;
+
+        public DefaultPointsToValueGenerator()
+        {
+            _defaultPointsToValueMapBuilder = ImmutableDictionary.CreateBuilder<AnalysisEntity, PointsToAbstractValue>();
+        }
+
         public PointsToAbstractValue GetOrCreateDefaultValue(AnalysisEntity analysisEntity)
         {
             Debug.Assert(!analysisEntity.Type.HasValueCopySemantics());

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Analyzer.Utilities.Extensions;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
+{
+    /// <summary>
+    /// Generates and stores the default <see cref="PointsToAbstractValue"/> for <see cref="AnalysisEntity"/> instances generated for member and element reference operations.
+    /// </summary>
+    internal sealed class DefaultPointsToValueGenerator
+    {
+        private readonly ImmutableDictionary<AnalysisEntity, PointsToAbstractValue>.Builder _defaultPointsToValueMapBuilder
+            = ImmutableDictionary.CreateBuilder<AnalysisEntity, PointsToAbstractValue>();
+        private ImmutableDictionary<AnalysisEntity, PointsToAbstractValue> _lazyDefaultPointsToValueMap;
+        public PointsToAbstractValue GetOrCreateDefaultValue(AnalysisEntity analysisEntity)
+        {
+            Debug.Assert(!analysisEntity.Type.HasValueCopySemantics());
+            Debug.Assert(_lazyDefaultPointsToValueMap == null);
+
+            if (!_defaultPointsToValueMapBuilder.TryGetValue(analysisEntity, out PointsToAbstractValue value))
+            {
+                value = analysisEntity.SymbolOpt?.Kind == SymbolKind.Local ?
+                    PointsToAbstractValue.Undefined :
+                    new PointsToAbstractValue(AbstractLocation.CreateAnalysisEntityDefaultLocation(analysisEntity));
+                _defaultPointsToValueMapBuilder.Add(analysisEntity, value);
+            }
+
+            return value;
+        }
+
+        public ImmutableDictionary<AnalysisEntity, PointsToAbstractValue> GetDefaultPointsToValueMap()
+        {
+            _lazyDefaultPointsToValueMap = _lazyDefaultPointsToValueMap ?? _defaultPointsToValueMapBuilder.ToImmutableDictionary();
+            return _lazyDefaultPointsToValueMap;
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -17,11 +17,9 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
         public static PointsToAbstractValue NoLocation = new PointsToAbstractValue(PointsToAbstractValueKind.NoLocation);
         public static PointsToAbstractValue Unknown = new PointsToAbstractValue(PointsToAbstractValueKind.Unknown);
         
-        public PointsToAbstractValue(ImmutableHashSet<AbstractLocation> locations, PointsToAbstractValueKind kind)
+        private PointsToAbstractValue(ImmutableHashSet<AbstractLocation> locations, PointsToAbstractValueKind kind)
         {
-            Debug.Assert(kind != PointsToAbstractValueKind.Known || !locations.IsEmpty);
-            Debug.Assert(kind != PointsToAbstractValueKind.NoLocation || locations.IsEmpty);
-            Debug.Assert(kind != PointsToAbstractValueKind.Undefined || locations.IsEmpty);
+            Debug.Assert(locations.IsEmpty == (kind != PointsToAbstractValueKind.Known));
 
             Locations = locations;
             Kind = kind;
@@ -36,6 +34,12 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
         public PointsToAbstractValue(AbstractLocation location)
             : this(ImmutableHashSet.Create(location), PointsToAbstractValueKind.Known)
         {
+        }
+
+        public PointsToAbstractValue(ImmutableHashSet<AbstractLocation> locations)
+            : this (locations, PointsToAbstractValueKind.Known)
+        {
+            Debug.Assert(!locations.IsEmpty);
         }
 
         public ImmutableHashSet<AbstractLocation> Locations { get; }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
@@ -72,19 +72,12 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
                 {
                     return value1;
                 }
-
-                var kind = value1.Kind == PointsToAbstractValueKind.Known && value2.Kind == PointsToAbstractValueKind.Known ?
-                    PointsToAbstractValueKind.Known :
-                    PointsToAbstractValueKind.Unknown;
-
-                var mergedLocations = _locationsDomain.Merge(value1.Locations, value2.Locations);
-                if (mergedLocations.IsEmpty)
+                else if (value1.Kind == PointsToAbstractValueKind.Unknown || value2.Kind == PointsToAbstractValueKind.Unknown)
                 {
-                    Debug.Assert(kind == PointsToAbstractValueKind.Unknown);
                     return PointsToAbstractValue.Unknown;
                 }
 
-                return new PointsToAbstractValue(mergedLocations, kind);
+                return new PointsToAbstractValue(_locationsDomain.Merge(value1.Locations, value2.Locations));
             }
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -6,19 +6,19 @@ using Microsoft.CodeAnalysis.Operations.ControlFlow;
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 {
     using PointsToAnalysisData = IDictionary<AnalysisEntity, PointsToAbstractValue>;
-    using PointsToAnalysisDomain = AnalysisEntityMapAbstractDomain<PointsToAbstractValue>;
 
     /// <summary>
     /// Dataflow analysis to track locations pointed to by <see cref="AnalysisEntity"/> and <see cref="IOperation"/> instances.
     /// </summary>
     internal partial class PointsToAnalysis : ForwardDataFlowAnalysis<PointsToAnalysisData, PointsToBlockAnalysisResult, PointsToAbstractValue>
     {
-        public static readonly PointsToAnalysisDomain PointsToAnalysisDomainInstance = new PointsToAnalysisDomain(PointsToAbstractValueDomain.Default);
+        private readonly DefaultPointsToValueGenerator _defaultPointsToValueGenerator;
         public static readonly AbstractValueDomain<PointsToAbstractValue> PointsToAbstractValueDomainInstance = PointsToAbstractValueDomain.Default;
 
-        private PointsToAnalysis(PointsToAnalysisDomain analysisDomain, PointsToDataFlowOperationVisitor operationVisitor)
+        private PointsToAnalysis(PointsToAnalysisDomain analysisDomain, PointsToDataFlowOperationVisitor operationVisitor, DefaultPointsToValueGenerator defaultPointsToValueGenerator)
             : base(analysisDomain, operationVisitor)
         {
+            _defaultPointsToValueGenerator = defaultPointsToValueGenerator;
         }
 
         public static DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> GetOrComputeResult(
@@ -27,11 +27,13 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null,
             bool pessimisticAnalysis = true)
         {
-            var operationVisitor = new PointsToDataFlowOperationVisitor(PointsToAbstractValueDomain.Default, owningSymbol, pessimisticAnalysis, nullAnalysisResultOpt);
-            var pointsToAnalysis = new PointsToAnalysis(PointsToAnalysisDomainInstance, operationVisitor);
+            var defaultPointsToValueGenerator = new DefaultPointsToValueGenerator();
+            var analysisDomain = new PointsToAnalysisDomain(defaultPointsToValueGenerator, PointsToAbstractValueDomain.Default);
+            var operationVisitor = new PointsToDataFlowOperationVisitor(defaultPointsToValueGenerator, analysisDomain, PointsToAbstractValueDomain.Default, owningSymbol, pessimisticAnalysis, nullAnalysisResultOpt);
+            var pointsToAnalysis = new PointsToAnalysis(analysisDomain, operationVisitor, defaultPointsToValueGenerator);
             return pointsToAnalysis.GetOrComputeResultCore(cfg);
         }
 
-        internal override PointsToBlockAnalysisResult ToResult(BasicBlock basicBlock, DataFlowAnalysisInfo<PointsToAnalysisData> blockAnalysisData) => new PointsToBlockAnalysisResult(basicBlock, blockAnalysisData);
+        internal override PointsToBlockAnalysisResult ToResult(BasicBlock basicBlock, DataFlowAnalysisInfo<PointsToAnalysisData> blockAnalysisData) => new PointsToBlockAnalysisResult(basicBlock, blockAnalysisData, _defaultPointsToValueGenerator.GetDefaultPointsToValueMap());
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisDomain.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
+{
+    /// <summary>
+    /// An abstract domain implementation for analyses that store dictionary typed data.
+    /// </summary>
+    internal class PointsToAnalysisDomain: AnalysisEntityMapAbstractDomain<PointsToAbstractValue>
+    {
+        private readonly DefaultPointsToValueGenerator _defaultPointsToValueGenerator;
+
+        public PointsToAnalysisDomain(DefaultPointsToValueGenerator defaultPointsToValueGenerator, AbstractValueDomain<PointsToAbstractValue> valueDomain)
+            : base(valueDomain)
+        {
+            _defaultPointsToValueGenerator = defaultPointsToValueGenerator;
+        }
+
+        protected override PointsToAbstractValue GetDefaultValue(AnalysisEntity analysisEntity)
+            => _defaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity);
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisDomain.cs
@@ -1,14 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 {
     /// <summary>
-    /// An abstract domain implementation for analyses that store dictionary typed data.
+    /// An abstract analysis domain implementation <see cref="PointsToAnalysis"/>.
     /// </summary>
     internal class PointsToAnalysisDomain: AnalysisEntityMapAbstractDomain<PointsToAbstractValue>
     {
@@ -20,7 +15,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             _defaultPointsToValueGenerator = defaultPointsToValueGenerator;
         }
 
-        protected override PointsToAbstractValue GetDefaultValue(AnalysisEntity analysisEntity)
-            => _defaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity);
+        protected override PointsToAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => _defaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
@@ -22,21 +22,24 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     /// </summary>
     internal sealed class AbstractLocation : IEquatable<AbstractLocation>
     {
-        private AbstractLocation(IOperation creationOpt, ISymbol symbolOpt, ITypeSymbol locationType)
+        private AbstractLocation(IOperation creationOpt, AnalysisEntity analysisEntityOpt, ISymbol symbolOpt, ITypeSymbol locationType)
         {
-            Debug.Assert(creationOpt != null ^ symbolOpt != null);
+            Debug.Assert(creationOpt != null ^ symbolOpt != null ^ analysisEntityOpt != null);
             Debug.Assert(locationType != null);
 
             CreationOpt = creationOpt;
+            AnalysisEntityOpt = analysisEntityOpt;
             SymbolOpt = symbolOpt;
             LocationType = locationType;
         }
 
-        public static AbstractLocation CreateAllocationLocation(IOperation creation, ITypeSymbol locationType) => new AbstractLocation(creation, symbolOpt: null, locationType: locationType);
-        public static AbstractLocation CreateThisOrMeLocation(INamedTypeSymbol namedTypeSymbol) => new AbstractLocation(creationOpt: null, symbolOpt: namedTypeSymbol, locationType: namedTypeSymbol);
-        public static AbstractLocation CreateSymbolLocation(ISymbol symbol) => new AbstractLocation(creationOpt: null, symbolOpt: symbol, locationType: symbol.GetMemerOrLocalOrParameterType());
+        public static AbstractLocation CreateAllocationLocation(IOperation creation, ITypeSymbol locationType) => new AbstractLocation(creation, analysisEntityOpt: null, symbolOpt: null, locationType: locationType);
+        public static AbstractLocation CreateAnalysisEntityDefaultLocation(AnalysisEntity analysisEntity) => new AbstractLocation(creationOpt: null, analysisEntityOpt: analysisEntity, symbolOpt: null, locationType: analysisEntity.Type);
+        public static AbstractLocation CreateThisOrMeLocation(INamedTypeSymbol namedTypeSymbol) => new AbstractLocation(creationOpt: null, analysisEntityOpt: null, symbolOpt: namedTypeSymbol, locationType: namedTypeSymbol);
+        public static AbstractLocation CreateSymbolLocation(ISymbol symbol) => new AbstractLocation(creationOpt: null, analysisEntityOpt: null, symbolOpt: symbol, locationType: symbol.GetMemerOrLocalOrParameterType());
 
         public IOperation CreationOpt { get; }
+        public AnalysisEntity AnalysisEntityOpt { get; }
         public ISymbol SymbolOpt { get; }
         public ITypeSymbol LocationType { get; }
         
@@ -69,6 +72,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
 
             return other != null &&
                 CreationOpt == other.CreationOpt &&
+                AnalysisEntityOpt == other.AnalysisEntityOpt &&
                 SymbolOpt == other.SymbolOpt &&
                 LocationType == other.LocationType;
         }
@@ -76,7 +80,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         public override int GetHashCode()
         {
             return HashUtilities.Combine(CreationOpt?.GetHashCode() ?? 0,
-                HashUtilities.Combine(SymbolOpt?.GetHashCode() ?? 0, LocationType.GetHashCode()));
+                HashUtilities.Combine(SymbolOpt?.GetHashCode() ?? 0,
+                HashUtilities.Combine(AnalysisEntityOpt?.GetHashCode() ?? 0, LocationType.GetHashCode())));
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -17,12 +16,21 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         {
         }
 
+        protected virtual TValue GetDefaultValue(AnalysisEntity analysisEntity)
+            => ValueDomain.UnknownOrMayBeValue;
+
         protected override IDictionary<AnalysisEntity, TValue> MergeCore(IDictionary<AnalysisEntity, TValue> map1, IDictionary<AnalysisEntity, TValue> map2)
         {
             Debug.Assert(map1 != null);
             Debug.Assert(map2 != null);
 
-            var resultMap = new Dictionary<AnalysisEntity, TValue>();
+            TValue GetMergedValueForEntityPresentInOneMap(AnalysisEntity key, TValue value)
+            {
+                var defaultValue = GetDefaultValue(key);
+                return key.SymbolOpt != null ? ValueDomain.Merge(value, defaultValue) : defaultValue;
+            }
+
+            var resultMap = new Dictionary<AnalysisEntity, TValue>();            
             foreach (var entry1 in map1)
             {
                 AnalysisEntity key1 = entry1.Key;
@@ -30,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 var equivalentKeys2 = map2.Keys.Where(key => key.EqualsIgnoringInstanceLocation(key1));
                 if (!equivalentKeys2.Any())
                 {
-                    // Absence of entity from one branch indicates we don't know its values.
-                    TValue mergedValue = ValueDomain.Merge(value1, ValueDomain.UnknownOrMayBeValue);
+                    TValue mergedValue = GetMergedValueForEntityPresentInOneMap(key1, value1);
                     resultMap.Add(key1, mergedValue);
                     continue;
                 }
@@ -56,6 +63,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                             // PERF: Do not add a new key-value pair to the resultMap if the value is UnknownOrMayBeValue.
                             continue;
                         }
+                        else if (key1.SymbolOpt == null || key1.SymbolOpt != key2.SymbolOpt)
+                        {
+                            // PERF: Do not add a add a new key-value pair to the resultMap for unrelated entities or non-symbol based entities.
+                            continue;
+                        }
 
                         resultMap[mergedKey] = mergedValue;
                     }
@@ -68,8 +80,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 var value2 = kvp.Value;
                 if (!resultMap.ContainsKey(key2))
                 {
-                    // Absence of entity from one branch indicates we don't know its values.
-                    TValue mergedValue = ValueDomain.Merge(value2, ValueDomain.UnknownOrMayBeValue);
+                    TValue mergedValue = GetMergedValueForEntityPresentInOneMap(key2, value2);
                     resultMap.Add(key2, mergedValue);
                 }
             }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         {
         }
 
-        protected virtual TValue GetDefaultValue(AnalysisEntity analysisEntity)
-            => ValueDomain.UnknownOrMayBeValue;
+        protected virtual TValue GetDefaultValue(AnalysisEntity analysisEntity) => ValueDomain.UnknownOrMayBeValue;
 
         protected override IDictionary<AnalysisEntity, TValue> MergeCore(IDictionary<AnalysisEntity, TValue> map1, IDictionary<AnalysisEntity, TValue> map2)
         {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/SetAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/SetAbstractDomain.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow
 {
@@ -69,10 +69,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 return value1;
             }
 
-            var builder = ImmutableHashSet.CreateBuilder<T>();
-            builder.UnionWith(value1);
-            builder.UnionWith(value2);
-            return builder.ToImmutable();
+            return ImmutableHashSet.CreateRange(value1.Concat(value2));
         }
     }
 }


### PR DESCRIPTION
Commit https://github.com/dotnet/roslyn-analyzers/pull/1620/commits/8bc1cdfccbd29640edfd6d37b1c1645f5be534f2 improved preciseness of PointsTo analysis by tracking known location subset even for entities with PointsToAbstractValueKind.Unknown. This led to a considerable performance regression in building Roslyn.sln. This change fixes that regression by optimizing PointsToAnalysis to not create unnecessary key-value pairs for non-symbol entities and unrelated symbol based entities. With this change, the performance for building Roslyn.sln with or without dispose rules is almost identical.