### PR TITLE
Implement CA1062 (ValidateArgumentsOfPublicMethods) based on DFA

### DIFF
--- a/nuget/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.props
+++ b/nuget/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.props
@@ -9,6 +9,7 @@
   <PropertyGroup>
     <CodeAnalysisRuleSetOverrides>
       $(CodeAnalysisRuleSetOverrides);
+      -Microsoft.Design#CA1062;
       -Microsoft.Reliability#CA2000;
       -Microsoft.Security#CA2100;
       -Microsoft.Usage#CA2213;

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/MicrosoftDesignAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/MicrosoftDesignAnalyzersResources.resx
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ValidateArgumentsOfPublicMethodsDescription" xml:space="preserve">
+    <value>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</value>
+  </data>
+  <data name="ValidateArgumentsOfPublicMethodsMessage" xml:space="preserve">
+    <value>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</value>
+  </data>
+  <data name="ValidateArgumentsOfPublicMethodsTitle" xml:space="preserve">
+    <value>Validate arguments of public methods</value>
+  </data>
+</root>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/ValidateArgumentsOfPublicMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/ValidateArgumentsOfPublicMethods.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Operations.DataFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.Design
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class ValidateArgumentsOfPublicMethods : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA1062";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftDesignAnalyzersResources.ValidateArgumentsOfPublicMethodsTitle), MicrosoftDesignAnalyzersResources.ResourceManager, typeof(MicrosoftDesignAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftDesignAnalyzersResources.ValidateArgumentsOfPublicMethodsMessage), MicrosoftDesignAnalyzersResources.ResourceManager, typeof(MicrosoftDesignAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftDesignAnalyzersResources.ValidateArgumentsOfPublicMethodsDescription), MicrosoftDesignAnalyzersResources.ResourceManager, typeof(MicrosoftDesignAnalyzersResources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
+                                                                             s_localizableTitle,
+                                                                             s_localizableMessage,
+                                                                             DiagnosticCategory.Design,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             description: s_localizableDescription,
+                                                                             helpLinkUri: "https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods",
+                                                                             customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                compilationContext.RegisterOperationBlockAction(operationBlockContext =>
+                {
+                    // Analyze externally visible methods with reference type parameters.
+                    if (!(operationBlockContext.OwningSymbol is IMethodSymbol containingMethod) ||
+                        !containingMethod.IsExternallyVisible() ||
+                        !containingMethod.Parameters.Any(p => p.Type.IsReferenceType))
+                    {
+                        return;
+                    }
+
+                    // Bail out early if we have no parameter references in the method body. 
+                    if (!operationBlockContext.OperationBlocks.HasAnyOperationDescendant<IParameterReferenceOperation>())
+                    {
+                        return;
+                    }
+
+                    // Perform analysis of all direct/indirect parameter usages in the method to get all non-validated usages that can cause a null dereference.
+                    ImmutableDictionary<IParameterSymbol, SyntaxNode> hazardousParameterUsages = null;
+                    foreach (var operationBlock in operationBlockContext.OperationBlocks)
+                    {
+                        if (operationBlock is IBlockOperation topmostBlock)
+                        {
+                            hazardousParameterUsages = ParameterValidationAnalysis.GetOrComputeHazardousParameterUsages(topmostBlock, operationBlockContext.Compilation, containingMethod);
+                            break;
+                        }
+                    }
+
+                    if (hazardousParameterUsages != null)
+                    {
+                        foreach (var kvp in hazardousParameterUsages)
+                        {
+                            IParameterSymbol parameter = kvp.Key;
+                            SyntaxNode node = kvp.Value;
+
+                            // In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+                            var arg1 = containingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                            var arg2 = parameter.Name;
+                            var diagnostic = node.CreateDiagnostic(Rule, arg1, arg2);
+                            operationBlockContext.ReportDiagnostic(diagnostic);
+                        }
+                    }
+                });
+
+            });
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/ValidateArgumentsOfPublicMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/ValidateArgumentsOfPublicMethods.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Design
                     }
 
                     // Bail out early if we have no parameter references in the method body. 
-                    if (!operationBlockContext.OperationBlocks.HasAnyOperationDescendant<IParameterReferenceOperation>())
+                    if (!operationBlockContext.OperationBlocks.HasAnyOperationDescendant(OperationKind.ParameterReference))
                     {
                         return;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.cs.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.de.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.es.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.fr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.it.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.ja.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.ko.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.pl.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.pt-BR.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.ru.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.tr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.zh-Hans.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/xlf/MicrosoftDesignAnalyzersResources.zh-Hant.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../MicrosoftDesignAnalyzersResources.resx">
+    <body>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsDescription">
+        <source>An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</source>
+        <target state="new">An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument. If the method is designed to be called only by known assemblies, you should make the method internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsMessage">
+        <source>In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</source>
+        <target state="new">In externally visible method '{0}', validate parameter '{1}' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidateArgumentsOfPublicMethodsTitle">
+        <source>Validate arguments of public methods</source>
+        <target state="new">Validate arguments of public methods</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
+{
+    /// <summary>
+    /// Abstract copy value shared by a set of one of more <see cref="AnalysisEntity"/> instances tracked by <see cref="CopyAnalysis"/>.
+    /// </summary>
+    internal class CopyAbstractValue : IEquatable<CopyAbstractValue>
+    {
+        public static CopyAbstractValue NotApplicable = new CopyAbstractValue(CopyAbstractValueKind.NotApplicable);
+        public static CopyAbstractValue Invalid = new CopyAbstractValue(CopyAbstractValueKind.Invalid);
+        public static CopyAbstractValue Unknown = new CopyAbstractValue(CopyAbstractValueKind.Unknown);
+        
+        private CopyAbstractValue(ImmutableHashSet<AnalysisEntity> analysisEntities, CopyAbstractValueKind kind)
+        {
+            Debug.Assert(analysisEntities.IsEmpty == (kind != CopyAbstractValueKind.Known));
+
+            AnalysisEntities = analysisEntities;
+            Kind = kind;
+        }
+
+        private CopyAbstractValue(CopyAbstractValueKind kind)
+            : this(ImmutableHashSet<AnalysisEntity>.Empty, kind)
+        {
+            Debug.Assert(kind != CopyAbstractValueKind.Known);
+        }
+
+        public CopyAbstractValue(AnalysisEntity analysisEntity)
+            : this(ImmutableHashSet.Create(analysisEntity), CopyAbstractValueKind.Known)
+        {
+        }
+
+        public CopyAbstractValue(ImmutableHashSet<AnalysisEntity> analysisEntities)
+            : this (analysisEntities, CopyAbstractValueKind.Known)
+        {
+            Debug.Assert(!analysisEntities.IsEmpty);
+        }
+
+        public CopyAbstractValue WithEntityRemoved(AnalysisEntity entityToRemove)
+        {
+            Debug.Assert(AnalysisEntities.Contains(entityToRemove));
+            Debug.Assert(AnalysisEntities.Count > 1);
+            Debug.Assert(Kind == CopyAbstractValueKind.Known);
+
+            return new CopyAbstractValue(AnalysisEntities.Remove(entityToRemove));
+        }
+
+        public ImmutableHashSet<AnalysisEntity> AnalysisEntities { get; }
+        public CopyAbstractValueKind Kind { get; }
+
+        public static bool operator ==(CopyAbstractValue value1, CopyAbstractValue value2)
+        {
+            if ((object)value1 == null)
+            {
+                return (object)value2 == null;
+            }
+
+            return value1.Equals(value2);
+        }
+
+        public static bool operator !=(CopyAbstractValue value1, CopyAbstractValue value2)
+        {
+            return !(value1 == value2);
+        }
+
+        public bool Equals(CopyAbstractValue other)
+        {
+            return other != null &&
+                Kind == other.Kind &&
+                AnalysisEntities.SetEquals(other.AnalysisEntities);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as CopyAbstractValue);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = HashUtilities.Combine(Kind.GetHashCode(), AnalysisEntities.Count.GetHashCode());
+            foreach (var location in AnalysisEntities)
+            {
+                hashCode = HashUtilities.Combine(location.GetHashCode(), hashCode);
+            }
+
+            return hashCode;
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValueKind.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValueKind.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
+{
+    /// <summary>
+    /// Kind for the <see cref="CopyAbstractValue"/>.
+    /// </summary>
+    internal enum CopyAbstractValueKind
+    {
+        /// <summary>
+        /// Not applicable.
+        /// </summary>
+        NotApplicable,
+
+        /// <summary>
+        /// Copy shared by one or more <see cref="AnalysisEntity"/> instances.
+        /// </summary>
+        Known,
+
+        /// <summary>
+        /// Copy may or may not be shared by other <see cref="AnalysisEntity"/> instances.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// Invalid state for an unreachable path from predicate analysis.
+        /// </summary>
+        Invalid,
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyAbstractValueDomain.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
+{
+    using CopyAnalysisData = IDictionary<AnalysisEntity, CopyAbstractValue>;
+
+    internal partial class CopyAnalysis : ForwardDataFlowAnalysis<CopyAnalysisData, CopyBlockAnalysisResult, CopyAbstractValue>
+    {
+        /// <summary>
+        /// Abstract value domain for <see cref="CopyAnalysis"/> to merge and compare <see cref="CopyAbstractValue"/> values.
+        /// </summary>
+        private class CopyAbstractValueDomain : AbstractValueDomain<CopyAbstractValue>
+        {
+            public static CopyAbstractValueDomain Default = new CopyAbstractValueDomain();
+            private readonly SetAbstractDomain<AnalysisEntity> _entitiesDomain = new SetAbstractDomain<AnalysisEntity>();
+
+            private CopyAbstractValueDomain() { }
+
+            public override CopyAbstractValue Bottom => CopyAbstractValue.NotApplicable;
+
+            public override CopyAbstractValue UnknownOrMayBeValue => CopyAbstractValue.Unknown;
+
+            public override int Compare(CopyAbstractValue oldValue, CopyAbstractValue newValue)
+            {
+                if (oldValue == null)
+                {
+                    return newValue == null ? 0 : -1;
+                }
+                else if (newValue == null)
+                {
+                    return 1;
+                }
+
+                if (ReferenceEquals(oldValue, newValue))
+                {
+                    return 0;
+                }
+
+                if (oldValue.Kind == newValue.Kind)
+                {
+                    return _entitiesDomain.Compare(oldValue.AnalysisEntities, newValue.AnalysisEntities) * -1;
+                }
+                else if (oldValue.Kind < newValue.Kind)
+                {
+                    return -1;
+                }
+                else
+                {
+                    return 1;
+                }
+            }
+
+            public override CopyAbstractValue Merge(CopyAbstractValue value1, CopyAbstractValue value2)
+            {
+                if (value1 == null)
+                {
+                    return value2;
+                }
+                else if (value2 == null)
+                {
+                    return value1;
+                }
+                else if(value1.Kind == CopyAbstractValueKind.Invalid || value1.Kind == CopyAbstractValueKind.NotApplicable)
+                {
+                    return value2;
+                }
+                else if (value2.Kind == CopyAbstractValueKind.Invalid || value2.Kind == CopyAbstractValueKind.NotApplicable)
+                {
+                    return value1;
+                }
+                else if (value1.Kind == CopyAbstractValueKind.Unknown || value2.Kind == CopyAbstractValueKind.Unknown)
+                {
+                    return CopyAbstractValue.Unknown;
+                }
+
+                var mergedLocations = _entitiesDomain.Intersect(value1.AnalysisEntities, value2.AnalysisEntities);
+                return mergedLocations.IsEmpty ? CopyAbstractValue.Unknown : new CopyAbstractValue(mergedLocations);
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
@@ -1,0 +1,185 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
+{
+    using CopyAnalysisData = IDictionary<AnalysisEntity, CopyAbstractValue>;
+
+    internal partial class CopyAnalysis : ForwardDataFlowAnalysis<CopyAnalysisData, CopyBlockAnalysisResult, CopyAbstractValue>
+    {
+        /// <summary>
+        /// Operation visitor to flow the copy values across a given statement in a basic block.
+        /// </summary>
+        private sealed class CopyDataFlowOperationVisitor : AnalysisEntityDataFlowOperationVisitor<CopyAnalysisData, CopyAbstractValue>
+        {
+            public CopyDataFlowOperationVisitor(
+                CopyAbstractValueDomain valueDomain,
+                ISymbol owningSymbol,
+                WellKnownTypeProvider wellKnownTypeProvider,
+                bool pessimisticAnalysis,
+                DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt,
+                DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt)
+                : base(valueDomain, owningSymbol, wellKnownTypeProvider, pessimisticAnalysis, predicateAnalysis: true, nullAnalysisResultOpt: nullAnalysisResultOpt, copyAnalysisResultOpt: null, pointsToAnalysisResultOpt: pointsToAnalysisResultOpt)
+            {
+            }
+
+            protected override IEnumerable<AnalysisEntity> TrackedEntities => CurrentAnalysisData.Keys;
+
+            protected override bool HasAbstractValue(AnalysisEntity analysisEntity) => CurrentAnalysisData.ContainsKey(analysisEntity);
+
+            protected override CopyAbstractValue GetAbstractValue(AnalysisEntity analysisEntity) => CurrentAnalysisData.TryGetValue(analysisEntity, out var value) ? value : CopyAbstractValue.Unknown;
+
+            protected override CopyAbstractValue GetCopyAbstractValue(IOperation operation) => base.GetCachedAbstractValue(operation);
+            
+            protected override CopyAbstractValue GetAbstractDefaultValue(ITypeSymbol type) => CopyAbstractValue.NotApplicable;
+
+            protected override void SetAbstractValue(AnalysisEntity analysisEntity, CopyAbstractValue value)
+            {
+                SetAbstractValue(CurrentAnalysisData, analysisEntity, value, fromPredicate: false);
+            }
+
+            private static void SetAbstractValue(CopyAnalysisData copyAnalysisData, AnalysisEntity analysisEntity, CopyAbstractValue value, bool fromPredicate)
+            {
+                // Handle updating the existing value if not setting the value from predicate analysis.
+                if (!fromPredicate &&
+                    copyAnalysisData.TryGetValue(analysisEntity, out CopyAbstractValue existingValue))
+                {
+                    if (existingValue == value)
+                    {
+                        // Assigning the same value to the entity.
+                        Debug.Assert(existingValue.AnalysisEntities.Contains(analysisEntity));
+                        return;
+                    }
+
+                    if (existingValue.AnalysisEntities.Count > 1)
+                    {
+                        var newValueForEntitiesInOldSet = existingValue.WithEntityRemoved(analysisEntity);
+                        foreach (var entityToUpdate in newValueForEntitiesInOldSet.AnalysisEntities)
+                        {
+                            Debug.Assert(copyAnalysisData[entityToUpdate] == existingValue);
+                            copyAnalysisData[entityToUpdate] = newValueForEntitiesInOldSet;
+                        }
+                    }
+                }
+
+                // Handle setting the new value.
+                var newAnalysisEntities = value.AnalysisEntities.Add(analysisEntity);
+                if (fromPredicate)
+                {
+                    // Also include the existing values for the analysis entity.
+                    if (copyAnalysisData.TryGetValue(analysisEntity, out existingValue))
+                    {
+                        if (existingValue.Kind == CopyAbstractValueKind.Invalid)
+                        {
+                            return;
+                        }
+
+                        newAnalysisEntities = newAnalysisEntities.Union(existingValue.AnalysisEntities);
+                    }
+                }
+
+                var newValue = new CopyAbstractValue(newAnalysisEntities);
+                foreach (var entityToUpdate in newAnalysisEntities)
+                {
+                    copyAnalysisData[entityToUpdate] = newValue;
+                }
+            }
+
+            protected override void SetValueForParameterOnEntry(IParameterSymbol parameter, AnalysisEntity analysisEntity)
+            {
+                // Create a dummy copy value for each parameter.
+                SetAbstractValue(analysisEntity, new CopyAbstractValue(analysisEntity));
+            }
+
+            protected override void SetValueForParameterOnExit(IParameterSymbol parameter, AnalysisEntity analysisEntity)
+            {
+                // Do not escape the copy value for parameter at exit.
+            }
+
+            protected override void ResetCurrentAnalysisData(CopyAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);
+
+            protected override CopyAbstractValue ComputeAnalysisValueForReferenceOperation(IOperation operation, CopyAbstractValue defaultValue)
+            {
+                if (AnalysisEntityFactory.TryCreate(operation, out AnalysisEntity analysisEntity))
+                {
+                    return CurrentAnalysisData.TryGetValue(analysisEntity, out CopyAbstractValue value) ? value : new CopyAbstractValue(analysisEntity);
+                }
+                else
+                {
+                    return defaultValue;
+                }
+            }
+
+            protected override CopyAbstractValue ComputeAnalysisValueForOutArgument(AnalysisEntity analysisEntity, IArgumentOperation operation, CopyAbstractValue defaultValue)
+            {
+                var value = new CopyAbstractValue(analysisEntity);
+                SetAbstractValue(analysisEntity, value);
+                return value;
+            }
+
+            #region Predicate analysis
+            protected override void SetValueForEqualsOrNotEqualsComparisonOperator(IBinaryOperation operation, CopyAnalysisData negatedCurrentAnalysisData, bool equals)
+            {
+                Debug.Assert(operation.IsComparisonOperator());
+
+                if (AnalysisEntityFactory.TryCreate(operation.LeftOperand, out AnalysisEntity leftEntity) &&
+                    AnalysisEntityFactory.TryCreate(operation.RightOperand, out AnalysisEntity rightEntity))
+                {
+                    var analysisData = equals ? CurrentAnalysisData : negatedCurrentAnalysisData;
+                    var otherAnalysisData = equals ? negatedCurrentAnalysisData : CurrentAnalysisData;
+                    if (!analysisData.TryGetValue(rightEntity, out CopyAbstractValue rightValue))
+                    {
+                        rightValue = new CopyAbstractValue(rightEntity);
+                    }
+                    else if (rightValue.AnalysisEntities.Contains(leftEntity))
+                    {
+                        // We have "a == b && a == b" or "a != b && a != b"
+                        // For both cases, condition on right is always true and redundant.
+                        return;
+                    }
+                    else if (otherAnalysisData.TryGetValue(rightEntity, out rightValue) &&
+                        rightValue.AnalysisEntities.Contains(leftEntity))
+                    {
+                        // We have "a == b && a != b" or "a != b && a == b"
+                        // For both cases, condition on right is always false and hence CurrentAnalysisData is infeasible and values in negated are unknown
+                        foreach (var entity in rightValue.AnalysisEntities)
+                        {
+                            SetAbstractValue(CurrentAnalysisData, entity, CopyAbstractValue.Invalid, fromPredicate: true);
+                            SetAbstractValue(negatedCurrentAnalysisData, entity, CopyAbstractValue.Unknown, fromPredicate: true);
+                        }
+
+                        return;
+                    }
+
+                    SetAbstractValue(analysisData, leftEntity, rightValue, fromPredicate: true);
+                }
+            }
+
+            #endregion
+
+            // TODO: Remove these temporary methods once we move to compiler's CFG
+            // https://github.com/dotnet/roslyn-analyzers/issues/1567
+            #region Temporary methods to workaround lack of *real* CFG
+            protected override CopyAnalysisData MergeAnalysisData(CopyAnalysisData value1, CopyAnalysisData value2)
+                => CopyAnalysisDomain.Instance.Merge(value1, value2);
+            protected override CopyAnalysisData GetClonedAnalysisData(CopyAnalysisData analysisData)
+                => GetClonedAnalysisDataHelper(analysisData);
+            protected override bool Equals(CopyAnalysisData value1, CopyAnalysisData value2)
+                => EqualsHelper(value1, value2);
+            #endregion
+
+            #region Visitor overrides
+            public override CopyAbstractValue DefaultVisit(IOperation operation, object argument)
+            {
+                var _ = base.DefaultVisit(operation, argument);
+                return CopyAbstractValue.Unknown;
+            }
+            #endregion
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
+{
+    using CopyAnalysisData = IDictionary<AnalysisEntity, CopyAbstractValue>;
+    
+    /// <summary>
+    /// Dataflow analysis to track <see cref="AnalysisEntity"/> instances that share the same value.
+    /// </summary>
+    internal partial class CopyAnalysis : ForwardDataFlowAnalysis<CopyAnalysisData, CopyBlockAnalysisResult, CopyAbstractValue>
+    {
+        private CopyAnalysis(CopyAnalysisDomain analysisDomain, CopyDataFlowOperationVisitor operationVisitor)
+            : base(analysisDomain, operationVisitor)
+        {
+        }
+
+        public static DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue> GetOrComputeResult(
+            ControlFlowGraph cfg,
+            ISymbol owningSymbol,
+            WellKnownTypeProvider wellKnownTypeProvider,
+            DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null,
+            DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt = null,
+            bool pessimisticAnalysis = true)
+        {
+            var operationVisitor = new CopyDataFlowOperationVisitor(CopyAbstractValueDomain.Default, owningSymbol, 
+                wellKnownTypeProvider, pessimisticAnalysis, nullAnalysisResultOpt, pointsToAnalysisResultOpt);
+            var copyAnalysis = new CopyAnalysis(CopyAnalysisDomain.Instance, operationVisitor);
+            return copyAnalysis.GetOrComputeResultCore(cfg, cacheResult: true);
+        }
+
+        internal override CopyBlockAnalysisResult ToResult(BasicBlock basicBlock, DataFlowAnalysisInfo<CopyAnalysisData> blockAnalysisData) => new CopyBlockAnalysisResult(basicBlock, blockAnalysisData);
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisDomain.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
+{
+    using CopyAnalysisData = IDictionary<AnalysisEntity, CopyAbstractValue>;
+
+    internal partial class CopyAnalysis : ForwardDataFlowAnalysis<CopyAnalysisData, CopyBlockAnalysisResult, CopyAbstractValue>
+    {
+        /// <summary>
+        /// An abstract analysis domain implementation <see cref="CopyAnalysis"/>.
+        /// </summary>
+        private class CopyAnalysisDomain : AnalysisEntityMapAbstractDomain<CopyAbstractValue>
+        {
+            public static readonly CopyAnalysisDomain Instance = new CopyAnalysisDomain(CopyAbstractValueDomain.Default);
+
+            private CopyAnalysisDomain(AbstractValueDomain<CopyAbstractValue> valueDomain)
+            : base(valueDomain)
+            {
+            }
+
+            protected override CopyAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => new CopyAbstractValue(analysisEntity);
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyBlockAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyBlockAnalysisResult.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
+{
+    using CopyAnalysisData = IDictionary<AnalysisEntity, CopyAbstractValue>;
+
+    /// <summary>
+    /// Result from execution of <see cref="CopyAnalysis"/> on a basic block.
+    /// It store copy values for each <see cref="AnalysisEntity"/> at the start and end of the basic block.
+    /// </summary>
+    internal class CopyBlockAnalysisResult : AbstractBlockAnalysisResult<CopyAnalysisData, CopyAbstractValue>
+    {
+        public CopyBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<CopyAnalysisData> blockAnalysisData)
+            : base (basicBlock)
+        {
+            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, CopyAbstractValue>.Empty;
+            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, CopyAbstractValue>.Empty;
+        }
+
+        public ImmutableDictionary<AnalysisEntity, CopyAbstractValue> InputData { get; }
+        public ImmutableDictionary<AnalysisEntity, CopyAbstractValue> OutputData { get; }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
@@ -23,57 +23,49 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
 
         public static DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> GetOrComputeResult(
             ControlFlowGraph cfg,
-            INamedTypeSymbol iDisposable,
-            INamedTypeSymbol taskType,
-            ImmutableHashSet<INamedTypeSymbol> collectionTypes,
-            ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
             ISymbol owningSymbol,
+            WellKnownTypeProvider wellKnownTypeProvider,
+            ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
         {
-            return GetOrComputeResultCore(cfg, iDisposable, taskType, collectionTypes,
-                disposeOwnershipTransferLikelyTypes, owningSymbol, pointsToAnalysisResult,
+            return GetOrComputeResultCore(cfg, owningSymbol, wellKnownTypeProvider, disposeOwnershipTransferLikelyTypes, pointsToAnalysisResult,
                 nullAnalysisResultOpt, trackInstanceFields: false, trackedInstanceFieldPointsToMap: out var _);
         }
 
         public static DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> GetOrComputeResult(
             ControlFlowGraph cfg,
-            INamedTypeSymbol iDisposable,
-            INamedTypeSymbol taskType,
-            ImmutableHashSet<INamedTypeSymbol> collectionTypes,
-            ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
             ISymbol owningSymbol,
+            WellKnownTypeProvider wellKnownTypeProvider,
+            ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
             bool trackInstanceFields,
             out ImmutableDictionary<IFieldSymbol, PointsToAnalysis.PointsToAbstractValue> trackedInstanceFieldPointsToMap,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null)
         {
-            return GetOrComputeResultCore(cfg, iDisposable, taskType, collectionTypes,
-                disposeOwnershipTransferLikelyTypes, owningSymbol, pointsToAnalysisResult,
+            return GetOrComputeResultCore(cfg, owningSymbol, wellKnownTypeProvider, disposeOwnershipTransferLikelyTypes, pointsToAnalysisResult,
                 nullAnalysisResultOpt, trackInstanceFields, out trackedInstanceFieldPointsToMap);
         }
 
         private static DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> GetOrComputeResultCore(
             ControlFlowGraph cfg,
-            INamedTypeSymbol iDisposable,
-            INamedTypeSymbol taskType,
-            ImmutableHashSet<INamedTypeSymbol> collectionTypes,
-            ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
             ISymbol owningSymbol,
+            WellKnownTypeProvider wellKnownTypeProvider,
+            ImmutableHashSet<INamedTypeSymbol> disposeOwnershipTransferLikelyTypes,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt,
             bool trackInstanceFields,
             out ImmutableDictionary<IFieldSymbol, PointsToAnalysis.PointsToAbstractValue> trackedInstanceFieldPointsToMap)
         {
             Debug.Assert(cfg != null);
-            Debug.Assert(iDisposable != null);
+            Debug.Assert(wellKnownTypeProvider.IDisposable != null);
             Debug.Assert(owningSymbol != null);
             Debug.Assert(pointsToAnalysisResult != null);
 
-            var operationVisitor = new DisposeDataFlowOperationVisitor(iDisposable, taskType, collectionTypes,
-                disposeOwnershipTransferLikelyTypes, DisposeAbstractValueDomain.Default, owningSymbol, trackInstanceFields, pointsToAnalysisResult, nullAnalysisResultOpt);
+            var operationVisitor = new DisposeDataFlowOperationVisitor(DisposeAbstractValueDomain.Default, owningSymbol, wellKnownTypeProvider,
+                disposeOwnershipTransferLikelyTypes, trackInstanceFields, pointsToAnalysisResult, nullAnalysisResultOpt);
             var disposeAnalysis = new DisposeAnalysis(DisposeAnalysisDomainInstance, operationVisitor);
-            var result = disposeAnalysis.GetOrComputeResultCore(cfg);
+            var result = disposeAnalysis.GetOrComputeResultCore(cfg, cacheResult: false);
             trackedInstanceFieldPointsToMap = trackInstanceFields ? operationVisitor.TrackedInstanceFieldPointsToMap : null;
             return result;
         }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAbstractValue.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
         Undefined,
         Null,
         NotNull,
-        MaybeNull
+        MaybeNull,
+        Invalid
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullAbstractValueDomain.cs
@@ -35,11 +35,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
                 {
                     result = NullAbstractValue.MaybeNull;
                 }
-                else if (value1 == NullAbstractValue.Undefined)
+                else if (value1 == NullAbstractValue.Invalid || value1 == NullAbstractValue.Undefined)
                 {
                     result = value2;
                 }
-                else if (value2 == NullAbstractValue.Undefined)
+                else if (value2 == NullAbstractValue.Invalid || value2 == NullAbstractValue.Undefined)
                 {
                     result = value1;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.cs
@@ -22,12 +22,15 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
         public static DataFlowAnalysisResult<NullBlockAnalysisResult, NullAbstractValue> GetOrComputeResult(
             ControlFlowGraph cfg,
             ISymbol owningSymbol,
+            WellKnownTypeProvider wellKnownTypeProvider,
+            DataFlowAnalysisResult<CopyAnalysis.CopyBlockAnalysisResult, CopyAnalysis.CopyAbstractValue> copyAnalysisResultOpt = null,
             bool pessimisticAnalysis = true,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt = null)
         {
-            var operationVisitor = new NullDataFlowOperationVisitor(NullAbstractValueDomain.Default, owningSymbol, pessimisticAnalysis, pointsToAnalysisResultOpt);
+            var operationVisitor = new NullDataFlowOperationVisitor(NullAbstractValueDomain.Default, owningSymbol,
+                wellKnownTypeProvider, pessimisticAnalysis, copyAnalysisResultOpt, pointsToAnalysisResultOpt);
             var nullAnalysis = new NullAnalysis(NullAnalysisDomainInstance, operationVisitor);
-            return nullAnalysis.GetOrComputeResultCore(cfg);
+            return nullAnalysis.GetOrComputeResultCore(cfg, cacheResult: true);
         }
 
         internal override NullBlockAnalysisResult ToResult(BasicBlock basicBlock, DataFlowAnalysisInfo<IDictionary<AnalysisEntity, NullAbstractValue>> blockAnalysisData) => new NullBlockAnalysisResult(basicBlock, blockAnalysisData);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAbstractValue.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis
+{
+    /// <summary>
+    /// Abstract validation value for <see cref="AbstractLocation"/>/<see cref="IOperation"/> tracked by <see cref="ParameterValidationAnalysis"/>.
+    /// </summary>
+    internal enum ParameterValidationAbstractValue
+    {
+        /// <summary>
+        /// Analysis is not applicable for this location.
+        /// </summary>
+        NotApplicable,
+
+        /// <summary>
+        /// Location has not been validated.
+        /// </summary>
+        NotValidated,
+
+        /// <summary>
+        /// Location has been validated.
+        /// </summary>
+        Validated,
+
+        /// <summary>
+        /// Location may have been validated.
+        /// </summary>
+        MayBeValidated
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationAbstractValueDomain.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis
+{
+    using ParameterValidationAnalysisData = IDictionary<AbstractLocation, ParameterValidationAbstractValue>;
+
+    internal partial class ParameterValidationAnalysis : ForwardDataFlowAnalysis<ParameterValidationAnalysisData, ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue>
+    {
+        /// <summary>
+        /// Abstract value domain for <see cref="ParameterValidationAnalysis"/> to merge and compare <see cref="ParameterValidationAbstractValue"/> values.
+        /// </summary>
+        private class ParameterValidationAbstractValueDomain : AbstractValueDomain<ParameterValidationAbstractValue>
+        {
+            public static ParameterValidationAbstractValueDomain Default = new ParameterValidationAbstractValueDomain();
+
+            private ParameterValidationAbstractValueDomain() { }
+
+            public override ParameterValidationAbstractValue Bottom => ParameterValidationAbstractValue.NotApplicable;
+
+            public override ParameterValidationAbstractValue UnknownOrMayBeValue => ParameterValidationAbstractValue.MayBeValidated;
+
+            public override int Compare(ParameterValidationAbstractValue oldValue, ParameterValidationAbstractValue newValue)
+            {
+                return Comparer<ParameterValidationAbstractValue>.Default.Compare(oldValue, newValue);
+            }
+
+            public override ParameterValidationAbstractValue Merge(ParameterValidationAbstractValue value1, ParameterValidationAbstractValue value2)
+            {
+                if (value1 == value2)
+                {
+                    return value1;
+                }
+                else if (value1 == ParameterValidationAbstractValue.NotApplicable ||
+                    value2 == ParameterValidationAbstractValue.NotApplicable)
+                {
+                    return ParameterValidationAbstractValue.NotApplicable;
+                }
+
+                return ParameterValidationAbstractValue.MayBeValidated;
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
@@ -1,0 +1,334 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis
+{
+    using ParameterValidationAnalysisData = IDictionary<AbstractLocation, ParameterValidationAbstractValue>;
+
+    internal partial class ParameterValidationAnalysis : ForwardDataFlowAnalysis<ParameterValidationAnalysisData, ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue>
+    {
+        /// <summary>
+        /// Operation visitor to flow the location validation values across a given statement in a basic block.
+        /// </summary>
+        private sealed class ParameterValidationDataFlowOperationVisitor : AbstractLocationDataFlowOperationVisitor<ParameterValidationAnalysisData, ParameterValidationAbstractValue>
+        {
+            private readonly Func<IBlockOperation, IMethodSymbol, (DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue> parameterValidationAnalysisResult, ImmutableDictionary<IParameterSymbol, SyntaxNode> hazardousParameterUsages)> _getOrComputeLocationAnalysisResultOpt;
+            private readonly ImmutableDictionary<IParameterSymbol, SyntaxNode>.Builder _hazardousParameterUsageBuilderOpt;
+
+            public ParameterValidationDataFlowOperationVisitor(
+                ParameterValidationAbstractValueDomain valueDomain,
+                ISymbol owningSymbol,
+                WellKnownTypeProvider wellKnownTypeProvider,
+                Func<IBlockOperation, IMethodSymbol, (DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue>, ImmutableDictionary<IParameterSymbol, SyntaxNode>)> getOrComputeLocationAnalysisResultOpt,
+                DataFlowAnalysisResult<NullBlockAnalysisResult, NullAbstractValue> nullAnalysisResult,
+                DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult,
+                bool pessimisticAnalysis,
+                bool trackHazardousParameterUsages = false)
+                : base(valueDomain, owningSymbol, wellKnownTypeProvider, pessimisticAnalysis, predicateAnalysis: false, nullAnalysisResultOpt: nullAnalysisResult, copyAnalysisResultOpt: null, pointsToAnalysisResultOpt: pointsToAnalysisResult)
+            {
+                Debug.Assert(owningSymbol.Kind == SymbolKind.Method);
+                Debug.Assert(nullAnalysisResult != null);
+                Debug.Assert(pointsToAnalysisResult != null);
+
+                _getOrComputeLocationAnalysisResultOpt = getOrComputeLocationAnalysisResultOpt;
+                if (trackHazardousParameterUsages)
+                {
+                    _hazardousParameterUsageBuilderOpt = ImmutableDictionary.CreateBuilder<IParameterSymbol, SyntaxNode>();
+                }
+            }
+
+            public override int GetHashCode()
+            {
+                return HashUtilities.Combine(_hazardousParameterUsageBuilderOpt?.GetHashCode() ?? 0,
+                    HashUtilities.Combine(_getOrComputeLocationAnalysisResultOpt?.GetHashCode() ?? 0, base.GetHashCode()));
+            }
+
+            public ImmutableDictionary<IParameterSymbol, SyntaxNode> HazardousParameterUsages
+            {
+                get
+                {
+                    Debug.Assert(_hazardousParameterUsageBuilderOpt != null);
+                    return _hazardousParameterUsageBuilderOpt.ToImmutable();
+                }
+            }
+
+            protected override ParameterValidationAbstractValue GetAbstractDefaultValue(ITypeSymbol type) => ValueDomain.Bottom;
+
+            protected override ParameterValidationAbstractValue GetAbstractValue(AbstractLocation location)
+                => CurrentAnalysisData.TryGetValue(location, out var value) ? value : ValueDomain.Bottom;
+
+            protected override void ResetCurrentAnalysisData(ParameterValidationAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);
+
+            private bool IsTrackedLocation(AbstractLocation location) =>
+                location.SymbolOpt is IParameterSymbol parameter && parameter.Type.IsReferenceType && parameter.ContainingSymbol == OwningSymbol;
+
+            private bool IsNotOrMaybeValidatedLocation(AbstractLocation location) =>
+                CurrentAnalysisData.TryGetValue(location, out var value) &&
+                (value == ParameterValidationAbstractValue.NotValidated || value == ParameterValidationAbstractValue.MayBeValidated);
+
+            protected override void SetAbstractValue(AbstractLocation location, ParameterValidationAbstractValue value)
+            {
+                if (IsTrackedLocation(location))
+                {
+                    CurrentAnalysisData[location] = value;
+                }
+            }
+
+            private void SetAbstractValue(IEnumerable<AbstractLocation> locations, ParameterValidationAbstractValue value)
+            {
+                foreach (var location in locations)
+                {
+                    SetAbstractValue(location, value);
+                }
+            }
+
+            protected override void SetAbstractValueForAssignment(IOperation target, IOperation assignedValueOperation, ParameterValidationAbstractValue assignedValue)
+            {
+                // We are only tracking default parameter locations.
+            }
+
+            protected override void SetAbstractValueForElementInitializer(IOperation instance, ImmutableArray<AbstractIndex> indices, ITypeSymbol elementType, IOperation initializer, ParameterValidationAbstractValue value)
+            {
+                // We are only tracking default parameter locations.
+            }
+
+            protected override void SetAbstractValueForSymbolDeclaration(ISymbol symbol, IOperation initializer, ParameterValidationAbstractValue initializerValue)
+            {
+                // We are only tracking parameter symbol locations.
+                Debug.Assert(symbol.Kind != SymbolKind.Parameter);
+            }
+
+            protected override void SetValueForParameterPointsToLocationOnEntry(IParameterSymbol parameter, PointsToAbstractValue pointsToAbstractValue)
+            {
+                if (pointsToAbstractValue.Kind == PointsToAbstractValueKind.Known)
+                {
+                    Debug.Assert(pointsToAbstractValue.Locations.Count == 1);
+                    var value = HasValidatedNotNullAttribute(parameter) ? ParameterValidationAbstractValue.Validated : ParameterValidationAbstractValue.NotValidated;
+                    SetAbstractValue(pointsToAbstractValue.Locations, value);
+                }
+            }
+
+            private static bool HasValidatedNotNullAttribute(IParameterSymbol parameter)
+                => parameter.GetAttributes().Any(attr => attr.AttributeClass.Name.Equals("ValidatedNotNullAttribute", StringComparison.OrdinalIgnoreCase));
+
+            protected override void SetValueForParameterPointsToLocationOnExit(IParameterSymbol parameter, AnalysisEntity analysisEntity, PointsToAbstractValue pointsToAbstractValue)
+            {
+                // Mark parameters as validated if they are non-null at all non-exception return paths and null at one of the unhandled throw operations.
+                var notValidatedLocations = pointsToAbstractValue.Locations.Where(IsNotOrMaybeValidatedLocation);
+                if (notValidatedLocations.Any())
+                {
+                    if (TryGetNullAbstractValueAtCurrentBlockEntry(analysisEntity, out NullAbstractValue nullAbstractValue) &&
+                        nullAbstractValue == NullAbstractValue.NotNull &&
+                        TryGetMergedNullAbstractValueAtUnhandledThrowOperationsInGraph(analysisEntity, out NullAbstractValue mergedValueAtUnhandledThrowOperations) &&
+                        mergedValueAtUnhandledThrowOperations != NullAbstractValue.NotNull)
+                    {
+                        SetAbstractValue(notValidatedLocations, ParameterValidationAbstractValue.Validated);
+                    }
+                }
+            }
+
+            private void ValidateOperation(IOperation operation)
+            {
+                var notValidatedLocations = GetNotValidatedLocations(operation);
+                SetAbstractValue(notValidatedLocations, ParameterValidationAbstractValue.Validated);
+            }
+
+            private IEnumerable<AbstractLocation> GetNotValidatedLocations(IOperation operation)
+            {
+                var pointsToLocation = GetPointsToAbstractValue(operation);
+                return pointsToLocation.Locations.Where(IsNotOrMaybeValidatedLocation);
+            }
+
+            private static bool IsHazardousIfNull(IOperation operation)
+            {
+                if (operation.Kind == OperationKind.ConditionalAccessInstance)
+                {
+                    return false;
+                }
+
+                switch (operation.Parent)
+                {
+                    case IMemberReferenceOperation memberReference:
+                        return memberReference.Instance == operation;
+
+                    case IArrayElementReferenceOperation arrayElementReference:
+                        return arrayElementReference.ArrayReference == operation;
+
+                    case IInvocationOperation invocation:
+                        return invocation.Instance == operation;
+                }
+
+                return false;
+            }
+
+            private void HandlePotentiallyHazardousOperation(IOperation operation, IEnumerable<AbstractLocation> nonValidatedLocations)
+            {
+                Debug.Assert(_hazardousParameterUsageBuilderOpt != null);
+
+                if (GetNullAbstractValue(operation) == NullAbstractValue.NotNull)
+                {
+                    // We are sure the value is non-null, so cannot be hazardous.
+                    return;
+                }
+
+                foreach (var location in nonValidatedLocations)
+                {
+                    Debug.Assert(IsNotOrMaybeValidatedLocation(location));
+
+                    var parameter = (IParameterSymbol)location.SymbolOpt;
+                    SyntaxNode syntaxNode = operation.Syntax;
+                    if (!_hazardousParameterUsageBuilderOpt.TryGetValue(parameter, out SyntaxNode currentSyntaxNode) ||
+                        syntaxNode.SpanStart < currentSyntaxNode.SpanStart)
+                    {
+                        _hazardousParameterUsageBuilderOpt[parameter] = syntaxNode;
+                    }
+                }
+            }
+
+            // TODO: Remove these temporary methods once we move to compiler's CFG
+            // https://github.com/dotnet/roslyn-analyzers/issues/1567
+            #region Temporary methods to workaround lack of *real* CFG
+            protected override ParameterValidationAnalysisData MergeAnalysisData(ParameterValidationAnalysisData value1, ParameterValidationAnalysisData value2)
+                => ParameterValidationAnalysisDomainInstance.Merge(value1, value2);
+            protected override ParameterValidationAnalysisData GetClonedAnalysisData(ParameterValidationAnalysisData analysisData)
+                => GetClonedAnalysisDataHelper(analysisData);
+            protected override bool Equals(ParameterValidationAnalysisData value1, ParameterValidationAnalysisData value2)
+                => EqualsHelper(value1, value2);
+
+            #endregion
+
+            #region Visit overrides
+            public override ParameterValidationAbstractValue Visit(IOperation operation, object argument)
+            {
+                var value = base.Visit(operation, argument);
+                if (operation != null)
+                {
+                    if (_hazardousParameterUsageBuilderOpt != null &&
+                        IsHazardousIfNull(operation))
+                    {
+                        var notValidatedLocations = GetNotValidatedLocations(operation);
+                        HandlePotentiallyHazardousOperation(operation, notValidatedLocations);
+                    }
+                }
+
+                return value;
+            }
+
+            public override ParameterValidationAbstractValue VisitArgumentCore(IArgumentOperation operation, object argument)
+            {
+                var value = base.VisitArgumentCore(operation, argument);
+
+                // Arguments to validation methods must be marked as validated.
+                var notValidatedLocations = GetNotValidatedLocations(operation);
+                if (notValidatedLocations.Any())
+                {
+                    if (_getOrComputeLocationAnalysisResultOpt != null)
+                    {
+                        IMethodSymbol targetMethod = null;
+                        if (operation.Parent is IInvocationOperation invocation)
+                        {
+                            targetMethod = invocation.TargetMethod;
+                        }
+                        else if (operation.Parent is IObjectCreationOperation objectCreation)
+                        {
+                            targetMethod = objectCreation.Constructor;
+                        }
+
+                        if (targetMethod != null &&
+                            targetMethod != OwningSymbol)
+                        {
+                            if (targetMethod.ContainingType.SpecialType == SpecialType.System_String)
+                            {
+                                if (targetMethod.IsStatic &&
+                                    targetMethod.Name.StartsWith("IsNull", StringComparison.Ordinal) &&
+                                    targetMethod.Parameters.Length == 1)
+                                {
+                                    // string.IsNullOrXXX check.
+                                    SetAbstractValue(notValidatedLocations, ParameterValidationAbstractValue.Validated);
+                                }
+                            }
+                            else if (WellKnownTypeProvider.Exception != null && targetMethod.ContainingType.DerivesFrom(WellKnownTypeProvider.Exception))
+                            {
+                                // FxCop compat: special cases handled by FxCop.
+                                //  1. First argument of type System.Runtime.Serialization.SerializationInfo to System.Exception.GetObjectData or its override is validated.
+                                //  2. First argument of type System.Runtime.Serialization.SerializationInfo to constructor of System.Exception or its subtype is validated.
+                                if (operation.Parameter.Type == WellKnownTypeProvider.SerializationInfo)
+                                {
+                                    switch (targetMethod.MethodKind)
+                                    {
+                                        case MethodKind.Ordinary:
+                                            if (targetMethod.Name.Equals("GetObjectData", StringComparison.OrdinalIgnoreCase))
+                                            {
+                                                SetAbstractValue(notValidatedLocations, ParameterValidationAbstractValue.Validated);
+                                            }
+                                            break;
+
+                                        case MethodKind.Constructor:
+                                            SetAbstractValue(notValidatedLocations, ParameterValidationAbstractValue.Validated);
+                                            break;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                var methodTopmostBlock = targetMethod.GetTopmostOperationBlock(WellKnownTypeProvider.Compilation);
+                                if (methodTopmostBlock != null)
+                                {
+                                    var invokedMethodAnalysisResult = _getOrComputeLocationAnalysisResultOpt(methodTopmostBlock, targetMethod);
+                                    var invokedMethodLocationAnalysisResult = invokedMethodAnalysisResult.parameterValidationAnalysisResult;
+                                    var hazardousParameterUsagesInInvokedMethod = invokedMethodAnalysisResult.hazardousParameterUsages;
+                                    if (invokedMethodLocationAnalysisResult != null)
+                                    {
+                                        Debug.Assert(hazardousParameterUsagesInInvokedMethod != null);
+
+                                        // Non-validated argument passed to private/internal methods might be hazardous.
+                                        if (hazardousParameterUsagesInInvokedMethod.ContainsKey(operation.Parameter))
+                                        {
+                                            if (_hazardousParameterUsageBuilderOpt != null && !targetMethod.IsExternallyVisible())
+                                            {
+                                                HandlePotentiallyHazardousOperation(operation, notValidatedLocations);
+                                            }
+                                        }
+                                        else if (!targetMethod.IsVirtual && !targetMethod.IsOverride)
+                                        {
+                                            // Check if this is a non-virtual non-override method that validates the argument.
+                                            BasicBlock invokedMethodExitBlock = invokedMethodLocationAnalysisResult.ControlFlowGraph.Exit;
+                                            foreach (var kvp in invokedMethodLocationAnalysisResult[invokedMethodExitBlock].OutputData)
+                                            {
+                                                AbstractLocation parameterLocation = kvp.Key;
+                                                ParameterValidationAbstractValue parameterValue = kvp.Value;
+                                                Debug.Assert(parameterLocation.SymbolOpt is IParameterSymbol invokedMethodParameter && invokedMethodParameter.ContainingSymbol == targetMethod);
+
+                                                // Check if the matching parameter was validated by the invoked method.
+                                                if ((IParameterSymbol)parameterLocation.SymbolOpt == operation.Parameter &&
+                                                    parameterValue == ParameterValidationAbstractValue.Validated)
+                                                {
+                                                    SetAbstractValue(notValidatedLocations, ParameterValidationAbstractValue.Validated);
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return value;
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
@@ -22,14 +22,14 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis
         /// </summary>
         private sealed class ParameterValidationDataFlowOperationVisitor : AbstractLocationDataFlowOperationVisitor<ParameterValidationAnalysisData, ParameterValidationAbstractValue>
         {
-            private readonly Func<IBlockOperation, IMethodSymbol, (DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue> parameterValidationAnalysisResult, ImmutableDictionary<IParameterSymbol, SyntaxNode> hazardousParameterUsages)> _getOrComputeLocationAnalysisResultOpt;
+            private readonly Func<IBlockOperation, IMethodSymbol, ParameterValidationResultWithHazardousUsages> _getOrComputeLocationAnalysisResultOpt;
             private readonly ImmutableDictionary<IParameterSymbol, SyntaxNode>.Builder _hazardousParameterUsageBuilderOpt;
 
             public ParameterValidationDataFlowOperationVisitor(
                 ParameterValidationAbstractValueDomain valueDomain,
                 ISymbol owningSymbol,
                 WellKnownTypeProvider wellKnownTypeProvider,
-                Func<IBlockOperation, IMethodSymbol, (DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue>, ImmutableDictionary<IParameterSymbol, SyntaxNode>)> getOrComputeLocationAnalysisResultOpt,
+                Func<IBlockOperation, IMethodSymbol, ParameterValidationResultWithHazardousUsages> getOrComputeLocationAnalysisResultOpt,
                 DataFlowAnalysisResult<NullBlockAnalysisResult, NullAbstractValue> nullAnalysisResult,
                 DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult,
                 bool pessimisticAnalysis,
@@ -278,9 +278,9 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis
                                 var methodTopmostBlock = targetMethod.GetTopmostOperationBlock(WellKnownTypeProvider.Compilation);
                                 if (methodTopmostBlock != null)
                                 {
-                                    var invokedMethodAnalysisResult = _getOrComputeLocationAnalysisResultOpt(methodTopmostBlock, targetMethod);
-                                    var invokedMethodLocationAnalysisResult = invokedMethodAnalysisResult.parameterValidationAnalysisResult;
-                                    var hazardousParameterUsagesInInvokedMethod = invokedMethodAnalysisResult.hazardousParameterUsages;
+                                    ParameterValidationResultWithHazardousUsages invokedMethodAnalysisResult = _getOrComputeLocationAnalysisResultOpt(methodTopmostBlock, targetMethod);
+                                    var invokedMethodLocationAnalysisResult = invokedMethodAnalysisResult.ParameterValidationAnalysisResult;
+                                    var hazardousParameterUsagesInInvokedMethod = invokedMethodAnalysisResult.HazardousParameterUsages;
                                     if (invokedMethodLocationAnalysisResult != null)
                                     {
                                         Debug.Assert(hazardousParameterUsagesInInvokedMethod != null);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
@@ -137,12 +137,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis
                 }
             }
 
-            private void ValidateOperation(IOperation operation)
-            {
-                var notValidatedLocations = GetNotValidatedLocations(operation);
-                SetAbstractValue(notValidatedLocations, ParameterValidationAbstractValue.Validated);
-            }
-
             private IEnumerable<AbstractLocation> GetNotValidatedLocations(IOperation operation)
             {
                 var pointsToLocation = GetPointsToAbstractValue(operation);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationResultWithHazardousUsages.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationResultWithHazardousUsages.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis
+{
+    using ParameterValidationAnalysisData = IDictionary<AbstractLocation, ParameterValidationAbstractValue>;
+
+    internal partial class ParameterValidationAnalysis : ForwardDataFlowAnalysis<ParameterValidationAnalysisData, ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue>
+    {
+        private sealed class ParameterValidationResultWithHazardousUsages
+        {
+            public ParameterValidationResultWithHazardousUsages(
+                DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue> parameterValidationAnalysisResult,
+                ImmutableDictionary<IParameterSymbol, SyntaxNode> hazardousParameterUsages)
+            {
+                ParameterValidationAnalysisResult = parameterValidationAnalysisResult;
+                HazardousParameterUsages = hazardousParameterUsages;
+            }
+
+            public DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue> ParameterValidationAnalysisResult { get; }
+            public ImmutableDictionary<IParameterSymbol, SyntaxNode> HazardousParameterUsages { get; }
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis
+{
+    using ParameterValidationAnalysisData = IDictionary<AbstractLocation, ParameterValidationAbstractValue>;
+    using ParameterValidationAnalysisDomain = MapAbstractDomain<AbstractLocation, ParameterValidationAbstractValue>;
+
+    /// <summary>
+    /// Dataflow analysis to track <see cref="ParameterValidationAbstractValue"/> of <see cref="AbstractLocation"/>/<see cref="IOperation"/> instances.
+    /// </summary>
+    internal partial class ParameterValidationAnalysis : ForwardDataFlowAnalysis<ParameterValidationAnalysisData, ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue>
+    {
+        public static readonly ParameterValidationAnalysisDomain ParameterValidationAnalysisDomainInstance = new ParameterValidationAnalysisDomain(ParameterValidationAbstractValueDomain.Default);
+
+        private ParameterValidationAnalysis(ParameterValidationAnalysisDomain analysisDomain, ParameterValidationDataFlowOperationVisitor operationVisitor)
+            : base(analysisDomain, operationVisitor)
+        {
+        }
+
+        public static ImmutableDictionary<IParameterSymbol, SyntaxNode> GetOrComputeHazardousParameterUsages(
+            IOperation topmostBlock,
+            Compilation compilation,
+            ISymbol owningSymbol,
+            bool pessimisticAnalysis = true)
+        {
+            Debug.Assert(topmostBlock != null);
+
+            var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(compilation);
+            (DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue> parameterValidationAnalysisResult, ImmutableDictionary<IParameterSymbol, SyntaxNode> hazardousParameterUsages) GetOrComputeLocationAnalysisResultForInvokedMethod(IBlockOperation methodTopmostBlock, IMethodSymbol method)
+            {
+                // getOrComputeLocationAnalysisResultOpt = null, so we do interprocedural analysis only one level down.
+                Debug.Assert(methodTopmostBlock != null);
+                return GetOrComputeResult(methodTopmostBlock, method, wellKnownTypeProvider, getOrComputeLocationAnalysisResultOpt: null, pessimisticAnalysis: pessimisticAnalysis);
+            };
+
+            var result = GetOrComputeResult(topmostBlock, owningSymbol, wellKnownTypeProvider, GetOrComputeLocationAnalysisResultForInvokedMethod, pessimisticAnalysis);
+            return result.hazardousParameterUsages;
+        }
+
+        private static (DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue> parameterValidationAnalysisResult, ImmutableDictionary<IParameterSymbol, SyntaxNode> hazardousParameterUsages) GetOrComputeResult(
+            IOperation topmostBlock,
+            ISymbol owningSymbol,
+            WellKnownTypeProvider wellKnownTypeProvider,
+            Func<IBlockOperation, IMethodSymbol, (DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue>, ImmutableDictionary<IParameterSymbol, SyntaxNode>)> getOrComputeLocationAnalysisResultOpt,
+            bool pessimisticAnalysis)
+        {
+            var cfg = ControlFlowGraph.Create(topmostBlock);
+            var nullAnalysisResult = NullAnalysis.NullAnalysis.GetOrComputeResult(cfg, owningSymbol, wellKnownTypeProvider);
+            var pointsToAnalysisResult = PointsToAnalysis.PointsToAnalysis.GetOrComputeResult(cfg, owningSymbol, wellKnownTypeProvider, nullAnalysisResult);
+            var copyAnalysisResult = CopyAnalysis.CopyAnalysis.GetOrComputeResult(cfg, owningSymbol, wellKnownTypeProvider, nullAnalysisResultOpt: nullAnalysisResult, pointsToAnalysisResultOpt: pointsToAnalysisResult);
+            // Do another null analysis pass to improve the results from PointsTo and Copy analysis.
+            nullAnalysisResult = NullAnalysis.NullAnalysis.GetOrComputeResult(cfg, owningSymbol, wellKnownTypeProvider, copyAnalysisResult, pointsToAnalysisResultOpt: pointsToAnalysisResult);
+            return GetOrComputeResult(cfg, owningSymbol, wellKnownTypeProvider, nullAnalysisResult, pointsToAnalysisResult, getOrComputeLocationAnalysisResultOpt, pessimisticAnalysis);
+        }
+
+        private static (DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue> parameterValidationAnalysisResult, ImmutableDictionary<IParameterSymbol, SyntaxNode> hazardousParameterUsages) GetOrComputeResult(
+            ControlFlowGraph cfg,
+            ISymbol owningSymbol,
+            WellKnownTypeProvider wellKnownTypeProvider,
+            DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResult,
+            DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResult,
+            Func<IBlockOperation, IMethodSymbol, (DataFlowAnalysisResult<ParameterValidationBlockAnalysisResult, ParameterValidationAbstractValue>, ImmutableDictionary<IParameterSymbol, SyntaxNode>)> getOrComputeLocationAnalysisResultOpt,
+            bool pessimisticAnalysis)
+        {
+            var operationVisitor = new ParameterValidationDataFlowOperationVisitor(ParameterValidationAbstractValueDomain.Default,
+                owningSymbol, wellKnownTypeProvider, getOrComputeLocationAnalysisResultOpt, nullAnalysisResult, pointsToAnalysisResult, pessimisticAnalysis);
+            var analysis = new ParameterValidationAnalysis(ParameterValidationAnalysisDomainInstance, operationVisitor);
+            var analysisResult = analysis.GetOrComputeResultCore(cfg, cacheResult: true);
+
+            var newOperationVisitor = new ParameterValidationDataFlowOperationVisitor(ParameterValidationAbstractValueDomain.Default,
+                    owningSymbol, wellKnownTypeProvider, getOrComputeLocationAnalysisResultOpt, nullAnalysisResult, pointsToAnalysisResult, pessimisticAnalysis, trackHazardousParameterUsages: true);
+            var resultBuilder = new DataFlowAnalysisResultBuilder<ParameterValidationAnalysisData>();
+            foreach (var block in cfg.Blocks)
+            {
+                var data = ParameterValidationAnalysisDomainInstance.Clone(analysisResult[block].InputData);
+                data = Flow(newOperationVisitor, block, data);
+            }
+
+            return (analysisResult, newOperationVisitor.HazardousParameterUsages);
+        }
+
+        internal override ParameterValidationBlockAnalysisResult ToResult(BasicBlock basicBlock, DataFlowAnalysisInfo<ParameterValidationAnalysisData> blockAnalysisData) => new ParameterValidationBlockAnalysisResult(basicBlock, blockAnalysisData);
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationBlockAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationBlockAnalysisResult.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis
+{
+    using ParameterValidationAnalysisData = IDictionary<AbstractLocation, ParameterValidationAbstractValue>;
+
+    /// <summary>
+    /// Result from execution of <see cref="ParameterValidationAnalysis"/> on a basic block.
+    /// It stores ParameterValidation values for each <see cref="AbstractLocation"/> at the start and end of the basic block.
+    /// </summary>
+    internal class ParameterValidationBlockAnalysisResult : AbstractBlockAnalysisResult<ParameterValidationAnalysisData, ParameterValidationAbstractValue>
+    {
+        public ParameterValidationBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<ParameterValidationAnalysisData> blockAnalysisData)
+            : base (basicBlock)
+        {
+            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<AbstractLocation, ParameterValidationAbstractValue>.Empty;
+            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<AbstractLocation, ParameterValidationAbstractValue>.Empty;
+        }
+
+        public ImmutableDictionary<AbstractLocation, ParameterValidationAbstractValue> InputData { get; }
+        public ImmutableDictionary<AbstractLocation, ParameterValidationAbstractValue> OutputData { get; }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 
         public PointsToAbstractValue GetOrCreateDefaultValue(AnalysisEntity analysisEntity)
         {
-            Debug.Assert(!analysisEntity.Type.HasValueCopySemantics());
+            Debug.Assert(analysisEntity.Type.IsReferenceType);
             Debug.Assert(_lazyDefaultPointsToValueMap == null);
 
             if (!_defaultPointsToValueMapBuilder.TryGetValue(analysisEntity, out PointsToAbstractValue value))

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
     {
         public static PointsToAbstractValue Undefined = new PointsToAbstractValue(PointsToAbstractValueKind.Undefined);
         public static PointsToAbstractValue NoLocation = new PointsToAbstractValue(PointsToAbstractValueKind.NoLocation);
+        public static PointsToAbstractValue NullLocation = new PointsToAbstractValue(ImmutableHashSet.Create(AbstractLocation.Null), PointsToAbstractValueKind.Known);
         public static PointsToAbstractValue Unknown = new PointsToAbstractValue(PointsToAbstractValueKind.Unknown);
         
         private PointsToAbstractValue(ImmutableHashSet<AbstractLocation> locations, PointsToAbstractValueKind kind)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 {
@@ -77,7 +78,13 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
                     return PointsToAbstractValue.Unknown;
                 }
 
-                return new PointsToAbstractValue(_locationsDomain.Merge(value1.Locations, value2.Locations));
+                var mergedLocations = _locationsDomain.Merge(value1.Locations, value2.Locations);
+                if (mergedLocations.Count == 1 && mergedLocations.Single().IsNull)
+                {
+                    return PointsToAbstractValue.NullLocation;
+                }
+
+                return new PointsToAbstractValue(mergedLocations);
             }
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisDomain.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 {
     /// <summary>
@@ -7,14 +9,14 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
     /// </summary>
     internal class PointsToAnalysisDomain: AnalysisEntityMapAbstractDomain<PointsToAbstractValue>
     {
-        private readonly DefaultPointsToValueGenerator _defaultPointsToValueGenerator;
-
         public PointsToAnalysisDomain(DefaultPointsToValueGenerator defaultPointsToValueGenerator, AbstractValueDomain<PointsToAbstractValue> valueDomain)
             : base(valueDomain)
         {
-            _defaultPointsToValueGenerator = defaultPointsToValueGenerator;
+            DefaultPointsToValueGenerator = defaultPointsToValueGenerator;
         }
 
-        protected override PointsToAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => _defaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity);
+        public DefaultPointsToValueGenerator DefaultPointsToValueGenerator { get; }
+
+        protected override PointsToAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => DefaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContainsNonLiteralState.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContainsNonLiteralState.cs
@@ -11,10 +11,9 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
         Undefined = 0,
         /// <summary>The variable does not contain any instances of non-literal string.</summary>
         No,
-        /// <summary>The variable contains at least one instance of a non-literal string.</summary>
-        Yes,
         /// <summary>The variable may or may not contain instances of a non-literal string.</summary>
         Maybe,
-
+        /// <summary>The variable state is invalid due to predicate analysis.</summary>
+        Invalid,
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAbstractValue.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using Analyzer.Utilities;
@@ -14,9 +15,9 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
     internal partial class StringContentAbstractValue : IEquatable<StringContentAbstractValue>
     {
         public static readonly StringContentAbstractValue UndefinedState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.Undefined);
+        public static readonly StringContentAbstractValue InvalidState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.Invalid);
         public static readonly StringContentAbstractValue MayBeContainsNonLiteralState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.Maybe);
         public static readonly StringContentAbstractValue DoesNotContainNonLiteralState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.No);
-        public static readonly StringContentAbstractValue ContainsNonLiteralState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.Yes);
         private static readonly StringContentAbstractValue ContainsEmpyStringLiteralState = new StringContentAbstractValue(ImmutableHashSet.Create(string.Empty), StringContainsNonLiteralState.No);
 
         public static StringContentAbstractValue Create(string literal)
@@ -45,8 +46,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
                 {
                     case StringContainsNonLiteralState.Undefined:
                         return UndefinedState;
-                    case StringContainsNonLiteralState.Yes:
-                        return ContainsNonLiteralState;
+                    case StringContainsNonLiteralState.Invalid:
+                        return InvalidState;
                     case StringContainsNonLiteralState.No:
                         return DoesNotContainNonLiteralState;
                     default:
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
         /// Gets a collection of the string literals that could possibly make up the contents of this string <see cref="Operand"/>.
         /// </summary>
         public ImmutableHashSet<string> LiteralValues { get; }
-        
+
         public override bool Equals(object obj)
         {
             return Equals(obj as StringContentAbstractValue);
@@ -123,32 +124,40 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 
         private static StringContainsNonLiteralState Merge(StringContainsNonLiteralState value1, StringContainsNonLiteralState value2)
         {
-            // + U Y M N
-            // U U Y M N
-            // Y Y Y M M
+            // + U I M N
+            // U U U M N
+            // I U I M N
             // M M M M M
             // N N N M N
             if (value1 == StringContainsNonLiteralState.Maybe || value2 == StringContainsNonLiteralState.Maybe)
             {
                 return StringContainsNonLiteralState.Maybe;
             }
-            else if (value1 == StringContainsNonLiteralState.Undefined)
+            else if (value1 == StringContainsNonLiteralState.Invalid || value1 == StringContainsNonLiteralState.Undefined)
             {
                 return value2;
             }
-            else if (value2 == StringContainsNonLiteralState.Undefined)
+            else if (value2 == StringContainsNonLiteralState.Invalid || value2 == StringContainsNonLiteralState.Undefined)
             {
                 return value1;
             }
-            else if (value1 != value2)
-            {
-                // One of the values must be 'Yes' and other value must be 'No'.
-                return StringContainsNonLiteralState.Maybe;
-            }
-            else
-            {
-                return value1;
-            }
+
+            Debug.Assert(value1 == StringContainsNonLiteralState.No);
+            Debug.Assert(value2 == StringContainsNonLiteralState.No);
+            return StringContainsNonLiteralState.No;
+        }
+
+        public bool IsLiteralState => NonLiteralState == StringContainsNonLiteralState.No;
+
+        public StringContentAbstractValue IntersectLiteralValues(StringContentAbstractValue value2)
+        {
+            Debug.Assert(IsLiteralState);
+            Debug.Assert(value2.IsLiteralState);
+
+            // Merge Literals
+            var mergedLiteralValues = this.LiteralValues.Intersect(value2.LiteralValues);
+            var nonLiteralState = mergedLiteralValues.IsEmpty ? StringContainsNonLiteralState.Invalid : StringContainsNonLiteralState.No;
+            return new StringContentAbstractValue(mergedLiteralValues, nonLiteralState);
         }
 
         /// <summary>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
@@ -2,6 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 {
@@ -17,16 +20,21 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
             public StringContentDataFlowOperationVisitor(
                 StringContentAbstractValueDomain valueDomain,
                 ISymbol owningSymbol,
+                WellKnownTypeProvider wellKnownTypeProvider,
                 bool pessimisticAnalysis,
+                DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue> copyAnalysisResultOpt,
                 DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt,
                 DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt)
-                : base(valueDomain, owningSymbol, pessimisticAnalysis, nullAnalysisResultOpt, pointsToAnalysisResultOpt)
+                : base(valueDomain, owningSymbol, wellKnownTypeProvider, pessimisticAnalysis, predicateAnalysis: true,
+                      nullAnalysisResultOpt: nullAnalysisResultOpt, copyAnalysisResultOpt: copyAnalysisResultOpt, pointsToAnalysisResultOpt: pointsToAnalysisResultOpt)
             {
             }
 
             protected override IEnumerable<AnalysisEntity> TrackedEntities => CurrentAnalysisData.Keys;
 
-            protected override void SetAbstractValue(AnalysisEntity analysisEntity, StringContentAbstractValue value) => CurrentAnalysisData[analysisEntity] = value;
+            protected override void SetAbstractValue(AnalysisEntity analysisEntity, StringContentAbstractValue value) => SetAbstractValue(CurrentAnalysisData, analysisEntity, value);
+
+            private static void SetAbstractValue(StringContentAnalysisData analysisData, AnalysisEntity analysisEntity, StringContentAbstractValue value) => analysisData[analysisEntity] = value;
 
             protected override bool HasAbstractValue(AnalysisEntity analysisEntity) => CurrentAnalysisData.ContainsKey(analysisEntity);
 
@@ -36,13 +44,59 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 
             protected override void ResetCurrentAnalysisData(StringContentAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);
 
+            #region Predicate analysis
+            private static bool IsValidValueForPredicateAnalysis(StringContainsNonLiteralState value) => value == StringContainsNonLiteralState.No;
+
+            protected override void SetValueForEqualsOrNotEqualsComparisonOperator(IBinaryOperation operation, StringContentAnalysisData negatedCurrentAnalysisData, bool equals)
+            {
+                Debug.Assert(operation.IsComparisonOperator());
+
+                var analysisData = equals ? CurrentAnalysisData : negatedCurrentAnalysisData;
+
+                // Handle 'a == "SomeString"' and 'a != "SomeString"'
+                SetValueForComparisonOperator(operation.LeftOperand, operation.RightOperand, analysisData);
+
+                // Handle '"SomeString" == a' and '"SomeString" != a'
+                SetValueForComparisonOperator(operation.RightOperand, operation.LeftOperand, analysisData);
+            }
+
+            private void SetValueForComparisonOperator(IOperation target, IOperation assignedValue, StringContentAnalysisData analysisData)
+            {
+                StringContentAbstractValue stringContentValue = GetCachedAbstractValue(assignedValue);
+                if (stringContentValue.IsLiteralState &&
+                    AnalysisEntityFactory.TryCreate(target, out AnalysisEntity targetEntity))
+                {
+                    if (analysisData.TryGetValue(targetEntity, out StringContentAbstractValue existingValue) &&
+                        existingValue.IsLiteralState)
+                    {
+                        stringContentValue = stringContentValue.IntersectLiteralValues(existingValue);
+                    }
+
+                    CopyAbstractValue copyValue = GetCopyAbstractValue(target);
+                    if (copyValue.Kind == CopyAbstractValueKind.Known)
+                    {
+                        Debug.Assert(copyValue.AnalysisEntities.Contains(targetEntity));
+                        foreach (var analysisEntity in copyValue.AnalysisEntities)
+                        {
+                            SetAbstractValue(analysisData, analysisEntity, stringContentValue);
+                        }
+                    }
+                    else
+                    {
+                        SetAbstractValue(analysisData, targetEntity, stringContentValue);
+                    }                    
+                }
+            }
+
+            #endregion
+
             // TODO: Remove these temporary methods once we move to compiler's CFG
             // https://github.com/dotnet/roslyn-analyzers/issues/1567
             #region Temporary methods to workaround lack of *real* CFG
             protected override StringContentAnalysisData MergeAnalysisData(StringContentAnalysisData value1, StringContentAnalysisData value2)
                 => StringContentAnalysisDomainInstance.Merge(value1, value2);
-            protected override StringContentAnalysisData GetClonedAnalysisData()
-                => GetClonedAnalysisData(CurrentAnalysisData);
+            protected override StringContentAnalysisData GetClonedAnalysisData(StringContentAnalysisData analysisData)
+                => GetClonedAnalysisDataHelper(analysisData);
             protected override bool Equals(StringContentAnalysisData value1, StringContentAnalysisData value2)
                 => EqualsHelper(value1, value2);
             #endregion
@@ -64,14 +118,14 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
                     }
                     else
                     {
-                        return StringContentAbstractValue.ContainsNonLiteralState;
+                        return StringContentAbstractValue.MayBeContainsNonLiteralState;
                     }
                 }
 
                 return ValueDomain.UnknownOrMayBeValue;
             }
 
-            public override StringContentAbstractValue VisitBinaryOperator(IBinaryOperation operation, object argument)
+            public override StringContentAbstractValue VisitBinaryOperatorCore(IBinaryOperation operation, object argument)
             {
                 switch (operation.OperatorKind)
                 {
@@ -82,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
                         return leftValue.MergeBinaryAdd(rightValue);
 
                     default:
-                        return base.VisitBinaryOperator(operation, argument);
+                        return base.VisitBinaryOperatorCore(operation, argument);
                 }
             }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
@@ -45,8 +45,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
             protected override void ResetCurrentAnalysisData(StringContentAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);
 
             #region Predicate analysis
-            private static bool IsValidValueForPredicateAnalysis(StringContainsNonLiteralState value) => value == StringContainsNonLiteralState.No;
-
             protected override void SetValueForEqualsOrNotEqualsComparisonOperator(IBinaryOperation operation, StringContentAnalysisData negatedCurrentAnalysisData, bool equals)
             {
                 Debug.Assert(operation.IsComparisonOperator());

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.cs
@@ -23,13 +23,16 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
         public static DataFlowAnalysisResult<StringContentBlockAnalysisResult, StringContentAbstractValue> GetOrComputeResult(
             ControlFlowGraph cfg,
             ISymbol owningSymbol,
+            WellKnownTypeProvider wellKnownTypeProvider,
+            DataFlowAnalysisResult<CopyAnalysis.CopyBlockAnalysisResult, CopyAnalysis.CopyAbstractValue> copyAnalysisResultOpt,
             DataFlowAnalysisResult<NullAnalysis.NullBlockAnalysisResult, NullAnalysis.NullAbstractValue> nullAnalysisResultOpt = null,
             DataFlowAnalysisResult<PointsToAnalysis.PointsToBlockAnalysisResult, PointsToAnalysis.PointsToAbstractValue> pointsToAnalysisResultOpt = null,
             bool pessimisticAnalsysis = true)
         {
-            var operationVisitor = new StringContentDataFlowOperationVisitor(StringContentAbstractValueDomain.Default, owningSymbol, pessimisticAnalsysis, nullAnalysisResultOpt, pointsToAnalysisResultOpt);
+            var operationVisitor = new StringContentDataFlowOperationVisitor(StringContentAbstractValueDomain.Default, owningSymbol,
+                wellKnownTypeProvider, pessimisticAnalsysis, copyAnalysisResultOpt, nullAnalysisResultOpt, pointsToAnalysisResultOpt);
             var nullAnalysis = new StringContentAnalysis(StringContentAnalysisDomainInstance, operationVisitor);
-            return nullAnalysis.GetOrComputeResultCore(cfg);
+            return nullAnalysis.GetOrComputeResultCore(cfg, cacheResult: false);
         }
 
         internal override StringContentBlockAnalysisResult ToResult(BasicBlock basicBlock, DataFlowAnalysisInfo<StringContentAnalysisData> blockAnalysisData) => new StringContentBlockAnalysisResult(basicBlock, blockAnalysisData);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraph.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraph.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 
@@ -10,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
     /// NOTE: This class is temporary and will be removed once we move to the CFG exposed from Microsoft.CodeAnalysis
     /// </summary>
     [DebuggerDisplay("CFG ({_blocks.Count} blocks)")]
-    internal class ControlFlowGraph
+    internal class ControlFlowGraph : IEquatable<ControlFlowGraph>
     {
         private ImmutableHashSet<BasicBlock>.Builder _blocks;
 
@@ -21,8 +22,10 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
             return result;
         }
 
-        public ControlFlowGraph()
+        public ControlFlowGraph(IOperation rootOperation)
         {
+            RootOperation = rootOperation;
+
             _blocks = ImmutableHashSet.CreateBuilder<BasicBlock>();
             Entry = new BasicBlock(BasicBlockKind.Entry);
             Exit = new BasicBlock(BasicBlockKind.Exit);
@@ -31,6 +34,7 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
             AddBlock(Exit);
         }
 
+        public IOperation RootOperation { get; }
         public BasicBlock Entry { get; private set; }
         public BasicBlock Exit { get; private set; }
         public ImmutableHashSet<BasicBlock> Blocks => _blocks.ToImmutable();
@@ -47,5 +51,9 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
             _blocks.Add(from);
             _blocks.Add(to);
         }
+
+        public override bool Equals(object obj) => Equals(obj as ControlFlowGraph);
+        public bool Equals(ControlFlowGraph other) => RootOperation == other?.RootOperation;
+        public override int GetHashCode() => RootOperation.GetHashCode();
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraph.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraph.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 
@@ -11,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
     /// NOTE: This class is temporary and will be removed once we move to the CFG exposed from Microsoft.CodeAnalysis
     /// </summary>
     [DebuggerDisplay("CFG ({_blocks.Count} blocks)")]
-    internal class ControlFlowGraph : IEquatable<ControlFlowGraph>
+    internal class ControlFlowGraph
     {
         private ImmutableHashSet<BasicBlock>.Builder _blocks;
 
@@ -51,9 +50,5 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
             _blocks.Add(from);
             _blocks.Add(to);
         }
-
-        public override bool Equals(object obj) => Equals(obj as ControlFlowGraph);
-        public bool Equals(ControlFlowGraph other) => RootOperation == other?.RootOperation;
-        public override int GetHashCode() => RootOperation.GetHashCode();
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraphGenerator.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraphGenerator.cs
@@ -103,9 +103,9 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
 
         public ControlFlowGraph Generate(IOperation body)
         {
-            _graph = new ControlFlowGraph();
+            _graph = new ControlFlowGraph(body);
 
-            CreateBlocks(body);
+            CreateBlocks();
             ConnectBlocks();
 
             var result = _graph;
@@ -117,10 +117,10 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
             return result;
         }
 
-        private void CreateBlocks(IOperation body)
+        private void CreateBlocks()
         {
             var collector = new StatementCollector();
-            collector.Visit(body);
+            collector.Visit(_graph.RootOperation);
 
             foreach (var statement in collector.Statements)
             {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
@@ -22,27 +22,43 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     /// </summary>
     internal sealed class AbstractLocation : IEquatable<AbstractLocation>
     {
-        private AbstractLocation(IOperation creationOpt, AnalysisEntity analysisEntityOpt, ISymbol symbolOpt, ITypeSymbol locationType)
+        public static readonly AbstractLocation Null = new AbstractLocation(creationOpt: null, analysisEntityOpt: null, symbolOpt: null, locationTypeOpt: null);
+
+        private AbstractLocation(IOperation creationOpt, AnalysisEntity analysisEntityOpt, ISymbol symbolOpt, ITypeSymbol locationTypeOpt)
+        {
+            CreationOpt = creationOpt;
+            AnalysisEntityOpt = analysisEntityOpt;
+            SymbolOpt = symbolOpt;
+            LocationTypeOpt = locationTypeOpt;
+        }
+
+        private static AbstractLocation Create(IOperation creationOpt, AnalysisEntity analysisEntityOpt, ISymbol symbolOpt, ITypeSymbol locationType)
         {
             Debug.Assert(creationOpt != null ^ symbolOpt != null ^ analysisEntityOpt != null);
             Debug.Assert(locationType != null);
 
-            CreationOpt = creationOpt;
-            AnalysisEntityOpt = analysisEntityOpt;
-            SymbolOpt = symbolOpt;
-            LocationType = locationType;
+            return new AbstractLocation(creationOpt, analysisEntityOpt, symbolOpt, locationType);
         }
 
-        public static AbstractLocation CreateAllocationLocation(IOperation creation, ITypeSymbol locationType) => new AbstractLocation(creation, analysisEntityOpt: null, symbolOpt: null, locationType: locationType);
-        public static AbstractLocation CreateAnalysisEntityDefaultLocation(AnalysisEntity analysisEntity) => new AbstractLocation(creationOpt: null, analysisEntityOpt: analysisEntity, symbolOpt: null, locationType: analysisEntity.Type);
-        public static AbstractLocation CreateThisOrMeLocation(INamedTypeSymbol namedTypeSymbol) => new AbstractLocation(creationOpt: null, analysisEntityOpt: null, symbolOpt: namedTypeSymbol, locationType: namedTypeSymbol);
-        public static AbstractLocation CreateSymbolLocation(ISymbol symbol) => new AbstractLocation(creationOpt: null, analysisEntityOpt: null, symbolOpt: symbol, locationType: symbol.GetMemerOrLocalOrParameterType());
+        public static AbstractLocation CreateAllocationLocation(IOperation creation, ITypeSymbol locationType) => Create(creation, analysisEntityOpt: null, symbolOpt: null, locationType: locationType);
+        public static AbstractLocation CreateAnalysisEntityDefaultLocation(AnalysisEntity analysisEntity) => Create(creationOpt: null, analysisEntityOpt: analysisEntity, symbolOpt: null, locationType: analysisEntity.Type);
+        public static AbstractLocation CreateThisOrMeLocation(INamedTypeSymbol namedTypeSymbol) => Create(creationOpt: null, analysisEntityOpt: null, symbolOpt: namedTypeSymbol, locationType: namedTypeSymbol);
+        public static AbstractLocation CreateSymbolLocation(ISymbol symbol) => Create(creationOpt: null, analysisEntityOpt: null, symbolOpt: symbol, locationType: symbol.GetMemerOrLocalOrParameterType());
 
         public IOperation CreationOpt { get; }
         public AnalysisEntity AnalysisEntityOpt { get; }
         public ISymbol SymbolOpt { get; }
-        public ITypeSymbol LocationType { get; }
-        
+        public ITypeSymbol LocationTypeOpt { get; }
+        public bool IsNull
+        {
+            get
+            {
+                var isNull = ReferenceEquals(this, Null);
+                Debug.Assert(isNull || LocationTypeOpt != null);
+                return isNull;
+            }
+        }
+
         public override bool Equals(object obj)
         {
             return Equals(obj as AbstractLocation);
@@ -74,14 +90,14 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 CreationOpt == other.CreationOpt &&
                 AnalysisEntityOpt == other.AnalysisEntityOpt &&
                 SymbolOpt == other.SymbolOpt &&
-                LocationType == other.LocationType;
+                LocationTypeOpt == other.LocationTypeOpt;
         }
 
         public override int GetHashCode()
         {
             return HashUtilities.Combine(CreationOpt?.GetHashCode() ?? 0,
                 HashUtilities.Combine(SymbolOpt?.GetHashCode() ?? 0,
-                HashUtilities.Combine(AnalysisEntityOpt?.GetHashCode() ?? 0, LocationType.GetHashCode())));
+                HashUtilities.Combine(AnalysisEntityOpt?.GetHashCode() ?? 0, LocationTypeOpt?.GetHashCode() ?? 0)));
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             AnalysisEntity parentOpt = null;
             if (instanceOpt?.Type != null)
             {
-                if (instanceOpt.Type.HasValueCopySemantics())
+                if (instanceOpt.Type.IsValueType)
                 {
                     if (TryCreate(instanceOpt, out parentOpt))
                     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
@@ -10,19 +10,28 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     /// It stores:
     ///  (1) Analysis values for all operations in the graph and
     ///  (2) <see cref="AbstractBlockAnalysisResult{TAnalysisData, TAbstractAnalysisValue}"/> for every basic block in the graph.
+    ///  (3) Merged analysis state for all the unhandled throw operations in the graph.
     /// </summary>
     internal class DataFlowAnalysisResult<TAnalysisResult, TAbstractAnalysisValue>
         where TAnalysisResult: class
     {
         private readonly ImmutableDictionary<BasicBlock, TAnalysisResult> _basicBlockStateMap;
         private readonly ImmutableDictionary<IOperation, TAbstractAnalysisValue> _operationStateMap;
-        public DataFlowAnalysisResult(ImmutableDictionary<BasicBlock, TAnalysisResult> basicBlockStateMap, ImmutableDictionary<IOperation, TAbstractAnalysisValue> operationStateMap)
+        public DataFlowAnalysisResult(
+            ImmutableDictionary<BasicBlock, TAnalysisResult> basicBlockStateMap,
+            ImmutableDictionary<IOperation, TAbstractAnalysisValue> operationStateMap,
+            TAnalysisResult mergedStateForUnhandledThrowOperationsOpt,
+            ControlFlowGraph cfg)
         {
             _basicBlockStateMap = basicBlockStateMap;
             _operationStateMap = operationStateMap;
+            MergedStateForUnhandledThrowOperationsOpt = mergedStateForUnhandledThrowOperationsOpt;
+            ControlFlowGraph = cfg;
         }
 
         public TAnalysisResult this[BasicBlock block] => _basicBlockStateMap[block];
         public TAbstractAnalysisValue this[IOperation operation] => _operationStateMap[operation];
+        public TAnalysisResult MergedStateForUnhandledThrowOperationsOpt;
+        public ControlFlowGraph ControlFlowGraph { get; }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -363,15 +363,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             throw new NotImplementedException();
         }
 
-        [Conditional("DEBUG")]
-        protected void AssertValidPredicateAnalysisValue(TAbstractAnalysisValue value)
-        {
-            Debug.Assert(PredicateAnalysis);
-            Debug.Assert(NegatedCurrentAnalysisDataStack.Count > 0);
-            Debug.Assert(!ReferenceEquals(value, ValueDomain.Bottom));
-            Debug.Assert(!ReferenceEquals(value, ValueDomain.UnknownOrMayBeValue));
-        }
-
         #endregion region
 
         #region Helper methods to handle initialization/assignment operations
@@ -1189,11 +1180,18 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 {
                     leftNegatedCurrentAnalysisData = GetClonedAnalysisData(NegatedCurrentAnalysisDataStack.Peek());
 
-                    // For conditional or ('||'), we execute the right operand only if left operand condition is false.
-                    // So we use the current NegatedCurrentAnalysisData as both the CurrentAnalysisData and the current NegatedCurrentAnalysisData.
+                    // 1. For conditional or ('||'), we execute the right operand only if left operand condition is false.
+                    //    So we use the current NegatedCurrentAnalysisData as both the CurrentAnalysisData and the current NegatedCurrentAnalysisData.
+                    // 2. For conditional and ('&&'), we execute the right operand only if left operand condition is true.
+                    //    So we use the CurrentAnalysisData as both the CurrentAnalysisData and the current NegatedCurrentAnalysisData.
                     if (operation.IsConditionalOrOpertator())
                     {
                         CurrentAnalysisData = GetClonedAnalysisData(NegatedCurrentAnalysisDataStack.Peek());
+                    }
+                    else if (operation.IsConditionalAndOpertator())
+                    {
+                        NegatedCurrentAnalysisDataStack.Pop();
+                        NegatedCurrentAnalysisDataStack.Push(GetClonedCurrentAnalysisData());
                     }
                 }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/SetAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/SetAbstractDomain.cs
@@ -50,7 +50,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             return result;
         }
 
-        public override ImmutableHashSet<T> Merge(ImmutableHashSet<T> value1, ImmutableHashSet<T> value2)
+        public override ImmutableHashSet<T> Merge(ImmutableHashSet<T> value1, ImmutableHashSet<T> value2) => MergeOrIntersect(value1, value2, merge: true);
+
+        public ImmutableHashSet<T> Intersect(ImmutableHashSet<T> value1, ImmutableHashSet<T> value2) => MergeOrIntersect(value1, value2, merge: false);
+
+        private static ImmutableHashSet<T> MergeOrIntersect(ImmutableHashSet<T> value1, ImmutableHashSet<T> value2, bool merge)
         {
             if (value1 == null)
             {
@@ -69,7 +73,9 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 return value1;
             }
 
-            return ImmutableHashSet.CreateRange(value1.Concat(value2));
+            var values = merge ? value1.Concat(value2) : value1.Intersect(value2);
+            return ImmutableHashSet.CreateRange(values);
         }
+
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/WellKnownTypeProvider.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/WellKnownTypeProvider.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using Analyzer.Utilities;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    /// <summary>
+    /// Provides and caches well known types in a compilation for <see cref="DataFlowAnalysis"/>.
+    /// </summary>
+    internal class WellKnownTypeProvider
+    {
+        private static readonly ConditionalWeakTable<Compilation, WellKnownTypeProvider> s_providerCache =
+            new ConditionalWeakTable<Compilation, WellKnownTypeProvider>();
+        private static readonly ConditionalWeakTable<Compilation, WellKnownTypeProvider>.CreateValueCallback s_ProviderCacheCallback =
+            new ConditionalWeakTable<Compilation, WellKnownTypeProvider>.CreateValueCallback(compilation => new WellKnownTypeProvider(compilation));
+
+        private WellKnownTypeProvider(Compilation compilation)
+        {
+            Compilation = compilation;
+            Exception = WellKnownTypes.Exception(compilation);
+            Contract = WellKnownTypes.SystemDiagnosticContractsContract(compilation);
+            IDisposable = WellKnownTypes.IDisposable(compilation);
+            Task = WellKnownTypes.Task(compilation);
+            CollectionTypes = GetWellKnownCollectionTypes(compilation);
+            SerializationInfo = WellKnownTypes.SerializationInfo(compilation);
+        }
+
+        public static WellKnownTypeProvider GetOrCreate(Compilation compilation) => s_providerCache.GetValue(compilation, s_ProviderCacheCallback);
+
+        public Compilation Compilation { get; }
+
+        /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for <see cref="System.Exception"/>
+        /// </summary>
+        public INamedTypeSymbol Exception { get; }
+
+        /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for <see cref="System.Diagnostics.Contracts.Contract"/>
+        /// </summary>
+        public INamedTypeSymbol Contract { get; }
+
+        /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for <see cref="System.IDisposable"/>
+        /// </summary>
+        public INamedTypeSymbol IDisposable { get; }
+
+        /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for <see cref="System.Threading.Tasks.Task"/>
+        /// </summary>
+        public INamedTypeSymbol Task { get; }
+
+        /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for <see cref="System.Runtime.Serialization.SerializationInfo"/>
+        /// </summary>
+        public INamedTypeSymbol SerializationInfo { get; }
+
+        /// <summary>
+        /// Set containing following named types, if not null:
+        /// 1. <see cref="INamedTypeSymbol"/> for <see cref="System.Collections.ICollection"/>
+        /// 2. <see cref="INamedTypeSymbol"/> for <see cref="System.Collections.Generic.ICollection{T}"/>
+        /// 3. <see cref="INamedTypeSymbol"/> for <see cref="System.Collections.Generic.IReadOnlyCollection{T}"/>
+        /// </summary>
+        public ImmutableHashSet<INamedTypeSymbol> CollectionTypes { get; }
+
+        private static ImmutableHashSet<INamedTypeSymbol> GetWellKnownCollectionTypes(Compilation compilation)
+        {
+            var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>();
+            var iCollection = WellKnownTypes.ICollection(compilation);
+            if (iCollection != null)
+            {
+                builder.Add(iCollection);
+            }
+
+            var genericICollection = WellKnownTypes.GenericICollection(compilation);
+            if (genericICollection != null)
+            {
+                builder.Add(genericICollection);
+            }
+
+            var genericIReadOnlyCollection = WellKnownTypes.GenericIReadOnlyCollection(compilation);
+            if (genericIReadOnlyCollection != null)
+            {
+                builder.Add(genericIReadOnlyCollection);
+            }
+
+            return builder.ToImmutable();
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Reliability/DisposeObjectsBeforeLosingScope.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Reliability/DisposeObjectsBeforeLosingScope.cs
@@ -54,11 +54,11 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Reliability
                         return;
                     }
 
-                    ControlFlowGraph cfg;
                     DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult;
-                    if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockContext.OperationBlocks, containingMethod, out cfg, out disposeAnalysisResult))
+                    if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockContext.OperationBlocks, containingMethod, out disposeAnalysisResult))
                     {
-                        ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[cfg.Exit].OutputData;
+                        BasicBlock exitBlock = disposeAnalysisResult.ControlFlowGraph.Exit;
+                        ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[exitBlock].OutputData;
                         foreach (var kvp in disposeDataAtExit)
                         {
                             AbstractLocation location = kvp.Key;

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Security/ReviewSqlQueriesForSecurityVulnerabilities.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Security/ReviewSqlQueriesForSecurityVulnerabilities.cs
@@ -8,6 +8,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Operations.ControlFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis;
 using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis;
@@ -213,9 +215,11 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Security
                 if (topmostBlock != null)
                 {
                     var cfg = ControlFlowGraph.Create(topmostBlock);
-                    var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod);
-                    var pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod, nullAnalysisResult);
-                    var stringContentResult = StringContentAnalysis.GetOrComputeResult(cfg, containingMethod, nullAnalysisResult, pointsToAnalysisResult);
+                    var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(operationContext.Compilation);
+                    var copyAnalysisResult = CopyAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider);
+                    var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider);
+                    var pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, nullAnalysisResult);
+                    var stringContentResult = StringContentAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, copyAnalysisResult, nullAnalysisResult, pointsToAnalysisResult);
                     StringContentAbstractValue value = stringContentResult[argumentValue];
                     if (value.NonLiteralState == StringContainsNonLiteralState.No)
                     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposableFieldsShouldBeDisposed.cs
@@ -85,12 +85,10 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
 
                     if (disposeAnalysisHelper.HasAnyDisposableCreationDescendant(operationBlockStartContext.OperationBlocks, containingMethod))
                     {
-                        ControlFlowGraph cfg;
                         DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult;
                         DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult;
-                        if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext.OperationBlocks, containingMethod, out cfg, out disposeAnalysisResult, out pointsToAnalysisResult))
+                        if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext.OperationBlocks, containingMethod, out disposeAnalysisResult, out pointsToAnalysisResult))
                         {
-                            Debug.Assert(cfg != null);
                             Debug.Assert(disposeAnalysisResult != null);
                             Debug.Assert(pointsToAnalysisResult != null);
 
@@ -138,20 +136,20 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
                         var disposableFields = disposeAnalysisHelper.GetDisposableFields(containingMethod.ContainingType);
                         if (!disposableFields.IsEmpty)
                         {
-                            ControlFlowGraph cfg;
                             DataFlowAnalysisResult<DisposeBlockAnalysisResult, DisposeAbstractValue> disposeAnalysisResult;
                             DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue> pointsToAnalysisResult;
                             ImmutableDictionary<IFieldSymbol, PointsToAbstractValue> trackedInstanceFieldPointsToMap;
                             if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext.OperationBlocks, containingMethod, trackInstanceFields: true,
-                                cfg: out cfg, disposeAnalysisResult: out disposeAnalysisResult, pointsToAnalysisResult: out pointsToAnalysisResult, trackedInstanceFieldPointsToMap: out trackedInstanceFieldPointsToMap))
+                                disposeAnalysisResult: out disposeAnalysisResult, pointsToAnalysisResult: out pointsToAnalysisResult, trackedInstanceFieldPointsToMap: out trackedInstanceFieldPointsToMap))
                             {
+                                BasicBlock exitBlock = disposeAnalysisResult.ControlFlowGraph.Exit;
                                 foreach (var fieldWithPointsToValue in trackedInstanceFieldPointsToMap)
                                 {
                                     IFieldSymbol field = fieldWithPointsToValue.Key;
                                     PointsToAbstractValue pointsToValue = fieldWithPointsToValue.Value;
 
                                     Debug.Assert(field.Type.IsDisposable(disposeAnalysisHelper.IDisposable));
-                                    ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[cfg.Exit].OutputData;
+                                    ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[exitBlock].OutputData;
                                     var disposed = false;
                                     foreach (var location in pointsToValue.Locations)
                                     {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Design/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Design/ValidateArgumentsOfPublicMethodsTests.cs
@@ -1,0 +1,2527 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeQuality.Analyzers.Exp.Design;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Design
+{
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ParameterValidationAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+    public partial class ValidateArgumentsOfPublicMethodsTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new ValidateArgumentsOfPublicMethods();
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new ValidateArgumentsOfPublicMethods();
+
+        private new DiagnosticResult GetCSharpResultAt(int line, int column, string methodSignature, string parameterName) =>
+            GetCSharpResultAt(line, column, ValidateArgumentsOfPublicMethods.Rule, methodSignature, parameterName);
+
+        private new DiagnosticResult GetBasicResultAt(int line, int column, string methodSignature, string parameterName) =>
+            GetBasicResultAt(line, column, ValidateArgumentsOfPublicMethods.Rule, methodSignature, parameterName);
+
+        [Fact]
+        public void ValueTypeParameter_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public struct C
+{
+    public int X;
+}
+
+public class Test
+{
+    public int M1(C c)
+    {
+        return c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Structure C
+    Public X As Integer
+End Structure
+
+Public Class Test
+    Public Function M1(c As C) As Integer
+        Return c.X
+    End Function
+End Class");
+        }
+
+        [Fact]
+        public void ReferenceTypeParameter_NoUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class Test
+{
+    public void M1(string str)
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class Test
+    Public Sub M1(str As String)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void ReferenceTypeParameter_NoHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class Test
+{
+    public void M1(string str)
+    {
+        var x = str;
+        M2(str);
+    }
+
+    private void M2(string str)
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class Test
+    Public Sub M1(str As String)
+        Dim x = str
+        M2(str)
+    End Sub
+
+    Private Sub M2(str As String)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void NonExternallyVisibleMethod_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    private int M1(C c)
+    {
+        return c.X;
+    }
+
+    internal int M2(C c)
+    {
+        return c.X;
+    }
+}
+
+internal class Test2
+{
+    public int M1(C c)
+    {
+        return c.X;
+    }
+
+    protected int M2(C c)
+    {
+        return c.X;
+    }
+
+    internal int M3(C c)
+    {
+        return c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Private Function M1(c As C) As Integer
+        Return c.X
+    End Function
+
+    Friend Function M2(c As C) As Integer
+        Return c.X
+    End Function
+End Class
+
+Friend Class Test2
+    Public Function M1(c As C) As Integer
+        Return c.X
+    End Function
+
+    Protected Function M2(c As C) As Integer
+        Return c.X
+    End Function
+
+    Friend Function M3(c As C) As Integer
+        Return c.X
+    End Function
+End Class");
+        }
+
+        [Fact]
+        public void HazardousUsage_MethodReference_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class Test
+{
+    public void M1(string str)
+    {
+        var x = str.ToString();
+    }
+}
+",
+            // Test0.cs(6,17): warning CA1062: In externally visible method 'void Test.M1(string str)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(6, 17, "void Test.M1(string str)", "str"));
+
+            VerifyBasic(@"
+Public Class Test
+    Public Sub M1(str As String)
+        Dim x = str.ToString()
+    End Sub
+End Class
+",
+            // Test0.vb(4,17): warning CA1062: In externally visible method 'Sub Test.M1(str As String)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(4, 17, "Sub Test.M1(str As String)", "str"));
+        }
+
+        [Fact]
+        public void HazardousUsage_FieldReference_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var x = c.X;
+    }
+}
+",
+            // Test0.cs(11,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(11, 17, "void Test.M1(C c)", "c"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim x = c.X
+    End Sub
+End Class
+",
+            // Test0.vb(8,17): warning CA1062: In externally visible method 'Sub Test.M1(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(8, 17, "Sub Test.M1(c As C)", "c"));
+        }
+
+        [Fact]
+        public void HazardousUsage_PropertyReference_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X { get; }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var x = c.X;
+    }
+}
+",
+            // Test0.cs(11,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(11, 17, "void Test.M1(C c)", "c"));
+
+            VerifyBasic(@"
+Public Class C
+    Public ReadOnly Property X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim x = c.X
+    End Sub
+End Class
+",
+            // Test0.vb(8,17): warning CA1062: In externally visible method 'Sub Test.M1(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(8, 17, "Sub Test.M1(c As C)", "c"));
+        }
+
+        [Fact]
+        public void HazardousUsage_EventReference_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public delegate void MyDelegate();
+    public event MyDelegate X;
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        c.X += MyHandler;
+    }
+
+    private void MyHandler()
+    {
+    }
+}
+",
+            // Test0.cs(12,9): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(12, 9, "void Test.M1(C c)", "c"));
+
+            VerifyBasic(@"
+Public Class C
+    Public Event X()
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        AddHandler c.X, AddressOf MyHandler
+    End Sub
+
+    Private Sub MyHandler()
+    End Sub
+End Class
+",
+            // Test0.vb(8,20): warning CA1062: In externally visible method 'Sub Test.M1(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(8, 20, "Sub Test.M1(c As C)", "c"));
+        }
+
+        [Fact]
+        public void HazardousUsage_ArrayElementReference_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class Test
+{
+    public void M1(Test[] tArray)
+    {
+        var x = tArray[0];
+    }
+}
+",
+            // Test0.cs(6,17): warning CA1062: In externally visible method 'void Test.M1(Test[] tArray)', validate parameter 'tArray' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(6, 17, "void Test.M1(Test[] tArray)", "tArray"));
+
+            VerifyBasic(@"
+Public Class Test
+    Public Sub M1(tArray As Test())
+        Dim x = tArray(0)
+    End Sub
+End Class
+",
+            // Test0.vb(4,17): warning CA1062: In externally visible method 'Sub Test.M1(tArray As Test())', validate parameter 'tArray' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(4, 17, "Sub Test.M1(tArray As Test())", "tArray"));
+        }
+
+        [Fact]
+        public void MultipleHazardousUsages_OneReportPerParameter_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+    public int Y;    
+}
+
+public class Test
+{
+    public void M1(C c1, C c2)
+    {
+        var x = c1.X;   // Diagnostic
+        var y = c1.Y;
+        var x2 = c1.X;
+
+        var x3 = c2.X;   // Diagnostic
+        var y2 = c2.Y;
+        var x4 = c2.X;
+    }
+}
+",
+        // Test0.cs(12,17): warning CA1062: In externally visible method 'void Test.M1(C c1, C c2)', validate parameter 'c1' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+        GetCSharpResultAt(12, 17, "void Test.M1(C c1, C c2)", "c1"),
+        // Test0.cs(16,18): warning CA1062: In externally visible method 'void Test.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+        GetCSharpResultAt(16, 18, "void Test.M1(C c1, C c2)", "c2"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+    Public Y As Integer
+End Class
+
+Public Class Test
+
+    Public Sub M1(c1 As C, c2 As C)
+        Dim x = c1.X    ' Diagnostic
+        Dim y = c1.Y
+        Dim x2 = c1.X
+
+        Dim x3 = c2.X    ' Diagnostic
+        Dim y2 = c2.Y
+        Dim x4 = c2.X
+    End Sub
+End Class
+",
+            // Test0.vb(10,17): warning CA1062: In externally visible method 'Sub Test.M1(c1 As C, c2 As C)', validate parameter 'c1' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(10, 17, "Sub Test.M1(c1 As C, c2 As C)", "c1"),
+            // Test0.vb(14,18): warning CA1062: In externally visible method 'Sub Test.M1(c1 As C, c2 As C)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(14, 18, "Sub Test.M1(c1 As C, c2 As C)", "c2"));
+        }
+
+        [Fact]
+        public void HazardousUsage_OptionalParameter_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class Test
+{
+    private const string _constStr = """";
+    public void M1(string str = _constStr)
+    {
+        var x = str.ToString();
+    }
+}
+",
+            // Test0.cs(7,17): warning CA1062: In externally visible method 'void Test.M1(string str = "")', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(7, 17, @"void Test.M1(string str = """")", "str"));
+
+            VerifyBasic(@"
+Public Class Test
+    Private Const _constStr As String = """"
+    Public Sub M1(Optional str As String = _constStr)
+        Dim x = str.ToString()
+    End Sub
+End Class
+",
+            // Test0.vb(5,17): warning CA1062: In externally visible method 'Sub Test.M1(str As String = "")', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(5, 17, @"Sub Test.M1(str As String = """")", "str"));
+        }
+
+        [Fact]
+        public void ConditionalAccessUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+        var y = x?.ToString();
+        
+        var z = c?.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(str As String, c As C)
+        Dim x = str
+        Dim y = x?.ToString()
+
+        Dim z = c?.X
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void ValidatedNonNullAttribute_PossibleNullRefUsage_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class ValidatedNotNullAttribute : System.Attribute
+{
+}
+
+public class Test
+{
+    public void M1([ValidatedNotNullAttribute]string str)
+    {
+        var x = str.ToString();
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class ValidatedNotNullAttribute
+    Inherits System.Attribute
+End Class
+
+Public Class Test
+    Public Sub M1(<ValidatedNotNullAttribute>str As String)
+        Dim x = str.ToString()
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ValidatedNonNullAttribute_PossibleNullRefUsageOnDifferentParam_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class ValidatedNotNullAttribute : System.Attribute
+{
+}
+
+public class Test
+{
+    public void M1([ValidatedNotNullAttribute]string str, string str2)
+    {
+        var x = str.ToString() + str2.ToString();
+    }
+}
+",
+            // Test0.cs(10,34): warning CA1062: In externally visible method 'void Test.M1(string str, string str2)', validate parameter 'str2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(10, 34, "void Test.M1(string str, string str2)", "str2"));
+
+            VerifyBasic(@"
+Public Class ValidatedNotNullAttribute
+    Inherits System.Attribute
+End Class
+
+Public Class Test
+    Public Sub M1(<ValidatedNotNullAttribute>str As String, str2 As String)
+        Dim x = str.ToString() + str2.ToString()
+    End Sub
+End Class
+",
+            // Test0.vb(8,34): warning CA1062: In externally visible method 'Sub Test.M1(str As String, str2 As String)', validate parameter 'str2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(8, 34, "Sub Test.M1(str As String, str2 As String)", "str2"));
+        }
+
+        [Fact]
+        public void DefiniteSimpleAssignment_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+        x = ""newString"";
+        var y = x.ToString();
+
+        c = new C();
+        var z = c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(str As String, c As C)
+        Dim x = str
+        x = ""newString""
+        Dim y = x.ToString()
+
+        c = New C()
+        Dim z = c.X
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void AssignedToFieldAndValidated_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    private C _c;
+    private Test _t;
+    public void M1(C c)
+    {
+        _c = c;
+        _t._c = c;
+        if (c == null)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+
+        var z = _c.X + _t._c.X + c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Private _c As C
+    Private _t As Test
+    Public Sub M1(c As C)
+        _c = c
+        _t._c = c
+        If c Is Nothing Then
+            Throw New ArgumentNullException(NameOf(c))
+        End If
+
+        Dim z = _c.X + _t._c.X + c.X
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void AssignedToFieldAndNotValidated_BeforeHazardousUsages_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    private C _c;
+    private Test _t;
+    public void M1(C c)
+    {
+        _t._c = c;
+        var z = _t._c.X;
+        if (c == null)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+    }
+
+    public void M2(C c)
+    {
+        _c = c;
+        _t._c = c;
+        var z = _c.X + _t._c.X;
+        if (c == null)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+    }
+}
+",
+            // Test0.cs(16,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(16, 17, "void Test.M1(C c)", "c"),
+            // Test0.cs(27,17): warning CA1062: In externally visible method 'void Test.M2(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(27, 17, "void Test.M2(C c)", "c"));
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Private _c As C
+    Private _t As Test
+    Public Sub M1(c As C)
+        _t._c = c
+        Dim z = _t._c.X
+        If c Is Nothing Then
+            Throw New ArgumentNullException(NameOf(c))
+        End If
+    End Sub
+
+    Public Sub M2(c As C)
+        _c = c
+        _t._c = c
+        Dim z = _c.X + _t._c.X
+        If c Is Nothing Then
+            Throw New ArgumentNullException(NameOf(c))
+        End If
+    End Sub
+End Class",
+            // Test0.vb(13,17): warning CA1062: In externally visible method 'Sub Test.M1(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(13, 17, "Sub Test.M1(c As C)", "c"),
+            // Test0.vb(22,17): warning CA1062: In externally visible method 'Sub Test.M2(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(22, 17, "Sub Test.M2(c As C)", "c"));
+        }
+
+        [Fact]
+        public void MayBeAssigned_BeforeHazardousUsages_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c, bool flag)
+    {
+        var x = str;
+        if (flag)
+        {
+            x = ""newString"";
+            c = new C();
+        }
+
+        // Below may or may not cause null refs
+        var y = x.ToString();
+        var z = c.X;
+    }
+}
+",
+            // Test0.cs(19,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c, bool flag)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(19, 17, "void Test.M1(string str, C c, bool flag)", "str"),
+            // Test0.cs(20,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c, bool flag)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(20, 17, "void Test.M1(string str, C c, bool flag)", "c"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(str As String, c As C, flag As Boolean)
+        Dim x = str
+
+        If flag Then
+            x = ""newString""
+            c = New C()
+        End If
+        
+        ' Below may or may not cause null refs
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+End Class",
+            // Test0.vb(16,17): warning CA1062: In externally visible method 'Sub Test.M1(str As String, c As C, flag As Boolean)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(16, 17, "Sub Test.M1(str As String, c As C, flag As Boolean)", "str"),
+            // Test0.vb(17,17): warning CA1062: In externally visible method 'Sub Test.M1(str As String, c As C, flag As Boolean)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(17, 17, "Sub Test.M1(str As String, c As C, flag As Boolean)", "c"));
+        }
+
+        [Fact]
+        public void ConditionalButDefiniteNonNullAssigned_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c, bool flag)
+    {
+        var x = str;
+        if (str == null || c == null)
+        {
+            x = ""newString"";
+            c = new C();
+        }
+
+        // x and c are both non-null here.
+        var y = x.ToString();
+        var z = c.X;
+    }
+
+    public void M2(string str, C c, bool flag)
+    {
+        var x = str;
+        if (str == null)
+        {
+            x = ""newString"";
+        }
+
+        if (c == null)
+        {
+            c = new C();
+        }
+
+        // x and c are both non-null here.
+        var y = x.ToString();
+        var z = c.X;
+    }
+
+    public void M3(string str, C c, bool flag)
+    {
+        var x = str ?? ""newString"";
+        c = c ?? new C();
+
+        // x and c are both non-null here.
+        var y = x.ToString();
+        var z = c.X;
+    }
+
+    public void M4(string str, C c, bool flag)
+    {
+        var x = str != null ? str : ""newString"";
+        c = c != null ? c : new C();
+
+        // x and c are both non-null here.
+        var y = x.ToString();
+        var z = c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(ByVal str As String, ByVal c As C, ByVal flag As Boolean)
+        Dim x = str
+        If str Is Nothing OrElse c Is Nothing Then
+            x = ""newString""
+            c = New C()
+        End If
+
+        ' x and c are both non-null here.
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+
+    Public Sub M2(ByVal str As String, ByVal c As C, ByVal flag As Boolean)
+        Dim x = str
+        If str Is Nothing Then
+            x = ""newString""
+        End If
+
+        If c Is Nothing Then
+            c = New C()
+        End If
+
+        ' x and c are both non-null here.
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+
+    Public Sub M3(ByVal str As String, ByVal c As C, ByVal flag As Boolean)
+        Dim x = If(str, ""newString"")
+        c = If(c, New C())
+
+        ' x and c are both non-null here.
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+
+    Public Sub M4(ByVal str As String, ByVal c As C, ByVal flag As Boolean)
+        Dim x = If(str IsNot Nothing, str, ""newString"")
+        c = If(c IsNot Nothing, c, New C())
+
+        ' x and c are both non-null here.
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+
+End Class");
+        }
+
+        [Fact]
+        public void ThrowOnNull_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+        if (str == null)
+        {
+            throw new ArgumentNullException(nameof(str));
+        }
+
+        if (c == null)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+
+        var y = x.ToString();
+        var z = c.X;
+    }
+
+    public void M2(string str, C c)
+    {
+        var x = str;
+        if (str == null || c == null)
+        {
+            throw new ArgumentException();
+        }
+
+        var y = x.ToString();
+        var z = c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(ByVal str As String, ByVal c As C)
+        Dim x = str
+        If str Is Nothing Then
+            Throw New ArgumentNullException(NameOf(str))
+        End If
+
+        If c Is Nothing Then
+            Throw New ArgumentNullException(NameOf(c))
+        End If
+
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+
+    Public Sub M2(ByVal str As String, ByVal c As C)
+        Dim x = str
+        If str Is Nothing OrElse c Is Nothing Then
+            Throw New ArgumentException()
+        End If
+
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void ThrowOnNullForSomeParameter_HazardousUsageForDifferentParameter_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        if (str == null)
+        {
+            throw new System.ArgumentNullException(nameof(str));
+        }
+
+        var x = str;
+        var y = x.ToString();
+
+        var z = c.X;
+    }
+
+    public void M2(string str, C c)
+    {
+        var x = str;
+        if (str == null)
+        {
+            if (c == null)
+            {
+                throw new System.ArgumentNullException(nameof(c));
+            }
+
+            throw new System.ArgumentNullException(nameof(str));
+        }
+
+        var y = x.ToString();
+
+        var z = c.X;
+    }
+}
+",
+            // Test0.cs(19,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(19, 17, "void Test.M1(string str, C c)", "c"),
+            // Test0.cs(37,17): warning CA1062: In externally visible method 'void Test.M2(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(37, 17, "void Test.M2(string str, C c)", "c"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(str As String, c As C)
+        If str Is Nothing Then
+            Throw New System.ArgumentNullException(NameOf(str))
+        End If
+
+        Dim x = str
+        Dim y = x.ToString()
+
+        Dim z = c.X
+    End Sub
+
+    Public Sub M2(str As String, c As C)
+        Dim x = str
+        If str Is Nothing Then
+            If c Is Nothing Then
+                Throw New System.ArgumentNullException(NameOf(c))
+            End If
+
+            Throw New System.ArgumentNullException(NameOf(str))
+        End If
+
+        Dim y = x.ToString()
+
+        Dim z = c.X
+    End Sub
+End Class
+",
+            // Test0.vb(15,17): warning CA1062: In externally visible method 'Sub Test.M1(str As String, c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(15, 17, "Sub Test.M1(str As String, c As C)", "c"),
+            // Test0.vb(30,17): warning CA1062: In externally visible method 'Sub Test.M2(str As String, c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(30, 17, "Sub Test.M2(str As String, c As C)", "c"));
+        }
+
+        [Fact]
+        public void ThrowOnNull_AfterHazardousUsages_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var z = c.X;
+        if (c == null)
+        {
+            throw new System.ArgumentNullException(nameof(c));
+        }
+    }
+}
+",
+            // Test0.cs(11,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(11, 17, "void Test.M1(C c)", "c"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim z = c.X
+        If c Is Nothing Then
+            Throw New System.ArgumentNullException(NameOf(c))
+        End If
+    End Sub
+End Class
+",
+            // Test0.vb(8,17): warning CA1062: In externally visible method 'Sub Test.M1(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(8, 17, "Sub Test.M1(c As C)", "c"));
+        }
+
+        [Fact]
+        public void NullCoalescingThrowExpressionOnNull_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str ?? throw new ArgumentNullException(nameof(str));
+        var y = x.ToString();
+
+        c = c ?? throw new ArgumentNullException(nameof(c));
+        var z = c.X;
+    }
+}
+");
+            // Throw expression not supported for VB.
+        }
+
+        [Fact]
+        public void ThrowOnNull_UncommonNullCheckSyntax_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+        if (null == str)
+        {
+            throw new ArgumentNullException(nameof(str));
+        }
+
+        if (null == c)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+
+        var y = x.ToString();
+        var z = c.X;
+    }
+
+    public void M2(string str, C c)
+    {
+        var x = str;
+        if ((object)str == null)
+        {
+            throw new ArgumentNullException(nameof(str));
+        }
+
+        if (null == (object)c)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+
+        var y = x.ToString();
+        var z = c.X;
+    }
+
+    public void M3(string str, C c)
+    {
+        var x = str;
+        object myNullObject = null;
+        if (str == myNullObject || myNullObject == c)
+        {
+            throw new ArgumentException();
+        }
+
+        var y = x.ToString();
+        var z = c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(ByVal str As String, ByVal c As C)
+        Dim x = str
+        If Nothing Is str Then
+            Throw New ArgumentNullException(NameOf(str))
+        End If
+
+        If Nothing Is c Then
+            Throw New ArgumentNullException(NameOf(c))
+        End If
+
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+
+    Public Sub M2(ByVal str As String, ByVal c As C)
+        Dim x = str
+        If DirectCast(str, System.Object) Is Nothing Then
+            Throw New ArgumentNullException(NameOf(str))
+        End If
+
+        If Nothing Is CType(c, System.Object) Then
+            Throw New ArgumentNullException(NameOf(c))
+        End If
+
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+
+    Public Sub M3(ByVal str As String, ByVal c As C)
+        Dim x = str
+        Dim myNullObject As System.Object = Nothing
+        If str Is myNullObject OrElse myNullObject Is c Then
+            Throw New ArgumentException()
+        End If
+
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void ContractCheck_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+        System.Diagnostics.Contracts.Contract.Requires(x != null);
+        System.Diagnostics.Contracts.Contract.Requires(c != null);
+        var y = str.ToString();
+        var z = c.X;
+    }
+
+    public void M2(string str, C c)
+    {
+        var x = str;
+        System.Diagnostics.Contracts.Contract.Requires(x != null && c != null);
+        var y = str.ToString();
+        var z = c.X;
+    }
+
+    public void M3(C c1, C c2)
+    {
+        System.Diagnostics.Contracts.Contract.Requires(c1 != null && c1 == c2);
+        var z = c1.X + c2.X;
+    }
+
+    void M4_Assume(C c)
+    {
+        System.Diagnostics.Contracts.Contract.Assume(c != null);
+        var z = c.X;
+    }
+
+    void M5_Assert(C c)
+    {
+        System.Diagnostics.Contracts.Contract.Assert(c != null);
+        var z = c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+
+    Public X As Integer
+End Class
+
+Public Class Test
+
+    Public Sub M1(str As String, c As C)
+        Dim x = str
+        System.Diagnostics.Contracts.Contract.Requires(x IsNot Nothing)
+        System.Diagnostics.Contracts.Contract.Requires(c IsNot Nothing)
+        Dim y = str.ToString()
+        Dim z = c.X
+    End Sub
+
+    Public Sub M2(str As String, c As C)
+        Dim x = str
+        System.Diagnostics.Contracts.Contract.Requires(x IsNot Nothing AndAlso c IsNot Nothing)
+        Dim y = str.ToString()
+        Dim z = c.X
+    End Sub
+
+    Public Sub M3(c1 As C, c2 As C)
+        System.Diagnostics.Contracts.Contract.Requires(c1 IsNot Nothing AndAlso c1 Is c2)
+        Dim z = c1.X + c2.X
+    End Sub
+
+    Private Sub M4_Assume(c As C)
+        System.Diagnostics.Contracts.Contract.Assume(c IsNot Nothing)
+        Dim z = c.X
+    End Sub
+
+    Private Sub M5_Assert(c As C)
+        System.Diagnostics.Contracts.Contract.Assert(c IsNot Nothing)
+        Dim z = c.X
+    End Sub
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void ContractCheck_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    private C _c;
+    public void M1(string str, C c)
+    {
+        var x = str;
+        System.Diagnostics.Contracts.Contract.Requires(x == null);
+        System.Diagnostics.Contracts.Contract.Requires(c == _c);
+        var y = str.ToString();
+        var z = c.X;    // No diagnostic as we don't know the value of _c.
+    }
+
+    public void M2(string str, C c)
+    {
+        var x = str;
+        System.Diagnostics.Contracts.Contract.Requires(x != null || c != null);
+        var y = str.ToString();
+        var z = c.X;
+    }
+
+    public void M3(C c1, C c2)
+    {
+        System.Diagnostics.Contracts.Contract.Requires(c1 == null && c1 == c2);
+        var z = c2.X;
+    }
+
+    public void M4(C c1, C c2)
+    {
+        System.Diagnostics.Contracts.Contract.Requires(c1 == null && c1 == c2 && c2 != null);   // Infeasible condition
+        var z = c2.X;
+    }
+}
+",
+            // Test0.cs(15,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(15, 17, "void Test.M1(string str, C c)", "str"),
+            // Test0.cs(23,17): warning CA1062: In externally visible method 'void Test.M2(string str, C c)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(23, 17, "void Test.M2(string str, C c)", "str"),
+            // Test0.cs(24,17): warning CA1062: In externally visible method 'void Test.M2(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(24, 17, "void Test.M2(string str, C c)", "c"),
+            // Test0.cs(30,17): warning CA1062: In externally visible method 'void Test.M3(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(30, 17, "void Test.M3(C c1, C c2)", "c2"),
+            // Test0.cs(36,17): warning CA1062: In externally visible method 'void Test.M4(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(36, 17, "void Test.M4(C c1, C c2)", "c2"));
+
+            VerifyBasic(@"
+Public Class C
+
+    Public X As Integer
+End Class
+
+Public Class Test
+
+    Private _c As C
+
+    Public Sub M1(str As String, c As C)
+        Dim x = str
+        System.Diagnostics.Contracts.Contract.Requires(x Is Nothing)
+        System.Diagnostics.Contracts.Contract.Requires(c Is _c)
+        Dim y = str.ToString()
+        Dim z = c.X     ' No diagnostic as we don't know the value of _c.
+    End Sub
+
+    Public Sub M2(str As String, c As C)
+        Dim x = str
+        System.Diagnostics.Contracts.Contract.Requires(x IsNot Nothing OrElse c IsNot Nothing)
+        Dim y = str.ToString()
+        Dim z = c.X
+    End Sub
+
+    Public Sub M3(c1 As C, c2 As C)
+        System.Diagnostics.Contracts.Contract.Requires(c1 Is Nothing AndAlso c1 Is c2)
+        Dim z = c2.X
+    End Sub
+
+    Public Sub M4(c1 As C, c2 As C)
+        System.Diagnostics.Contracts.Contract.Requires(c1 Is Nothing AndAlso c1 Is c2 AndAlso c2 IsNot Nothing)
+        Dim z = c2.X
+    End Sub
+End Class",
+            // Test0.vb(15,17): warning CA1062: In externally visible method 'Sub Test.M1(str As String, c As C)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(15, 17, "Sub Test.M1(str As String, c As C)", "str"),
+            // Test0.vb(22,17): warning CA1062: In externally visible method 'Sub Test.M2(str As String, c As C)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(22, 17, "Sub Test.M2(str As String, c As C)", "str"),
+            // Test0.vb(23,17): warning CA1062: In externally visible method 'Sub Test.M2(str As String, c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(23, 17, "Sub Test.M2(str As String, c As C)", "c"),
+            // Test0.vb(28,17): warning CA1062: In externally visible method 'Sub Test.M3(c1 As C, c2 As C)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(28, 17, "Sub Test.M3(c1 As C, c2 As C)", "c2"),
+            // Test0.vb(33,17): warning CA1062: In externally visible method 'Sub Test.M4(c1 As C, c2 As C)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(33, 17, "Sub Test.M4(c1 As C, c2 As C)", "c2"));
+        }
+
+        [Fact]
+        public void ReturnOnNull_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        if (str == null)
+        {
+            return;
+        }
+
+        if (c == null)
+        {
+            return;
+        }
+
+        var x = str;
+        var y = x.ToString();
+
+        var z = c.X;
+    }
+
+    public void M2(string str, C c)
+    {
+        if (str == null || c == null)
+        {
+            return;
+        }
+
+        var x = str;
+        var y = x.ToString();
+
+        var z = c.X;
+    }
+
+    public void M3(string str, C c)
+    {
+        if (str == null || c == null)
+        {
+            return;
+        }
+        else
+        {
+            var x = str;
+            var y = x.ToString();
+
+            var z = c.X;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(str As String, c As C)
+        If str Is Nothing Then
+            Return
+        End If
+
+        If c Is Nothing Then
+            Return
+        End If
+
+        Dim x = str
+        Dim y = x.ToString()
+
+        Dim z = c.X
+    End Sub
+
+    Public Sub M2(str As String, c As C)
+        If str Is Nothing OrElse c Is Nothing Then
+            Return
+        End If
+
+        Dim x = str
+        Dim y = x.ToString()
+
+        Dim z = c.X
+    End Sub
+
+    Public Sub M3(str As String, c As C)
+        If str Is Nothing OrElse c Is Nothing Then
+            Return
+        Else
+            Dim x = str
+            Dim y = x.ToString()
+
+            Dim z = c.X
+        End If
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ReturnOnNullForSomeParameter_HazardousUsageForDifferentParameter_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        if (str == null)
+        {
+            return;
+        }
+
+        var x = str;
+        var y = x.ToString();
+
+        var z = c.X;
+    }
+
+    public void M2(string str, C c)
+    {
+        var x = str;
+        if (str == null)
+        {
+            if (c == null)
+            {
+                return;
+            }
+
+            return;
+        }
+
+        var y = x.ToString();
+
+        var z = c.X;
+    }
+}
+",
+            // Test0.cs(19,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(19, 17, "void Test.M1(string str, C c)", "c"),
+            // Test0.cs(37,17): warning CA1062: In externally visible method 'void Test.M2(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(37, 17, "void Test.M2(string str, C c)", "c"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(str As String, c As C)
+        If str Is Nothing Then
+            Return
+        End If
+
+        Dim x = str
+        Dim y = x.ToString()
+
+        Dim z = c.X
+    End Sub
+
+    Public Sub M2(str As String, c As C)
+        Dim x = str
+        If str Is Nothing Then
+            If c Is Nothing Then
+                Return
+            End If
+
+            Return
+        End If
+
+        Dim y = x.ToString()
+
+        Dim z = c.X
+    End Sub
+End Class
+",
+            // Test0.vb(15,17): warning CA1062: In externally visible method 'Sub Test.M1(str As String, c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(15, 17, "Sub Test.M1(str As String, c As C)", "c"),
+            // Test0.vb(30,17): warning CA1062: In externally visible method 'Sub Test.M2(str As String, c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(30, 17, "Sub Test.M2(str As String, c As C)", "c"));
+        }
+
+        [Fact]
+        public void StringIsNullCheck_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class Test
+{
+    public void M1(string str)
+    {
+        if (!string.IsNullOrEmpty(str))
+        {
+            var y = str.ToString();
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class Test
+    Public Sub M1(ByVal str As String)
+        If Not String.IsNullOrEmpty(str) Then
+            Dim y = str.ToString()
+        End If
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void StringIsNullCheck_WithCopyAnalysis_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class Test
+{
+    public void M1(string str)
+    {
+        var x = str;
+        if (!string.IsNullOrEmpty(str))
+        {
+            var y = x.ToString();
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class Test
+    Public Sub M1(ByVal str As String)
+        Dim x = str
+        If Not String.IsNullOrEmpty(str) Then
+            Dim y = x.ToString()
+        End If
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void SpecialCase_ExceptionGetObjectData_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Runtime.Serialization;
+
+public class MyException : Exception
+{
+    public MyException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(MyException ex, SerializationInfo info, StreamingContext context)
+    {
+        if (ex != null)
+        {
+            ex.GetObjectData(info, context);
+            var name = info.AssemblyName;
+        }
+    }
+
+    public void M2(SerializationInfo info, StreamingContext context)
+    {
+        var ex = new MyException(info, context);
+        var name = info.AssemblyName;
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+Imports System.Runtime.Serialization
+
+Public Class MyException
+    Inherits Exception
+    Public Sub New(info As SerializationInfo, context As StreamingContext)
+        MyBase.New(info, context)
+    End Sub
+
+    Public Overrides Sub GetObjectData(info As SerializationInfo, context As StreamingContext)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(ex As MyException, info As SerializationInfo, context As StreamingContext)
+        If ex IsNot Nothing Then
+            ex.GetObjectData(info, context)
+            Dim name = info.AssemblyName
+        End If
+    End Sub
+
+    Public Sub M2(info As SerializationInfo, context As StreamingContext)
+        Dim ex = New MyException(info, context)
+        Dim name = info.AssemblyName
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void NullCheckWithNegationBasedCondition_BeforeHazardousUsages_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+        if (!(str == null || !(null != c)))
+        {
+            var y = x.ToString();
+            var z = c.X;
+        }        
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(ByVal str As String, ByVal c As C)
+        Dim x = str
+        If Not (str Is Nothing OrElse Not (Nothing IsNot c)) Then
+            Dim y = x.ToString()
+            Dim z = c.X
+        End If
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void HazardousUsageInInvokedMethod_PrivateMethod_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c1, C c2)
+    {
+        M2(c1); // No diagnostic
+        M3(c2); // Diagnostic
+    }
+
+    private static void M2(C c)
+    {
+    }
+
+    private static void M3(C c)
+    {
+        var x = c.X;
+    }
+}
+",
+            // Test0.cs(12,12): warning CA1062: In externally visible method 'void Test.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(12, 12, "void Test.M1(C c1, C c2)", "c2"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c1 As C, c2 As C)
+        M2(c1) ' No diagnostic
+        M3(c2) ' Diagnostic
+    End Sub
+
+    Private Shared Sub M2(c As C)
+    End Sub
+
+    Private Shared Sub M3(c As C)
+        Dim x = c.X
+    End Sub
+End Class
+",
+            // Test0.vb(9,12): warning CA1062: In externally visible method 'Sub Test.M1(c1 As C, c2 As C)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(9, 12, "Sub Test.M1(c1 As C, c2 As C)", "c2"));
+        }
+
+        [Fact]
+        public void HazardousUsageInInvokedMethod_PublicMethod_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c1, C c2)
+    {
+        M2(c1); // No diagnostic
+        M3(c2); // No diagnostic here, diagnostic in M3
+    }
+
+    public void M2(C c)
+    {
+    }
+
+    public void M3(C c)
+    {
+        var x = c.X;    // Diagnostic
+    }
+}
+",
+            // Test0.cs(21,17): warning CA1062: In externally visible method 'void Test.M3(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(21, 17, "void Test.M3(C c)", "c"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c1 As C, c2 As C)
+        M2(c1) ' No diagnostic
+        M3(c2) ' Diagnostic
+    End Sub
+
+    Public Sub M2(c As C)
+    End Sub
+
+    Public Sub M3(c As C)
+        Dim x = c.X
+    End Sub
+End Class
+",
+            // Test0.vb(16,17): warning CA1062: In externally visible method 'Sub Test.M3(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(16, 17, "Sub Test.M3(c As C)", "c"));
+        }
+
+        [Fact]
+        public void HazardousUsageInInvokedMethod_PrivateMethod_MultipleLevelsDown_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        M2(c); // No diagnostic, currently we do not analyze invocations in invoked method.
+    }
+
+    private static void M2(C c)
+    {
+        M3(c);
+    }
+
+    private static void M3(C c)
+    {
+        var x = c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        M2(c) ' No diagnostic, currently we do not analyze invocations in invoked method.
+    End Sub
+
+    Private Shared Sub M2(c As C)
+        M3(c)
+    End Sub
+
+    Private Shared Sub M3(c As C)
+        Dim x = c.X
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void HazardousUsageInInvokedMethod_WithInvocationCycles_Diagnostic()
+        {
+            // Code with cyclic call graph to verify we don't analyze indefinitely.
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c1, C c2)
+    {
+        M2(c1); // No diagnostic
+        M3(c2); // Diagnostic
+    }
+
+    private static void M2(C c)
+    {
+        M3(c);
+    }
+
+    private static void M3(C c)
+    {
+        M2(c);
+        var x = c.X;
+    }
+}
+",
+            // Test0.cs(12,12): warning CA1062: In externally visible method 'void Test.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(12, 12, "void Test.M1(C c1, C c2)", "c2"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c1 As C, c2 As C)
+        M2(c1) ' No diagnostic
+        M3(c2) ' Diagnostic
+    End Sub
+
+    Private Shared Sub M2(c As C)
+    End Sub
+
+    Private Shared Sub M3(c As C)
+        Dim x = c.X
+    End Sub
+End Class
+",
+            // Test0.vb(9,12): warning CA1062: In externally visible method 'Sub Test.M1(c1 As C, c2 As C)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(9, 12, "Sub Test.M1(c1 As C, c2 As C)", "c2"));
+        }
+
+        [Fact]
+        public void HazardousUsageInInvokedMethod_InvokedAfterValidation_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        if (c != null)
+        {
+            M2(c); // No diagnostic
+        }
+    }
+
+    private static void M2(C c)
+    {
+        var x = c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        If c IsNot Nothing Then
+            M2(c) ' No diagnostic
+        End If
+    End Sub
+
+    Private Shared Sub M2(c As C)
+        Dim x = c.X
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ValidatedInInvokedMethod_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        M2(c); // Validation method
+        var x = c.X;    // No diagnostic here.
+    }
+
+    private static void M2(C c)
+    {
+        if (c == null)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        M2(c) ' Validation method
+        Dim x = c.X
+    End Sub
+
+    Private Shared Sub M2(c As C)
+        If c Is Nothing Then
+            Throw New ArgumentNullException(NameOf(c))
+        End If
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void MaybeValidatedInInvokedMethod_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    private bool _flag;
+
+    public void M1(C c)
+    {
+        M2(c); // Validation method - validates 'c' on some paths.
+        var x = c.X;    // Diagnostic.
+    }
+
+    private void M2(C c)
+    {
+        if (_flag && c == null)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+    }
+}
+",
+            // Test0.cs(16,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(16, 17, "void Test.M1(C c)", "c"));
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Private _flag As Boolean
+
+    Public Sub M1(c As C)
+        M2(c) ' Validation method - validates 'c' on some paths.
+        Dim x = c.X     ' Diagnostic
+    End Sub
+
+    Private Sub M2(c As C)
+        If _flag AndAlso c Is Nothing Then
+            Throw New ArgumentNullException(NameOf(c))
+        End If
+    End Sub
+End Class",
+            // Test0.vb(13,17): warning CA1062: In externally visible method 'Sub Test.M1(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(13, 17, "Sub Test.M1(c As C)", "c"));
+        }
+
+        [Fact]
+        public void ValidatedButNoExceptionThrownInInvokedMethod_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        M2(c);
+        var x = c.X;    // Diagnostic.
+    }
+
+    public void M2(C c)
+    {
+        if (c == null)
+        {
+            return;
+        }
+
+        var x = c.X;    // No Diagnostic.
+    }
+}
+",
+            // Test0.cs(14,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(14, 17, "void Test.M1(C c)", "c"));
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        M2(c)
+        Dim x = c.X     ' Diagnostic
+    End Sub
+
+    Public Sub M2(c As C)
+        If c Is Nothing Then
+            Return
+        End If
+
+        Dim x = c.X     ' No Diagnostic
+    End Sub
+End Class",
+            // Test0.vb(11,17): warning CA1062: In externally visible method 'Sub Test.M1(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(11, 17, "Sub Test.M1(c As C)", "c"));
+        }
+
+        [Fact]
+        public void ValidatedInInvokedMethod_AfterHazardousUsage_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var x = c.X;    // Diagnostic.
+        M2(c); // Validation method
+    }
+
+    private static void M2(C c)
+    {
+        if (c == null)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+    }
+}
+",
+            // Test0.cs(13,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(13, 17, "void Test.M1(C c)", "c"));
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim x = c.X     ' Diagnostic
+        M2(c) ' Validation method
+    End Sub
+
+    Private Shared Sub M2(c As C)
+        If c Is Nothing Then
+            Throw New ArgumentNullException(NameOf(c))
+        End If
+    End Sub
+End Class",
+            // Test0.vb(10,17): warning CA1062: In externally visible method 'Sub Test.M1(c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(10, 17, "Sub Test.M1(c As C)", "c"));
+        }
+
+        [Fact]
+        public void WhileLoop_NullCheckInCondition_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+        while (str != null && c != null)
+        {
+            var y = x.ToString();
+            var z = c.X;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Sub M1(str As String, c As C)
+        Dim x = str
+        While str IsNot Nothing AndAlso c IsNot Nothing
+            Dim y = x.ToString()
+            Dim z = c.X
+        End While
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void WhileLoop_NullCheckInCondition_HazardousUsageOnExit_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+        while (str != null && c != null)
+        {
+            var y = x.ToString();
+            var z = c.X;
+        }
+
+        x = str.ToString();
+        var z2 = c.X;
+    }
+}
+",
+            // Test0.cs(18,13): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(18, 13, "void Test.M1(string str, C c)", "str"),
+            // Test0.cs(19,18): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(19, 18, "void Test.M1(string str, C c)", "c"));
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(str As String, c As C)
+        Dim x = str
+        While str IsNot Nothing AndAlso c IsNot Nothing
+            Dim y = x.ToString()
+            Dim z = c.X
+        End While
+
+        x = str.ToString()
+        Dim z2 = c.X
+    End Sub
+End Class",
+            // Test0.vb(14,13): warning CA1062: In externally visible method 'Sub Test.M1(str As String, c As C)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(14, 13, "Sub Test.M1(str As String, c As C)", "str"),
+            // Test0.vb(15,18): warning CA1062: In externally visible method 'Sub Test.M1(str As String, c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(15, 18, "Sub Test.M1(str As String, c As C)", "c"));
+        }
+
+        [Fact]
+        public void ForLoop_NullCheckInCondition_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        for (var x = str; str != null && c != null;)
+        {
+            var y = x.ToString();
+            var z = c.X;
+        }
+    }
+}
+");
+        }
+
+        [Fact]
+        public void ForLoop_NullCheckInCondition_HazardousUsageOnExit_Diagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        for (var x = str; str != null;)
+        {
+            var y = x.ToString();
+            var z = c.X;    // Diagnostic
+        }
+
+        var x2 = str.ToString();    // Diagnostic
+        var z2 = c.X;
+    }
+}
+",
+            // Test0.cs(14,21): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(14, 21, "void Test.M1(string str, C c)", "c"),
+            // Test0.cs(17,18): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(17, 18, "void Test.M1(string str, C c)", "str"));
+        }
+
+        [Fact]
+        public void LocalFunctionInvocation_EmptyBody_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+
+        void MyLocalFunction()
+        {
+        };
+
+        MyLocalFunction();    // This should not change state of parameters if we analyzed the local function.
+        var y = x.ToString();
+        var z = c.X;
+    }
+}
+");
+
+            // VB has no local functions.
+        }
+
+        [Fact]
+        public void LocalFunction_HazardousUsagesInBody_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+
+        void MyLocalFunction()
+        {
+            // Below should fire diagnostics if we analyzed the local function invocation.
+            var y = x.ToString();
+            var z = c.X;
+        };
+
+        MyLocalFunction();
+    }
+}
+");
+
+            // VB has no local functions.
+        }
+
+        [Fact]
+        public void LambdaInvocation_EmptyBody_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+
+        System.Action myLambda = () =>
+        {
+        };
+
+        myLambda();    // This should not change state of parameters if we analyzed the lambda.
+        var y = x.ToString();
+        var z = c.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(str As String, c As C)
+        Dim x = str
+
+        Dim myLambda As System.Action = Sub()
+                                        End Sub
+
+        myLambda()      ' This should not change state of parameters if we analyzed the lambda.
+        Dim y = x.ToString()
+        Dim z = c.X
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void Lambda_HazardousUsagesInBody_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(string str, C c)
+    {
+        var x = str;
+
+        System.Action myLambda = () =>
+        {
+            // Below should fire diagnostics if we analyzed the lambda invocation.
+            var y = x.ToString();
+            var z = c.X;
+        };
+
+        myLambda();
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public X As Integer
+End Class
+
+Public Class Test
+    Public Sub M1(str As String, c As C)
+        Dim x = str
+
+        Dim myLambda As System.Action = Sub()
+                                            ' Below should fire diagnostics if we analyzed the lambda invocation.
+                                            Dim y = x.ToString()
+                                            Dim z = c.X
+                                        End Sub
+
+        myLambda()
+    End Sub
+End Class");
+        }        
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
@@ -7,6 +7,9 @@ using Xunit;
 
 namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Reliability
 {
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.DisposeAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
     public partial class DisposeObjectsBeforeLosingScopeTests : DiagnosticAnalyzerTestBase
     {
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new DisposeObjectsBeforeLosingScope();
@@ -3179,7 +3182,7 @@ class Test
             // VB has no local functions.
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1571")]
         public void LocalFunctionInvocation_CapturedValueAssignedNewDisposable_Diagnostic()
         {
             VerifyCSharp(@"
@@ -3354,7 +3357,7 @@ Module Test
 End Module");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1571")]
         public void LambdaInvocation_CapturedValueAssignedNewDisposable_Diagnostic()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests.cs
@@ -12,13 +12,13 @@ namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Security
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new ReviewSqlQueriesForSecurityVulnerabilities();
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new ReviewSqlQueriesForSecurityVulnerabilities();
 
-        private new DiagnosticResult GetCSharpResultAt(int line, int column, string invokedSymbol, string containingMethod) =>
+        protected new DiagnosticResult GetCSharpResultAt(int line, int column, string invokedSymbol, string containingMethod) =>
             GetCSharpResultAt(line, column, ReviewSqlQueriesForSecurityVulnerabilities.Rule, invokedSymbol, containingMethod);
 
-        private new DiagnosticResult GetBasicResultAt(int line, int column, string invokedSymbol, string containingMethod) =>
+        protected new DiagnosticResult GetBasicResultAt(int line, int column, string invokedSymbol, string containingMethod) =>
             GetBasicResultAt(line, column, ReviewSqlQueriesForSecurityVulnerabilities.Rule, invokedSymbol, containingMethod);
 
-        private const string SetupCodeCSharp = @"
+        protected const string SetupCodeCSharp = @"
 using System.Data;
 
 class Command : IDbCommand
@@ -102,7 +102,7 @@ class Adapter : IDataAdapter
     }
 }";
 
-        private const string SetupCodeBasic = @"
+        protected const string SetupCodeBasic = @"
 Imports System
 Imports System.Data
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
@@ -7460,7 +7460,7 @@ class Test
             Command c = new Command1(param, param);
         }}
 
-        //// 3. Creation in else: non-const in left, non-const in right.
+        // 3. Creation in else: non-const in left, non-const in right.
         if (param != str && param != str2)
         {{
         }}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
@@ -7460,26 +7460,8 @@ class Test
             Command c = new Command1(param, param);
         }}
 
-        // 3. Creation in else: non-const in left, non-const in right.
+        //// 3. Creation in else: non-const in left, non-const in right.
         if (param != str && param != str2)
-        {{
-        }}
-        else
-        {{
-            Command c = new Command1(param, param);
-        }}
-
-        // 4. Creation in else: non-const in left, non-const different variable in right.
-        if (param != str && param2 != str2)
-        {{
-        }}
-        else
-        {{
-            Command c = new Command1(param, param);
-        }}
-
-        // 5. Creation in else: negation of non-const in left, maybe-const in right.
-        if (str2 != param && param == strMayBeConst)
         {{
         }}
         else
@@ -7518,18 +7500,6 @@ Module Test
 
         ' 3. Creation in else: non-const in left, non-const in right.
         If str2 <> param AndAlso param <> str Then
-        Else
-            Dim c As New Command1(param, param)
-        End If
-        
-        ' 4. Creation in else: non-const in left, non-const differen variable in right.
-        If str2 <> param AndAlso param2 <> str Then
-        Else
-            Dim c As New Command1(param, param)
-        End If
-        
-        ' 5. Creation in else: negation of non-const in left, maybe-const in right.
-        If str2 <> param AndAlso param = strMayBeConst Then
         Else
             Dim c As New Command1(param, param)
         End If
@@ -7579,7 +7549,7 @@ class Test
         }}
         else
         {{
-            Command c = new Command1(param, param);
+            Command c = new Command2(param, param); // Diagnostic where left of '&&' is true and right of '&&' is false.
         }}
 
         // 3. Creation in if and else: maybe-const in left, negation of non-const in right.
@@ -7591,15 +7561,39 @@ class Test
         {{
             Command c = new Command2(param, param); // Diagnostic (if left is false, param maybe non-const)
         }}
+
+        // 4. Creation in else: non-const in left, non-const different variable in right.
+        if (param != str && param2 != str2)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command2(param, param); // Diagnostic (if left is true and right is false, param maybe non-const)
+        }}
+
+        // 5. Creation in else: negation of non-const in left, maybe-const in right.
+        if (str2 != param && param == strMayBeConst)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command2(param, param); // Diagnostic (if left is true and right is false, param maybe non-const)
+        }}
     }}
 }}
 ",
             // Test0.cs(117,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(117, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
+            // Test0.cs(121,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(121, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
             // Test0.cs(127,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(127, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
             // Test0.cs(131,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
-            GetCSharpResultAt(131, 25, "Command2.Command2(string cmd, string parameter2)", "M1"));
+            GetCSharpResultAt(131, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
+            // Test0.cs(140, 25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(140, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
+            // Test0.cs(149,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(149, 25, "Command2.Command2(string cmd, string parameter2)", "M1"));
 
             VerifyBasic($@"
 {SetupCodeBasic}
@@ -7633,7 +7627,7 @@ Module Test
         If str2 <> param AndAlso param = strMayBeConst Then
             Dim c As New Command2(param, param) ' Diagnostic
         Else
-            Dim c As New Command1(param, param)
+            Dim c As New Command2(param, param) ' Diagnostic where left of 'AndAlso' is true and right of 'AndAlso' is false.
         End If
 
         ' 3. Creation in if and else: maybe-const in left, negation of non-const in right.
@@ -7642,14 +7636,32 @@ Module Test
         Else
             Dim c As New Command2(param, param) ' Diagnostic (if left is false, param maybe non-const)
         End If
+
+        ' 4. Creation in else: non-const in left, non-const differen variable in right.
+        If str2 <> param AndAlso param2 <> str Then
+        Else
+            Dim c As New Command2(param, param) ' Diagnostic (if left is true and right is false, param maybe non-const)
+        End If
+        
+        ' 5. Creation in else: negation of non-const in left, maybe-const in right.
+        If str2 <> param AndAlso param = strMayBeConst Then
+        Else
+            Dim c As New Command2(param, param) ' Diagnostic (if left is true and right is false, param maybe non-const)
+        End If
     End Sub
 End Module",
             // Test0.vb(151,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
             GetBasicResultAt(151, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(153,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(153, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
             // Test0.vb(158,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
             GetBasicResultAt(158, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
             // Test0.vb(160,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
-            GetBasicResultAt(160, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"));
+            GetBasicResultAt(160, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(166,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(166, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(172,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(172, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"));
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
@@ -8020,7 +8032,7 @@ class Test
 
         if (param == strConst && !(strConst2 == param || param == strMayBeNonConst))
         {{
-            Command c = new Command3(param, param);
+            Command c = new Command3(param, param);   // No diagnostic here as first condition ensures param == strConst.
         }}
         else
         {{
@@ -8040,8 +8052,6 @@ class Test
 ",
             // Test0.cs(142,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(142, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
-            // Test0.cs(147,25): warning CA2100: Review if the query string passed to 'Command3.Command3(string cmd, string parameter2)' in 'M1', accepts any user input.
-            GetCSharpResultAt(147, 25, "Command3.Command3(string cmd, string parameter2)", "M1"),
             // Test0.cs(151,25): warning CA2100: Review if the query string passed to 'Command4.Command4(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(151, 25, "Command4.Command4(string cmd, string parameter2)", "M1"),
             // Test0.cs(160,25): warning CA2100: Review if the query string passed to 'Command6.Command6(string cmd, string parameter2)' in 'M1', accepts any user input.
@@ -8105,7 +8115,7 @@ Module Test
         End If
 
         If param = strConst AndAlso Not(strConst2 = param OrElse param = strMayBeNonConst) Then
-            Dim c As Command = New Command3(param, param)
+            Dim c As Command = New Command3(param, param)   ' No diagnostic here as first condition ensures param = strConst.
         Else
             Dim c As Command = New Command4(param, param)
         End If
@@ -8119,8 +8129,6 @@ Module Test
 End Module",
             // Test0.vb(175,32): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
             GetBasicResultAt(175, 32, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
-            // Test0.vb(179,32): warning CA2100: Review if the query string passed to 'Sub Command3.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
-            GetBasicResultAt(179, 32, "Sub Command3.New(cmd As String, parameter2 As String)", "M1"),
             // Test0.vb(181,32): warning CA2100: Review if the query string passed to 'Sub Command4.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
             GetBasicResultAt(181, 32, "Sub Command4.New(cmd As String, parameter2 As String)", "M1"),
             // Test0.vb(187,32): warning CA2100: Review if the query string passed to 'Sub Command6.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
@@ -5,7 +5,8 @@ using Xunit;
 
 namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Security
 {
-    public partial class ReviewSQLQueriesForSecurityVulnerabilitiesTests : DiagnosticAnalyzerTestBase
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+    public class ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis : ReviewSQLQueriesForSecurityVulnerabilitiesTests
     {
         [Fact]
         public void FlowAnalysis_LocalWithConstantInitializer_NoDiagnostic()
@@ -1846,6 +1847,7 @@ End Module",
             GetBasicResultAt(141, 18, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsToAnalysis_CopySemanticsForString_NoDiagnostic()
         {
@@ -1893,6 +1895,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceTypeCopy_NoDiagnostic()
         {
@@ -1940,6 +1943,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueTypeCopy_NoDiagnostic()
         {
@@ -1987,6 +1991,7 @@ Structure Test
 End Structure");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceTypeNestingCopy_NoDiagnostic()
         {
@@ -2068,6 +2073,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueTypeNestingCopy_Diagnostic()
         {
@@ -2152,6 +2158,7 @@ End Class",
             GetBasicResultAt(153, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
 
         public void FlowAnalysis_PointsTo_ValueTypeNestingCopy_02_Diagnostic()
@@ -2233,6 +2240,7 @@ End Class",
             GetBasicResultAt(149, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceTypeAllocationAndInitializer_Diagnostic()
         {
@@ -2294,6 +2302,7 @@ End Class",
             GetBasicResultAt(143, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceTypeAllocationAndInitializer_NoDiagnostic()
         {
@@ -2365,6 +2374,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_Diagnostic()
         {
@@ -2426,6 +2436,7 @@ End Class",
             GetBasicResultAt(143, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_NoDiagnostic()
         {
@@ -2498,6 +2509,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_02_NoDiagnostic()
         {
@@ -2574,6 +2586,7 @@ Structure Test
 End Structure");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceTypeCollectionInitializer_Diagnostic()
         {
@@ -2654,6 +2667,7 @@ End Class",
             GetBasicResultAt(151, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1570")]
         public void FlowAnalysis_PointsTo_ReferenceTypeCollectionInitializer_NoDiagnostic()
         {
@@ -2726,6 +2740,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_DynamicObjectCreation_Diagnostic()
         {
@@ -2766,6 +2781,7 @@ class Test
             GetCSharpResultAt(112, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_DynamicObjectCreation_NoDiagnostic()
         {
@@ -2811,6 +2827,7 @@ class Test
 ");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_AnonymousObjectCreation_Diagnostic()
         {
@@ -2858,6 +2875,7 @@ End Class",
             GetBasicResultAt(135, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1568")]
         public void FlowAnalysis_PointsTo_AnonymousObjectCreation_NoDiagnostic()
         {
@@ -2915,6 +2933,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived__Diagnostic()
         {
@@ -2991,6 +3010,7 @@ End Class",
             GetBasicResultAt(150, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_NoDiagnostic()
         {
@@ -3063,6 +3083,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_Diagnostic()
         {
@@ -3155,6 +3176,7 @@ End Class",
             GetBasicResultAt(156, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_02_Diagnostic()
         {
@@ -3254,6 +3276,7 @@ End Class",
             GetBasicResultAt(159, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_NoDiagnostic()
         {
@@ -3342,6 +3365,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_ThisInstanceReference_Diagnostic()
         {
@@ -3414,6 +3438,7 @@ End Class",
             GetBasicResultAt(146, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_ThisInstanceReference_NoDiagnostic()
         {
@@ -3500,6 +3525,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueType_ThisInstanceReference_Diagnostic()
         {
@@ -3572,6 +3598,7 @@ End Structure",
             GetBasicResultAt(146, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueType_ThisInstanceReference_NoDiagnostic()
         {
@@ -3658,6 +3685,7 @@ Structure Test
 End Structure");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_InvocationInstanceReceiver_Diagnostic()
         {
@@ -3746,6 +3774,7 @@ End Class",
             GetBasicResultAt(150, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueType_InvocationInstanceReceiver_Diagnostic()
         {
@@ -3834,6 +3863,7 @@ End Structure",
             GetBasicResultAt(150, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_Argument_Diagnostic()
         {
@@ -3943,6 +3973,7 @@ End Class",
             GetBasicResultAt(155, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceType_ThisArgument_Diagnostic()
         {
@@ -4031,6 +4062,7 @@ End Class",
             GetBasicResultAt(150, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueType_Argument_NoDiagnostic()
         {
@@ -4114,6 +4146,7 @@ Structure Test
 End Structure");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueType_Argument_Diagnostic()
         {
@@ -4188,6 +4221,7 @@ End Structure",
             GetBasicResultAt(145, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ValueType_ThisArgument_NoDiagnostic()
         {
@@ -4268,6 +4302,7 @@ Structure Test
 End Structure");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ConstantArrayElement_NoDiagnostic()
         {
@@ -4311,6 +4346,7 @@ Module Test
 End Module");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_NonConstantArrayElement_Diagnostic()
         {
@@ -4358,6 +4394,7 @@ End Module",
             GetBasicResultAt(135, 18, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1577")]
         public void FlowAnalysis_PointsTo_ConstantArrayElement_NonConstantIndex_NoDiagnostic()
         {
@@ -4401,6 +4438,7 @@ Module Test
 End Module");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_NonConstantArrayElement_NonConstantIndex_Diagnostic()
         {
@@ -4450,6 +4488,7 @@ End Module",
             GetBasicResultAt(136, 18, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ArrayInitializer_ConstantArrayElement_NoDiagnostic()
         {
@@ -4493,6 +4532,7 @@ Module Test
 End Module");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ArrayInitializer_NonConstantArrayElement_Diagnostic()
         {
@@ -4538,6 +4578,7 @@ End Module",
             GetBasicResultAt(135, 18, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ConstantArrayElement_ArrayFieldInReferenceType_NoDiagnostic()
         {
@@ -4620,6 +4661,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_NonConstantArrayElement_ArrayFieldInReferenceType_Diagnostic()
         {
@@ -4718,6 +4760,7 @@ End Class",
             GetBasicResultAt(156, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ConstantArrayElement_ArrayFieldInValueType_NoDiagnostic()
         {
@@ -4800,6 +4843,7 @@ Structure Test
 End Structure");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_NonConstantArrayElement_ArrayFieldInValueType_Diagnostic()
         {
@@ -4898,6 +4942,7 @@ End Structure",
             GetBasicResultAt(156, 13, "Sub Adapter1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ConstantArrayElement_IndexerFieldInReferenceType_NoDiagnostic()
         {
@@ -5001,6 +5046,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_NonConstantArrayElement_IndexerFieldInReferenceType_Diagnostic()
         {
@@ -5188,6 +5234,7 @@ End Class
             GetBasicResultAt(148, 15, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_ReferenceTypeArray_NoDiagnostic()
         {
@@ -5257,6 +5304,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_AutoGeneratedProperty_NoDiagnostic()
         {
@@ -5303,6 +5351,7 @@ Class Test
 End Class");
         }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
         public void FlowAnalysis_PointsTo_CustomProperty_Diagnostic()
         {
@@ -5364,6 +5413,2987 @@ Class Test
 End Class",
             // Test0.vb(146,18): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
             GetBasicResultAt(146, 18, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        if (param == """")
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if ("""" == param)
+        {{
+            Command c2 = new Command1(param, param);
+        }}
+
+        if (param != """")
+        {{
+        }}
+        else
+        {{
+            Command c3 = new Command1(param, param);
+        }}
+
+        if ("""" != param)
+        {{
+        }}
+        else
+        {{
+            Command c4 = new Command1(param, param);
+        }}
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String)
+        If param = """" Then
+            Dim c As New Command1(param, param)
+        End If
+
+        If """" = param Then
+            Dim c2 As New Command1(param, param)
+        End If
+
+        If param <> """" Then
+        Else 
+            Dim c3 As New Command1(param, param)
+        End If
+
+        If """" <> param Then
+        Else 
+            Dim c4 As New Command1(param, param)
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        if (param != """")
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if ("""" != param)
+        {{
+            Command c2 = new Command1(param, param);
+        }}
+    }}
+}}
+",
+            // Test0.cs(99,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(99, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(104,26): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(104, 26, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String)
+        If param <> """" Then
+            Dim c As New Command1(param, param)
+        End If
+
+        If """" <> param Then
+            Dim c2 As New Command1(param, param)
+        End If
+    End Sub
+End Module",
+            // Test0.vb(134,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(134, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(138,23): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(138, 23, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_WithNegation_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        if (!(param != """"))
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if (!("""" != param))
+        {{
+            Command c2 = new Command1(param, param);
+        }}
+
+        if (!!(param != """"))
+        {{
+        }}
+        else
+        {{
+            Command c3 = new Command1(param, param);
+        }}
+
+        if (!("""" == param))
+        {{
+        }}
+        else
+        {{
+            Command c4 = new Command1(param, param);
+        }}
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String)
+        If Not (param <> """") Then
+            Dim c As New Command1(param, param)
+        End If
+
+        If Not ("""" <> param) Then
+            Dim c2 As New Command1(param, param)
+        End If
+
+        If Not Not (param <> """") Then
+        Else 
+            Dim c3 As New Command1(param, param)
+        End If
+
+        If Not ("""" = param) Then
+        Else 
+            Dim c4 As New Command1(param, param)
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_WithNegation_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        if (!(param == """"))
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if (!!("""" != param))
+        {{
+            Command c2 = new Command1(param, param);
+        }}
+
+        if (!("""" != param))
+        {{
+        }}
+        else
+        {{
+            Command c3 = new Command1(param, param);
+        }}
+    }}
+}}
+",
+            // Test0.cs(99,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(99, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(104,26): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(104, 26, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(112,26): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(112, 26, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String)
+        If Not (param = """") Then
+            Dim c As New Command1(param, param)
+        End If
+
+        If Not Not ("""" <> param) Then
+            Dim c2 As New Command1(param, param)
+        End If
+
+        If Not ("""" <> param) Then
+        Else
+            Dim c3 As New Command1(param, param)
+        End If
+    End Sub
+End Module",
+            // Test0.vb(134,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(134, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(138,23): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(138, 23, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(143,23): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(143, 23, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithLocal_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        string str = """";
+        if (param == str)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if (str == param)
+        {{
+            Command c2 = new Command1(param, param);
+        }}
+
+        if (param != str)
+        {{
+        }}
+        else
+        {{
+            Command c3 = new Command1(param, param);
+        }}
+
+        if (str != param)
+        {{
+        }}
+        else
+        {{
+            Command c4 = new Command1(param, param);
+        }}
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String)
+        Dim str = """"
+        If param = str Then
+            Dim c As New Command1(param, param)
+        End If
+
+        If str = param Then
+            Dim c2 As New Command1(param, param)
+        End If
+
+        If param <> str Then
+        Else 
+            Dim c3 As New Command1(param, param)
+        End If
+
+        If str <> param Then
+        Else 
+            Dim c4 As New Command1(param, param)
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithLocal_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2, bool flag)
+    {{
+        string str = flag ? param2 : """";
+        string str2 = param2;
+        if (param == str)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if (str2 == param)
+        {{
+            Command c2 = new Command1(param, param);
+        }}
+
+        if (param != str2)
+        {{
+        }}
+        else
+        {{
+            Command c3 = new Command1(param, param);
+        }}
+
+        if (str != param)
+        {{
+        }}
+        else
+        {{
+            Command c4 = new Command1(param, param);
+        }}
+    }}
+}}
+",
+            // Test0.cs(101,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(101, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(106,26): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(106, 26, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(114,26): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(114, 26, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(122,26): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(122, 26, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim str = If(flag, param2, """")
+        Dim str2 = param2
+        If param = str Then
+            Dim c As New Command1(param, param)
+        End If
+
+        If str2 = param Then
+            Dim c2 As New Command1(param, param)
+        End If
+
+        If param <> str2 Then
+        Else 
+            Dim c3 As New Command1(param, param)
+        End If
+
+        If str <> param Then
+        Else 
+            Dim c4 As New Command1(param, param)
+        End If
+    End Sub
+End Module",
+            // Test0.vb(136,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(136, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(140,23): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(140, 23, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(145,23): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(145, 23, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(150,23): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(150, 23, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_NestedIfElse_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2)
+    {{
+        string str = """";
+        if (param == str)
+        {{
+            if (param2 != str)
+            {{
+            }}
+            else
+            {{
+                Command c = new Command1(param, param);
+                c = new Command1(param2, param2);
+            }}
+        }}
+
+        if (str == param)
+        {{
+            Command c = new Command1(param, param);
+        }}
+        else if (param2 != str)
+        {{
+            if ((str + ""a"") != param)
+            {{
+            }}
+            else
+            {{
+                Command c = new Command1(param, param);
+            }}
+        }}
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String)
+        Dim str = """"
+        If param = str Then
+            If param2 <> str Then
+            Else
+                Dim c As Command = New Command1(param, param)
+                c = New Command1(param2, param2)
+            End If
+        End If
+
+        If str = param Then
+            Dim c As Command = New Command1(param, param)
+        ElseIf param2 <> str Then
+            If(str & ""a"") <> param Then
+            Else
+                Dim c As Command = New Command1(param, param)
+            End If
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_NestedIfElse_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command3 : Command
+{{
+    public Command3(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command4 : Command
+{{
+    public Command4(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2)
+    {{
+        string str = """";
+        string str2 = param2;
+        if (param == str || param != str2)
+        {{
+            Command c = new Command1(param, param);
+            if (param == param2)
+            {{
+                Command c2 = new Command2(param2, param2);
+            }}
+        }}
+
+        if (param == str)
+        {{
+        }}
+        else
+        {{
+            if (str != param2 || param2 == str)
+            {{
+                Command c = new Command3(param2, param2);
+            }}
+            else
+            {{
+            }}
+
+            Command c2 = new Command4(param, param);
+        }}
+    }}
+}}
+",
+            // Test0.cs(122,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(122, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(125,30): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(125, 30, "Command2.Command2(string cmd, string parameter2)", "M1"),
+            // Test0.cs(136,29): warning CA2100: Review if the query string passed to 'Command3.Command3(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(136, 29, "Command3.Command3(string cmd, string parameter2)", "M1"),
+            // Test0.cs(142,26): warning CA2100: Review if the query string passed to 'Command4.Command4(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(142, 26, "Command4.Command4(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+    Public Sub New(ByVal cmd As String, ByVal parameter2 As String)
+    End Sub
+End Class
+
+Class Command2
+    Inherits Command
+    Public Sub New(ByVal cmd As String, ByVal parameter2 As String)
+    End Sub
+End Class
+
+Class Command3
+    Inherits Command
+    Public Sub New(ByVal cmd As String, ByVal parameter2 As String)
+    End Sub
+End Class
+
+Class Command4
+    Inherits Command
+    Public Sub New(ByVal cmd As String, ByVal parameter2 As String)
+    End Sub
+End Class
+
+Class Test
+    Private Sub M1(ByVal param As String, ByVal param2 As String)
+        Dim str As String = """"
+        Dim str2 As String = param2
+
+        If param = str OrElse param <> str2 Then
+            Dim c As Command = New Command1(param, param)
+            If param = param2 Then
+                Dim c2 As Command = New Command2(param2, param2)
+            End If
+        End If
+
+        If param = str Then
+        Else
+            If str <> param2 OrElse param2 = str Then
+                Dim c As Command = New Command3(param2, param2)
+            Else
+            End If
+            Dim c2 As Command = New Command4(param, param)
+        End If
+    End Sub
+End Class",
+            // Test0.vb(154,32): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(154, 32, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(156,37): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(156, 37, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(163,36): warning CA2100: Review if the query string passed to 'Sub Command3.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(163, 36, "Sub Command3.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(166,33): warning CA2100: Review if the query string passed to 'Sub Command4.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(166, 33, "Sub Command4.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_Loops()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        Command c = null;
+        string str = """";
+        while (param == str)
+        {{
+            c = new Command1(param, param); // param == str here
+        }}
+
+        c = new Command2(param, param); // param is unknown here
+    }}
+
+    void M2(string param)
+    {{
+        Command c = null;
+        string str = """";
+        do
+        {{
+            c = new Command2(param, param); // param is unknown here.
+        }}
+        while (param != str);
+
+        c = new Command1(param, param); // param == str here
+    }}
+
+    void M3(string param, string param2)
+    {{
+        Command c = null;
+        string str = """";
+        for (param = str; param2 != str;)
+        {{
+            c = new Command1(param, param); // param == str here
+            c = new Command2(param2, param2); // param2 != str here
+        }}
+        
+        c = new Command1(param2, param2); // param2 == str here
+        c = new Command1(param, param); // param == str here
+    }}
+}}
+",
+            // Test0.cs(111,13): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(111, 13, "Command2.Command2(string cmd, string parameter2)", "M1"),
+            // Test0.cs(120,17): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M2', accepts any user input.
+            GetCSharpResultAt(120, 17, "Command2.Command2(string cmd, string parameter2)", "M2"),
+            // Test0.cs(134,17): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M3', accepts any user input.
+            GetCSharpResultAt(134, 17, "Command2.Command2(string cmd, string parameter2)", "M3"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command2
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    ' While loop
+    Private Sub M1(ByVal param As String)
+        Dim c As Command = Nothing
+        Dim str As String = """"
+        While param = str
+            c = New Command1(param, param) ' param == str here
+        End While
+
+        c = New Command2(param, param) ' param is unknown here
+    End Sub
+
+    ' Do-While top loop
+    Private Sub M2(ByVal param As String)
+        Dim c As Command = Nothing
+        Dim str As String = """"
+        Do While param <> str
+            c = New Command2(param, param) ' param is unknown here
+        Loop
+
+        c = New Command1(param, param) ' param = str here
+    End Sub
+
+    ' Do-Until top loop
+    Private Sub M3(ByVal param As String)
+        Dim c As Command = Nothing
+        Dim str As String = """"
+        Do Until param <> str
+            c = New Command1(param, param) ' param = str here
+        Loop
+
+        c = New Command2(param, param) ' param is unknown here
+    End Sub
+
+    ' Do-While bottom loop
+    Private Sub M4(ByVal param As String)
+        Dim c As Command = Nothing
+        Dim str As String = """"
+        Do
+            c = New Command2(param, param) ' param is unknown here
+        Loop While param <> str
+
+        c = New Command1(param, param) ' param = str here
+    End Sub
+
+    ' Do-Until bottom loop
+    Private Sub M5(ByVal param As String)
+        Dim c As Command = Nothing
+        Dim str As String = """"
+        Do
+            c = New Command2(param, param) ' param is unknown here
+        Loop Until param = str
+
+        c = New Command1(param, param) ' param = str here
+    End Sub
+End Module",
+            // Test0.vb(147,13): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(147, 13, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(155,17): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M2', accepts any user input.
+            GetBasicResultAt(155, 17, "Sub Command2.New(cmd As String, parameter2 As String)", "M2"),
+            // Test0.vb(169,13): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M3', accepts any user input.
+            GetBasicResultAt(169, 13, "Sub Command2.New(cmd As String, parameter2 As String)", "M3"),
+            // Test0.vb(177,17): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M4', accepts any user input.
+            GetBasicResultAt(177, 17, "Sub Command2.New(cmd As String, parameter2 As String)", "M4"),
+            // Test0.vb(188,17): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M5', accepts any user input.
+            GetBasicResultAt(188, 17, "Sub Command2.New(cmd As String, parameter2 As String)", "M5"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_SwitchStatement()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    // Const in all switch cases.
+    void M1(string param, string param2, int i)
+    {{
+        string str = """";
+        switch (i)
+        {{
+            case 0:
+                param = str;
+                break;
+            case 1 :
+                param = str;
+                break;
+            default:
+                param2 = str;
+                param = param2;
+                break;
+        }}
+
+        Command c = new Command1(param, param); // param = str here
+    }}
+
+    // Const in all switch cases except one which has a return.
+    void M2(string param, string param2, int i)
+    {{
+        string str = """";
+        switch (i)
+        {{
+            case 0:
+                param = str;
+                break;
+            case 1 :
+                param = str + ""a"";
+                break;
+            default:
+                param = param2;
+                return;
+        }}
+
+        Command c = new Command1(param, param); // param is const here
+    }}
+
+    // Non-const in one of the intermediate switch case.
+    void M3(string param, string param2, int i)
+    {{
+        string str = """";
+        switch (i)
+        {{
+            case 0:
+                param = str;
+                break;
+            case 1 :
+                break;
+            default:
+                param = str;
+                break;
+        }}
+
+        Command c = new Command2(param, param); // param is unknown here for i = 1.
+    }}
+
+    // No default clause.
+    void M4(string param, string param2, int i)
+    {{
+        string str = """";
+        switch (i)
+        {{
+            case 0:
+                param = str;
+                break;
+            case 1 :
+                param = str;
+                break;
+        }}
+
+        Command c = new Command2(param, param); // param is unknown here for i != 0 or 1.
+    }}
+
+    // Switch case with multiple clauses.
+    void M5(string param, string param2, int i)
+    {{
+        string str = """";
+        switch (i)
+        {{
+            case 0:
+            case 1:
+            default:
+                param = str;
+                break;
+        }}
+
+        Command c = new Command1(param, param); // param is const here.
+    }}
+}}
+",
+            // Test0.cs(159,21): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M3', accepts any user input.
+            GetCSharpResultAt(159, 21, "Command2.Command2(string cmd, string parameter2)", "M3"),
+            // Test0.cs(176,21): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M4', accepts any user input.
+            GetCSharpResultAt(176, 21, "Command2.Command2(string cmd, string parameter2)", "M4"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command2
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    ' Const in all switch cases.
+    Private Sub M1(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Select Case i
+            Case 0
+                param = str
+            Case 1
+                param = str
+            Case Else
+                param2 = str
+                param = param2
+        End Select
+
+        Dim c As Command = New Command1(param, param) ' param = str here
+    End Sub
+
+    ' Const in all switch cases except one which has a return.
+    Private Sub M2(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Select Case i
+            Case 0
+                param = str
+            Case 1
+                param = str & ""a""
+            Case Else
+                param = param2
+                Return
+        End Select
+
+        Dim c As Command = New Command1(param, param) ' param is const here
+    End Sub
+
+    ' Non-const in one of the intermediate switch case.
+    Private Sub M3(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Select Case i
+            Case 0
+                param = str
+            Case 1
+                Exit Select
+            Case Else
+                param = str
+        End Select
+
+        Dim c As Command = New Command2(param, param) ' param is unknown here for i = 1.
+    End Sub
+
+    ' No Case Else
+    Private Sub M4(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Select Case i
+            Case 0
+                param = str
+            Case 1
+                param = str
+        End Select
+
+        Dim c As Command = New Command2(param, param) ' param is unknown here for i != 0 or 1.
+    End Sub
+
+    ' Switch case with multiple clauses.
+    Private Sub M5(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Select Case i
+            Case 0, 1
+                param = str
+            Case Else
+                param = str
+        End Select
+
+        Dim c As Command = New Command1(param, param) ' param = str here.
+    End Sub
+End Module",
+            // Test0.vb(183,28): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M3', accepts any user input.
+            GetBasicResultAt(183, 28, "Sub Command2.New(cmd As String, parameter2 As String)", "M3"),
+            // Test0.vb(196,28): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M4', accepts any user input.
+            GetBasicResultAt(196, 28, "Sub Command2.New(cmd As String, parameter2 As String)", "M4"));
+        }
+
+        [Fact]
+        public void FlowAnalysis_TryCatch()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, int i)
+    {{
+        string str = """";
+        if (param != str)
+        {{
+            throw new System.ArgumentException();
+        }}
+
+        Command c = new Command1(param, param); // param = str here
+    }}
+
+    void M2(string param, string param2, int i)
+    {{
+        string str = """";
+        try
+        {{
+            param = param2;
+        }}
+        finally
+        {{
+            param = str;
+        }}
+
+        Command c = new Command1(param, param); // param is str here
+    }}
+
+    void M3(string param, string param2, int i)
+    {{
+        string str = """";
+        try
+        {{
+            param = str;
+        }}
+        catch (System.Exception ex)
+        {{
+            param = param2;
+        }}
+
+        Command c = new Command2(param, param); // param is unknown here for catch.
+    }}
+
+    void M4(string param, string param2, int i)
+    {{
+        string str = """";
+        try
+        {{
+            param = str;
+        }}
+        catch (System.IO.IOException ex)
+        {{
+            param = param2;
+        }}
+        catch (System.Exception ex)
+        {{
+            param = str;
+        }}
+
+        Command c = new Command2(param, param); // param is unknown here for IOException.
+    }}
+
+    void M5(string param, string param2, int i)
+    {{
+        string str = """";
+        try
+        {{
+        }}
+        catch (System.Exception ex)
+        {{
+            param = param2;
+        }}
+        finally
+        {{
+            param = str;
+        }}
+
+        Command c = new Command1(param, param); // param is str here from finally.
+    }}
+
+    void M6(string param, string param2, int i)
+    {{
+        string str = """";
+        try
+        {{
+            if (i == 0)
+            {{
+                throw new System.ArgumentException();
+            }}
+            param = str;
+        }}
+        catch (System.ArgumentException ex)
+        {{
+            param = param2;
+        }}
+        catch (System.Exception ex)
+        {{
+            param = str;
+        }}
+
+        Command c = new Command2(param, param); // param is unknown here for ArgumentException.
+    }}
+}}
+",
+            // Test0.cs(140,21): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M3', accepts any user input.
+            GetCSharpResultAt(140, 21, "Command2.Command2(string cmd, string parameter2)", "M3"),
+            // Test0.cs(159,21): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M4', accepts any user input.
+            GetCSharpResultAt(159, 21, "Command2.Command2(string cmd, string parameter2)", "M4"),
+            // Test0.cs(200,21): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M6', accepts any user input.
+            GetCSharpResultAt(200, 21, "Command2.Command2(string cmd, string parameter2)", "M6"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command2
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Private Sub M1(ByVal param As String, ByVal i As Integer)
+        Dim str As String = """"
+        If param <> str Then
+            Throw New System.ArgumentException()
+        End If
+
+        Dim c As Command = New Command1(param, param) ' param = str here
+    End Sub
+
+    Private Sub M2(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Try
+            param = param2
+        Finally
+            param = str
+        End Try
+
+        Dim c As Command = New Command1(param, param) ' param = str here
+    End Sub
+
+    Private Sub M3(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Try
+            param = str
+        Catch ex As System.Exception
+            param = param2
+        End Try
+
+        Dim c As Command = New Command2(param, param) ' param is unknown here for catch.
+    End Sub
+
+    Private Sub M4(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Try
+            param = str
+        Catch ex As System.IO.IOException
+            param = param2
+        Catch ex As System.Exception
+            param = str
+        End Try
+
+        Dim c As Command = New Command2(param, param) ' param is unknown here for IOException.
+    End Sub
+
+    Private Sub M5(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Try
+        Catch ex As System.Exception
+            param = param2
+        Finally
+            param = str
+        End Try
+
+        Dim c As Command = New Command1(param, param) ' param is str here from finally.
+    End Sub
+
+    Private Sub M6(ByVal param As String, ByVal param2 As String, ByVal i As Integer)
+        Dim str As String = """"
+        Try
+            If i = 0 Then
+                Throw New System.ArgumentException()
+            End If
+
+            param = str
+        Catch ex As System.ArgumentException
+            param = param2
+        Catch ex As System.Exception
+            param = str
+        End Try
+
+        Dim c As Command = New Command2(param, param) ' param is unknown here for ArgumentException.
+    End Sub
+End Module",
+            // Test0.vb(167,28): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M3', accepts any user input.
+            GetBasicResultAt(167, 28, "Sub Command2.New(cmd As String, parameter2 As String)", "M3"),
+            // Test0.vb(180,28): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M4', accepts any user input.
+            GetBasicResultAt(180, 28, "Sub Command2.New(cmd As String, parameter2 As String)", "M4"),
+            // Test0.vb(209,28): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M6', accepts any user input.
+            GetBasicResultAt(209, 28, "Sub Command2.New(cmd As String, parameter2 As String)", "M6"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_CatchFilter()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        string str = """";
+        try
+        {{
+        }}
+        catch (System.Exception ex) when (param == str)
+        {{
+            var c = new Command1(param, param); // param == str here from filter.
+        }}
+    }}
+
+    void M2(string param)
+    {{
+        string str = """";
+        try
+        {{
+            param = str;
+        }}
+        catch (System.Exception ex) when (param == str)
+        {{
+        }}
+
+        var c = new Command1(param, param); // param == str here from try and filter.
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Private Sub M1(ByVal param As String)
+        Dim str As String = """"
+        Try
+        Catch ex As System.Exception When param = str
+            Dim c = New Command1(param, param)  ' param = str here from filter.
+        End Try
+    End Sub
+
+    Private Sub M2(ByVal param As String)
+        Dim str As String = """"
+        Try
+            param = str
+        Catch ex As System.Exception When param = str
+        End Try
+
+        Dim c = New Command1(param, param) ' param = str here from try and filter.
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_CopyAnalysis_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2, string param3)
+    {{
+        string str = ""a"";
+        if (param == str && param == param2)
+        {{
+            Command c = new Command1(param2, param2);
+        }}
+
+        param = param2;
+        if (param == str)
+        {{
+            Command c = new Command1(param2, param2);
+        }}
+
+        if (param == str && param2 == str)
+        {{
+            Command c = new Command1(param, param);
+            c = new Command1(param2, param2);
+        }}
+
+        string str2 = ""b"";
+        if (param2 != str2)
+        {{
+        }}
+        else
+        {{
+            param2 = param3;
+            Command c = new Command1(param, param);
+        }}
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, param3 As String)
+        Dim str = ""a""
+        If param = str AndAlso param = param2 Then
+            Dim c As Command = New Command1(param2, param2)
+        End If
+
+        param = param2
+        If param = str Then
+            Dim c As Command = New Command1(param2, param2)
+        End If
+
+        If param = str AndAlso param2 = str Then
+            Dim c As Command = New Command1(param, param)
+            c = New Command1(param2, param2)
+        End If
+
+        Dim str2 = ""b""
+        If str2 <> param2 Then
+        Else
+            param2 = param3
+            Dim c As Command = New Command1(param, param)
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_CopyAnalysis_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command3 : Command
+{{
+    public Command3(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command4 : Command
+{{
+    public Command4(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command5 : Command
+{{
+    public Command5(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command6 : Command
+{{
+    public Command6(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command7 : Command
+{{
+    public Command7(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2, string param3)
+    {{
+        string str = param3;
+        if (param == str && param == param2)
+        {{
+            Command c = new Command1(param2, param2);
+        }}
+
+        str = ""a"";
+        param = param2;
+        // Always false, we set the copy values of the involved variables to invalid to prevent unnecessary diagnostics.
+        if (param2 == str && param != str)
+        {{
+            Command c = new Command2(param2, param2);
+        }}
+
+        // Always true, but does not tell anything about value of param2 in either if or else.
+        // Else branch can never be entered, hence we set the copy values of the involved variables to invalid.
+        if (param2 == str || param != str)
+        {{
+            Command c = new Command3(param2, param2);
+        }}
+        else
+        {{
+            Command c = new Command4(param2, param2);
+        }}
+
+        if (param == str && param2 == str)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command5(param, param);
+            c = new Command6(param2, param2);
+        }}
+
+        string str2 = ""b"";
+        if (param2 != str2)
+        {{
+            param2 = ""a"";
+            Command c = new Command7(param, param);
+        }}
+    }}
+}}
+",
+            // Test0.cs(142,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(142, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(157,25): warning CA2100: Review if the query string passed to 'Command3.Command3(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(157, 25, "Command3.Command3(string cmd, string parameter2)", "M1"),
+            // Test0.cs(169,25): warning CA2100: Review if the query string passed to 'Command5.Command5(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(169, 25, "Command5.Command5(string cmd, string parameter2)", "M1"),
+            // Test0.cs(170,17): warning CA2100: Review if the query string passed to 'Command6.Command6(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(170, 17, "Command6.Command6(string cmd, string parameter2)", "M1"),
+            // Test0.cs(177,25): warning CA2100: Review if the query string passed to 'Command7.Command7(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(177, 25, "Command7.Command7(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command2
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command3
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command4
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command5
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command6
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command7
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Private Sub M1(ByVal param As String, ByVal param2 As String, ByVal param3 As String)
+        Dim str As String = param3
+        If param = str AndAlso param = param2 Then
+            Dim c As Command = New Command1(param2, param2)
+        End If
+
+        str = ""a""
+        param = param2
+        ' Always false, we set the copy values of the involved variables to invalid to prevent unnecessary diagnostics.
+        If param2 = str AndAlso param <> str Then
+            Dim c As Command = New Command2(param2, param2)
+        End If
+
+        ' Always true, but does not tell anything about value of param2 in either if or else.
+        ' Else branch can never be entered, hence we set the copy values of the involved variables to invalid.
+        If param2 = str OrElse param <> str Then
+            Dim c As Command = New Command3(param2, param2)
+        Else
+            Dim c As Command = New Command4(param2, param2)
+        End If
+
+        If param = str AndAlso param2 = str Then
+        Else
+            Dim c As Command = New Command5(param, param)
+            c = New Command6(param2, param2)
+        End If
+
+        Dim str2 As String = ""b""
+        If param2 <> str2 Then
+            param2 = ""a""
+            Dim c As Command = New Command7(param, param)
+        End If
+    End Sub
+End Module",
+            // Test0.vb(177,32): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(177, 32, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(190,32): warning CA2100: Review if the query string passed to 'Sub Command3.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(190, 32, "Sub Command3.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(197,32): warning CA2100: Review if the query string passed to 'Sub Command5.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(197, 32, "Sub Command5.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(198,17): warning CA2100: Review if the query string passed to 'Sub Command6.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(198, 17, "Sub Command6.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(204,32): warning CA2100: Review if the query string passed to 'Sub Command7.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(204, 32, "Sub Command7.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ConditionalOr_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2, bool flag)
+    {{
+        string str = """";
+        string str2 = flag ? ""a"" : ""b"";
+        string strMayBeConst = param2;
+
+        // 1. const in left, const in right.
+        if (param == str || param == str2)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 2. Creation in else: negation of non-const in left, maybe-const in right.
+        if (str2 != param || param == strMayBeConst)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 3. Creation in else: maybe-const in left, negation of non-const in right.
+        if (param == strMayBeConst || str2 != param)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim str = """"
+        Dim str2 = If(flag, ""a"", ""b"")
+        Dim strMayBeConst = param2
+
+        ' 1. const in left, const in right.
+        If param = str OrElse param = str2 Then
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 2. Creation in else: negation of non-const in left, maybe-const in right.
+        If str2 <> param OrElse param = strMayBeConst Then
+        Else
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 3. Creation in else: maybe-const in left, negation of non-const in right.
+        If param = strMayBeConst OrElse str2 <> param Then
+        Else
+            Dim c As New Command1(param, param)
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ConditionalOr_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2, bool flag)
+    {{
+        string str = """";
+        string str2 = flag ? ""a"" : ""b"";
+        string strMayBeConst = param2;
+
+        // 1. const in left, const in right.
+        if (param == str || param == str2)
+        {{
+            Command c = new Command1(param, param); // No diagnostic
+        }}
+
+        // 2. Creation in if and else: negation of non-const in left, maybe-const in right.
+        if (str2 != param || param == strMayBeConst)
+        {{
+            Command c = new Command2(param, param); // Diagnostic
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 3. Creation in if and else: maybe-const in left, negation of non-const in right.
+        if (param == strMayBeConst || str2 != param)
+        {{
+            Command c = new Command2(param, param); // Diagnostic
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+    }}
+}}
+",
+            // Test0.cs(117,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(117, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
+            // Test0.cs(127,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(127, 25, "Command2.Command2(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command2
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim str = """"
+        Dim str2 = If(flag, ""a"", ""b"")
+        Dim strMayBeConst = param2
+
+        ' 1. const in left, const in right.
+        If param = str OrElse param = str2 Then
+            Dim c As New Command1(param, param) ' No diagnostic
+        End If
+
+        ' 2. Creation in if and else: negation of non-const in left, maybe-const in right.
+        If str2 <> param OrElse param = strMayBeConst Then
+            Dim c As New Command2(param, param)
+        Else
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 3. Creation in if and else: maybe-const in left, negation of non-const in right.
+        If param = strMayBeConst OrElse str2 <> param Then
+            Dim c As New Command2(param, param)
+        Else
+            Dim c As New Command1(param, param)
+        End If
+    End Sub
+End Module",
+            // Test0.vb(151,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(151, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(158,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(158, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ConditionalOr_02_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2, bool flag)
+    {{
+        string str = """";
+        string str2 = flag ? ""a"" : ""b"";
+        string strMayBeConst = param2;
+
+        // 1. const in left, const in right.
+        if (param == str || param == str2)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 2. const in left, maybe-const in right.
+        if (param == str || str2 != param)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 3. const in left, maybe-const in right, creation in else.
+        if (param == str || strMayBeConst != param)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 4. maybe-const in left, const in right.
+        if (param == strMayBeConst || str2 != param)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 5. maybe-const in left and right.
+        if (param == strMayBeConst || param == strMayBeConst + ""c"")
+        {{
+            Command c = new Command1(param, param);
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+    }}
+}}
+",
+            // Test0.cs(107,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(107, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(113,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(113, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(122,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(122, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(128,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(128, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(134,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(134, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(138,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(138, 25, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim str = """"
+        Dim str2 = If(flag, ""a"", ""b"")
+        Dim strMayBeConst = param2
+
+        ' 1. const in left, const in right.
+        If param = str OrElse param = str2 Then
+        Else
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 2. const in left, maybe-const in right.
+        If str = param OrElse strMayBeConst <> param Then
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 3. maybe-const in left, const in right.
+        If param = strMayBeConst OrElse param <> str2 Then
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 4. maybe-const in left, const in right.
+        If param = strMayBeConst OrElse str2 <> param Then
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 5. maybe-const in left and right.
+        If param = strMayBeConst OrElse param = strMayBeConst + ""c"" Then
+            Dim c As New Command1(param, param)
+        Else 
+            Dim c As New Command1(param, param)
+        End If
+    End Sub
+End Module",
+            // Test0.vb(140,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(140, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(145,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(145, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(150,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(150, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(155,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(155, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(160,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(160, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(162,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(162, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ConditionalAnd_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2, bool flag)
+    {{
+        string str = """";
+        string str2 = flag ? ""a"" : ""b"";
+        string strMayBeConst = param2;
+
+        // 1. const in left, const in right.
+        if (param == str && param2 == str2)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 2. maybe-const in left, const in right.
+        if (param == strMayBeConst && str2 == param)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 3. Creation in else: non-const in left, non-const in right.
+        if (param != str && param != str2)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 4. Creation in else: non-const in left, non-const different variable in right.
+        if (param != str && param2 != str2)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 5. Creation in else: negation of non-const in left, maybe-const in right.
+        if (str2 != param && param == strMayBeConst)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim str = """"
+        Dim str2 = If(flag, ""a"", ""b"")
+        Dim strMayBeConst = param2
+
+        ' 1. const in left, const in right.
+        If param = str AndAlso param2 = str2 Then
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 2. maybe-const in left, const in right.
+        If param = strMayBeConst AndAlso str2 = param Then
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 3. Creation in else: non-const in left, non-const in right.
+        If str2 <> param AndAlso param <> str Then
+        Else
+            Dim c As New Command1(param, param)
+        End If
+        
+        ' 4. Creation in else: non-const in left, non-const differen variable in right.
+        If str2 <> param AndAlso param2 <> str Then
+        Else
+            Dim c As New Command1(param, param)
+        End If
+        
+        ' 5. Creation in else: negation of non-const in left, maybe-const in right.
+        If str2 <> param AndAlso param = strMayBeConst Then
+        Else
+            Dim c As New Command1(param, param)
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ConditionalAnd_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2, bool flag)
+    {{
+        string str = """";
+        string str2 = flag ? ""a"" : ""b"";
+        string strMayBeConst = param2;
+
+        // 1. const in left, const in right.
+        if (param == str && param2 == str2)
+        {{
+            Command c = new Command1(param, param); // No diagnostic
+        }}
+
+        // 2. Creation in if and else: negation of non-const in left, maybe-const in right.
+        if (str2 != param && param == strMayBeConst)
+        {{
+            Command c = new Command2(param, param); // Diagnostic
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 3. Creation in if and else: maybe-const in left, negation of non-const in right.
+        if (param == strMayBeConst && str2 != param)
+        {{
+            Command c = new Command2(param, param); // Diagnostic (if both are true, param maybe non-const)
+        }}
+        else
+        {{
+            Command c = new Command2(param, param); // Diagnostic (if left is false, param maybe non-const)
+        }}
+    }}
+}}
+",
+            // Test0.cs(117,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(117, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
+            // Test0.cs(127,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(127, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
+            // Test0.cs(131,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(131, 25, "Command2.Command2(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command2
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim str = """"
+        Dim str2 = If(flag, ""a"", ""b"")
+        Dim strMayBeConst = param2
+
+        ' 1. const in left, const in right.
+        If param = str AndAlso param2 = str2 Then
+            Dim c As New Command1(param, param) ' No diagnostic
+        End If
+
+        ' 2. Creation in if and else: negation of non-const in left, maybe-const in right.
+        If str2 <> param AndAlso param = strMayBeConst Then
+            Dim c As New Command2(param, param) ' Diagnostic
+        Else
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 3. Creation in if and else: maybe-const in left, negation of non-const in right.
+        If param = strMayBeConst AndAlso str2 <> param Then
+            Dim c As New Command2(param, param) ' Diagnostic (if both are true, param maybe non-const)
+        Else
+            Dim c As New Command2(param, param) ' Diagnostic (if left is false, param maybe non-const)
+        End If
+    End Sub
+End Module",
+            // Test0.vb(151,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(151, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(158,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(158, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(160,22): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(160, 22, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ConditionalAnd_02_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, string param2, bool flag)
+    {{
+        string str = """";
+        string str2 = flag ? ""a"" : ""b"";
+        string strMayBeConst = param2;
+
+        // 1. const in left, const in right.
+        if (param == str && param == str2)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 2. const in left, maybe-const in right, creation in else.
+        if (param == str && str2 != param)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 3. const in left, maybe-const in right, creation in else.
+        if (param == str && strMayBeConst != param)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 4. maybe-const in left, non-const in right.
+        if (param == strMayBeConst && str2 != param)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        // 5. maybe-const in left and right.
+        if (param == strMayBeConst && param == strMayBeConst + ""c"")
+        {{
+            Command c = new Command1(param, param);
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+    }}
+}}
+",
+            // Test0.cs(107,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(107, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(116,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(116, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(125,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(125, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(131,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(131, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(137,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(137, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(141,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(141, 25, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim str = """"
+        Dim str2 = If(flag, ""a"", ""b"")
+        Dim strMayBeConst = param2
+
+        ' 1. const in left, const in right.
+        If param = str AndAlso param = str2 Then
+        Else
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 2. const in left, maybe-const in right.
+        If str = param AndAlso str2 <> param Then
+        Else
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 3. maybe-const in left, const in right, creation in else.
+        If param = str AndAlso strMayBeConst <> param Then
+        Else
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 4. maybe-const in left, non-const in right.
+        If param = strMayBeConst AndAlso str2 <> param Then
+            Dim c As New Command1(param, param)
+        End If
+
+        ' 5. maybe-const in left and right.
+        If param = strMayBeConst AndAlso param = strMayBeConst + ""c"" Then
+            Dim c As New Command1(param, param)
+        Else 
+            Dim c As New Command1(param, param)
+        End If
+    End Sub
+End Module",
+            // Test0.vb(140,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(140, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(146,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(146, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(152,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(152, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(157,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(157, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(162,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(162, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(164,22): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(164, 22, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_Conditional_WithNegation_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, bool flag)
+    {{
+        string str = """";
+        string str2 = flag ? ""a"" : ""b"";
+        if (param == str || !(param != str2))
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if (!(param != str) || str2 == param)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if (!(param == str || param == str2))
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if (!(!(str != param) && !!(param != str2)))
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, flag As Boolean)
+        Dim str = """"
+        Dim str2 = If(flag, ""a"", ""b"")
+        If param = str OrElse Not (param <> str2) Then
+            Dim c As New Command1(param, param)
+        End If
+
+        If Not (str <> param) OrElse str2 = param Then
+            Dim c2 As New Command1(param, param)
+        End If
+
+        If Not (param = str OrElse param = str2) Then
+        Else 
+            Dim c3 As New Command1(param, param)
+        End If
+
+        If Not (Not (str <> param) AndAlso Not Not (param <> str2)) Then
+        Else 
+            Dim c4 As New Command1(param, param)
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ConditionalAndOrNegation_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, bool flag, string param2)
+    {{
+        string strConst = """";
+        string strConst2 = flag ? ""a"" : """";
+        string strMayBeNonConst = flag ? ""c"" : param2;
+
+        if (param == strConst || !(strConst2 != param) && param != strMayBeNonConst)
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if (!(strConst2 == param && !(param != strConst)) || param == strMayBeNonConst)
+        {{
+        }}
+        else
+        {{
+            Command c = new Command1(param, param);
+        }}
+
+        if (param != strConst && !(strConst2 != param || param != strMayBeNonConst))
+        {{
+            Command c = new Command1(param, param);
+        }}
+    }}
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim strConst As String = """"
+        Dim strConst2 As String = If(flag, ""a"", """")
+        Dim strMayBeNonConst As String = If(flag, ""c"", param2)
+
+        If param = strConst OrElse Not(strConst2 <> param) AndAlso param <> strMayBeNonConst Then
+            Dim c As Command = New Command1(param, param)
+        End If
+
+        If Not(strConst2 = param AndAlso Not (param <> strConst)) OrElse param <> strMayBeNonConst Then
+        Else
+            Dim c As Command = New Command1(param, param)
+        End If
+
+        If param <> strConst AndAlso Not(strConst2 <> param OrElse param <> strMayBeNonConst) Then
+            Dim c As Command = New Command1(param, param)
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ConditionalAndOrNegation_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command3 : Command
+{{
+    public Command3(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command4 : Command
+{{
+    public Command4(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command5 : Command
+{{
+    public Command5(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command6 : Command
+{{
+    public Command6(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param, bool flag, string param2)
+    {{
+        string strConst = """";
+        string strConst2 = flag ? ""a"" : """";
+        string strMayBeNonConst = flag ? ""c"" : param2;
+
+        if (param != strConst && !(strConst2 != param || param != strConst))  // First and last conditions are opposites, so infeasible.
+        {{
+            Command c = new Command1(param, param);
+        }}
+        else
+        {{
+            Command c = new Command2(param, param);
+        }}
+
+        if (param == strConst && !(strConst2 == param || param == strMayBeNonConst))
+        {{
+            Command c = new Command3(param, param);
+        }}
+        else
+        {{
+            Command c = new Command4(param, param);
+        }}
+
+        if (param != strConst && !(strConst2 != param || param != strMayBeNonConst))
+        {{
+            Command c = new Command5(param, param);   // No diagnostic expected here
+        }}
+        else
+        {{
+            Command c = new Command6(param, param);
+        }}
+    }}
+}}
+",
+            // Test0.cs(142,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(142, 25, "Command2.Command2(string cmd, string parameter2)", "M1"),
+            // Test0.cs(147,25): warning CA2100: Review if the query string passed to 'Command3.Command3(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(147, 25, "Command3.Command3(string cmd, string parameter2)", "M1"),
+            // Test0.cs(151,25): warning CA2100: Review if the query string passed to 'Command4.Command4(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(151, 25, "Command4.Command4(string cmd, string parameter2)", "M1"),
+            // Test0.cs(160,25): warning CA2100: Review if the query string passed to 'Command6.Command6(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(160, 25, "Command6.Command6(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command2
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command3
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command4
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command5
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command6
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim strConst As String = """"
+        Dim strConst2 As String = If(flag, ""a"", """")
+        Dim strMayBeNonConst As String = If(flag, ""c"", param2)
+
+        If param <> strConst AndAlso Not(strConst2 <> param OrElse param <> strConst) Then ' First and last conditions are opposites, so infeasible.
+            Dim c As Command = New Command1(param, param)
+        Else
+            Dim c As Command = New Command2(param, param)
+        End If
+
+        If param = strConst AndAlso Not(strConst2 = param OrElse param = strMayBeNonConst) Then
+            Dim c As Command = New Command3(param, param)
+        Else
+            Dim c As Command = New Command4(param, param)
+        End If
+
+        If param <> strConst AndAlso Not(strConst2 <> param OrElse param <> strMayBeNonConst) Then
+            Dim c As Command = New Command5(param, param)   ' No diagnostic expected here
+        Else
+            Dim c As Command = New Command6(param, param)
+        End If
+    End Sub
+End Module",
+            // Test0.vb(175,32): warning CA2100: Review if the query string passed to 'Sub Command2.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(175, 32, "Sub Command2.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(179,32): warning CA2100: Review if the query string passed to 'Sub Command3.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(179, 32, "Sub Command3.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(181,32): warning CA2100: Review if the query string passed to 'Sub Command4.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(181, 32, "Sub Command4.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(187,32): warning CA2100: Review if the query string passed to 'Sub Command6.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(187, 32, "Sub Command6.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ComparisonInNonCondition_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        var x = param == """";  // This predicate should not affect subsequent code.
+        Command c = new Command1(param, param);
+    }}
+}}
+",
+            // Test0.cs(98,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(98, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Sub M1(param As String)
+        Dim x = param = """"    ' This predicate should not affect subsequent code.
+        Dim c As New Command1(param, param)
+    End Sub
+End Module",
+            // Test0.vb(134,18): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(134, 18, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ComparisonInNonCondition_02_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        Command c = null;
+        var x = param == """" && ((c = new Command1(param, param)) != null);    // Left operand of && ensures no diagnostic for Command1 instantiation.
+        c = new Command2(param, param);     // This code should fire as 'param == """"' does not apply here.
+    }}
+}}
+",
+            // Test0.cs(106,13): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(106, 13, "Command2.Command2(string cmd, string parameter2)", "M1"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ContractCheck_NoDiagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        System.Diagnostics.Contracts.Contract.Requires(param == """");
+        Command c = new Command1(param, param);
+    }}
+
+    void M2(string param, string param2)
+    {{
+        System.Diagnostics.Contracts.Contract.Requires(param == """" && param2 == param);
+        Command c = new Command1(param, param);
+        c = new Command1(param2, param2);
+    }}
+
+    void M3(string param, string param2)
+    {{
+        System.Diagnostics.Contracts.Contract.Requires(param == param2 && !(param2 != """"));
+        Command c = new Command1(param, param);
+        c = new Command1(param2, param2);
+    }}
+
+    void M4_Assume(string param)
+    {{
+        System.Diagnostics.Contracts.Contract.Assume(param == """");
+        Command c = new Command1(param, param);
+    }}
+
+    void M5_Assert(string param)
+    {{
+        System.Diagnostics.Contracts.Contract.Assert(param == """");
+        Command c = new Command1(param, param);
+    }}    
+}}
+");
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Private Sub M1(ByVal param As String)
+        System.Diagnostics.Contracts.Contract.Requires(param = """")
+        Dim c As Command = New Command1(param, param)
+    End Sub
+
+    Private Sub M2(ByVal param As String, ByVal param2 As String)
+        System.Diagnostics.Contracts.Contract.Requires(param = """" AndAlso param2 = param)
+        Dim c As Command = New Command1(param, param)
+        c = New Command1(param2, param2)
+    End Sub
+
+    Private Sub M3(ByVal param As String, ByVal param2 As String)
+        System.Diagnostics.Contracts.Contract.Requires(param = param2 AndAlso Not(param2 <> """"))
+        Dim c As Command = New Command1(param, param)
+        c = New Command1(param2, param2)
+    End Sub
+
+    Private Sub M4_Assume(ByVal param As String)
+        System.Diagnostics.Contracts.Contract.Assume(param = """")
+        Dim c As Command = New Command1(param, param)
+    End Sub
+
+    Private Sub M5_Assert(ByVal param As String)
+        System.Diagnostics.Contracts.Contract.Assert(param = """")
+        Dim c As Command = New Command1(param, param)
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+        [Fact]
+        public void FlowAnalysis_PredicateAnalysis_ContractCheck_Diagnostic()
+        {
+            VerifyCSharp($@"
+{SetupCodeCSharp}
+
+class Command1 : Command
+{{
+    public Command1(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Command2 : Command
+{{
+    public Command2(string cmd, string parameter2)
+    {{
+    }}
+}}
+
+class Test
+{{
+    void M1(string param)
+    {{
+        System.Diagnostics.Contracts.Contract.Requires(param != """");
+        Command c = new Command1(param, param);
+    }}
+
+    void M2(string param, string param2)
+    {{
+        param2 = """";
+        System.Diagnostics.Contracts.Contract.Requires(param == """" || param2 != param);
+        Command c = new Command1(param, param);
+        c = new Command2(param2, param2);   // No diagnostic.
+    }}
+
+    void M3(string param, string param2, string param3)
+    {{
+        System.Diagnostics.Contracts.Contract.Requires(param == param2 && !(param2 != """") || param2 == param3);
+        Command c = new Command1(param, param);
+        c = new Command1(param2, param2);
+    }}
+}}
+",
+            // Test0.cs(105,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+            GetCSharpResultAt(105, 21, "Command1.Command1(string cmd, string parameter2)", "M1"),
+            // Test0.cs(112,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M2', accepts any user input.
+            GetCSharpResultAt(112, 21, "Command1.Command1(string cmd, string parameter2)", "M2"),
+            // Test0.cs(119,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M3', accepts any user input.
+            GetCSharpResultAt(119, 21, "Command1.Command1(string cmd, string parameter2)", "M3"),
+            // Test0.cs(120,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M3', accepts any user input.
+            GetCSharpResultAt(120, 13, "Command1.Command1(string cmd, string parameter2)", "M3"));
+
+            VerifyBasic($@"
+{SetupCodeBasic}
+
+Class Command1
+    Inherits Command
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Class Command2
+    Inherits Command
+    Sub New(cmd As String, parameter2 As String)
+    End Sub
+End Class
+
+Module Test
+    Private Sub M1(ByVal param As String)
+        System.Diagnostics.Contracts.Contract.Requires(param <> """")
+        Dim c As Command = New Command1(param, param)
+    End Sub
+
+    Private Sub M2(ByVal param As String, ByVal param2 As String)
+        param2 = """"
+        System.Diagnostics.Contracts.Contract.Requires(param = """" OrElse param2 <> param)
+        Dim c As Command = New Command1(param, param)
+        c = New Command2(param2, param2)    ' No diagnostic
+    End Sub
+
+    Private Sub M3(ByVal param As String, ByVal param2 As String, param3 As String)
+        System.Diagnostics.Contracts.Contract.Requires(param = param2 AndAlso Not(param2 <> """") OrElse param2 = param3)
+        Dim c As Command = New Command1(param, param)
+        c = New Command1(param2, param2)
+    End Sub
+End Module",
+            // Test0.vb(139,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+            GetBasicResultAt(139, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+            // Test0.vb(145,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M2', accepts any user input.
+            GetBasicResultAt(145, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M2"),
+            // Test0.vb(151,28): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M3', accepts any user input.
+            GetBasicResultAt(151, 28, "Sub Command1.New(cmd As String, parameter2 As String)", "M3"),
+            // Test0.vb(152,13): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M3', accepts any user input.
+            GetBasicResultAt(152, 13, "Sub Command1.New(cmd As String, parameter2 As String)", "M3"));
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposableFieldsShouldBeDisposedTests.cs
@@ -7,6 +7,9 @@ using Xunit;
 
 namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Usage
 {
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.DisposeAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
     public partial class DisposableFieldsShouldBeDisposedTests : DiagnosticAnalyzerTestBase
     {
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new DisposableFieldsShouldBeDisposed();

--- a/src/Test.Utilities/Traits.cs
+++ b/src/Test.Utilities/Traits.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Test.Utilities
+{
+    public static class Traits
+    {
+        public const string DataflowAnalysis = nameof(DataflowAnalysis);
+#pragma warning disable CA1034 // Nested types should not be visible - test class matching the pattern used in Roslyn.
+        public static class Dataflow
+#pragma warning restore CA1034 // Nested types should not be visible
+        {
+            public const string CopyAnalysis = nameof(CopyAnalysis);
+            public const string NullAnalysis = nameof(NullAnalysis);
+            public const string PointsToAnalysis = nameof(PointsToAnalysis);
+            public const string StringContentAnalysis = nameof(StringContentAnalysis);
+            public const string DisposeAnalysis = nameof(DisposeAnalysis);
+            public const string ParameterValidationAnalysis = nameof(ParameterValidationAnalysis);
+
+            public const string PredicateAnalysis = nameof(PredicateAnalysis);
+        }
+    }
+}

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -336,17 +336,6 @@ namespace Analyzer.Utilities.Extensions
             return operationBlocks.HasAnyOperationDescendant(predicate: operation => operation is TOperation);
         }
 
-        public static bool HasAnyConditionalOperatorDescendant(this IOperation operation)
-        {
-            return operation.HasAnyOperationDescendant(predicate: o => o is IBinaryOperation b && b.IsConditionalOpertator());
-        }
-
-        /// <summary>
-        /// Indicates if the given <paramref name="binaryOperation"/> is a predicate operation used in a condition.
-        /// A predicate operation is either an <see cref="IsConditionalOpertator(IBinaryOperation)"/> or an <see cref="IsComparisonOperator(IBinaryOperation)"/>.
-        /// </summary>
-        public static bool IsPredicate(this IBinaryOperation binaryOperation) => binaryOperation.IsConditionalOpertator() || binaryOperation.IsComparisonOperator();
-
         /// <summary>
         /// Indicates if the given <paramref name="binaryOperation"/> is a ConditionalAnd/ConditionalOr operator ('&&' or '||').
         /// </summary>

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -330,10 +330,9 @@ namespace Analyzer.Utilities.Extensions
             return false;
         }
 
-        public static bool HasAnyOperationDescendant<TOperation>(this ImmutableArray<IOperation> operationBlocks)
-            where TOperation : IOperation
+        public static bool HasAnyOperationDescendant(this ImmutableArray<IOperation> operationBlocks, OperationKind kind)
         {
-            return operationBlocks.HasAnyOperationDescendant(predicate: operation => operation is TOperation);
+            return operationBlocks.HasAnyOperationDescendant(predicate: operation => operation.Kind == kind);
         }
 
         /// <summary>

--- a/src/Utilities/WellKnownTypes.cs
+++ b/src/Utilities/WellKnownTypes.cs
@@ -471,6 +471,11 @@ namespace Analyzer.Utilities
         {
             return compilation.GetTypeByMetadataName("NUnit.Framework.TheoryAttribute");
         }
+
+        public static INamedTypeSymbol SystemDiagnosticContractsContract(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Diagnostics.Contracts.Contract");
+        }
         #endregion
     }
 }


### PR DESCRIPTION
_An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic)._

Rule Documentation: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods.

Implementing this rule needed following support:
1. **Copy analysis** to keep track of set of analysis entities that hold the same value at any given program point
2. **Predicate analysis** to derive copy and nullness information about entities from conditional expressions.
3. **Parameter validation analysis** to track parameter locations of public APIs that need to be non-null before being used in context of a hazardous expression that can cause null dereference.
4. **Contract check analysis** to derive facts about entities from System.Diagnostics.Contracts.Contract method calls.
5. Handle **switch statement** (conservative analysis workaround)
6. Handle **try-catch-finally** (conservative analysis workaround)
7. Add unit test traits for different flow analyses

Fixes #404

TODO: #1630 (path sensitive analysis) to improve precision of this rule.