### PR TITLE
Implement DFA rule (CA1508: AvoidDeadConditionalCode)

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/ValidateArgumentsOfPublicMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Design/ValidateArgumentsOfPublicMethods.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
-using Microsoft.CodeAnalysis.Operations.DataFlow;
 using Microsoft.CodeAnalysis.Operations.DataFlow.ParameterValidationAnalysis;
 
 namespace Microsoft.CodeQuality.Analyzers.Exp.Design

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
@@ -3,8 +3,8 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis.Operations.ControlFlow;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
 {
@@ -40,11 +40,41 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
 
             protected override void SetAbstractValue(AnalysisEntity analysisEntity, CopyAbstractValue value)
             {
+                Debug.Assert(analysisEntity != null);
+                Debug.Assert(value != null);
+
                 SetAbstractValue(CurrentAnalysisData, analysisEntity, value, fromPredicate: false);
+
+                if (IsCurrentlyPerformingPredicateAnalysis)
+                {
+                    SetAbstractValue(NegatedCurrentAnalysisDataStack.Peek(), analysisEntity, value, fromPredicate: false);
+                }
             }
 
             private static void SetAbstractValue(CopyAnalysisData copyAnalysisData, AnalysisEntity analysisEntity, CopyAbstractValue value, bool fromPredicate)
             {
+                AssertValidCopyAnalysisData(copyAnalysisData);
+
+                // Don't track entities if do not know about it's instance location.
+                if (analysisEntity.HasUnknownInstanceLocation)
+                {
+                    return;
+                }
+
+                if (value.AnalysisEntities.Count > 0)
+                {
+                    if (copyAnalysisData.TryGetValue(value.AnalysisEntities.First(), out var fixedUpValue))
+                    {
+                        value = fixedUpValue;
+                    }
+
+                    var validEntities = value.AnalysisEntities.Where(entity => !entity.HasUnknownInstanceLocation).ToImmutableHashSet();
+                    if (validEntities.Count < value.AnalysisEntities.Count)
+                    {
+                        value = validEntities.Count > 0 ? new CopyAbstractValue(validEntities) : CopyAbstractValue.Unknown;
+                    }
+                }
+
                 // Handle updating the existing value if not setting the value from predicate analysis.
                 if (!fromPredicate &&
                     copyAnalysisData.TryGetValue(analysisEntity, out CopyAbstractValue existingValue))
@@ -62,6 +92,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
                         foreach (var entityToUpdate in newValueForEntitiesInOldSet.AnalysisEntities)
                         {
                             Debug.Assert(copyAnalysisData[entityToUpdate] == existingValue);
+                            Debug.Assert(newValueForEntitiesInOldSet.AnalysisEntities.Contains(entityToUpdate));
                             copyAnalysisData[entityToUpdate] = newValueForEntitiesInOldSet;
                         }
                     }
@@ -86,8 +117,12 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
                 var newValue = new CopyAbstractValue(newAnalysisEntities);
                 foreach (var entityToUpdate in newAnalysisEntities)
                 {
+                    Debug.Assert(newValue.AnalysisEntities.Count > 0);
+                    Debug.Assert(newValue.AnalysisEntities.Contains(entityToUpdate));
                     copyAnalysisData[entityToUpdate] = newValue;
                 }
+
+                AssertValidCopyAnalysisData(copyAnalysisData);
             }
 
             protected override void SetValueForParameterOnEntry(IParameterSymbol parameter, AnalysisEntity analysisEntity)
@@ -117,9 +152,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
 
             protected override CopyAbstractValue ComputeAnalysisValueForOutArgument(AnalysisEntity analysisEntity, IArgumentOperation operation, CopyAbstractValue defaultValue)
             {
-                var value = new CopyAbstractValue(analysisEntity);
-                SetAbstractValue(analysisEntity, value);
-                return value;
+                SetAbstractValue(analysisEntity, ValueDomain.UnknownOrMayBeValue);
+                return GetAbstractValue(analysisEntity);
             }
 
             #region Predicate analysis
@@ -127,7 +161,9 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
             {
                 Debug.Assert(operation.IsComparisonOperator());
 
-                if (AnalysisEntityFactory.TryCreate(operation.LeftOperand, out AnalysisEntity leftEntity) &&
+                if (GetCopyAbstractValue(operation.LeftOperand).Kind != CopyAbstractValueKind.Unknown &&
+                    GetCopyAbstractValue(operation.RightOperand).Kind != CopyAbstractValueKind.Unknown &&
+                    AnalysisEntityFactory.TryCreate(operation.LeftOperand, out AnalysisEntity leftEntity) &&
                     AnalysisEntityFactory.TryCreate(operation.RightOperand, out AnalysisEntity rightEntity))
                 {
                     var predicateKind = PredicateValueKind.Unknown;
@@ -141,8 +177,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
                         // For both cases, condition on right is always true or always false and redundant.
                         predicateKind = equals ? PredicateValueKind.AlwaysTrue : PredicateValueKind.AlwaysFalse;
                     }
-                    else if (negatedCurrentAnalysisData.TryGetValue(rightEntity, out rightValue) &&
-                        rightValue.AnalysisEntities.Contains(leftEntity))
+                    else if (negatedCurrentAnalysisData.TryGetValue(rightEntity, out var negatedRightValue) &&
+                        negatedRightValue.AnalysisEntities.Contains(leftEntity))
                     {
                         // We have "a == b || a == b" or "a == b || a != b"
                         // For both cases, condition on right is always true or always false and redundant.
@@ -189,6 +225,31 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
             public override CopyAbstractValue DefaultVisit(IOperation operation, object argument)
             {
                 var _ = base.DefaultVisit(operation, argument);
+                return CopyAbstractValue.Unknown;
+            }
+
+            public override CopyAbstractValue VisitConversion(IConversionOperation operation, object argument)
+            {
+                var operandValue = Visit(operation.Operand, argument);
+
+                if (TryInferConversion(operation, out bool alwaysSucceed, out bool alwaysFail))
+                {
+                    Debug.Assert(!alwaysSucceed || !alwaysFail);
+                    
+                    // Flow the copy value of the operand to the converted operation if conversion may succeed.
+                    if (!alwaysFail)
+                    {
+                        // For try cast, also ensure conversion always succeeds before flowing copy value.
+                        // TODO: For direct cast, we should check if conversion is implicit.
+                        // For now, we only flow values for reference type direct cast conversions.
+                        if (operation.IsTryCast && alwaysSucceed ||
+                            !operation.IsTryCast && operation.Type.IsReferenceType)
+                        {
+                            return operandValue;
+                        }
+                    }
+                }
+
                 return CopyAbstractValue.Unknown;
             }
             #endregion

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Operations.ControlFlow;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
@@ -29,6 +30,27 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
                 wellKnownTypeProvider, pessimisticAnalysis, nullAnalysisResultOpt, pointsToAnalysisResultOpt);
             var copyAnalysis = new CopyAnalysis(CopyAnalysisDomain.Instance, operationVisitor);
             return copyAnalysis.GetOrComputeResultCore(cfg, cacheResult: true);
+        }
+
+        [Conditional("DEBUG")]
+        public static void AssertValidCopyAnalysisEntity(AnalysisEntity analysisEntity)
+        {
+            Debug.Assert(!analysisEntity.HasUnknownInstanceLocation, "Don't track entities if do not know about it's instance location");
+        }
+
+        [Conditional("DEBUG")]
+        public static void AssertValidCopyAnalysisData(CopyAnalysisData map)
+        {
+            foreach (var kvp in map)
+            {
+                AssertValidCopyAnalysisEntity(kvp.Key);
+                Debug.Assert(kvp.Value.AnalysisEntities.Contains(kvp.Key));
+                foreach (var analysisEntity in kvp.Value.AnalysisEntities)
+                {
+                    AssertValidCopyAnalysisEntity(analysisEntity);
+                    Debug.Assert(map[analysisEntity] == kvp.Value);
+                }
+            }
         }
 
         internal override CopyBlockAnalysisResult ToResult(BasicBlock basicBlock, DataFlowAnalysisInfo<CopyAnalysisData> blockAnalysisData) => new CopyBlockAnalysisResult(basicBlock, blockAnalysisData);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisDomain.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
 {
@@ -11,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
         /// <summary>
         /// An abstract analysis domain implementation <see cref="CopyAnalysis"/>.
         /// </summary>
-        private class CopyAnalysisDomain : AnalysisEntityMapAbstractDomain<CopyAbstractValue>
+        private class CopyAnalysisDomain : MapAbstractDomain<AnalysisEntity, CopyAbstractValue>
         {
             public static readonly CopyAnalysisDomain Instance = new CopyAnalysisDomain(CopyAbstractValueDomain.Default);
 
@@ -20,7 +21,47 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
             {
             }
 
-            protected override CopyAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => new CopyAbstractValue(analysisEntity);
+            protected override CopyAnalysisData MergeCore(CopyAnalysisData map1, CopyAnalysisData map2)
+            {
+                Debug.Assert(map1 != null);
+                Debug.Assert(map2 != null);
+                AssertValidCopyAnalysisData(map1);
+                AssertValidCopyAnalysisData(map2);
+
+                var result = new Dictionary<AnalysisEntity, CopyAbstractValue>();
+                foreach (var kvp in map1)
+                {
+                    var key = kvp.Key;
+                    var value1 = kvp.Value;
+
+                    // If the key exists in both maps, use the merged value.
+                    // Otherwise, use the default value.
+                    CopyAbstractValue mergedValue;
+                    if (map2.TryGetValue(key, out var value2))
+                    {
+                        mergedValue = ValueDomain.Merge(value1, value2);
+                    }
+                    else
+                    {
+                        mergedValue = GetDefaultValue(key);
+                    }
+
+                    result.Add(key, mergedValue);
+                }
+
+                foreach (var kvp in map2)
+                {
+                    if (!result.ContainsKey(kvp.Key))
+                    {
+                        result.Add(kvp.Key, GetDefaultValue(kvp.Key));
+                    }
+                }
+
+                AssertValidCopyAnalysisData(result);
+                return result;
+
+                CopyAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => new CopyAbstractValue(analysisEntity);
+            }
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -77,9 +77,12 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
 
             protected override void SetAbstractValue(AbstractLocation location, DisposeAbstractValue value)
             {
-                Debug.Assert(location.LocationTypeOpt.IsDisposable(WellKnownTypeProvider.IDisposable));
+                Debug.Assert(location.IsNull || location.LocationTypeOpt.IsDisposable(WellKnownTypeProvider.IDisposable));
 
-                CurrentAnalysisData[location] = value;
+                if (!location.IsNull)
+                {
+                    CurrentAnalysisData[location] = value;
+                }
             }
 
             protected override void ResetCurrentAnalysisData(DisposeAnalysisData newAnalysisDataOpt = null) => ResetAnalysisData(CurrentAnalysisData, newAnalysisDataOpt);
@@ -159,6 +162,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
 
             protected override void SetAbstractValueForAssignment(IOperation target, IOperation assignedValueOperation, DisposeAbstractValue assignedValue)
             {
+                if (assignedValueOperation == null)
+                {
+                    return;
+                }
+
                 // Temporary workaround for missing dataflow support for tuples
                 // https://github.com/dotnet/roslyn-analyzers/issues/1571
                 if (assignedValueOperation?.Kind == OperationKind.Tuple)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
@@ -64,6 +64,11 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
             protected override NullAbstractValue GetDefaultValueForParameterOnExit(ITypeSymbol parameterType)
                 => parameterType.IsValueType ? NullAbstractValue.NotNull : NullAbstractValue.MaybeNull;
 
+            protected override NullAbstractValue ComputeAnalysisValueForReferenceOperation(IOperation operation, NullAbstractValue defaultValue)
+            {
+                return base.ComputeAnalysisValueForReferenceOperation(operation, defaultValue);
+            }
+
             #region Predicate analysis
             private static bool IsValidValueForPredicateAnalysis(NullAbstractValue value)
             {
@@ -237,7 +242,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
                     return NullAbstractValue.NotNull;
                 }
 
-                return value;
+                return NullAbstractValue.MaybeNull;
             }
 
             protected override NullAbstractValue VisitAssignmentOperation(IAssignmentOperation operation, object argument)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/NullAnalysis/NullAnalysis.NullDataFlowOperationVisitor.cs
@@ -64,11 +64,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis
             protected override NullAbstractValue GetDefaultValueForParameterOnExit(ITypeSymbol parameterType)
                 => parameterType.IsValueType ? NullAbstractValue.NotNull : NullAbstractValue.MaybeNull;
 
-            protected override NullAbstractValue ComputeAnalysisValueForReferenceOperation(IOperation operation, NullAbstractValue defaultValue)
-            {
-                return base.ComputeAnalysisValueForReferenceOperation(operation, defaultValue);
-            }
-
             #region Predicate analysis
             private static bool IsValidValueForPredicateAnalysis(NullAbstractValue value)
             {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisDomain.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
 {
+    using PointsToAnalysisData = IDictionary<AnalysisEntity, PointsToAbstractValue>;
+
     /// <summary>
     /// An abstract analysis domain implementation <see cref="PointsToAnalysis"/>.
     /// </summary>
@@ -18,5 +21,21 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
         public DefaultPointsToValueGenerator DefaultPointsToValueGenerator { get; }
 
         protected override PointsToAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => DefaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity);
+
+        public PointsToAnalysisData MergeAnalysisDataForBackEdge(PointsToAnalysisData map1, PointsToAnalysisData map2)
+        {
+            // Stop tracking points to values present in both branches.
+            List<AnalysisEntity> keysInMap1 = map1.Keys.ToList();
+            foreach (var key in keysInMap1)
+            {
+                if (map2.TryGetValue(key, out var value2) &&
+                    value2 != map1[key])
+                {
+                    map1[key] = PointsToAbstractValue.Unknown;
+                }
+            }
+
+            return Merge(map1, map2);
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAbstractValue.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
         public static readonly StringContentAbstractValue UndefinedState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.Undefined);
         public static readonly StringContentAbstractValue InvalidState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.Invalid);
         public static readonly StringContentAbstractValue MayBeContainsNonLiteralState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.Maybe);
-        public static readonly StringContentAbstractValue DoesNotContainNonLiteralState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.No);
+        public static readonly StringContentAbstractValue DoesNotContainLiteralOrNonLiteralState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.No);
         private static readonly StringContentAbstractValue ContainsEmpyStringLiteralState = new StringContentAbstractValue(ImmutableHashSet.Create(string.Empty), StringContainsNonLiteralState.No);
 
         public static StringContentAbstractValue Create(string literal)
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
                     case StringContainsNonLiteralState.Invalid:
                         return InvalidState;
                     case StringContainsNonLiteralState.No:
-                        return DoesNotContainNonLiteralState;
+                        return DoesNotContainLiteralOrNonLiteralState;
                     default:
                         return MayBeContainsNonLiteralState;
                 }
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
             return StringContainsNonLiteralState.No;
         }
 
-        public bool IsLiteralState => NonLiteralState == StringContainsNonLiteralState.No;
+        public bool IsLiteralState => !LiteralValues.IsEmpty && NonLiteralState == StringContainsNonLiteralState.No;
 
         public StringContentAbstractValue IntersectLiteralValues(StringContentAbstractValue value2)
         {
@@ -156,8 +156,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
 
             // Merge Literals
             var mergedLiteralValues = this.LiteralValues.Intersect(value2.LiteralValues);
-            var nonLiteralState = mergedLiteralValues.IsEmpty ? StringContainsNonLiteralState.Invalid : StringContainsNonLiteralState.No;
-            return new StringContentAbstractValue(mergedLiteralValues, nonLiteralState);
+            return mergedLiteralValues.IsEmpty ? InvalidState : new StringContentAbstractValue(mergedLiteralValues, StringContainsNonLiteralState.No);
         }
 
         /// <summary>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAnalysis.StringContentDataFlowOperationVisitor.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
                 return ValueDomain.UnknownOrMayBeValue;
             }
 
-            public override StringContentAbstractValue VisitBinaryOperatorCore(IBinaryOperation operation, object argument)
+            public override StringContentAbstractValue VisitBinaryOperator_NonConditional(IBinaryOperation operation, object argument)
             {
                 switch (operation.OperatorKind)
                 {
@@ -151,29 +151,21 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
                         return leftValue.MergeBinaryAdd(rightValue);
 
                     default:
-                        return base.VisitBinaryOperatorCore(operation, argument);
+                        return base.VisitBinaryOperator_NonConditional(operation, argument);
                 }
             }
 
-            public override StringContentAbstractValue VisitCompoundAssignment(ICompoundAssignmentOperation operation, object argument)
+            public override StringContentAbstractValue ComputeValueForCompoundAssignment(ICompoundAssignmentOperation operation, StringContentAbstractValue targetValue, StringContentAbstractValue assignedValue)
             {
-                StringContentAbstractValue value;
                 switch (operation.OperatorKind)
                 {
                     case BinaryOperatorKind.Add:
                     case BinaryOperatorKind.Concatenate:
-                        var leftValue = Visit(operation.Target, argument);
-                        var rightValue = Visit(operation.Value, argument);
-                        value = leftValue.MergeBinaryAdd(rightValue);
-                        break;
+                        return targetValue.MergeBinaryAdd(assignedValue);
 
                     default:
-                        value = base.VisitCompoundAssignment(operation, argument);
-                        break;
+                        return base.ComputeValueForCompoundAssignment(operation, targetValue, assignedValue);
                 }
-
-                SetAbstractValueForAssignment(operation.Target, operation.Value, value);
-                return value;
             }
 
             public override StringContentAbstractValue VisitNameOf(INameOfOperation operation, object argument)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraphGenerator.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraphGenerator.cs
@@ -140,7 +140,6 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
                     _labeledBlocks.Add(label.Label, _currentBlock);
                     break;
 
-                case OperationKind.Return:
                 case OperationKind.Branch:
                     isLastStatement = true;
                     break;

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -143,6 +143,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         public ITypeSymbol Type { get; }
         public AnalysisEntity ParentOpt { get; }
 
+        public bool HasUnknownInstanceLocation => InstanceLocation.Kind == PointsToAbstractValueKind.Unknown;
+
         public override bool Equals(object obj)
         {
             return Equals(obj as AnalysisEntity);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -193,7 +193,10 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         {
             if (AnalysisEntityFactory.TryCreate(operation, out AnalysisEntity analysisEntity))
             {
-                ResetValueTypeInstanceAnalysisData(analysisEntity);
+                if (analysisEntity.Type.HasValueCopySemantics())
+                {
+                    ResetValueTypeInstanceAnalysisData(analysisEntity);
+                }
             }
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -130,7 +130,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 }
             }
 
-            return resultBuilder.ToResult(ToResult, OperationVisitor.GetStateMap(), OperationVisitor.GetMergedDataForUnhandledThrowOperations(), cfg);
+            return resultBuilder.ToResult(ToResult, OperationVisitor.GetStateMap(),
+                OperationVisitor.GetPredicateValueKindMap(), OperationVisitor.GetMergedDataForUnhandledThrowOperations(), cfg);
         }
 
         private TAnalysisData Flow(BasicBlock block, TAnalysisData data)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -131,7 +131,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             }
 
             return resultBuilder.ToResult(ToResult, OperationVisitor.GetStateMap(),
-                OperationVisitor.GetPredicateValueKindMap(), OperationVisitor.GetMergedDataForUnhandledThrowOperations(), cfg);
+                OperationVisitor.GetPredicateValueKindMap(), OperationVisitor.GetMergedDataForUnhandledThrowOperations(),
+                cfg, OperationVisitor.ValueDomain.UnknownOrMayBeValue);
         }
 
         private TAnalysisData Flow(BasicBlock block, TAnalysisData data)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
@@ -17,20 +17,25 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     {
         private readonly ImmutableDictionary<BasicBlock, TAnalysisResult> _basicBlockStateMap;
         private readonly ImmutableDictionary<IOperation, TAbstractAnalysisValue> _operationStateMap;
+        private readonly ImmutableDictionary<IBinaryOperation, PredicateValueKind> _predicateValueKindMap;
+
         public DataFlowAnalysisResult(
             ImmutableDictionary<BasicBlock, TAnalysisResult> basicBlockStateMap,
             ImmutableDictionary<IOperation, TAbstractAnalysisValue> operationStateMap,
+            ImmutableDictionary<IBinaryOperation, PredicateValueKind> predicateValueKindMap,
             TAnalysisResult mergedStateForUnhandledThrowOperationsOpt,
             ControlFlowGraph cfg)
         {
             _basicBlockStateMap = basicBlockStateMap;
             _operationStateMap = operationStateMap;
+            _predicateValueKindMap = predicateValueKindMap;
             MergedStateForUnhandledThrowOperationsOpt = mergedStateForUnhandledThrowOperationsOpt;
             ControlFlowGraph = cfg;
         }
 
         public TAnalysisResult this[BasicBlock block] => _basicBlockStateMap[block];
         public TAbstractAnalysisValue this[IOperation operation] => _operationStateMap[operation];
+        public PredicateValueKind GetPredicateKind(IBinaryOperation operation) => _predicateValueKindMap.TryGetValue(operation, out var valueKind) ? valueKind : PredicateValueKind.Unknown;
         public TAnalysisResult MergedStateForUnhandledThrowOperationsOpt;
         public ControlFlowGraph ControlFlowGraph { get; }
     }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis.Operations.ControlFlow;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow
@@ -17,25 +19,43 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     {
         private readonly ImmutableDictionary<BasicBlock, TAnalysisResult> _basicBlockStateMap;
         private readonly ImmutableDictionary<IOperation, TAbstractAnalysisValue> _operationStateMap;
-        private readonly ImmutableDictionary<IBinaryOperation, PredicateValueKind> _predicateValueKindMap;
+        private readonly ImmutableDictionary<IOperation, PredicateValueKind> _predicateValueKindMap;
+        private readonly TAbstractAnalysisValue _defaultUnknownValue;
 
         public DataFlowAnalysisResult(
             ImmutableDictionary<BasicBlock, TAnalysisResult> basicBlockStateMap,
             ImmutableDictionary<IOperation, TAbstractAnalysisValue> operationStateMap,
-            ImmutableDictionary<IBinaryOperation, PredicateValueKind> predicateValueKindMap,
+            ImmutableDictionary<IOperation, PredicateValueKind> predicateValueKindMap,
             TAnalysisResult mergedStateForUnhandledThrowOperationsOpt,
-            ControlFlowGraph cfg)
+            ControlFlowGraph cfg,
+            TAbstractAnalysisValue defaultUnknownValue)
         {
             _basicBlockStateMap = basicBlockStateMap;
             _operationStateMap = operationStateMap;
             _predicateValueKindMap = predicateValueKindMap;
             MergedStateForUnhandledThrowOperationsOpt = mergedStateForUnhandledThrowOperationsOpt;
             ControlFlowGraph = cfg;
+            _defaultUnknownValue = defaultUnknownValue;
         }
 
         public TAnalysisResult this[BasicBlock block] => _basicBlockStateMap[block];
-        public TAbstractAnalysisValue this[IOperation operation] => _operationStateMap[operation];
+        public TAbstractAnalysisValue this[IOperation operation]
+        {
+            get
+            {
+                if (_operationStateMap.TryGetValue(operation, out var value))
+                {
+                    return value;
+                }
+
+                // We were requested for value of an operation in non-method body context (e.g. initializer), which is currently not supported.
+                // See https://github.com/dotnet/roslyn-analyzers/issues/1650 (Support for dataflow analysis for non-method body executable code)
+                Debug.Assert(operation.GetAncestor<IBlockOperation>(OperationKind.Block, predicateOpt: b => b.Parent == null) == null);
+                return _defaultUnknownValue;
+            }
+        }
         public PredicateValueKind GetPredicateKind(IBinaryOperation operation) => _predicateValueKindMap.TryGetValue(operation, out var valueKind) ? valueKind : PredicateValueKind.Unknown;
+        public PredicateValueKind GetPredicateKind(IConversionOperation operation) => _predicateValueKindMap.TryGetValue(operation, out var valueKind) ? valueKind : PredicateValueKind.Unknown;
         public TAnalysisResult MergedStateForUnhandledThrowOperationsOpt;
         public ControlFlowGraph ControlFlowGraph { get; }
     }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         public DataFlowAnalysisResult<TAnalysisResult, TAbstractAnalysisValue> ToResult<TAnalysisResult, TAbstractAnalysisValue>(
             Func<BasicBlock, DataFlowAnalysisInfo<TAnalysisData>, TAnalysisResult> getResult,
             ImmutableDictionary<IOperation, TAbstractAnalysisValue> stateMap,
+            ImmutableDictionary<IBinaryOperation, PredicateValueKind> predicateValueKindMap,
             TAnalysisData mergedDataForUnhandledThrowOperations,
             ControlFlowGraph cfg)
             where TAnalysisResult: class
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 mergedStateForUnhandledThrowOperations = getResult(cfg.Exit, info);
             }
 
-            return new DataFlowAnalysisResult<TAnalysisResult, TAbstractAnalysisValue>(resultBuilder.ToImmutable(), stateMap, mergedStateForUnhandledThrowOperations, cfg);
+            return new DataFlowAnalysisResult<TAnalysisResult, TAbstractAnalysisValue>(resultBuilder.ToImmutable(), stateMap, predicateValueKindMap, mergedStateForUnhandledThrowOperations, cfg);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
@@ -36,9 +36,10 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
         public DataFlowAnalysisResult<TAnalysisResult, TAbstractAnalysisValue> ToResult<TAnalysisResult, TAbstractAnalysisValue>(
             Func<BasicBlock, DataFlowAnalysisInfo<TAnalysisData>, TAnalysisResult> getResult,
             ImmutableDictionary<IOperation, TAbstractAnalysisValue> stateMap,
-            ImmutableDictionary<IBinaryOperation, PredicateValueKind> predicateValueKindMap,
+            ImmutableDictionary<IOperation, PredicateValueKind> predicateValueKindMap,
             TAnalysisData mergedDataForUnhandledThrowOperations,
-            ControlFlowGraph cfg)
+            ControlFlowGraph cfg,
+            TAbstractAnalysisValue defaultUnknownValue)
             where TAnalysisResult: class
         {
             var resultBuilder = ImmutableDictionary.CreateBuilder<BasicBlock, TAnalysisResult>();
@@ -57,7 +58,8 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 mergedStateForUnhandledThrowOperations = getResult(cfg.Exit, info);
             }
 
-            return new DataFlowAnalysisResult<TAnalysisResult, TAbstractAnalysisValue>(resultBuilder.ToImmutable(), stateMap, predicateValueKindMap, mergedStateForUnhandledThrowOperations, cfg);
+            return new DataFlowAnalysisResult<TAnalysisResult, TAbstractAnalysisValue>(resultBuilder.ToImmutable(), stateMap,
+                predicateValueKindMap, mergedStateForUnhandledThrowOperations, cfg, defaultUnknownValue);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/PredicateValueKind.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/PredicateValueKind.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    internal enum PredicateValueKind
+    {
+        /// <summary>
+        /// Predicate always evaluates to true.
+        /// </summary>
+        AlwaysTrue,
+
+        /// <summary>
+        /// Predicate always evaluates to false.
+        /// </summary>
+        AlwaysFalse,
+
+        /// <summary>
+        /// Predicate might evaluate to true or false.
+        /// </summary>
+        Unknown
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/AvoidDeadConditionalCode.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/AvoidDeadConditionalCode.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/AvoidDeadConditionalCode.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/AvoidDeadConditionalCode.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.Maintainability
+{
+    /// <summary>
+    /// CA1508: Flags conditional expressions which are always true/false and null checks for operations that are always null/non-null based on predicate analysis.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class AvoidDeadConditionalCode : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA1508";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftMaintainabilityAnalyzersResources.AvoidDeadConditionalCodeTitle), MicrosoftMaintainabilityAnalyzersResources.ResourceManager, typeof(MicrosoftMaintainabilityAnalyzersResources));
+        private static readonly LocalizableString s_localizableAlwaysTrueFalseOrNullMessage = new LocalizableResourceString(nameof(MicrosoftMaintainabilityAnalyzersResources.AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage), MicrosoftMaintainabilityAnalyzersResources.ResourceManager, typeof(MicrosoftMaintainabilityAnalyzersResources));
+        private static readonly LocalizableString s_localizableNeverNullMessage = new LocalizableResourceString(nameof(MicrosoftMaintainabilityAnalyzersResources.AvoidDeadConditionalCodeNeverNullMessage), MicrosoftMaintainabilityAnalyzersResources.ResourceManager, typeof(MicrosoftMaintainabilityAnalyzersResources));
+
+        internal static DiagnosticDescriptor AlwaysTrueFalseOrNullRule = new DiagnosticDescriptor(RuleId,
+                                                                             s_localizableTitle,
+                                                                             s_localizableAlwaysTrueFalseOrNullMessage,
+                                                                             DiagnosticCategory.Maintainability,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             helpLinkUri: null, // TODO: Add helplink
+                                                                             customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static DiagnosticDescriptor NeverNullRule = new DiagnosticDescriptor(RuleId,
+                                                                             s_localizableTitle,
+                                                                             s_localizableNeverNullMessage,
+                                                                             DiagnosticCategory.Maintainability,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             helpLinkUri: null, // TODO: Add helplink
+                                                                             customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(AlwaysTrueFalseOrNullRule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                compilationContext.RegisterOperationBlockStartAction(operationBlockStartContext =>
+                {
+                    if (!(operationBlockStartContext.OwningSymbol is IMethodSymbol containingMethod))
+                    {
+                        return;
+                    }
+
+                    foreach (var operationRoot in operationBlockStartContext.OperationBlocks)
+                    {
+                        IBlockOperation topmostBlock = operationRoot.GetTopmostParentBlock();
+                        if (topmostBlock != null && topmostBlock.HasAnyOperationDescendant(op => (op as IBinaryOperation)?.IsComparisonOperator() == true || op.Kind == OperationKind.Coalesce || op.Kind == OperationKind.ConditionalAccess))
+                        {
+                            var cfg = ControlFlowGraph.Create(topmostBlock);
+                            var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(operationBlockStartContext.Compilation);
+                            var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider);
+                            var pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, nullAnalysisResult);
+                            var copyAnalysisResult = CopyAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, nullAnalysisResultOpt: nullAnalysisResult, pointsToAnalysisResultOpt: pointsToAnalysisResult);
+                            // Do another null analysis pass to improve the results from PointsTo and Copy analysis.
+                            nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, copyAnalysisResult, pointsToAnalysisResultOpt: pointsToAnalysisResult);
+                            var stringContentAnalysisResult = StringContentAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, copyAnalysisResult, nullAnalysisResult, pointsToAnalysisResult);
+
+                            operationBlockStartContext.RegisterOperationAction(operationContext =>
+                            {
+                                PredicateValueKind GetPredicateKind(IBinaryOperation operation)
+                                {
+                                    if (operation.IsComparisonOperator())
+                                    {
+                                        PredicateValueKind binaryPredicateKind = nullAnalysisResult.GetPredicateKind(operation);
+                                        if (binaryPredicateKind != PredicateValueKind.Unknown)
+                                        {
+                                            return binaryPredicateKind;
+                                        }
+
+                                        binaryPredicateKind = copyAnalysisResult.GetPredicateKind(operation);
+                                        if (binaryPredicateKind != PredicateValueKind.Unknown)
+                                        {
+                                            return binaryPredicateKind;
+                                        }
+
+                                        binaryPredicateKind = stringContentAnalysisResult.GetPredicateKind(operation);
+                                        if (binaryPredicateKind != PredicateValueKind.Unknown)
+                                        {
+                                            return binaryPredicateKind;
+                                        };
+                                    }
+
+                                    return PredicateValueKind.Unknown;
+                                }
+
+                                var binaryOperation = (IBinaryOperation)operationContext.Operation;
+                                PredicateValueKind predicateKind = GetPredicateKind(binaryOperation);
+                                if (predicateKind != PredicateValueKind.Unknown &&
+                                    (!(binaryOperation.LeftOperand is IBinaryOperation leftBinary) || GetPredicateKind(leftBinary) == PredicateValueKind.Unknown) &&
+                                    (!(binaryOperation.RightOperand is IBinaryOperation rightBinary) || GetPredicateKind(rightBinary) == PredicateValueKind.Unknown))
+                                {
+                                    // '{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.
+                                    var arg1 = binaryOperation.Syntax.ToString();
+                                    var arg2 = predicateKind == PredicateValueKind.AlwaysTrue ? 
+                                        (binaryOperation.Language == LanguageNames.VisualBasic ? "True" : "true") :
+                                        (binaryOperation.Language == LanguageNames.VisualBasic ? "False" : "false");
+                                    var diagnostic = binaryOperation.CreateDiagnostic(AlwaysTrueFalseOrNullRule, arg1, arg2);
+                                    operationContext.ReportDiagnostic(diagnostic);
+                                }
+                            }, OperationKind.BinaryOperator);
+
+                            operationBlockStartContext.RegisterOperationAction(operationContext =>
+                            {
+                                IOperation nullCheckedOperation = operationContext.Operation.Kind == OperationKind.Coalesce ?
+                                    ((ICoalesceOperation)operationContext.Operation).Value :
+                                    ((IConditionalAccessOperation)operationContext.Operation).Operation;
+
+                                // '{0}' is always/never '{1}'. Remove or refactor the condition(s) to avoid dead code.
+                                DiagnosticDescriptor rule;
+                                switch (nullAnalysisResult[nullCheckedOperation])
+                                {
+                                    case NullAbstractValue.Null:
+                                        rule = AlwaysTrueFalseOrNullRule;
+                                        break;
+
+                                    case NullAbstractValue.NotNull:
+                                        rule = NeverNullRule;
+                                        break;
+
+                                    default:
+                                        return;
+                                }
+
+                                var arg1 = nullCheckedOperation.Syntax.ToString();
+                                var arg2 = nullCheckedOperation.Language == LanguageNames.VisualBasic ? "Nothing" : "null";
+                                var diagnostic = nullCheckedOperation.CreateDiagnostic(rule, arg1, arg2);
+                                operationContext.ReportDiagnostic(diagnostic);
+                            }, OperationKind.Coalesce, OperationKind.ConditionalAccess);
+                        }
+                    }
+                });
+            });
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.resx
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage" xml:space="preserve">
+    <value>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</value>
+  </data>
+  <data name="AvoidDeadConditionalCodeNeverNullMessage" xml:space="preserve">
+    <value>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</value>
+  </data>
+  <data name="AvoidDeadConditionalCodeTitle" xml:space="preserve">
+    <value>Avoid dead conditional code</value>
+  </data>
+</root>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.cs.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.de.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.es.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.fr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.it.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ja.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ko.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pl.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pt-BR.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ru.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.tr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hans.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hant.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../MicrosoftMaintainabilityAnalyzersResources.resx">
+    <body>
+      <trans-unit id="AvoidDeadConditionalCodeTitle">
+        <source>Avoid dead conditional code</source>
+        <target state="new">Avoid dead conditional code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeAlwaysTruFalseOrNullMessage">
+        <source>'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is always '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidDeadConditionalCodeNeverNullMessage">
+        <source>'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</source>
+        <target state="new">'{0}' is never '{1}'. Remove or refactor the condition(s) to avoid dead code.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.md
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.md
@@ -1,3 +1,23 @@
+### CA1062: Validate arguments of public methods ###
+
+An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against null.
+
+Category: Maintainability.
+
+Severity: Warning
+
+Help: [https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods)
+
+### CA1508: Avoid dead conditional code ###
+
+Conditional expressions which are always true/false and null checks for operations that are always null/non-null lead to dead code. Such conditional expressions should be removed or refactored to avoid dead code.
+
+Category: Maintainability.
+
+Severity: Warning
+
+Help: <To be added>
+
 ### CA2000: Dispose objects before losing scope ###
 
 A local object of a IDisposable type is created but the object is not disposed before all references to the object are out of scope.

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Design/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Design/ValidateArgumentsOfPublicMethodsTests.cs
@@ -1313,7 +1313,7 @@ public class Test
         System.Diagnostics.Contracts.Contract.Requires(x == null);
         System.Diagnostics.Contracts.Contract.Requires(c == _c);
         var y = str.ToString();
-        var z = c.X;    // No diagnostic as we don't know the value of _c.
+        var z = c.X;
     }
 
     public void M2(string str, C c)
@@ -1339,6 +1339,8 @@ public class Test
 ",
             // Test0.cs(15,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(15, 17, "void Test.M1(string str, C c)", "str"),
+            // Test0.cs(16,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(16, 17, "void Test.M1(string str, C c)", "c"),
             // Test0.cs(23,17): warning CA1062: In externally visible method 'void Test.M2(string str, C c)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(23, 17, "void Test.M2(string str, C c)", "str"),
             // Test0.cs(24,17): warning CA1062: In externally visible method 'void Test.M2(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
@@ -1363,7 +1365,7 @@ Public Class Test
         System.Diagnostics.Contracts.Contract.Requires(x Is Nothing)
         System.Diagnostics.Contracts.Contract.Requires(c Is _c)
         Dim y = str.ToString()
-        Dim z = c.X     ' No diagnostic as we don't know the value of _c.
+        Dim z = c.X
     End Sub
 
     Public Sub M2(str As String, c As C)
@@ -1385,6 +1387,8 @@ Public Class Test
 End Class",
             // Test0.vb(15,17): warning CA1062: In externally visible method 'Sub Test.M1(str As String, c As C)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetBasicResultAt(15, 17, "Sub Test.M1(str As String, c As C)", "str"),
+            // Test0.vb(16,17): warning CA1062: In externally visible method 'Sub Test.M1(str As String, c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetBasicResultAt(16, 17, "Sub Test.M1(str As String, c As C)", "c"),
             // Test0.vb(22,17): warning CA1062: In externally visible method 'Sub Test.M2(str As String, c As C)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetBasicResultAt(22, 17, "Sub Test.M2(str As String, c As C)", "str"),
             // Test0.vb(23,17): warning CA1062: In externally visible method 'Sub Test.M2(str As String, c As C)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -1,0 +1,1499 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeQuality.Analyzers.Exp.Maintainability;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Maintainability
+{
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+    public partial class AvoidDeadConditionalCodeTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new AvoidDeadConditionalCode();
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new AvoidDeadConditionalCode();
+
+        protected new DiagnosticResult GetCSharpResultAt(int line, int column, string condition, string reason) =>
+            GetCSharpResultAt(line, column, AvoidDeadConditionalCode.AlwaysTrueFalseOrNullRule, condition, reason);
+
+        protected new DiagnosticResult GetBasicResultAt(int line, int column, string condition, string reason) =>
+            GetBasicResultAt(line, column, AvoidDeadConditionalCode.AlwaysTrueFalseOrNullRule, condition, reason);
+
+        protected DiagnosticResult GetCSharpNeverNullResultAt(int line, int column, string condition, string reason) =>
+            GetCSharpResultAt(line, column, AvoidDeadConditionalCode.NeverNullRule, condition, reason);
+
+        protected DiagnosticResult GetBasicNeverNullResultAt(int line, int column, string condition, string reason) =>
+            GetBasicResultAt(line, column, AvoidDeadConditionalCode.NeverNullRule, condition, reason);
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void SimpleNullCompare_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param)
+    {
+        if (param == null)
+        {
+        }
+
+        if (null == param)
+        {
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String)
+        If param Is Nothing Then
+        End If
+
+        If Nothing Is param Then
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void SimpleNullCompare_AfterAssignment_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param)
+    {
+        param = null;
+        if (param == null)
+        {
+        }
+
+        if (null != param)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(7,13): warning CA1508: 'param == null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(7, 13, @"param == null", "true"),
+            // Test0.cs(11,13): warning CA1508: 'null != param' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(11, 13, @"null != param", "false"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String)
+        param = Nothing
+        If param Is Nothing Then
+        End If
+
+        If Nothing IsNot param Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(5,12): warning CA1508: 'param Is Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(5, 12, "param Is Nothing", "True"),
+            // Test0.vb(8,12): warning CA1508: 'Nothing IsNot param' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 12, "Nothing IsNot param", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ElseIf_NestedIf_NullCompare_IsNullValue_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param, C param2)
+    {
+        C cNull = null;
+        C cNotNull = new C();
+        C cMayBeNull = param2;
+        
+        if (param != cNull)
+        {
+        }
+        else if (param == cNotNull)
+        {
+        }
+        else if (param == cMayBeNull)
+        {
+            if (param != cNotNull)
+            {
+            }
+        }
+
+        if (cNull == param)
+        {
+            if (param != cNull)
+            {
+            }
+
+            if (param != cNotNull)
+            {
+            }
+
+            if (param != cMayBeNull)
+            {
+            }
+
+            if (param == cNull)
+            {
+            }
+
+            if (param == cNotNull)
+            {
+            }
+
+            if (param == cMayBeNull)
+            {
+            }
+        }
+    }
+}
+",
+            // Test0.cs(17,18): warning CA1508: 'param == cNotNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(17, 18, "param == cNotNull", "false"),
+            // Test0.cs(22,17): warning CA1508: 'param != cNotNull' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(22, 17, "param != cNotNull", "true"),
+            // Test0.cs(29,17): warning CA1508: 'param != cNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(29, 17, "param != cNull", "false"),
+            // Test0.cs(33,17): warning CA1508: 'param != cNotNull' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(33, 17, "param != cNotNull", "true"),
+            // Test0.cs(41,17): warning CA1508: 'param == cNull' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(41, 17, "param == cNull", "true"),
+            // Test0.cs(45,17): warning CA1508: 'param == cNotNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(45, 17, "param == cNotNull", "false"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Sub M(param As C, param2 As C)
+        Dim cNull As C = Nothing
+        Dim cNotNull As C = New C()
+        Dim cMayBeNull As C = param2
+
+        If param IsNot cNull Then
+        ElseIf param Is cNotNull Then
+        ElseIf param Is cMayBeNull Then
+            If param IsNot cNotNull Then
+            End If
+        End If
+
+        If cNull Is param Then
+            If param IsNot cNull Then
+            End If
+
+            If param IsNot cNotNull Then
+            End If
+
+            If param IsNot cMayBeNull Then
+            End If
+
+            If param Is cNull Then
+            End If
+
+            If param Is cNotNull Then
+            End If
+
+            If param Is cMayBeNull Then
+            End If
+        End If
+    End Sub
+End Module",
+            // Test0.vb(12,16): warning CA1508: 'param Is cNotNull' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(12, 16, "param Is cNotNull", "False"),
+            // Test0.vb(14,16): warning CA1508: 'param IsNot cNotNull' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(14, 16, "param IsNot cNotNull", "True"),
+            // Test0.vb(19,16): warning CA1508: 'param IsNot cNull' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(19, 16, "param IsNot cNull", "False"),
+            // Test0.vb(22,16): warning CA1508: 'param IsNot cNotNull' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(22, 16, "param IsNot cNotNull", "True"),
+            // Test0.vb(28,16): warning CA1508: 'param Is cNull' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(28, 16, "param Is cNull", "True"),
+            // Test0.vb(31,16): warning CA1508: 'param Is cNotNull' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(31, 16, "param Is cNotNull", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ElseIf_NestedIf_NullCompare_IsNotNullValue_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param, C param2)
+    {
+        C cNull = null;
+        C cNotNull = new C();
+        C cMayBeNull = param2;
+        
+        if (param != cNotNull)
+        {
+        }
+        else if (param == cNull)
+        {
+        }
+        else if (param == cMayBeNull)
+        {
+            if (param != cNull)
+            {
+            }
+        }
+
+        if (cNotNull == param)
+        {
+            if (param != cNull)
+            {
+            }
+
+            if (param != cNotNull)
+            {
+            }
+
+            if (param != cMayBeNull)
+            {
+            }
+
+            if (param == cNull)
+            {
+            }
+
+            if (param == cNotNull)
+            {
+            }
+
+            if (param == cMayBeNull)
+            {
+            }
+        }
+    }
+}
+",
+            // Test0.cs(17,18): warning CA1508: 'param == cNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(17, 18, "param == cNull", "false"),
+            // Test0.cs(22,17): warning CA1508: 'param != cNull' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(22, 17, "param != cNull", "true"),
+            // Test0.cs(29,17): warning CA1508: 'param != cNull' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(29, 17, "param != cNull", "true"),
+            // Test0.cs(33,17): warning CA1508: 'param != cNotNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(33, 17, "param != cNotNull", "false"),
+            // Test0.cs(41,17): warning CA1508: 'param == cNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(41, 17, "param == cNull", "false"),
+            // Test0.cs(45,17): warning CA1508: 'param == cNotNull' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(45, 17, "param == cNotNull", "true"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Sub M(param As C, param2 As C)
+        Dim cNull As C = Nothing
+        Dim cNotNull As C = New C()
+        Dim cMayBeNull As C = param2
+
+        If param IsNot cNotNull Then
+        ElseIf param Is cNotNull Then
+        ElseIf param Is cMayBeNull Then
+            If param IsNot cNotNull Then
+            End If
+        End If
+
+        If cNotNull Is param Then
+            If param IsNot cNull Then
+            End If
+
+            If param IsNot cNotNull Then
+            End If
+
+            If param IsNot cMayBeNull Then
+            End If
+
+            If param Is cNull Then
+            End If
+
+            If param Is cNotNull Then
+            End If
+
+            If param Is cMayBeNull Then
+            End If
+        End If
+    End Sub
+End Module",
+            // Test0.vb(12,16): warning CA1508: 'param Is cNotNull' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(12, 16, "param Is cNotNull", "True"),
+            // Test0.vb(14,16): warning CA1508: 'param IsNot cNotNull' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(14, 16, "param IsNot cNotNull", "False"),
+            // Test0.vb(19,16): warning CA1508: 'param IsNot cNull' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(19, 16, "param IsNot cNull", "True"),
+            // Test0.vb(22,16): warning CA1508: 'param IsNot cNotNull' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(22, 16, "param IsNot cNotNull", "False"),
+            // Test0.vb(28,16): warning CA1508: 'param Is cNull' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(28, 16, "param Is cNull", "False"),
+            // Test0.vb(31,16): warning CA1508: 'param Is cNotNull' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(31, 16, "param Is cNotNull", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ElseIf_NestedIf_NullCompare_IsNotNotNullValue_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param, C param2)
+    {
+        C cNull = null;
+        C cNotNull = new C();
+        C cMayBeNull = param2;
+        
+        if (param == cNotNull) // We do not track not-equal values so comparisons with cNotNull below are not flagged. 
+        {
+        }
+        else if (param == cNull)
+        {
+        }
+        else if (param == cMayBeNull)
+        {
+            if (param != cNotNull)
+            {
+            }
+        }
+
+        if (cNotNull != param)  // We do not track not-equal values so comparisons with cNotNull below are not flagged. 
+        {
+            if (param != cNull)
+            {
+            }
+
+            if (param != cNotNull)
+            {
+            }
+
+            if (param != cMayBeNull)
+            {
+            }
+
+            if (param == cNull)
+            {
+            }
+
+            if (param == cNotNull)
+            {
+            }
+
+            if (param == cMayBeNull)
+            {
+            }
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Sub M(param As C, param2 As C)
+        Dim cNull As C = Nothing
+        Dim cNotNull As C = New C()
+        Dim cMayBeNull As C = param2
+
+        If param Is cNotNull Then   ' We do not track not-equal values so comparisons with cNotNull below are not flagged.
+        ElseIf param Is cNotNull Then
+        ElseIf param Is cMayBeNull Then
+            If param IsNot cNotNull Then
+            End If
+        End If
+
+        If cNotNull IsNot param Then    ' We do not track not-equal values so comparisons with cNotNull below are not flagged.
+            If param IsNot cNull Then
+            End If
+
+            If param IsNot cNotNull Then
+            End If
+
+            If param IsNot cMayBeNull Then
+            End If
+
+            If param Is cNull Then
+            End If
+
+            If param Is cNotNull Then
+            End If
+
+            If param Is cMayBeNull Then
+            End If
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ElseIf_NestedIf_NullCompare_IsMayBeNullValue_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param, C param2)
+    {
+        C cNull = null;
+        C cNotNull = new C();
+        C cMayBeNull = param2;
+        
+        if (param == cMayBeNull) // We do not track maybe values so comparisons with cMayBeNull below are not flagged. 
+        {
+        }
+        else if (param == cNull)
+        {
+        }
+        else if (param == cMayBeNull)
+        {
+            if (param != cNotNull)
+            {
+            }
+        }
+
+        if (cMayBeNull != param)  // We do not track maybe values so comparisons with cMayBeNull below are not flagged. 
+        {
+            if (param != cNull)
+            {
+            }
+
+            if (param != cNotNull)
+            {
+            }
+
+            if (param != cMayBeNull)
+            {
+            }
+
+            if (param == cNull)
+            {
+            }
+
+            if (param == cNotNull)
+            {
+            }
+
+            if (param == cMayBeNull)
+            {
+            }
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Sub M(param As C, param2 As C)
+        Dim cNull As C = Nothing
+        Dim cNotNull As C = New C()
+        Dim cMayBeNull As C = param2
+
+        If param Is cMayBeNull Then   ' We do not track maybe values so comparisons with cNotNull below are not flagged.
+        ElseIf param Is cNotNull Then
+        ElseIf param Is cMayBeNull Then
+            If param IsNot cNotNull Then
+            End If
+        End If
+
+        If cMayBeNull IsNot param Then    ' We do not track maybe values so comparisons with cNotNull below are not flagged.
+            If param IsNot cNull Then
+            End If
+
+            If param IsNot cNotNull Then
+            End If
+
+            If param IsNot cMayBeNull Then
+            End If
+
+            If param Is cNull Then
+            End If
+
+            If param Is cNotNull Then
+            End If
+
+            If param Is cMayBeNull Then
+            End If
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_WhileLoop()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(string param)
+    {
+        string str = null;
+        while (param == str)
+        {
+            // param = null here
+            if (param == str)
+            {
+            }
+            if (param != str)
+            {
+            }
+        }
+
+        // param is not-null here
+        if (str == param)
+        {
+        }
+        if (str != param)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(10,17): warning CA1508: 'param == str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(10, 17, "param == str", "true"),
+            // Test0.cs(13,17): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(13, 17, "param != str", "false"),
+            // Test0.cs(19, 13): warning CA1508: 'str == param' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(19, 13, "str == param", "false"),
+            // Test0.cs(22,13): warning CA1508: 'str != param' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(22, 13, "str != param", "true"));
+
+            VerifyBasic(@"
+Module Test
+    ' While loop
+    Private Sub M1(ByVal param As String)
+        Dim str As String = Nothing
+        While param = str
+            ' param == null here
+            If param = str Then
+            End If
+            If param <> str Then
+            End If
+        End While
+
+        ' param is non-null here
+        If str = param Then
+            End If
+        If str <> param Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(8,16): warning CA1508: 'param = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 16, "param = str", "True"),
+            // Test0.vb(10,16): warning CA1508: 'param <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(10, 16, "param <> str", "False"),
+            // Test0.vb(15,12): warning CA1508: 'str = param' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(15, 12, "str = param", "False"),
+            // Test0.vb(17,12): warning CA1508: 'str <> param' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(17, 12, "str <> param", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_DoWhileLoop()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M(C param)
+    {
+        C cNotNull = new C();
+        do
+        {
+            // param is unknown here
+            if (cNotNull == param)
+            {
+            }
+            if (cNotNull != param)
+            {
+            }
+        }
+        while (param != cNotNull);
+
+        // param = cNotNull here
+        if (param == cNotNull)
+        {
+        }
+        if (param != cNotNull)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(24,13): warning CA1508: 'param == cNotNull' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(24, 13, "param == cNotNull", "true"),
+            // Test0.cs(27,13): warning CA1508: 'param != cNotNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(27, 13, "param != cNotNull", "false"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    ' Do-While top loop
+    Private Sub M(ByVal param As String)
+        Dim cNotNull As New C()
+        Do While param IsNot cNotNull
+            ' param is unknown here
+            If cNotNull Is param Then
+                End If
+            If cNotNull IsNot param Then
+            End If
+        Loop
+
+        ' param == cNotNull here
+        If param Is cNotNull Then
+        End If
+        If param IsNot cNotNull Then
+        End If
+    End Sub
+
+    ' Do-While bottom loop
+    Private Sub M2(ByVal param2 As String)
+        Dim cNotNull As New C()
+        Do
+            ' param2 is unknown here
+            If cNotNull Is param2 Then
+                End If
+            If cNotNull IsNot param2 Then
+            End If
+        Loop While param2 IsNot cNotNull
+
+        ' param2 == cNotNull here
+        If param2 Is cNotNull Then
+        End If
+        If param2 IsNot cNotNull Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(18,12): warning CA1508: 'param Is cNotNull' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(18, 12, "param Is cNotNull", "True"),
+            // Test0.vb(20,12): warning CA1508: 'param IsNot str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(20, 12, "param IsNot cNotNull", "False"),
+            // Test0.vb(36,12): warning CA1508: 'param2 Is str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(36, 12, "param2 Is cNotNull", "True"),
+            // Test0.vb(38,12): warning CA1508: 'param2 IsNot str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(38, 12, "param2 IsNot cNotNull", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_DoUntilLoop()
+        {
+            VerifyBasic(@"
+Module Test
+    ' Do-Until top loop
+    Private Sub M(ByVal param As String)
+        Dim str As String = Nothing
+        Do Until param <> str
+            ' param == str here
+            If param = str Then
+            End If
+            If param <> str Then
+            End If
+        Loop
+
+        ' param is non-null here
+        If str = param Then
+            End If
+        If str <> param Then
+        End If
+    End Sub
+
+    ' Do-Until bottom loop
+    Private Sub M2(ByVal param2 As String)
+        Dim str As String = Nothing
+        Do
+            ' param2 is unknown here
+            If str = param2 Then
+                End If
+            If str <> param2 Then
+            End If
+        Loop Until param2 = str
+
+        ' param2 == str here
+        If param2 = str Then
+        End If
+        If param2 <> str Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(8,16): warning CA1508: 'param = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 16, "param = str", "True"),
+            // Test0.vb(10,16): warning CA1508: 'param <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(10, 16, "param <> str", "False"),
+            // Test0.vb(15,12): warning CA1508: 'str = param' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(15, 12, "str = param", "False"),
+            // Test0.vb(17,12): warning CA1508: 'str <> param' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(17, 12, "str <> param", "True"),
+            // Test0.vb(33,12): warning CA1508: 'param2 = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(33, 12, "param2 = str", "True"),
+            // Test0.vb(35,12): warning CA1508: 'param2 <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(35, 12, "param2 <> str", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ForLoop()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(C param, C param2)
+    {
+        C cNotNull = new C();
+        for (param = cNotNull; param2 != cNotNull;)
+        {
+            // param = cNotNull here
+            if (param == cNotNull)
+            {
+            }
+            if (param != cNotNull)
+            {
+            }
+
+            // param2 != cNotNull here, but we don't track not-contained values so no diagnostic.
+            if (param2 == cNotNull)
+            {
+            }
+            if (param2 != cNotNull)
+            {
+            }
+        }
+        
+        // param2 == cNotNull here
+        if (cNotNull == param2)
+        {
+        }
+        if (cNotNull != param2)
+        {
+        }
+        
+        // param == cNotNull here
+        if (cNotNull == param)
+        {
+        }
+        if (cNotNull != param)
+        {
+        }
+    }
+}
+
+class C
+{
+}
+",
+            // Test0.cs(10,17): warning CA1508: 'param == cNotNull' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(10, 17, "param == cNotNull", "true"),
+            // Test0.cs(13,17): warning CA1508: 'param != cNotNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(13, 17, "param != cNotNull", "false"),
+            // Test0.cs(27,13): warning CA1508: 'cNotNull == param2' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(27, 13, "cNotNull == param2", "true"),
+            // Test0.cs(30,13): warning CA1508: 'cNotNull != param2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(30, 13, "cNotNull != param2", "false"),
+            // Test0.cs(35,13): warning CA1508: 'cNotNull == param' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(35, 13, "cNotNull == param", "true"),
+            // Test0.cs(38,13): warning CA1508: 'cNotNull != param' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(38, 13, "cNotNull != param", "false"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCompare_CopyAnalysis()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(C param, C param2)
+    {
+        C cNotNull = new C();
+        if (param == cNotNull && param2 == cNotNull && param == param2)
+        {
+        }
+
+        param = param2;
+        if (param != cNotNull || param2 != cNotNull)
+        {
+        }
+    }
+}
+
+class C
+{
+}
+",
+            // Test0.cs(7,56): warning CA1508: 'param == param2' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(7, 56, "param == param2", "true"),
+            // Test0.cs(12,34): warning CA1508: 'param2 != cNotNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(12, 34, "param2 != cNotNull", "false"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As C, param2 As C)
+        Dim cNotNull As New C()
+        If param Is cNotNull AndAlso param2 Is cNotNull AndAlso param Is param2 Then
+        End If
+
+        param = param2
+        If param IsNot cNotNull OrElse param2 IsNot cNotNull Then
+        End If
+    End Sub
+End Module
+
+Class C
+End Class
+",
+            // Test0.vb(5,65): warning CA1508: 'param Is param2' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(5, 65, "param Is param2", "True"),
+            // Test0.vb(9,40): warning CA1508: 'param2 IsNot cNotNull' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(9, 40, "param2 IsNot cNotNull", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ConditionalOr_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, string param2)
+    {
+        string strNotNull = """";
+        string strNull = null;
+        string strMayBeNull = param2;
+
+        if (param == strNotNull || param == strNull)
+        {
+        }
+
+        if (strNull != param || param == strMayBeNull)
+        {
+        }
+
+        if (param == strMayBeNull || strNull != param)
+        {
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, param2 As String)
+        Dim strNotNull = """"
+        Dim strNull = Nothing
+        Dim strMayBeNull = param2
+
+        If param = strNotNull OrElse param = strNull Then
+        End If
+
+        If strNull <> param OrElse param = strMayBeNull Then
+        End If
+
+        If param = strMayBeNull OrElse strNull <> param Then
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ConditionalOr_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, string param2)
+    {
+        string strNotNull = """";
+        string strNull = null;
+        string strMayBeNull = param2;
+
+        if (strNull != param || param == strNotNull)
+        {
+        }
+
+        if (param != strNotNull || strNull != param)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(10,33): warning CA1508: 'param == strNotNull' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(10, 33, "param == strNotNull", "false"),
+            // Test0.cs(14,36): warning CA1508: 'strNull != param' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(14, 36, "strNull != param", "true"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, param2 As String)
+        Dim strNotNull = """"
+        Dim strNull = Nothing
+        Dim strMayBeNull = param2
+
+        If strNull <> param OrElse param = strNotNull Then
+        End If
+
+        If param <> strNotNull OrElse strNull <> param Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(8,36): warning CA1508: 'param = strNotNull' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 36, "param = strNotNull", "False"),
+            // Test0.vb(11,39): warning CA1508: 'strNull <> param' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(11, 39, "strNull <> param", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ConditionalAnd_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, string param2)
+    {
+        string strNotNull = """";
+        string strNull = null;
+        string strMayBeNull = param2;
+
+        if (param == strNotNull && param2 == strNull)
+        {
+        }
+
+        if (param == strMayBeNull && strNull == param)
+        {
+        }
+
+        if (param != strNotNull && param != strNull)
+        {
+        }
+
+        if (param != strNotNull && param2 != strNull)
+        {
+        }
+
+        if (strNull != param && param == strMayBeNull)
+        {
+        }
+
+        if (param2 == strNull && param != strNotNull && param == param2)
+        {
+        }
+
+        if (strNull != param && param == strNotNull)
+        {
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim strNotNull = """"
+        Dim strNull = Nothing
+        Dim strMayBeNull = param2
+
+        If param = strNotNull AndAlso param2 = strNull Then
+        End If
+
+        If param = strMayBeNull AndAlso strNull = param Then
+        End If
+
+        If strNull <> param AndAlso param <> strNotNull Then
+        End If
+        
+        If strNull <> param AndAlso param2 <> strNotNull Then
+        End If
+        
+        If strNull <> param AndAlso param = strMayBeNull Then
+        End If
+
+        If param2 = strNull AndAlso param <> strNotNull AndAlso param = param2 Then
+        End If
+
+        If strNull <> param AndAlso param = strNotNull Then
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ConditionalAnd_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, string param2)
+    {
+        string strNotNull = """";
+        string strNull = null;
+        string strMayBeNull = param2;
+
+        if (param == strNotNull && param != strNull)
+        {
+        }
+
+        if (strNull != param || (param == strMayBeNull && strNull != param))
+        {
+        }
+    }
+}
+",
+            // Test0.cs(10,36): warning CA1508: 'param != strNull' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(10, 36, "param != strNull", "true"),
+            // Test0.cs(14,59): warning CA1508: 'strNull != param' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(14, 59, "strNull != param", "false"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, param2 As String)
+        Dim strNotNull = """"
+        Dim strNull = Nothing
+        Dim strMayBeNull = param2
+
+        If param = strNotNull AndAlso param <> strNull Then
+        End If
+
+        If strNull <> param OrElse (param = strMayBeNull AndAlso strNull <> param) Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(8,39): warning CA1508: 'param <> strNull' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 39, "param <> strNull", "True"),
+            // Test0.vb(11,66): warning CA1508: 'strNull <> param' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(11, 66, "strNull <> param", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ConditionaAndOrNullCompare_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param)
+    {
+        string str = """";
+        if (param != null || param == str)
+        {
+        }
+
+        if (null == param && param != str)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(7,30): warning CA1508: 'param == str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(7, 30, "param == str", "false"),
+            // Test0.cs(11,30): warning CA1508: 'param != str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(11, 30, "param != str", "true"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String)
+        Dim str = """"
+        If param <> Nothing OrElse param = str Then
+        End If
+
+        If Nothing = param AndAlso param <> str Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(5,36): warning CA1508: 'param = str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(5, 36, "param = str", "False"),
+            // Test0.vb(8,36): warning CA1508: 'param <> str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 36, "param <> str", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ContractCheck_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param)
+    {
+        System.Diagnostics.Contracts.Contract.Requires(param != null);
+    }
+
+    void M2(C param, C param2, C param3)
+    {
+        System.Diagnostics.Contracts.Contract.Requires(param == param2 && !(param2 != null) || param2 == param3);
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        System.Diagnostics.Contracts.Contract.Requires(param IsNot Nothing)
+    End Sub
+
+    Private Sub M2(param As C, param2 As C, param3 As C)
+        System.Diagnostics.Contracts.Contract.Requires(param Is param2 AndAlso Not(param2 IsNot Nothing) OrElse param2 Is param3)
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ContractCheck_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param)
+    {
+        C c = null;
+        param = null;
+        System.Diagnostics.Contracts.Contract.Requires(param == c);
+    }
+
+    void M2(C param)
+    {
+        C c = null;
+        param = null;
+        System.Diagnostics.Contracts.Contract.Requires(param != c);
+    }
+
+    void M3(C param)
+    {
+        var c = new C();
+        param = param ?? c;
+        System.Diagnostics.Contracts.Contract.Requires(param == null);
+    }
+
+    void M4(C param)
+    {
+        var c = new C();
+        param = param ?? c;
+        System.Diagnostics.Contracts.Contract.Requires(param != null);
+    }
+}
+",
+            // Test0.cs(12,56): warning CA1508: 'param == c' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(12, 56, "param == c", "true"),
+            // Test0.cs(19,56): warning CA1508: 'param != c' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(19, 56, "param != c", "false"),
+            // Test0.cs(26,56): warning CA1508: 'param == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(26, 56, "param == null", "false"),
+            // Test0.cs(33,56): warning CA1508: 'param != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(33, 56, "param != null", "true"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        Dim c As C = Nothing
+        param = Nothing
+        System.Diagnostics.Contracts.Contract.Requires(param Is c)
+    End Sub
+
+    Private Sub M2(param As C)
+        Dim c As C = Nothing
+        param = Nothing
+        System.Diagnostics.Contracts.Contract.Requires(param IsNot c)
+    End Sub
+
+    Private Sub M3(param As C)
+        Dim c As C = New C()
+        param = If (param, c)
+        System.Diagnostics.Contracts.Contract.Requires(param Is Nothing)
+    End Sub
+
+    Private Sub M4(param As C)
+        Dim c As C = New C()
+        param = If (param, c)
+        System.Diagnostics.Contracts.Contract.Requires(param IsNot Nothing)
+    End Sub
+End Module",
+            // Test0.vb(9,56): warning CA1508: 'param Is c' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(9, 56, "param Is c", "True"),
+            // Test0.vb(15,56): warning CA1508: 'param IsNot c' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(15, 56, "param IsNot c", "False"),
+            // Test0.vb(21,56): warning CA1508: 'param Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(21, 56, "param Is Nothing", "False"),
+            // Test0.vb(27,56): warning CA1508: 'param IsNot Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(27, 56, "param IsNot Nothing", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_InAssignment_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param)
+    {
+        C c = null;
+        param = null;
+        bool flag = param == c;
+    }
+}
+",
+            // Test0.cs(12,21): warning CA1508: 'param == c' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(12, 21, "param == c", "true"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        Dim c As C = Nothing
+        param = Nothing
+        Dim flag As Boolean = param Is c
+    End Sub
+End Module",
+            // Test0.vb(9,31): warning CA1508: 'param Is c' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(9, 31, "param Is c", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCoalesce_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param, bool flag)
+    {
+        param = param ?? new C();
+
+        C c = flag ? null : new C();
+        c = c ?? new C();
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Private Sub M1(param As C, flag As Boolean)
+        param = If (param, New C())
+
+        Dim c As C = If (flag, Nothing, New C())
+        c = If (c, New C())
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCoalesce_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param)
+    {
+        C c = null;
+        param = c ?? new C();
+    }
+
+    void M2(C param)
+    {
+        C c = new C();
+        param = c ?? new C();
+    }
+
+    void M3(C param)
+    {
+        var local = param ?? throw new System.ArgumentNullException(nameof(param));
+        local = local ?? new C();
+    }
+}
+",
+            // Test0.cs(11,17): warning CA1508: 'c' is always 'null'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(11, 17, "c", "null"),
+            // Test0.cs(17,17): warning CA1508: 'c' is never 'null'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpNeverNullResultAt(17, 17, "c", "null"),
+            // Test0.cs(23,17): warning CA1508: 'local' is never 'null'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpNeverNullResultAt(23, 17, "local", "null"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        Dim c As C = Nothing
+        param = If (c, New C())
+    End Sub
+
+    Private Sub M2(param As C)
+        Dim c As C = New C()
+        param = If (c, New C())
+    End Sub
+End Module",
+            // Test0.vb(8,21): warning CA1508: 'c' is always 'Nothing'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 21, "c", "Nothing"),
+            // Test0.vb(13,21): warning CA1508: 'c' is never 'Nothing'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicNeverNullResultAt(13, 21, "c", "Nothing"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ConditionalAccess_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public int X;
+}
+
+class Test
+{
+    void M1(C param, bool flag)
+    {
+        var x = param?.X;
+
+        C c = flag ? null : new C();
+        x = c?.X;
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+    Public X As Integer
+End Class
+
+Module Test
+    Private Sub M1(param As C, flag As Boolean)
+        Dim x = param?.X
+
+        Dim c As C = If (flag, Nothing, New C())
+        x = c?.X
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ConditionalAccess_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public int X;
+}
+
+class Test
+{
+    void M1(C param)
+    {
+        param = null;
+        var x = param?.X;
+    }
+
+    void M2(C param)
+    {
+        param = new C();
+        var x = param?.X;
+    }
+
+    void M3(C param)
+    {
+        var local = param ?? throw new System.ArgumentNullException(nameof(param));
+        var x = local?.X;
+    }
+}
+",
+            // Test0.cs(12,17): warning CA1508: 'param' is always 'null'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(12, 17, "param", "null"),
+            // Test0.cs(18,17): warning CA1508: 'param' is never 'null'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpNeverNullResultAt(18, 17, "param", "null"),
+            // Test0.cs(24,17): warning CA1508: 'local' is never 'null'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpNeverNullResultAt(24, 17, "local", "null"));
+
+            VerifyBasic(@"
+Class C
+    Public X As Integer
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        param = Nothing
+        Dim x = param?.X
+    End Sub
+
+    Private Sub M2(param As C)
+        param = New C()
+        Dim x = param?.X
+    End Sub
+End Module",
+            // Test0.vb(9,17): warning CA1508: 'param' is always 'Nothing'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(9, 17, "param", "Nothing"),
+            // Test0.vb(14,17): warning CA1508: 'param' is never 'Nothing'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicNeverNullResultAt(14, 17, "param", "Nothing"));
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -619,6 +619,188 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact]
+        public void NullCompare_WhileLoop_02()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(string param, string param2)
+    {
+        if (param != null)
+        {
+            while (param != null)
+            {
+                param = param2;
+            }
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    ' While loop
+    Private Sub M1(param As String, param2 As String)
+        If param IsNot Nothing Then
+            While param IsNot Nothing
+                param = param2
+            End While
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_WhileLoop_03()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public C ContainingC => new C();
+}
+
+class Test
+{
+    void M(C param)
+    {
+        if (param == null || param.ContainingC == null)
+        {
+            return;
+        }
+
+        while (param != null)
+        {
+            param = param.ContainingC;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+    Public ReadOnly Property ContainingC As C
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        If param Is Nothing OrElse param.ContainingC Is Nothing Then
+            Return
+        End If
+
+        While param IsNot Nothing
+            param = param.ContainingC
+        End While
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_WhileLoop_04()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+class Test
+{
+    private Test Next { get; }
+    private C[] CInstances { get; }
+    void M(bool flag)
+    {
+        var current = this;
+        while (current != null)
+        {
+            foreach (var x in current.CInstances)
+            {
+                if (flag) return;
+            }
+            current = current.Next;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+    Public ReadOnly Property ContainingC As C
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        If param Is Nothing OrElse param.ContainingC Is Nothing Then
+            Return
+        End If
+
+        While param IsNot Nothing
+            param = param.ContainingC
+        End While
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_WhileLoop_05()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(C[] args)
+    {
+        C local = null;
+        int i = 0;
+        while (i < args.Length)
+        {
+            // local may or may not be null here.
+            if (local == null)
+            {
+                local = new C();
+            }
+
+            i++;
+        }
+        
+        // local may or may not be null here.
+        if (local != null)
+        {
+            return;
+        }
+    }
+}
+
+class C
+{
+}
+");
+            VerifyBasic(@"
+Module Test
+    Sub M1(args As C())
+        Dim local As C = Nothing
+        Dim i As Integer = 0
+        While args.Length
+            ' local may or may not be null here.
+            If local Is Nothing Then
+                local = New C()
+            End If
+            i = i + 1
+        End While
+
+        ' local may or may not be null here.
+        If local IsNot Nothing Then
+            Return
+        End If
+    End Sub
+End Module
+
+Class C
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
         public void NullCompare_DoWhileLoop()
         {
             VerifyCSharp(@"
@@ -711,6 +893,52 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact]
+        public void NullCompare_DoWhileLoop_02()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public C ContainingC => new C();
+}
+
+class Test
+{
+    void M(C param)
+    {
+        if (param.ContainingC == null)
+        {
+            return;
+        }
+
+        do
+        {
+            param = param.ContainingC;
+        }
+        while (param != null);
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+    Public ReadOnly Property ContainingC As C
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        If param.ContainingC Is Nothing Then
+            Return
+        End If
+
+        Do 
+            param = param.ContainingC
+        Loop While param IsNot Nothing
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
         public void NullCompare_DoUntilLoop()
         {
             VerifyBasic(@"
@@ -728,7 +956,7 @@ Module Test
 
         ' param is non-null here
         If str = param Then
-            End If
+        End If
         If str <> param Then
         End If
     End Sub
@@ -739,7 +967,7 @@ Module Test
         Do
             ' param2 is unknown here
             If str = param2 Then
-                End If
+            End If
             If str <> param2 Then
             End If
         Loop Until param2 = str
@@ -828,6 +1056,464 @@ class C
             GetCSharpResultAt(35, 13, "cNotNull == param", "true"),
             // Test0.cs(38,13): warning CA1508: 'cNotNull != param' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(38, 13, "cNotNull != param", "false"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ForLoop_02()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(C[] args)
+    {
+        foreach (var arg in args)
+        {
+            if (arg == null)
+            {
+                return;
+            }
+        }
+    }
+}
+
+class C
+{
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ForLoop_03()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(C[] args)
+    {
+        C local = null;
+        for (int i = 0; i < args.Length; i++)
+        {
+            // local may or may not be null here.
+            if (local == null)
+            {
+                local = new C();
+            }
+        }
+        
+        // local may or may not be null here.
+        if (local != null)
+        {
+            return;
+        }
+    }
+}
+
+class C
+{
+}
+");
+            VerifyBasic(@"
+Module Test
+    Sub M1(args As C())
+        Dim local As C = Nothing
+        For i As Integer = 0 To args.Length
+            ' local may or may not be null here.
+            If local Is Nothing Then
+                local = New C()
+            End If
+        Next
+
+        ' local may or may not be null here.
+        If local IsNot Nothing Then
+            Return
+        End If
+    End Sub
+End Module
+
+Class C
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ValueCompare_ForLoop()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(string[] args, int j)
+    {
+        int i;
+        for (i = j; i < args.Length; i++)
+        {
+        }
+        
+        if (i == j)
+        {
+            return;
+        }
+    }
+}
+");
+            VerifyBasic(@"
+Module Test
+    Sub M1(args As C(), j As Integer)
+        Dim i As Integer
+        For i = j To args.Length
+        Next
+
+        If i = j Then
+            Return
+        End If
+    End Sub
+End Module
+
+Class C
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_ForEachLoop()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(C[] args)
+    {
+        C local = null;
+        foreach (var c in args)
+        {
+            // local may or may not be null here.
+            if (local == null)
+            {
+                local = new C();
+            }
+        }
+        
+        // local may or may not be null here.
+        if (local != null)
+        {
+            return;
+        }
+    }
+}
+
+class C
+{
+}
+");
+            VerifyBasic(@"
+Module Test
+    Sub M1(args As C())
+        Dim local As C = Nothing
+        For Each c in args
+            ' local may or may not be null here.
+            If local Is Nothing Then
+                local = New C()
+            End If
+        Next
+
+        ' local may or may not be null here.
+        If local IsNot Nothing Then
+            Return
+        End If
+    End Sub
+End Module
+
+Class C
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_SwitchStatement_01_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(C param, int i)
+    {
+        switch (i)
+        {
+            case 0:
+                param = new C();
+                break;
+
+            case 1:
+                param = null;
+                break;
+
+            default:
+                return;
+        }
+        
+        if (param != null)
+        {
+        }
+    }
+}
+
+class C
+{
+}
+");
+            VerifyBasic(@"
+Class Test
+    Private Sub M(param As C, i As Integer)
+        Select Case i
+            Case 0
+                param = New C()
+            Case 1
+                param = Nothing
+            Case Else
+                Return
+        End Select
+
+        If param IsNot Nothing Then
+        End If
+    End Sub
+End Class
+
+Class C
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_SwitchStatement_02_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(C param, int i)
+    {
+        switch (i)
+        {
+            case 0:
+                param = new C();
+                break;
+
+            case 1:                
+                return;
+
+            default:
+                param = null;
+                break;
+        }
+        
+        if (param != null)
+        {
+        }
+    }
+}
+
+class C
+{
+}
+");
+            VerifyBasic(@"
+Class Test
+    Private Sub M(param As C, i As Integer)
+        Select Case i
+            Case 0
+                param = New C()
+            Case 1
+                Return
+            Case Else
+                param = Nothing
+        End Select
+
+        If param IsNot Nothing Then
+        End If
+    End Sub
+End Class
+
+Class C
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_SwitchStatement_03_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(C param, int i)
+    {
+        switch (i)
+        {
+            case 0:
+                param = new C();
+                return;
+
+            case 1:                
+                return;
+
+            default:
+                param = new C();
+                return;
+        }
+        
+        if (param != null)
+        {
+        }
+    }
+}
+
+class C
+{
+}
+");
+            VerifyBasic(@"
+Class Test
+    Private Sub M(param As C, i As Integer)
+        Select Case i
+            Case 0
+                param = New C()
+                Return
+            Case 1
+                Return
+            Case Else
+                param = Nothing
+                Return
+        End Select
+
+        If param IsNot Nothing Then
+        End If
+    End Sub
+End Class
+
+Class C
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_SwitchStatement_01_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(C param, int i)
+    {
+        switch (i)
+        {
+            case 0:
+                param = new C();
+                break;
+
+            case 1:
+                param = new C();
+                break;
+
+            default:
+                return;
+        }
+        
+        if (param != null)
+        {
+        }
+    }
+}
+
+class C
+{
+}
+",
+            // Test0.cs(20,13): warning CA1508: 'param != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(20, 13, "param != null", "true"));
+            VerifyBasic(@"
+Class Test
+    Private Sub M(param As C, i As Integer)
+        Select Case i
+            Case 0
+                param = New C()
+            Case 1
+                param = New C()
+            Case Else
+                Return
+        End Select
+
+        If param IsNot Nothing Then
+        End If
+    End Sub
+End Class
+
+Class C
+End Class
+",
+            // Test0.vb(13,12): warning CA1508: 'param IsNot Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(13, 12, "param IsNot Nothing", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_SwitchStatement_02_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(C param, int i)
+    {
+        switch (i)
+        {
+            default:
+                param = null;
+                break;
+
+            case 1:
+                return;
+
+            case 0:
+                param = null;
+                break;
+        }
+        
+        if (param != null)
+        {
+        }
+    }
+}
+
+class C
+{
+}
+",
+            // Test0.cs(20,13): warning CA1508: 'param != null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(20, 13, "param != null", "false"));
+
+            VerifyBasic(@"
+Class Test
+    Private Sub M(param As C, i As Integer)
+        Select Case i
+            Case 1
+                Return
+            Case 0
+                param = Nothing
+            Case Else
+                param = Nothing
+        End Select
+
+        If param IsNot Nothing Then
+        End If
+    End Sub
+End Class
+
+Class C
+End Class
+",
+            // Test0.vb(13,12): warning CA1508: 'param IsNot Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(13, 12, "param IsNot Nothing", "False"));
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
@@ -1308,6 +1994,51 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact]
+        public void NullCompare_Nested_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C param)
+    {
+        if (param == null)
+        {
+            param = M2();
+            if (param == null)
+            {
+            }
+        }
+    }
+
+    C M2() => new C();
+}
+");
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        If param Is Nothing Then
+            param = M2()
+            If param Is Nothing Then
+            End If
+        End If
+    End Sub
+
+    Private Function M2() As C
+        Return New C()
+    End Function
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
         public void NullCoalesce_NoDiagnostic()
         {
             VerifyCSharp(@"
@@ -1397,6 +2128,69 @@ End Module",
             GetBasicResultAt(8, 21, "c", "Nothing"),
             // Test0.vb(13,21): warning CA1508: 'c' is never 'Nothing'. Remove or refactor the condition(s) to avoid dead code.
             GetBasicNeverNullResultAt(13, 21, "c", "Nothing"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCoalesce_NullableValueType_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public int X;
+}
+
+class Test
+{
+    void M1(C param)
+    {
+        var x = param?.X ?? 0;
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+    Public X As Integer
+End Class
+
+Module Test
+    Private Sub M1(param As C)
+        Dim x = If(param?.X, 0)
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCoalesce_NullableValueType_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(int? x)
+    {
+        x = null;
+        if (x == null)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(7,13): warning CA1508: 'x == null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(7, 13, "x == null", "true"));
+
+            VerifyBasic(@"
+Module Test
+    Private Sub M1(x As Integer?)
+        x = Nothing
+        If x Is Nothing Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(5,12): warning CA1508: 'x Is Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(5, 12, "x Is Nothing", "True"));
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
@@ -1529,6 +2323,2036 @@ Class Test
         Dim x2 = If(_c, new C())
     End Sub
 End Class");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterTryCast_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1(C c)
+    {
+        if (c == null)
+        {
+            return;
+        }
+
+        var d = c as D;
+        if (d == null)
+        {
+            return;
+        }
+
+        if (c is D)
+        {
+            return;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+  Inherits C
+End Class
+
+Class Test
+    Private Sub M1(c As C)
+        If c Is Nothing Then
+            Return
+        End If
+
+        Dim d = TryCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+
+        If TypeOf(c) Is D Then
+            Return
+        End If
+    End Sub
+End Class");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterTryCast_02_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1(C c, bool flag)
+    {
+        if (flag)
+        {
+            c = new D();
+        }
+        else
+        {
+            c = new C();
+        }
+
+        var d = c as D;
+        if (d == null)
+        {
+            return;
+        }
+
+        if (d == c)
+        {
+            return;
+        }
+    }
+
+    void M2(C c, bool flag)
+    {
+        if (flag)
+        {
+            c = new D();
+        }
+        else
+        {
+            c = null;
+        }
+
+        var d = c as D;
+        if (d == null)
+        {
+            return;
+        }
+
+        if (d == c)
+        {
+            return;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+  Inherits C
+End Class
+
+Class Test
+    Private Sub M1(c As C, flag As Boolean)
+        If flag Then
+            c = New D()
+        Else
+            c = New C()
+        End If
+
+        Dim d = TryCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+
+        If d Is c Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M2(c As C, flag As Boolean)
+        If flag Then
+            c = New D()
+        Else
+            c = Nothing
+        End If
+
+        Dim d = TryCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+
+        If d Is c Then
+            Return
+        End If
+    End Sub
+End Class");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterTryCast_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1(C c)
+    {
+        c = new D();
+        var d = c as D;
+        if (d == null)
+        {
+            return;
+        }
+    }
+
+    void M2(C c)
+    {
+        c = new D();
+        var d = c as D;
+        if (d == c)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(16,13): warning CA1508: 'd == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(16, 13, "d == null", "false"),
+            // Test0.cs(26,13): warning CA1508: 'd == c' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(26, 13, "d == c", "true"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+  Inherits C
+End Class
+
+Class Test
+    Private Sub M1(c As C)
+        c = New D()
+        Dim d = TryCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M2(c As C)
+        c = New D()
+        Dim d = TryCast(c, D)
+        If d Is c Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(13,12): warning CA1508: 'd Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(13, 12, "d Is Nothing", "False"),
+            // Test0.vb(21,12): warning CA1508: 'd Is c' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(21, 12, "d Is c", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterTryCast_02_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class E_DerivesFromD: D
+{
+}
+
+class F_DerivesFromC: C
+{
+}
+
+class G_DerivesFromF: F_DerivesFromC
+{
+}
+
+class Test
+{
+    void M1(C c, bool flag)
+    {
+        if (flag)
+        {
+            c = new D();
+        }
+        else
+        {
+            c = new E_DerivesFromD();
+        }
+
+        var d = c as D;
+        if (d == null)
+        {
+            return;
+        }
+    }
+
+    void M2(C c, bool flag)
+    {
+        if (flag)
+        {
+            c = new D();
+        }
+        else
+        {
+            c = new E_DerivesFromD();
+        }
+
+        var d = c as D;
+        if (d != c)
+        {
+            return;
+        }
+    }
+
+    void M3(C c, bool flag)
+    {
+        if (flag)
+        {
+            c = new F_DerivesFromC();
+        }
+        else
+        {
+            c = new G_DerivesFromF();
+        }
+
+        var d = c as D;
+        if (d == null)
+        {
+            return;
+        }
+    }
+
+    void M4(C c, bool flag)
+    {
+        if (flag)
+        {
+            c = new F_DerivesFromC();
+        }
+        else
+        {
+            c = new G_DerivesFromF();
+        }
+
+        var d = c as D;
+        if (d != c)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(36,13): warning CA1508: 'd == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(36, 13, "d == null", "false"),
+            // Test0.cs(54,13): warning CA1508: 'd != c' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(54, 13, "d != c", "false"),
+            // Test0.cs(72,13): warning CA1508: 'd == null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(72, 13, "d == null", "true"),
+            // Test0.cs(90,13): warning CA1508: 'd != c' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(90, 13, "d != c", "true"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+    Inherits C
+
+End Class
+
+Class E_DerivesFromD
+    Inherits D
+
+End Class
+
+Class F_DerivesFromC
+    Inherits C
+
+End Class
+
+Class G_DerivesFromF
+    Inherits F_DerivesFromC
+
+End Class
+
+Class Test
+
+    Private Sub M1(c As C, flag As Boolean)
+        If flag Then
+            c = New D()
+        Else
+            c = New E_DerivesFromD()
+        End If
+
+        Dim d = TryCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M2(c As C, flag As Boolean)
+        If flag Then
+            c = New D()
+        Else
+            c = New E_DerivesFromD()
+        End If
+
+        Dim d = TryCast(c, D)
+        If d IsNot c Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M3(c As C, flag As Boolean)
+        If flag Then
+            c = New F_DerivesFromC()
+        Else
+            c = New G_DerivesFromF()
+        End If
+
+        Dim d = TryCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M4(c As C, flag As Boolean)
+        If flag Then
+            c = New F_DerivesFromC()
+        Else
+            c = New G_DerivesFromF()
+        End If
+
+        Dim d = TryCast(c, D)
+        If d IsNot c Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(35,12): warning CA1508: 'd Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(35, 12, "d Is Nothing", "False"),
+            // Test0.vb(48,12): warning CA1508: 'd IsNot c' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(48, 12, "d IsNot c", "False"),
+            // Test0.vb(61,12): warning CA1508: 'd Is Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(61, 12, "d Is Nothing", "True"),
+            // Test0.vb(74,12): warning CA1508: 'd IsNot c' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(74, 12, "d IsNot c", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterTryCast_Interfaces_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+interface I
+{
+}
+
+interface I2 : I
+{
+}
+
+class C : I
+{
+}
+
+class Test
+{
+    void M1(object o)
+    {
+        if (o == null)
+        {
+            return;
+        }
+
+        var i = o as I;
+        if (i == null)
+        {
+            return;
+        }
+
+        var i2 = i as I2;
+        if (i2 == null)
+        {
+            return;
+        }
+
+        var c = i as C;
+        if (c == null)
+        {
+            return;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Interface I
+End Interface
+
+Interface I2
+    Inherits I
+End Interface
+
+Class C
+    Implements I
+End Class
+
+Class Test
+    Private Sub M1(o As Object)
+        If o Is Nothing Then
+            Return
+        End If
+
+        Dim i = TryCast(o, I)
+        If i Is Nothing Then
+            Return
+        End If
+
+        Dim i2 = TryCast(i, I2)
+        If i2 Is Nothing Then
+            Return
+        End If
+
+        Dim c = TryCast(i, C)
+        If c Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterTryCast_Interfaces_Diagnostic()
+        {
+            VerifyCSharp(@"
+interface I
+{
+}
+
+interface I2 : I
+{
+}
+
+class C : I
+{
+}
+
+class Test
+{
+    void M1(C c, I2 i2)
+    {
+        if (c == null || i2 == null)
+        {
+            return;
+        }
+
+        var i = c as I;
+        if (i == null)
+        {
+            return;
+        }
+
+        i = i2 as I;
+        if (i == null)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(24,13): warning CA1508: 'i == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(24, 13, "i == null", "false"),
+            // Test0.cs(30,13): warning CA1508: 'i == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(30, 13, "i == null", "false"));
+
+            VerifyBasic(@"
+Interface I
+End Interface
+
+Interface I2
+    Inherits I
+End Interface
+
+Class C
+    Implements I
+End Class
+
+Class Test
+    Private Sub M1(c As C, i2 As I2)
+        If c Is Nothing OrElse i2 Is Nothing Then
+            Return
+        End If
+
+        Dim i = TryCast(c, I)
+        If i Is Nothing Then
+            Return
+        End If
+
+        i = TryCast(i2, I)
+        If i Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(20,12): warning CA1508: 'i Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(20, 12, "i Is Nothing", "False"),
+            // Test0.vb(25,12): warning CA1508: 'i Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(25, 12, "i Is Nothing", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterTryCast_TypeParameter_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D : C
+{
+}
+
+class Test<T>
+    where T : C
+{
+    void M1(C c)
+    {
+        if (c == null)
+        {
+            return;
+        }
+
+        var t = c as T;
+        if (t == null)
+        {
+            return;
+        }
+    }
+
+    void M2(T t)
+    {
+        if (t == null)
+        {
+            return;
+        }
+
+        var d = t as D;
+        if (d == null)
+        {
+            return;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+    Inherits C
+End Class
+
+Class Test(Of T As C)
+    Private Sub M1(c As C)
+        If c Is Nothing Then
+            Return
+        End If
+
+        Dim t = TryCast(c, T)
+        If t Is Nothing Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M2(t As T)
+        If t Is Nothing Then
+            Return
+        End If
+
+        Dim d = TryCast(t, D)
+        If d Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterTryCast_TypeParameter_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D : C
+{
+}
+
+class Test<T>
+    where T : C
+{
+    void M1(T t)
+    {
+        if (t == null)
+        {
+            return;
+        }
+
+        var c = t as C;
+        if (c == null)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(21,13): warning CA1508: 'c == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(21, 13, "c == null", "false"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+    Inherits C
+End Class
+
+Class Test(Of T As C)
+    Private Sub M1(t As T)
+        If t Is Nothing Then
+            Return
+        End If
+
+        Dim c = TryCast(t, C)
+        If c Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(16,12): warning CA1508: 'c Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(16, 12, "c Is Nothing", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1(C c, bool flag)
+    {
+        if (flag)
+        {
+            c = new D();
+        }
+        else
+        {
+            c = null;
+        }
+
+        var d = (D)c;
+        if (d == null)
+        {
+            return;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+  Inherits C
+End Class
+
+Class Test
+    Private Sub M1(c As C, flag As Boolean)
+        If flag Then
+            c = New D()
+        Else
+            c = Nothing
+        End If
+
+        Dim d = TryCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_NarrowingConversion_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(int value)
+    {
+        if ((sbyte)value == value)
+        {
+        }
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1(C c)
+    {
+        if (c == null)
+        {
+            return;
+        }
+
+        var d = (D)c;
+        if (d == null)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(20,13): warning CA1508: 'd == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(20, 13, "d == null", "false"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+  Inherits C
+End Class
+
+Class Test
+    Private Sub M1(c As C)
+        If c Is Nothing Then
+            Return
+        End If
+
+        Dim d = DirectCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(16,12): warning CA1508: 'd Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(16, 12, "d Is Nothing", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_02_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1(C c)
+    {
+        if (c == null)
+        {
+            return;
+        }
+
+        var d = (D)c;
+        if (d == c)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(20,13): warning CA1508: 'd == c' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(20, 13, "d == c", "true"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+  Inherits C
+End Class
+
+Class Test
+    Private Sub M1(c As C)
+        If c Is Nothing Then
+            Return
+        End If
+
+        Dim d = DirectCast(c, D)
+        If d Is c Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(16,12): warning CA1508: 'd Is c' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(16, 12, "d Is c", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_03_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1(C c, bool flag)
+    {
+        if (flag)
+        {
+            c = new D();
+        }
+        else
+        {
+            c = new C();
+        }
+
+        var d = (D)c;
+        if (d == null)
+        {
+            return;
+        }
+
+        if (d == c)
+        {
+            return;
+        }
+    }
+
+    void M2(C c, bool flag)
+    {
+        if (flag)
+        {
+            c = new D();
+        }
+        else
+        {
+            c = null;
+        }
+
+        var d = (D)c;
+        if (d == null)
+        {
+            return;
+        }
+
+        if (d == c)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(24,13): warning CA1508: 'd == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(24, 13, "d == null", "false"),
+            // Test0.cs(29,13): warning CA1508: 'd == c' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(29, 13, "d == c", "true"),
+            // Test0.cs(52,13): warning CA1508: 'd == c' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(52, 13, "d == c", "true"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+  Inherits C
+End Class
+
+Class Test
+    Private Sub M1(c As C, flag As Boolean)
+        If flag Then
+            c = New D()
+        Else
+            c = New C()
+        End If
+
+        Dim d = DirectCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+
+        If d Is c Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M2(c As C, flag As Boolean)
+        If flag Then
+            c = New D()
+        Else
+            c = Nothing
+        End If
+
+        Dim d = DirectCast(c, D)
+        If d Is Nothing Then
+            Return
+        End If
+
+        If d Is c Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(18,12): warning CA1508: 'd Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(18, 12, "d Is Nothing", "False"),
+            // Test0.vb(22,12): warning CA1508: 'd Is c' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(22, 12, "d Is c", "True"),
+            // Test0.vb(39,12): warning CA1508: 'd Is c' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(39, 12, "d Is c", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_04_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1(C c)
+    {
+        c = new D();
+        var local = c;
+        var d = (D)c;
+        if (d == local)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(17,13): warning CA1508: 'd == local' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(17, 13, "d == local", "true"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+  Inherits C
+End Class
+
+Class Test
+    Private Sub M1(c As C)
+        c = New D()
+        Dim local = c
+        Dim d = DirectCast(c, D)
+        If d Is local Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(14,12): warning CA1508: 'd Is local' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(14, 12, "d Is local", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_05_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class E_DerivesFromC : C
+{
+}
+
+class Test
+{
+    void M1(C c)
+    {
+        c = new E_DerivesFromC();
+        var local = c;
+        var d = (D)c;
+        if (d == local)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(21,13): warning CA1508: 'd == local' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(21, 13, "d == local", "true"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+  Inherits C
+End Class
+
+Class E_DerivesFromC
+  Inherits C
+End Class
+
+Class Test
+    Private Sub M1(c As C)
+        c = New E_DerivesFromC()
+        Dim local = c
+        Dim d = DirectCast(c, D)
+        If d Is local Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(18,12): warning CA1508: 'd Is local' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(18, 12, "d Is local", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_Interfaces_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+interface I
+{
+}
+
+interface I2 : I
+{
+}
+
+class C : I
+{
+}
+
+class Test
+{
+    void M1(object o)
+    {
+        var i = (I)o;
+        if (i == null)
+        {
+            return;
+        }
+    }
+
+    void M2(I i)
+    {
+        var i2 = (I2)i;
+        if (i2 == null)
+        {
+            return;
+        }
+    }
+
+    void M3(I i)
+    {
+        var c = (C)i;
+        if (c == null)
+        {
+            return;
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Interface I
+End Interface
+
+Interface I2
+    Inherits I
+End Interface
+
+Class C
+    Implements I
+End Class
+
+Class Test
+    Private Sub M1(o As Object)
+        Dim i = DirectCast(o, I)
+        If i Is Nothing Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M2(i As I)
+        Dim i2 = DirectCast(i, I2)
+        If i2 Is Nothing Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M3(i As I)
+        Dim c = DirectCast(i, C)
+        If c Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_Interfaces_Diagnostic()
+        {
+            VerifyCSharp(@"
+interface I
+{
+}
+
+interface I2 : I
+{
+}
+
+class C : I
+{
+}
+
+class Test
+{
+    void M1(C c, I2 i2)
+    {
+        if (c == null || i2 == null)
+        {
+            return;
+        }
+
+        var i = (I)c;
+        if (i == null)
+        {
+            return;
+        }
+
+        i = (I)i2;
+        if (i == null)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(24,13): warning CA1508: 'i == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(24, 13, "i == null", "false"),
+            // Test0.cs(30,13): warning CA1508: 'i == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(30, 13, "i == null", "false"));
+
+            VerifyBasic(@"
+Interface I
+End Interface
+
+Interface I2
+    Inherits I
+End Interface
+
+Class C
+    Implements I
+End Class
+
+Class Test
+    Private Sub M1(c As C, i2 As I2)
+        If c Is Nothing OrElse i2 Is Nothing Then
+            Return
+        End If
+
+        Dim i = DirectCast(c, I)
+        If i Is Nothing Then
+            Return
+        End If
+
+        i = DirectCast(i2, I)
+        If i Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(20,12): warning CA1508: 'i Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(20, 12, "i Is Nothing", "False"),
+            // Test0.vb(25,12): warning CA1508: 'i Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(25, 12, "i Is Nothing", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_Interfaces_02_Diagnostic()
+        {
+            VerifyCSharp(@"
+interface I
+{
+}
+
+interface I2 : I
+{
+}
+
+class C : I
+{
+}
+
+class Test
+{
+    void M1(object o)
+    {
+        if (o == null)
+        {
+            return;
+        }
+
+        var i = (I)o;
+        if (i == null)
+        {
+            return;
+        }
+
+        var i2 = (I2)i;
+        if (i2 == null)
+        {
+            return;
+        }
+
+        var c = (C)i;
+        if (c == null)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(24,13): warning CA1508: 'i == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(24, 13, "i == null", "false"),
+            // Test0.cs(30,13): warning CA1508: 'i2 == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(30, 13, "i2 == null", "false"),
+            // Test0.cs(36,13): warning CA1508: 'c == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(36, 13, "c == null", "false"));
+
+            VerifyBasic(@"
+Interface I
+End Interface
+
+Interface I2
+    Inherits I
+End Interface
+
+Class C
+    Implements I
+End Class
+
+Class Test
+    Private Sub M1(o As Object)
+        If o Is Nothing Then
+            Return
+        End If
+
+        Dim i = DirectCast(o, I)
+        If i Is Nothing Then
+            Return
+        End If
+
+        Dim i2 = DirectCast(i, I2)
+        If i2 Is Nothing Then
+            Return
+        End If
+
+        Dim c = DirectCast(i, C)
+        If c Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(20,12): warning CA1508: 'i Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(20, 12, "i Is Nothing", "False"),
+            // Test0.vb(25,12): warning CA1508: 'i2 Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(25, 12, "i2 Is Nothing", "False"),
+            // Test0.vb(30,12): warning CA1508: 'c Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(30, 12, "c Is Nothing", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_TypeParameter_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D : C
+{
+}
+
+class Test<T>
+    where T : C
+{
+    void M1(T t)
+    {
+        if (t == null)
+        {
+            return;
+        }
+
+        var d = (D)t;   // Compiler error CS0030: Cannot convert type 'T' to 'D'
+        if (d == null)
+        {
+            return;
+        }
+    }
+}
+", TestValidationMode.AllowCompileErrors);
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+    Inherits C
+End Class
+
+Class Test(Of T As C)
+    Private Sub M1(t As T)
+        If t Is Nothing Then
+            Return
+        End If
+
+        Dim d = DirectCast(t, D)    '  Compiler error BC30311: Value of type 'T' cannot be converted to 'D'
+        If d Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class", TestValidationMode.AllowCompileErrors);
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AfterDirectCast_TypeParameter_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D : C
+{
+}
+
+class Test<T>
+    where T : C
+{
+    void M1(C c)
+    {
+        if (c == null)
+        {
+            return;
+        }
+
+        var t = (T)c;
+        if (t == null)
+        {
+            return;
+        }
+    }
+
+    void M2(T t)
+    {
+        if (t == null)
+        {
+            return;
+        }
+
+        var c = (C)t;
+        if (c == null)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(21,13): warning CA1508: 't == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(21, 13, "t == null", "false"),
+            // Test0.cs(35,13): warning CA1508: 'c == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(35, 13, "c == null", "false"));
+
+            VerifyBasic(@"
+Class C
+End Class
+
+Class D
+    Inherits C
+End Class
+
+Class Test(Of T As C)
+    Private Sub M1(c As C)
+        If c Is Nothing Then
+            Return
+        End If
+
+        Dim t = DirectCast(c, T)
+        If t Is Nothing Then
+            Return
+        End If
+    End Sub
+
+    Private Sub M2(t As T)
+        If t Is Nothing Then
+            Return
+        End If
+
+        Dim c = DirectCast(t, C)
+        If c Is Nothing Then
+            Return
+        End If
+    End Sub
+End Class",
+            // Test0.vb(16,12): warning CA1508: 't Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(16, 12, "t Is Nothing", "False"),
+            // Test0.vb(27,12): warning CA1508: 'c Is Nothing' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(27, 12, "c Is Nothing", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_ThrowExpressionWithoutArgument_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(C c)
+    {
+        try
+        {
+        }
+        catch (System.Exception ex)
+        {
+            if (c == null)
+            {
+                throw;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AssignedInCatch_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1()
+    {
+        object o = null;
+        try
+        {
+        }
+        catch (System.Exception ex)
+        {
+            o = ex;
+        }
+        catch
+        {
+            o = null;
+        }
+
+        if (o != null)
+        {
+            return;
+        }
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_OutArgument_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public void Cleanup() { }
+}
+
+class Test
+{
+    bool M1()
+    {
+        C c = null;
+        try
+        {
+            if (M2(out c))
+            {
+                return true;
+            }
+        }
+        finally
+        {
+            c?.Cleanup();
+        }
+
+        return false;
+    }
+
+    bool M2(out C c)
+    {
+        c = new C();
+        return true;
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_RefArgument_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(int count)
+    {
+        int initialCount = count;
+        M2(ref count);
+        if (initialCount == count)
+        {
+        }
+    }
+
+    int M2(ref int count)
+    {
+        count++;
+        return 0;
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_LogicalOr_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(int x, int y)
+    {
+        var z = x;
+        z |= y;
+        if (z == x)
+        {
+        }
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_DeconstructionAssignment_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(int x, int y)
+    {
+        C c = null;
+        (c, x) = M2();
+        if (c != null)
+        {
+        }
+    }
+
+    (C, int) M2() => (new C(), 0);
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_DeconstructionAssignment_InLambda_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(int x, int y)
+    {
+        C c = null;
+        System.Action a = () => (c, x) = M2();
+        a();
+        if (c != null)
+        {
+        }
+    }
+
+    (C, int) M2() => (new C(), 0);
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1647")]
+        public void NullCheck_DeconstructionAssignment_InLambdaPassedAsArgument_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class Test
+{
+    void M1(int x, int y)
+    {
+        C c = null;
+        System.Action a = () => (c, x) = M2();
+        Invoke(a);
+        if (c != null)
+        {
+        }
+    }
+
+    (C, int) M2() => (new C(), 0);
+    void Invoke(System.Action a) => a();
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_AwaitExpression_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.Threading.Tasks;
+
+class Test
+{
+    Task<Test> M() => null;
+
+    async Task M2()
+    {
+        Test t = await M();
+        if (t == null)
+        {
+            return;
+        }
+    }
+}
+");
+            VerifyBasic(@"
+Imports System.Threading.Tasks
+
+Class Test
+    Private Function M() As Task(Of Test)
+        Return Nothing
+    End Function
+
+    Private Async Function M2() As Task
+        Dim t As Test = Await M()
+        If t Is Nothing Then
+            Return
+        End If
+    End Function
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCheck_CollectionAddAndCount_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.Collections.Generic;
+
+class Test
+{
+    void M(List<int> map)
+    {
+        System.Action a = () => {};
+        a();
+
+        var initialCount = map.Count;
+        map.Add(0);
+        if (map.Count == initialCount)
+        {
+            return;
+        }
+    }
+}
+
+class C
+{
+}
+");
+            VerifyBasic(@"
+Imports System.Collections.Immutable
+
+Class Test
+    Private Sub M(map As ImmutableDictionary(Of C, Integer).Builder, arr As C())
+        Dim initialCount = map.Count
+        For Each element in arr
+            map.Add(element, 0)
+        Next
+
+        If map.Count = initialCount Then
+            Return
+        End If
+    End Sub
+End Class
+
+Class C
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCheck_BothSidesOfEquals_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(Test a, Test b)
+    {
+        // If a is not-null, ensure b is not null.
+        // If a is null, b may or may not be null.
+        if ((a != null && b != null) == (a != null))
+        {
+            return;
+        }
+        if ((a != null) == (a != null && b != null))
+        {
+            return;
+        }
+    }
+}
+");
+            VerifyBasic(@"
+Class Test
+    Private Sub M(a As Test, b As Test)
+        ' If a is not-null, ensure b is not null.
+        ' If a is null, b may or may not be null.
+        If (a IsNot Nothing AndAlso b IsNot Nothing) = (a IsNot Nothing) Then
+            Return
+        End If
+        If (a IsNot Nothing) = (a IsNot Nothing AndAlso b IsNot Nothing) Then
+            Return
+        End If
+    End Sub
+End Class
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ConditionalAccessCheck_InsideLocalFunction_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    public bool Flag;
+    bool? M(Test t)
+    {
+        bool? MyFunc() { return t?.Flag; }
+
+        return MyFunc();
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ConditionalAccessCheck_InsideLocalFunction_02_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    public bool Flag;
+    bool? M(Test t)
+    {
+        return MyFunc();
+
+        bool? MyFunc() { return t?.Flag; }
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ConditionalAccessCheck_InsideInitializer_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public bool Flag;
+}
+
+class Base
+{
+    protected Base(bool b) { }
+}
+
+class Test : Base
+{
+    public Test(C c)
+        : base(c?.Flag == true)
+    {
+        var x = c?.Flag == true;
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1650")]
+        public void ConditionalAccessCheck_InsideInitializer_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public bool Flag;
+}
+
+class Base
+{
+    protected Base(bool b) { }
+}
+
+class Test : Base
+{
+    public Test(C c)
+        : base(c != null ? (c?.Flag == true) : false)
+    {
+        var x = c != null;
+    }
+}
+",
+            // Test0.cs(15,29): warning CA1508: 'c' is never 'null'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(15, 29, "c", "null"));
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -1495,5 +1495,40 @@ End Module",
             // Test0.vb(14,17): warning CA1508: 'param' is never 'Nothing'. Remove or refactor the condition(s) to avoid dead code.
             GetBasicNeverNullResultAt(14, 17, "param", "Nothing"));
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void ConditionalAccessNullCoalesce_Field_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public int X;
+}
+
+class Test
+{
+    public C _c;
+    void M1()
+    {
+        var x = _c?.X;
+        var y = _c ?? new C();
+    }
+}
+");
+
+            VerifyBasic(@"
+Class C
+    Public X As Integer
+End Class
+
+Class Test
+    Public _c As C
+    Private Sub M1()
+        Dim x = _c?.X
+        Dim x2 = If(_c, new C())
+    End Sub
+End Class");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/AvoidDeadConditionalCode_StringContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Maintainability/AvoidDeadConditionalCode_StringContentAnalysis.cs
@@ -1,0 +1,873 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Maintainability
+{
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
+    public partial class AvoidDeadConditionalCodeTests : DiagnosticAnalyzerTestBase
+    {
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void SimpleStringCompare_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param)
+    {
+        if (param == """")
+        {
+        }
+
+        if ("""" == param)
+        {
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String)
+        If param = """" Then
+        End If
+
+        If """" = param Then
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void SimpleStringCompare_AfterAssignment_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param)
+    {
+        param = """";
+        if (param == """")
+        {
+        }
+
+        if ("""" != param)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(7,13): warning CA1508: 'param == ""' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(7, 13, @"param == """"", "true"),
+            // Test0.cs(11,13): warning CA1508: '"" != param' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(11, 13, @""""" != param", "false"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String)
+        param = """"
+        If param = """" Then
+        End If
+
+        If """" <> param Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(5,12): warning CA1508: 'param = ""' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(5, 12, @"param = """"", "True"),
+            // Test0.vb(8,12): warning CA1508: '"" <> param' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 12, @""""" <> param", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void ElseIf_NestedIf_StringCompare_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param)
+    {
+        string str = """";
+        if (param != """")
+        {
+        }
+        else if (param == str)
+        {
+        }
+
+        if ("""" == param)
+        {
+            if (param != str)
+            {
+            }
+        }
+    }
+}
+",
+            // Test0.cs(10,18): warning CA1508: 'param == str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(10, 18, "param == str", "true"),
+            // Test0.cs(16,17): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(16, 17, "param != str", "false"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String)
+        Dim str = """"
+        If param <> """" Then
+        Else If param = str Then
+        End If
+
+        If """" = param Then
+            If param <> str Then
+            End If
+        End If
+    End Sub
+End Module",
+            // Test0.vb(6,17): warning CA1508: 'param = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(6, 17, "param = str", "True"),
+            // Test0.vb(10,16): warning CA1508: 'param <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(10, 16, "param <> str", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void ConditionaAndOrStringCompare_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param)
+    {
+        string str = """";
+        if (param != """" || param == str)
+        {
+        }
+
+        if ("""" == param && param != str)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(7,28): warning CA1508: 'param == str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(7, 28, "param == str", "true"),
+            // Test0.cs(11,28): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(11, 28, "param != str", "false"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String)
+        Dim str = """"
+        If param <> """" OrElse param = str Then
+        End If
+
+        If """" = param AndAlso param <> str Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(5,31): warning CA1508: 'param = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(5, 31, "param = str", "True"),
+            // Test0.vb(8,31): warning CA1508: 'param <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 31, "param <> str", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void ElseIf_NestedIf_StringCompare_DifferentLiteral_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param)
+    {
+        string str = ""a"";
+        if (param != """")
+        {
+        }
+        else if (param == str)
+        {
+        }
+
+        if ("""" == param)
+        {
+            if (param != str)
+            {
+            }
+        }
+    }
+}
+",
+            // Test0.cs(10,18): warning CA1508: 'param == str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(10, 18, "param == str", "false"),
+            // Test0.cs(16,17): warning CA1508: 'param != str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(16, 17, "param != str", "true"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String)
+        Dim str = ""a""
+        If param <> """" Then
+        Else If param = str Then
+        End If
+
+        If """" = param Then
+            If param <> str Then
+            End If
+        End If
+    End Sub
+End Module",
+            // Test0.vb(6,17): warning CA1508: 'param = str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(6, 17, "param = str", "False"),
+            // Test0.vb(10,16): warning CA1508: 'param <> str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(10, 16, "param <> str", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void ElseIf_NestedIf_StringCompare_DifferentLiterals_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, bool flag)
+    {
+        string str = flag ? ""a"" : """";
+        if (param != """")
+        {
+        }
+        else if (param == str)
+        {
+        }
+
+        if ("""" == param)
+        {
+            if (param != str)
+            {
+            }
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, flag As Boolean)
+        Dim str = If(flag, ""a"", """")
+        If param <> """" Then
+        Else If param = str Then
+        End If
+
+        If """" = param Then
+            If param <> str Then
+            End If
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_WhileLoop()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(string param)
+    {
+        string str = """";
+        while (param == str)
+        {
+            // param = str here
+            if (param == str)
+            {
+            }
+            if (param != str)
+            {
+            }
+        }
+
+        // param is unknown here
+        if (str == param)
+        {
+        }
+        if (str != param)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(10,17): warning CA1508: 'param == str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(10, 17, "param == str", "true"),
+            // Test0.cs(13,17): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(13, 17, "param != str", "false"));
+
+            VerifyBasic(@"
+Module Test
+    ' While loop
+    Private Sub M1(ByVal param As String)
+        Dim str As String = """"
+        While param = str
+            ' param == str here
+            If param = str Then
+            End If
+            If param <> str Then
+            End If
+        End While
+
+        ' param is unknown here
+        If str = param Then
+            End If
+        If str <> param Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(8,16): warning CA1508: 'param = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 16, "param = str", "True"),
+            // Test0.vb(10,16): warning CA1508: 'param <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(10, 16, "param <> str", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_DoWhileLoop()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(string param)
+    {
+        string str = """";
+        do
+        {
+            // param is unknown here
+            if (str == param)
+            {
+            }
+            if (str != param)
+            {
+            }
+        }
+        while (param != str);
+
+        // param = str here
+        if (param == str)
+        {
+        }
+        if (param != str)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(20,13): warning CA1508: 'param == str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(20, 13, "param == str", "true"),
+            // Test0.cs(23,13): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(23, 13, "param != str", "false"));
+
+            VerifyBasic(@"
+Module Test
+    ' Do-While top loop
+    Private Sub M(ByVal param As String)
+        Dim str As String = """"
+        Do While param <> str
+            ' param is unknown here
+            If str = param Then
+                End If
+            If str <> param Then
+            End If
+        Loop
+
+        ' param == str here
+        If param = str Then
+        End If
+        If param <> str Then
+        End If
+    End Sub
+
+    ' Do-While bottom loop
+    Private Sub M2(ByVal param2 As String)
+        Dim str As String = """"
+        Do
+            ' param2 is unknown here
+            If str = param2 Then
+                End If
+            If str <> param2 Then
+            End If
+        Loop While param2 <> str
+
+        ' param2 == str here
+        If param2 = str Then
+        End If
+        If param2 <> str Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(15,12): warning CA1508: 'param = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(15, 12, "param = str", "True"),
+            // Test0.vb(17,12): warning CA1508: 'param <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(17, 12, "param <> str", "False"),
+            // Test0.vb(33,12): warning CA1508: 'param2 = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(33, 12, "param2 = str", "True"),
+            // Test0.vb(35,12): warning CA1508: 'param2 <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(35, 12, "param2 <> str", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_DoUntilLoop()
+        {
+            VerifyBasic(@"
+Module Test
+    ' Do-Until top loop
+    Private Sub M(ByVal param As String)
+        Dim str As String = """"
+        Do Until param <> str
+            ' param == str here
+            If param = str Then
+            End If
+            If param <> str Then
+            End If
+        Loop
+
+        ' param is unknown here
+        If str = param Then
+            End If
+        If str <> param Then
+        End If
+    End Sub
+
+    ' Do-Until bottom loop
+    Private Sub M2(ByVal param2 As String)
+        Dim str As String = """"
+        Do
+            ' param2 is unknown here
+            If str = param2 Then
+                End If
+            If str <> param2 Then
+            End If
+        Loop Until param2 = str
+
+        ' param2 == str here
+        If param2 = str Then
+        End If
+        If param2 <> str Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(8,16): warning CA1508: 'param = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(8, 16, "param = str", "True"),
+            // Test0.vb(10,16): warning CA1508: 'param <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(10, 16, "param <> str", "False"),
+            // Test0.vb(33,12): warning CA1508: 'param2 = str' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(33, 12, "param2 = str", "True"),
+            // Test0.vb(35,12): warning CA1508: 'param2 <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(35, 12, "param2 <> str", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_ForLoop()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(string param, string param2)
+    {
+        string str = """";
+        for (param = str; param2 != str;)
+        {
+            // param = str here
+            if (param == str)
+            {
+            }
+            if (param != str)
+            {
+            }
+
+            // param2 != str here, but we don't track not-contained values so no diagnostic.
+            if (param2 == str)
+            {
+            }
+            if (param2 != str)
+            {
+            }
+        }
+        
+        // param2 == str here
+        if (str == param2)
+        {
+        }
+        if (str != param2)
+        {
+        }
+        
+        // param == str here
+        if (str == param)
+        {
+        }
+        if (str != param)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(10,17): warning CA1508: 'param == str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(10, 17, "param == str", "true"),
+            // Test0.cs(13,17): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(13, 17, "param != str", "false"),
+            // Test0.cs(27,13): warning CA1508: 'str == param2' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(27, 13, "str == param2", "true"),
+            // Test0.cs(30,13): warning CA1508: 'str != param2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(30, 13, "str != param2", "false"),
+            // Test0.cs(35,13): warning CA1508: 'str == param' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(35, 13, "str == param", "true"),
+            // Test0.cs(38,13): warning CA1508: 'str != param' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(38, 13, "str != param", "false"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void StringCompare_CopyAnalysis()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, string param2)
+    {
+        string str = ""a"";
+        if (param == str && param2 == str && param == param2)
+        {
+        }
+
+        param = param2;
+        if (param != str || param2 != str)
+        {
+        }
+    }
+}
+",
+            // Test0.cs(7,46): warning CA1508: 'param == param2' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(7, 46, "param == param2", "true"),
+            // Test0.cs(12,29): warning CA1508: 'param2 != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(12, 29, "param2 != str", "false"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, param2 As String)
+        Dim str = ""a""
+        If param = str AndAlso param2 = str AndAlso param = param2 Then
+        End If
+
+        param = param2
+        If param <> str OrElse param2 <> str Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(5,53): warning CA1508: 'param = param2' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(5, 53, "param = param2", "True"),
+            // Test0.vb(9,32): warning CA1508: 'param2 <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(9, 32, "param2 <> str", "False"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_WithNonLiteral_ConditionalOr_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, string param2, bool flag)
+    {
+        string str = """";
+        string str2 = flag ? ""a"" : ""b"";
+        string strMayBeConst = param2;
+
+        if (param == str || param == str2)
+        {
+        }
+
+        if (str2 != param || param == strMayBeConst)
+        {
+        }
+
+        if (param == strMayBeConst || str2 != param)
+        {
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim str = """"
+        Dim str2 = If(flag, ""a"", ""b"")
+        Dim strMayBeConst = param2
+
+        If param = str OrElse param = str2 Then
+        End If
+
+        If str2 <> param OrElse param = strMayBeConst Then
+        End If
+
+        If param = strMayBeConst OrElse str2 <> param Then
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_WithNonLiteral_ConditionalAnd_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, string param2, bool flag)
+    {
+        string str = """";
+        string str2 = flag ? ""a"" : ""b"";
+        string strMayBeConst = param2;
+
+        if (param == str && param2 == str2)
+        {
+        }
+
+        if (param == strMayBeConst && str2 == param)
+        {
+        }
+
+        if (param != str && param != str2)
+        {
+        }
+
+        if (param != str && param2 != str2)
+        {
+        }
+
+        if (str2 != param && param == strMayBeConst)
+        {
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim str = """"
+        Dim str2 = If(flag, ""a"", ""b"")
+        Dim strMayBeConst = param2
+
+        If param = str AndAlso param2 = str2 Then
+        End If
+
+        If param = strMayBeConst AndAlso str2 = param Then
+        End If
+
+        If str2 <> param AndAlso param <> str Then
+        End If
+        
+        If str2 <> param AndAlso param2 <> str Then
+        End If
+        
+        If str2 <> param AndAlso param = strMayBeConst Then
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_ConditionalAndOrNegation_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, bool flag, string param2)
+    {
+        string strConst = """";
+        string strConst2 = flag ? ""a"" : """";
+        string strMayBeNonConst = flag ? ""c"" : param2;
+
+        if (param == strConst || !(strConst2 != param) && param != strMayBeNonConst)
+        {
+        }
+
+        if (!(strConst2 == param && !(param != strConst)) || param == strMayBeNonConst)
+        {
+        }
+
+        if (param != strConst && !(strConst2 != param || param != strMayBeNonConst))
+        {
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean)
+        Dim strConst As String = """"
+        Dim strConst2 As String = If(flag, ""a"", """")
+        Dim strMayBeNonConst As String = If(flag, ""c"", param2)
+
+        If param = strConst OrElse Not(strConst2 <> param) AndAlso param <> strMayBeNonConst Then
+        End If
+
+        If Not(strConst2 = param AndAlso Not (param <> strConst)) OrElse param <> strMayBeNonConst Then
+        End If
+
+        If param <> strConst AndAlso Not(strConst2 <> param OrElse param <> strMayBeNonConst) Then
+        End If
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_ConditionalAndOrNegation_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param, bool flag, string param2, string param3)
+    {
+        string strConst = """";
+        string strConst2 = flag ? ""a"" : """";
+        string strMayBeNonConst = flag ? ""c"" : param2;
+
+        // First and last conditions are opposites, so infeasible.
+        if (param == strConst && !(strConst2 != param || param != strConst))
+        {
+        }
+
+        // First and last conditions are identical.
+        if (param == strConst && !(strConst2 != param || param == strConst)){
+        }
+
+        // Comparing with maybe const, no diagnostic
+        if (param3 == strConst && !(strConst2 == param3 || param3 == strMayBeNonConst))
+        {
+        }
+
+        // We don't track not-equals values, no diagnostic
+        if (param3 != strConst && !(strConst2 != param3 || param3 != strConst))
+        {
+        }
+    }
+}
+",
+            // Test0.cs(11,58): warning CA1508: 'param != strConst' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(11, 58, "param != strConst", "false"),
+            // Test0.cs(16,58): warning CA1508: 'param == strConst' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(16, 58, "param == strConst", "true"));
+
+            VerifyBasic(@"
+Module Test
+    Sub M1(param As String, param2 As String, flag As Boolean, param3 As String)
+        Dim strConst As String = """"
+        Dim strConst2 As String = If(flag, ""a"", """")
+        Dim strMayBeNonConst As String = If(flag, ""c"", param2)
+
+        ' First and last conditions are opposites, so infeasible.
+        If param = strConst AndAlso Not(strConst2 <> param OrElse param <> strConst) Then
+        End If
+
+        ' First and last conditions are identical.
+        If param = strConst AndAlso Not(strConst2 <> param OrElse param = strConst) Then
+        End If
+
+        ' Comparing with maybe const, no diagnostic
+        If param3 = strConst AndAlso Not(strConst2 = param3 OrElse param3 = strMayBeNonConst) Then
+        End If
+
+        ' We don't track not-equals values, no diagnostic
+        If param3 <> strConst AndAlso Not(strConst2 <> param3 OrElse param3 <> strConst) Then
+        End If
+    End Sub
+End Module",
+            // Test0.vb(9,67): warning CA1508: 'param <> strConst' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(9, 67, "param <> strConst", "False"),
+            // Test0.vb(13,67): warning CA1508: 'param = strConst' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(13, 67, "param = strConst", "True"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_ContractCheck_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M1(string param)
+    {
+        System.Diagnostics.Contracts.Contract.Requires(param != """");
+    }
+
+    void M2(string param, string param2)
+    {
+        param2 = """";
+        System.Diagnostics.Contracts.Contract.Requires(param == """" || param2 != param);
+    }
+
+    void M3(string param, string param2, string param3)
+    {
+        System.Diagnostics.Contracts.Contract.Requires(param == param2 && !(param2 != """") || param2 == param3);
+    }
+}
+");
+
+            VerifyBasic(@"
+Module Test
+    Private Sub M1(ByVal param As String)
+        System.Diagnostics.Contracts.Contract.Requires(param <> """")
+    End Sub
+
+    Private Sub M2(ByVal param As String, ByVal param2 As String)
+        param2 = """"
+        System.Diagnostics.Contracts.Contract.Requires(param = """" OrElse param2 <> param)
+    End Sub
+
+    Private Sub M3(ByVal param As String, ByVal param2 As String, param3 As String)
+        System.Diagnostics.Contracts.Contract.Requires(param = param2 AndAlso Not(param2 <> """") OrElse param2 = param3)
+    End Sub
+End Module");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+        [Fact]
+        public void StringCompare_ContractCheck_Diagnostic()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(string param)
+    {
+        var str = """";
+        param = """";
+        System.Diagnostics.Contracts.Contract.Requires(param == str);
+    }
+}
+",
+            // Test0.cs(8,56): warning CA1508: 'param == str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(8, 56, "param == str", "true"));
+
+            VerifyBasic(@"
+Module Test
+    Private Sub M(ByVal param As String)
+        Dim str = """"
+        param = """"
+        System.Diagnostics.Contracts.Contract.Requires(param <> str)
+    End Sub
+End Module",
+            // Test0.vb(6,56): warning CA1508: 'param <> str' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(6, 56, "param <> str", "False"));
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Reliability/DisposeObjectsBeforeLosingScopeTests.cs
@@ -1986,7 +1986,7 @@ Module Test
 End Module");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1648")]
         public void WhileLoop_MissingDisposeOnExit_Diagnostic()
         {
             VerifyCSharp(@"
@@ -2149,7 +2149,7 @@ Module Test
 End Module");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1648")]
         public void DoWhileLoop_MissingDisposeOnExit_Diagnostic()
         {
             VerifyCSharp(@"
@@ -2313,7 +2313,7 @@ Module Test
 End Module");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1648")]
         public void ForLoop_MissingDisposeOnExit_Diagnostic()
         {
             VerifyCSharp(@"
@@ -5473,6 +5473,33 @@ End Class
             GetBasicResultAt(15, 22, "Sub Test.M1()", "New A()"),
             // Test0.vb(20,22): warning CA2000: In method 'Sub Test.M2()', call System.IDisposable.Dispose on object created by 'New A()' before all references to it are out of scope.
             GetBasicResultAt(20, 22, "Sub Test.M2()", "New A()"));
+        }
+
+        [Fact]
+        public void DisposableAllocation_IncrementOperator_RegressionTest()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class Test
+{
+    private int i;
+    void M()
+    {
+        var a = new A();
+        i++;
+        a.Dispose();
+    }
+}
+");
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Security/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
@@ -377,10 +377,10 @@ Class Test
     End Sub
 
     Private Sub M1()
-        Dim t As Test = """"    ' Implicit user defined conversion
-        Dim str As String = t   ' Implicit user defined conversion
+        Dim t As Test = """"    ' Implicit user defined conversion
+        Dim str As String = t   ' Implicit user defined conversion
         Dim c As New Command1(str, str)
-    End Sub
+    End Sub
 
     Public Shared Widening Operator CType(ByVal value As String) As Test
         Return Nothing
@@ -451,10 +451,10 @@ Class Test
     End Sub
 
     Private Sub M1()
-        Dim t As Test = CType("""", Test)       ' Explicit user defined conversion
-        Dim str As String = CType(t, String)    ' Explicit user defined conversion
+        Dim t As Test = CType("""", Test)       ' Explicit user defined conversion
+        Dim str As String = CType(t, String)    ' Explicit user defined conversion
         Dim c As New Command1(str, str)
-    End Sub
+    End Sub
 
     Public Shared Narrowing Operator CType(ByVal value As String) As Test
         Return Nothing

--- a/src/Utilities/Extensions/DiagnosticExtensions.cs
+++ b/src/Utilities/Extensions/DiagnosticExtensions.cs
@@ -28,6 +28,14 @@ namespace Analyzer.Utilities.Extensions
             return node.GetLocation().CreateDiagnostic(rule, args);
         }
 
+        public static Diagnostic CreateDiagnostic(
+            this IOperation operation,
+            DiagnosticDescriptor rule,
+            params object[] args)
+        {
+            return operation.Syntax.CreateDiagnostic(rule, args);
+        }
+
         public static IEnumerable<Diagnostic> CreateDiagnostics(
             this IEnumerable<SyntaxToken> tokens,
             DiagnosticDescriptor rule,

--- a/src/Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -321,5 +321,19 @@ namespace Analyzer.Utilities.Extensions
 
             return null;
         }
+
+        public static bool IsLambdaOrLocalFunctionOrDelegate(this IMethodSymbol method)
+        {
+            switch (method.MethodKind)
+            {
+                case MethodKind.LambdaMethod:
+                case MethodKind.LocalFunction:
+                case MethodKind.DelegateInvoke:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -340,14 +340,14 @@ namespace Analyzer.Utilities.Extensions
         /// </summary>
         /// <param name="binaryOperation"></param>
         /// <returns></returns>
-        public static bool IsConditionalOpertator(this IBinaryOperation binaryOperation) => binaryOperation.IsConditionalAndOpertator() || binaryOperation.IsConditionalOrOpertator();
+        public static bool IsConditionalOperator(this IBinaryOperation binaryOperation) => binaryOperation.IsConditionalAndOperator() || binaryOperation.IsConditionalOrOperator();
 
         /// <summary>
         /// Indicates if the given <paramref name="binaryOperation"/> is a ConditionalAnd operator ('&&').
         /// </summary>
         /// <param name="binaryOperation"></param>
         /// <returns></returns>
-        public static bool IsConditionalAndOpertator(this IBinaryOperation binaryOperation)
+        public static bool IsConditionalAndOperator(this IBinaryOperation binaryOperation)
         {
             switch (binaryOperation.OperatorKind)
             {
@@ -368,7 +368,7 @@ namespace Analyzer.Utilities.Extensions
         /// </summary>
         /// <param name="binaryOperation"></param>
         /// <returns></returns>
-        public static bool IsConditionalOrOpertator(this IBinaryOperation binaryOperation)
+        public static bool IsConditionalOrOperator(this IBinaryOperation binaryOperation)
         {
             switch (binaryOperation.OperatorKind)
             {
@@ -407,5 +407,22 @@ namespace Analyzer.Utilities.Extensions
                     return false;
             }
         }
+
+        public static ITypeSymbol GetExceptionType(this IThrowOperation throwOperation)
+        {
+            if (throwOperation.Exception != null)
+            {
+                return throwOperation.Exception.Type;
+            }
+
+            var catchOperation = throwOperation.GetAncestor<ICatchClauseOperation>(OperationKind.CatchClause);
+            return catchOperation?.ExceptionType;
+        }
+
+        public static bool IsLambdaOrLocalFunctionOrDelegateInvocation(this IInvocationOperation operation)
+            => operation.TargetMethod.IsLambdaOrLocalFunctionOrDelegate();
+
+        public static bool IsLambdaOrLocalFunctionOrDelegateReference(this IMethodReferenceOperation operation)
+            => operation.Method.IsLambdaOrLocalFunctionOrDelegate();
     }
 }

--- a/src/Utilities/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Extensions/ITypeSymbolExtensions.cs
@@ -78,7 +78,7 @@ namespace Analyzer.Utilities.Extensions
             }
         }
 
-        public static bool DerivesFrom(this ITypeSymbol symbol, ITypeSymbol candidateBaseType, bool baseTypesOnly = false)
+        public static bool DerivesFrom(this ITypeSymbol symbol, ITypeSymbol candidateBaseType, bool baseTypesOnly = false, bool checkTypeParameterConstraints = true)
         {
             if (candidateBaseType == null || symbol == null)
             {
@@ -88,6 +88,18 @@ namespace Analyzer.Utilities.Extensions
             if (!baseTypesOnly && symbol.AllInterfaces.OfType<ITypeSymbol>().Contains(candidateBaseType))
             {
                 return true;
+            }
+
+            if (checkTypeParameterConstraints && symbol.TypeKind == TypeKind.TypeParameter)
+            {
+                var typeParameterSymbol = (ITypeParameterSymbol)symbol;
+                foreach (var constraintType in typeParameterSymbol.ConstraintTypes)
+                {
+                    if (constraintType.DerivesFrom(candidateBaseType, baseTypesOnly, checkTypeParameterConstraints))
+                    {
+                        return true;
+                    }
+                }
             }
 
             while (symbol != null)
@@ -149,6 +161,9 @@ namespace Analyzer.Utilities.Extensions
 
         public static bool HasValueCopySemantics(this ITypeSymbol typeSymbol)
             => typeSymbol.IsValueType || typeSymbol.SpecialType == SpecialType.System_String;
+
+        public static bool IsNonNullableValueType(this ITypeSymbol typeSymbol)
+            => typeSymbol != null && typeSymbol.IsValueType && typeSymbol.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T;
 
         public static Accessibility DetermineMinimalAccessibility(this ITypeSymbol typeSymbol)
         {


### PR DESCRIPTION
This rule flags conditional expressions which are always true/false and null checks for operations that are always null/non-null based on predicate analysis.

This PR is based upon https://github.com/dotnet/roslyn-analyzers/pull/1635, which adds predicate analysis that enables us to implement this simple rule utilizing its results. The only relevant commit for this PR on top of #1635 is https://github.com/dotnet/roslyn-analyzers/commit/746645e06051121c4fd492803c46d052f375c88a. I will rebase this PR once #1635 is merged.