### PR TITLE
Implement CA1303 (DoNotPassLiteralsAsLocalizedParameters) using Dataf…

### DIFF
--- a/nuget/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.props
+++ b/nuget/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.props
@@ -10,6 +10,7 @@
     <CodeAnalysisRuleSetOverrides>
       $(CodeAnalysisRuleSetOverrides);
       -Microsoft.Design#CA1062;
+      -Microsoft.Globalization#CA1303;
       -Microsoft.Reliability#CA2000;
       -Microsoft.Security#CA2100;
       -Microsoft.Usage#CA2213;

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/DoNotPassLiteralsAsLocalizedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/DoNotPassLiteralsAsLocalizedParameters.cs
@@ -1,0 +1,358 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Operations.ControlFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow;
+using Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.NullAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis;
+using Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.Globalization
+{
+    /// <summary>
+    /// CA1303: Do not pass literals as localized parameters
+    /// A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable.
+    /// This warning is raised when a literal string is passed as a value to a parameter or property and one or more of the following cases is true:
+    ///   1. The LocalizableAttribute attribute of the parameter or property is set to true.
+    ///   2. The parameter or property name contains "Text", "Message", or "Caption".
+    ///   3. The name of the string parameter that is passed to a Console.Write or Console.WriteLine method is either "value" or "format".
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class DoNotPassLiteralsAsLocalizedParameters : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA1303";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftGlobalizationAnalyzersResources.DoNotPassLiteralsAsLocalizedParametersTitle), MicrosoftGlobalizationAnalyzersResources.ResourceManager, typeof(MicrosoftGlobalizationAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftGlobalizationAnalyzersResources.DoNotPassLiteralsAsLocalizedParametersMessage), MicrosoftGlobalizationAnalyzersResources.ResourceManager, typeof(MicrosoftGlobalizationAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftGlobalizationAnalyzersResources.DoNotPassLiteralsAsLocalizedParametersDescription), MicrosoftGlobalizationAnalyzersResources.ResourceManager, typeof(MicrosoftGlobalizationAnalyzersResources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
+                                                                             s_localizableTitle,
+                                                                             s_localizableMessage,
+                                                                             DiagnosticCategory.Globalization,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             description: s_localizableDescription,
+                                                                             helpLinkUri: "https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters",
+                                                                             customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                INamedTypeSymbol localizableStateAttributeSymbol = WellKnownTypes.LocalizableAttribute(compilationContext.Compilation);
+                INamedTypeSymbol conditionalAttributeSymbol = WellKnownTypes.ConditionalAttribute(compilationContext.Compilation);
+                INamedTypeSymbol systemConsoleSymbol = WellKnownTypes.Console(compilationContext.Compilation);
+                ImmutableHashSet<INamedTypeSymbol> typesToIgnore = GetTypesToIgnore(compilationContext.Compilation);
+
+                compilationContext.RegisterOperationBlockStartAction(operationBlockStartContext =>
+                {
+                    if (!(operationBlockStartContext.OwningSymbol is IMethodSymbol containingMethod))
+                    {
+                        return;
+                    }
+
+                    var lazyStringContentResult = new Lazy<DataFlowAnalysisResult<StringContentBlockAnalysisResult, StringContentAbstractValue>>(
+                        valueFactory: ComputeStringContentAnalysisResult, isThreadSafe: false);
+
+                    operationBlockStartContext.RegisterOperationAction(operationContext =>
+                    {
+                        var argument = (IArgumentOperation)operationContext.Operation;
+                        switch (argument.Parent?.Kind)
+                        {
+                            case OperationKind.Invocation:
+                            case OperationKind.ObjectCreation:
+                                AnalyzeArgument(argument.Parameter, containingPropertySymbolOpt: null, operation: argument, reportDiagnostic: operationContext.ReportDiagnostic);
+                                return;
+                        }
+                    }, OperationKind.Argument);
+
+                    operationBlockStartContext.RegisterOperationAction(operationContext =>
+                    {
+                        var propertyReference = (IPropertyReferenceOperation)operationContext.Operation;
+                        if (propertyReference.Parent is IAssignmentOperation assignment &&
+                            assignment.Target == propertyReference &&
+                            !propertyReference.Property.IsIndexer &&
+                            propertyReference.Property.SetMethod?.Parameters.Length == 1)
+                        {
+                            IParameterSymbol valueSetterParam = propertyReference.Property.SetMethod.Parameters[0];
+                            AnalyzeArgument(valueSetterParam, propertyReference.Property, assignment, operationContext.ReportDiagnostic);
+                        }
+                    }, OperationKind.PropertyReference);
+
+                    void AnalyzeArgument(IParameterSymbol parameter, IPropertySymbol containingPropertySymbolOpt, IOperation operation, Action<Diagnostic> reportDiagnostic)
+                    {
+                        if (ShouldBeLocalized(parameter, containingPropertySymbolOpt, localizableStateAttributeSymbol, conditionalAttributeSymbol, systemConsoleSymbol, typesToIgnore))
+                        {
+                            StringContentAbstractValue stringContentValue = lazyStringContentResult.Value[operation];
+                            if (stringContentValue.IsLiteralState)
+                            {
+                                Debug.Assert(stringContentValue.LiteralValues.Count > 0);
+
+                                // FxCop compat: Do not fire if the literal value came from a default parameter value
+                                if (stringContentValue.LiteralValues.Count == 1 &&
+                                    parameter.IsOptional &&
+                                    parameter.ExplicitDefaultValue is string defaultValue &&
+                                    defaultValue == stringContentValue.LiteralValues.Single())
+                                {
+                                    return;
+                                }
+
+                                // FxCop compat: Do not fire if none of the string literals have any non-control character.
+                                if (!LiteralValuesHaveNonControlCharacters(stringContentValue.LiteralValues))
+                                {
+                                    return;
+                                }
+
+                                // FxCop compat: Filter out xml string literals.
+                                var filteredStrings = stringContentValue.LiteralValues.Where(literal => !LooksLikeXmlTag(literal));
+                                if (filteredStrings.Any())
+                                {
+                                    // Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".
+                                    var arg1 = containingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                                    var arg2 = parameter.Name;
+                                    var arg3 = parameter.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                                    var arg4 = FormatLiteralValues(filteredStrings);
+                                    var diagnostic = operation.CreateDiagnostic(Rule, arg1, arg2, arg3, arg4);
+                                    reportDiagnostic(diagnostic);
+                                }
+                            }
+                        }
+                    }
+
+                    DataFlowAnalysisResult<StringContentBlockAnalysisResult, StringContentAbstractValue> ComputeStringContentAnalysisResult()
+                    {
+                        foreach (var operationRoot in operationBlockStartContext.OperationBlocks)
+                        {
+                            IBlockOperation topmostBlock = operationRoot.GetTopmostParentBlock();
+                            if (topmostBlock != null)
+                            {
+                                var cfg = ControlFlowGraph.Create(topmostBlock);
+                                var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(operationBlockStartContext.Compilation);
+                                var nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider);
+                                var pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, nullAnalysisResult);
+                                var copyAnalysisResult = CopyAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, nullAnalysisResultOpt: nullAnalysisResult, pointsToAnalysisResultOpt: pointsToAnalysisResult);
+                                // Do another null analysis pass to improve the results from PointsTo and Copy analysis.
+                                nullAnalysisResult = NullAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, copyAnalysisResult, pointsToAnalysisResultOpt: pointsToAnalysisResult);
+                                return StringContentAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider, copyAnalysisResult, nullAnalysisResult, pointsToAnalysisResult);
+                            }
+                        }
+
+                        return null;
+                    }
+                });
+            });
+        }
+
+        private static ImmutableHashSet<INamedTypeSymbol> GetTypesToIgnore(Compilation compilation)
+        {
+            var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>();
+
+            var xmlWriter = WellKnownTypes.XmlWriter(compilation);
+            if (xmlWriter != null)
+            {
+                builder.Add(xmlWriter);
+            }
+
+            var webUILiteralControl = WellKnownTypes.WebUILiteralControl(compilation);
+            if (webUILiteralControl != null)
+            {
+                builder.Add(webUILiteralControl);
+            }
+
+            var unitTestingAssert = WellKnownTypes.UnitTestingAssert(compilation);
+            if (unitTestingAssert != null)
+            {
+                builder.Add(unitTestingAssert);
+            }
+
+            var unitTestingCollectionAssert = WellKnownTypes.UnitTestingCollectionAssert(compilation);
+            if (unitTestingCollectionAssert != null)
+            {
+                builder.Add(unitTestingCollectionAssert);
+            }
+
+            var unitTestingCollectionStringAssert = WellKnownTypes.UnitTestingCollectionStringAssert(compilation);
+            if (unitTestingCollectionStringAssert != null)
+            {
+                builder.Add(unitTestingCollectionStringAssert);
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static bool ShouldBeLocalized(
+            IParameterSymbol parameterSymbol,
+            IPropertySymbol containingPropertySymbolOpt,
+            INamedTypeSymbol localizableStateAttributeSymbol,
+            INamedTypeSymbol conditionalAttributeSymbol,
+            INamedTypeSymbol systemConsoleSymbol,
+            ImmutableHashSet<INamedTypeSymbol> typesToIgnore)
+        {
+            Debug.Assert(parameterSymbol.ContainingSymbol.Kind == SymbolKind.Method);
+
+            if (parameterSymbol.Type.SpecialType != SpecialType.System_String)
+            {
+                return false;
+            }
+
+            // Verify LocalizableAttributeState
+            if (localizableStateAttributeSymbol != null)
+            {
+                LocalizableAttributeState localizableAttributeState = GetLocalizableAttributeState(parameterSymbol, localizableStateAttributeSymbol);
+                switch (localizableAttributeState)
+                {
+                    case LocalizableAttributeState.False:
+                        return false;
+
+                    case LocalizableAttributeState.True:
+                        return true;
+
+                    default:
+                        break;
+                }
+            }
+
+            // FxCop compat checks.
+            if (typesToIgnore.Contains(parameterSymbol.ContainingType) ||
+                parameterSymbol.ContainingSymbol.HasAttribute(conditionalAttributeSymbol))
+            {
+                return false;
+            }
+
+            // FxCop compat: For overrides, check for localizability of the corresponding parameter in the overridden method.
+            var method = (IMethodSymbol)parameterSymbol.ContainingSymbol;
+            if (method.IsOverride &&
+                method.OverriddenMethod.Parameters.Length == method.Parameters.Length)
+            {
+                int parameterIndex = method.GetParameterIndex(parameterSymbol);
+                IParameterSymbol overridenParameter = method.OverriddenMethod.Parameters[parameterIndex];
+                if (overridenParameter.Type == parameterSymbol.Type)
+                {
+                    return ShouldBeLocalized(overridenParameter, containingPropertySymbolOpt, localizableStateAttributeSymbol, conditionalAttributeSymbol, systemConsoleSymbol, typesToIgnore);
+                }
+            }
+
+            // FxCop compat: If a localizable attribute isn't defined then fall back to name heuristics.
+            bool IsLocalizableByNameHeuristic(ISymbol symbol) =>
+                symbol.Name.Equals("message", StringComparison.OrdinalIgnoreCase) ||
+                symbol.Name.Equals("text", StringComparison.OrdinalIgnoreCase) ||
+                symbol.Name.Equals("caption", StringComparison.OrdinalIgnoreCase);
+
+            if (IsLocalizableByNameHeuristic(parameterSymbol) ||
+                containingPropertySymbolOpt != null && IsLocalizableByNameHeuristic(containingPropertySymbolOpt))
+            {
+                return true;
+            }
+
+            if (method.ContainingType.Equals(systemConsoleSymbol) &&
+                (method.Name.Equals("Write", StringComparison.Ordinal) ||
+                 method.Name.Equals("WriteLine", StringComparison.Ordinal)) &&
+                (parameterSymbol.Name.Equals("format", StringComparison.OrdinalIgnoreCase) ||
+                 parameterSymbol.Name.Equals("value", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static LocalizableAttributeState GetLocalizableAttributeState(ISymbol symbol, INamedTypeSymbol localizableAttributeTypeSymbol)
+        {
+            Debug.Assert(localizableAttributeTypeSymbol != null);
+            if (symbol == null)
+            {
+                return LocalizableAttributeState.Undefined;
+            }
+
+            LocalizableAttributeState localizedState = GetLocalizableAttributeStateCore(symbol.GetAttributes(), localizableAttributeTypeSymbol);
+            if (localizedState != LocalizableAttributeState.Undefined)
+            {
+                return localizedState;
+            }
+
+            ISymbol containingSymbol = (symbol as IMethodSymbol)?.AssociatedSymbol is IPropertySymbol propertySymbol ? propertySymbol : symbol.ContainingSymbol;
+            return GetLocalizableAttributeState(containingSymbol, localizableAttributeTypeSymbol);
+        }
+
+        private static LocalizableAttributeState GetLocalizableAttributeStateCore(ImmutableArray<AttributeData> attributeList, INamedTypeSymbol localizableAttributeTypeSymbol)
+        {
+            Debug.Assert(localizableAttributeTypeSymbol != null);
+
+            var localizableAttribute = attributeList.FirstOrDefault(attr => localizableAttributeTypeSymbol.Equals(attr.AttributeClass));
+            if (localizableAttribute != null &&
+                localizableAttribute.AttributeConstructor.Parameters.Length == 1 &&
+                localizableAttribute.AttributeConstructor.Parameters[0].Type.SpecialType == SpecialType.System_Boolean &&
+                localizableAttribute.ConstructorArguments.Length == 1 &&
+                localizableAttribute.ConstructorArguments[0].Kind == TypedConstantKind.Primitive &&
+                localizableAttribute.ConstructorArguments[0].Value is bool isLocalizable)
+            {
+                return isLocalizable ? LocalizableAttributeState.True : LocalizableAttributeState.False;
+            }
+
+            return LocalizableAttributeState.Undefined;
+        }
+
+        private static string FormatLiteralValues(IEnumerable<string> literalValues)
+        {
+            var literals = new StringBuilder();
+            foreach (string literal in literalValues.Order())
+            {
+                if (literals.Length > 0)
+                {
+                    literals.Append(", ");
+                }
+
+                literals.Append(literal);
+            }
+
+            return literals.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if the given string looks like an XML/HTML tag
+        /// </summary>
+        private static bool LooksLikeXmlTag(string literal)
+        {
+            // Call the trim function to remove any spaces around the beginning and end of the string so we can more accurately detect
+            // XML strings
+            string trimmedLiteral = literal.Trim();
+            return trimmedLiteral.Length > 2 && trimmedLiteral[0] == '<' && trimmedLiteral[trimmedLiteral.Length - 1] == '>';
+        }
+
+        /// <summary>
+        /// Returns true if any character in literalValues is not a control character
+        /// </summary>
+        private static bool LiteralValuesHaveNonControlCharacters(IEnumerable<string> literalValues)
+        {
+            foreach (string literal in literalValues)
+            {
+                foreach (char ch in literal)
+                {
+                    if (!char.IsControl(ch))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/LocalizableAttributeState.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/LocalizableAttributeState.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.Globalization
+{
+    internal enum LocalizableAttributeState
+    {
+        Undefined,
+        True,
+        False,
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/MicrosoftGlobalizationAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/MicrosoftGlobalizationAnalyzersResources.resx
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DoNotPassLiteralsAsLocalizedParametersDescription" xml:space="preserve">
+    <value>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</value>
+  </data>
+  <data name="DoNotPassLiteralsAsLocalizedParametersMessage" xml:space="preserve">
+    <value>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</value>
+  </data>
+  <data name="DoNotPassLiteralsAsLocalizedParametersTitle" xml:space="preserve">
+    <value>Do not pass literals as localized parameters</value>
+  </data>
+</root>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.cs.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.de.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.es.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.fr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.it.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.ja.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.ko.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.pl.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.pt-BR.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.ru.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.tr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.zh-Hans.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Globalization/xlf/MicrosoftGlobalizationAnalyzersResources.zh-Hant.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../MicrosoftGlobalizationAnalyzersResources.resx">
+    <body>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersDescription">
+        <source>A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</source>
+        <target state="new">A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersMessage">
+        <source>Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</source>
+        <target state="new">Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPassLiteralsAsLocalizedParametersTitle">
+        <source>Do not pass literals as localized parameters</source>
+        <target state="new">Do not pass literals as localized parameters</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.md
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.md
@@ -1,3 +1,13 @@
+### CA1303: Do not pass literals as localized parameters ###
+
+A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable.
+
+Category: Globalization
+
+Severity: Warning
+
+Help: [https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters)
+
 ### CA2000: Dispose objects before losing scope ###
 
 A local object of a IDisposable type is created but the object is not disposed before all references to the object are out of scope.

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Globalization/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Globalization/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -1,0 +1,1262 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeQuality.Analyzers.Exp.Globalization;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Globalization
+{
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.StringContentAnalysis)]
+    public partial class DoNotPassLiteralsAsLocalizedParametersTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new DoNotPassLiteralsAsLocalizedParameters();
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new DoNotPassLiteralsAsLocalizedParameters();
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, string containingMethod, string parameterName, string invokedMethod, string literals) =>
+            GetCSharpResultAt(line, column, DoNotPassLiteralsAsLocalizedParameters.Rule, containingMethod, parameterName, invokedMethod, literals);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, string containingMethod, string parameterName, string invokedMethod, string literals) =>
+            GetBasicResultAt(line, column, DoNotPassLiteralsAsLocalizedParameters.Rule, containingMethod, parameterName, invokedMethod, literals);
+
+        [Fact]
+        public void NonLocalizableParameter_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public void M(string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c, string param)
+    {
+        // Literal argument
+        var str = """";
+        c.M(str);
+
+        // Non-literal argument
+        c.M(param);
+    }
+}
+");
+
+            VerifyBasic(@"
+Public Class C
+    Public Sub M(param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C, param As String)
+        ' Literal argument
+        Dim str = """"
+        c.M(str)
+
+        ' Non-literal argument
+        c.M(param)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_NonLiteralArgument_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c, string param)
+    {
+        c.M(param);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C, param As String)
+        c.M(param)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_EmptyStringLiteralArgument_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = """";
+        c.M(str);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = """"
+        c.M(str)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_NonEmptyStringLiteralArgument_AllControlChars_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = new string(new char[] { '\u0058' });
+        c.M(str);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+Imports Microsoft.VisualBasic
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ChrW(&H0030)
+        c.M(str)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_StringLiteralArgument_Method_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        c.M(str);
+    }
+}
+",
+            // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(16, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.M(str)
+    End Sub
+End Class
+",
+            // Test0.vb(12,13): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(12, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String)", "a"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_StringLiteralArgument_Constructor_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public C([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        c = new C(str);
+    }
+}
+",
+            // Test0.cs(16,19): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'C.C(string param)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(16, 19, "void Test.M1(C c)", "param", "C.C(string param)", "a"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub New(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c = New C(str)
+    End Sub
+End Class
+",
+            // Test0.vb(12,19): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.New(param As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(12, 19, "Sub Test.M1(c As C)", "param", "Sub C.New(param As String)", "a"));
+        }
+
+        [Fact]
+        public void PropertyWithLocalizableAttribute_StringLiteralArgument_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    [LocalizableAttribute(true)]
+    public string P { get; set; }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        c.P = str;
+    }
+}
+",
+            // Test0.cs(15,9): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'value' of a call to 'void C.P.set'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(15, 9, "void Test.M1(C c)", "value", "void C.P.set", "a"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    <LocalizableAttribute(True)> _
+    Public Property P As String
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.P = str
+    End Sub
+End Class
+",
+            // Test0.vb(12,9): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'AutoPropertyValue' of a call to 'Property Set C.P(AutoPropertyValue As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(12, 9, "Sub Test.M1(c As C)", "AutoPropertyValue", "Property Set C.P(AutoPropertyValue As String)", "a"));
+        }
+
+        [Fact]
+        public void PropertySetterWithLocalizableAttribute_StringLiteralArgument_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public string P { get; [LocalizableAttribute(true)]set; }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        c.P = str;
+    }
+}
+",
+            // Test0.cs(14,9): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'value' of a call to 'void C.P.set'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(14, 9, "void Test.M1(C c)", "value", "void C.P.set", "a"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Private _p As String
+    Public Property P As String
+        Get
+            Return _p
+        End Get
+        <LocalizableAttribute(True)>
+        Set(valueCustom As String)
+            _p = valueCustom
+        End Set
+    End Property
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.P = str
+    End Sub
+End Class
+",
+
+            // Test0.vb(20,9): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'valueCustom' of a call to 'Property Set C.P(valueCustom As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(20, 9, "Sub Test.M1(c As C)", "valueCustom", "Property Set C.P(valueCustom As String)", "a"));
+        }
+
+        [Fact]
+        public void PropertySetterParameterWithLocalizableAttribute_StringLiteralArgument_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    private string _p;
+    public string P { get => _p; [param: LocalizableAttribute(true)]set => _p = value; }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        c.P = str;
+    }
+}
+",
+            // Test0.cs(15,9): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'value' of a call to 'void C.P.set'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(15, 9, "void Test.M1(C c)", "value", "void C.P.set", "a"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Private _p As String
+    Public Property P As String
+        Get
+            Return _p
+        End Get
+
+        Set(<LocalizableAttribute(True)> valueCustom As String)
+            _p = valueCustom
+        End Set
+    End Property
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.P = str
+    End Sub
+End Class
+",
+
+            // Test0.vb(20,9): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'valueCustom' of a call to 'Property Set C.P(valueCustom As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(20, 9, "Sub Test.M1(c As C)", "valueCustom", "Property Set C.P(valueCustom As String)", "a"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_MultipleStringLiteralArguments_Method_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param, string message)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        var message = ""m"";
+        c.M(str, message);
+    }
+}
+",
+            // Test0.cs(17,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param, string message)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(17, 13, "void Test.M1(C c)", "param", "void C.M(string param, string message)", "a"),
+            // Test0.cs(17,18): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'message' of a call to 'void C.M(string param, string message)'. Retrieve the following string(s) from a resource table instead: "m".
+            GetCSharpResultAt(17, 18, "void Test.M1(C c)", "message", "void C.M(string param, string message)", "m"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String, message As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        Dim message = ""m""
+        c.M(str, message)
+    End Sub
+End Class
+",
+            // Test0.vb(13,13): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String, message As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(13, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String, message As String)", "a"),
+            // Test0.vb(13,18): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'message' of a call to 'Sub C.M(param As String, message As String)'. Retrieve the following string(s) from a resource table instead: "m".
+            GetBasicResultAt(13, 18, "Sub Test.M1(c As C)", "message", "Sub C.M(param As String, message As String)", "m"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableFalseAttribute_StringLiteralArgument_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(false)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        c.M(str);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(False)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.M(str)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ContainingSymbolWithLocalizableTrueAttribute_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+[LocalizableAttribute(true)]
+public class C
+{
+    public void M(string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        c.M(str);
+    }
+}
+",
+            // Test0.cs(17,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(17, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+<LocalizableAttribute(True)> _
+Public Class C
+    Public Sub M(param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.M(str)
+    End Sub
+End Class
+",
+            // Test0.vb(13,13): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(13, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String)", "a"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableFalseAttribute_ContainingSymbolWithLocalizableTrueAttribute_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+[LocalizableAttribute(true)]
+public class C
+{
+    public void M([LocalizableAttribute(false)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        c.M(str);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+<LocalizableAttribute(True)>
+Public Class C
+    Public Sub M(<LocalizableAttribute(False)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.M(str)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableTrueAttribute_ContainingSymbolWithLocalizableFalseAttribute_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+[LocalizableAttribute(false)]
+public class C
+{
+    public void M([LocalizableAttribute(true)]string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a"";
+        c.M(str);
+    }
+}
+",
+            // Test0.cs(17,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(17, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+<LocalizableAttribute(False)> _
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.M(str)
+    End Sub
+End Class
+",
+            // Test0.vb(13,13): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(13, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String)", "a"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_OverriddenMethod_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class B
+{
+    public virtual void NonLocalizableMethod([LocalizableAttribute(false)] string param)
+    {
+    }
+
+    public virtual void LocalizableMethod([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class C : B
+{
+    public override void NonLocalizableMethod(string param)
+    {
+    }
+
+    public override void LocalizableMethod(string param)
+    {
+    }
+}
+
+public class Test
+{
+    void M1(C c)
+    {
+        var str = ""a"";
+        c.NonLocalizableMethod(str);
+        c.LocalizableMethod(str);
+    }
+}
+",
+            // Test0.cs(32,29): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.LocalizableMethod(string param)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(32, 29, "void Test.M1(C c)", "param", "void C.LocalizableMethod(string param)", "a"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class B
+    Public Overridable Sub NonLocalizableMethod(<LocalizableAttribute(False)> param As String)
+    End Sub
+
+    Public Overridable Sub LocalizableMethod(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class C
+    Inherits B
+    Public Overrides Sub NonLocalizableMethod(param As String)
+    End Sub
+
+    Public Overrides Sub LocalizableMethod(param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Private Sub M1(ByVal c As C)
+        Dim str = ""a""
+        c.NonLocalizableMethod(str)
+        c.LocalizableMethod(str)
+    End Sub
+End Class
+",
+            // Test0.vb(25,29): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.LocalizableMethod(param As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(25, 29, "Sub Test.M1(c As C)", "param", "Sub C.LocalizableMethod(param As String)", "a"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_StringLiteralArgument_MultiplePossibleLiterals_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c, bool flag)
+    {
+        var str = flag ? ""a"" : ""b"";
+        c.M(str);
+    }
+}
+",
+            // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c, bool flag)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a, b".
+            GetCSharpResultAt(16, 13, "void Test.M1(C c, bool flag)", "param", "void C.M(string param)", "a, b"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C, flag As Boolean)
+        Dim str = If(flag, ""a"", ""b"")
+        c.M(str)
+    End Sub
+End Class
+",
+            // Test0.vb(12,13): warning CA1303: Method 'Sub Test.M1(c As C, flag As Boolean)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a, b".
+            GetBasicResultAt(12, 13, "Sub Test.M1(c As C, flag As Boolean)", "param", "Sub C.M(param As String)", "a, b"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_StringLiteralArgument_MultiplePossibleLiterals_Ordering_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c, bool flag)
+    {
+        var str = flag ? ""b"" : ""a"";
+        c.M(str);
+    }
+}
+",
+            // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c, bool flag)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a, b".
+            GetCSharpResultAt(16, 13, "void Test.M1(C c, bool flag)", "param", "void C.M(string param)", "a, b"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C, flag As Boolean)
+        Dim str = If(flag, ""b"", ""a"")
+        c.M(str)
+    End Sub
+End Class
+",
+            // Test0.vb(12,13): warning CA1303: Method 'Sub Test.M1(c As C, flag As Boolean)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a, b".
+            GetBasicResultAt(12, 13, "Sub Test.M1(c As C, flag As Boolean)", "param", "Sub C.M(param As String)", "a, b"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_StringLiteralArgument_DefaultValue_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c, string param = ""a"")
+    {
+        c.M(param);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C, Optional param As String = ""a"")
+        c.M(param)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_XmlStringLiteralArgument_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        string str = ""<a>"";
+        c.M(str);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""<a>""
+        c.M(str)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_XmlStringLiteralArgument_Filtering_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c, bool flag)
+    {
+        string str = flag ? ""<a>"" : ""b"";
+        c.M(str);
+    }
+}
+",
+            // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c, bool flag)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "b".
+            GetCSharpResultAt(16, 13, "void Test.M1(C c, bool flag)", "param", "void C.M(string param)", "b"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C, flag As Boolean)
+        Dim str = If (flag, ""<a>"", ""b"")
+        c.M(str)
+    End Sub
+End Class
+",
+            // Test0.vb(12,13): warning CA1303: Method 'Sub Test.M1(c As C, flag As Boolean)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "b".
+            GetBasicResultAt(12, 13, "Sub Test.M1(c As C, flag As Boolean)", "param", "Sub C.M(param As String)", "b"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_SpecialCases_ConditionalMethod_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.Diagnostics;
+
+public class C
+{
+    [Conditional(""DEBUG"")]
+    public void M(string message)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        string str = ""a"";
+        c.M(str);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.Diagnostics
+
+Public Class C
+    <Conditional(""DEBUG"")>
+    Public Sub M(message As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.M(str)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_SpecialCases_XmlWriterMethod_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+using System.Xml;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(XmlWriter writer)
+    {
+        string str = ""a"";
+        writer.WriteString(str);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+Imports System.Xml
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(writer As XmlWriter)
+        Dim str = ""a""
+        writer.WriteString(str)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_SpecialCases_SystemConsoleWriteMethods_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class Test
+{
+    public void M1(string param)
+    {
+        string str = ""a"";
+        Console.Write(value: str);
+        Console.WriteLine(value: str);
+        Console.Write(format: str, arg0: param);
+        Console.WriteLine(format: str, arg0: param);
+    }
+}
+",
+            // Test0.cs(9,23): warning CA1303: Method 'void Test.M1(string param)' passes a literal string as parameter 'value' of a call to 'void Console.Write(string value)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(9, 23, "void Test.M1(string param)", "value", "void Console.Write(string value)", "a"),
+            // Test0.cs(10,27): warning CA1303: Method 'void Test.M1(string param)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(10, 27, "void Test.M1(string param)", "value", "void Console.WriteLine(string value)", "a"),
+            // Test0.cs(11,23): warning CA1303: Method 'void Test.M1(string param)' passes a literal string as parameter 'format' of a call to 'void Console.Write(string format, object arg0)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(11, 23, "void Test.M1(string param)", "format", "void Console.Write(string format, object arg0)", "a"),
+            // Test0.cs(12,27): warning CA1303: Method 'void Test.M1(string param)' passes a literal string as parameter 'format' of a call to 'void Console.WriteLine(string format, object arg0)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(12, 27, "void Test.M1(string param)", "format", "void Console.WriteLine(string format, object arg0)", "a"));
+
+            VerifyBasic(@"
+Imports System
+
+Public Class Test
+    Public Sub M1(param As String)
+        Dim str = ""a""
+        Console.Write(value:=str)
+        Console.WriteLine(value:=str)
+        Console.Write(format:=str, arg0:=param)
+        Console.WriteLine(format:=str, arg0:=param)
+    End Sub
+End Class
+",
+            // Test0.vb(7,23): warning CA1303: Method 'Sub Test.M1(param As String)' passes a literal string as parameter 'value' of a call to 'Sub Console.Write(value As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(7, 23, "Sub Test.M1(param As String)", "value", "Sub Console.Write(value As String)", "a"),
+            // Test0.vb(8,27): warning CA1303: Method 'Sub Test.M1(param As String)' passes a literal string as parameter 'value' of a call to 'Sub Console.WriteLine(value As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(8, 27, "Sub Test.M1(param As String)", "value", "Sub Console.WriteLine(value As String)", "a"),
+            // Test0.vb(9,23): warning CA1303: Method 'Sub Test.M1(param As String)' passes a literal string as parameter 'format' of a call to 'Sub Console.Write(format As String, arg0 As Object)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(9, 23, "Sub Test.M1(param As String)", "format", "Sub Console.Write(format As String, arg0 As Object)", "a"),
+            // Test0.vb(10,27): warning CA1303: Method 'Sub Test.M1(param As String)' passes a literal string as parameter 'format' of a call to 'Sub Console.WriteLine(format As String, arg0 As Object)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(10, 27, "Sub Test.M1(param As String)", "format", "Sub Console.WriteLine(format As String, arg0 As Object)", "a"));
+        }
+
+        [Fact]
+        public void ParameterWithLocalizableAttribute_SpecialCases_SystemWebUILiteralControl_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+using System.Web.UI;
+
+namespace System.Web.UI
+{
+    public class LiteralControl
+    {
+        public LiteralControl(string text)
+        {
+        }
+    }
+}
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(LiteralControl control)
+    {
+        string str = ""a"";
+        control = new LiteralControl(str);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+Imports System.Web.UI
+
+Namespace System.Web.UI
+    Public Class LiteralControl
+        Public Sub New(text As String)
+        End Sub
+    End Class
+End Namespace
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(control As LiteralControl)
+        Dim str = ""a""
+        control = New LiteralControl(str)
+    End Sub
+End Class
+");
+        }
+
+        [InlineData("Assert")]
+        [InlineData("CollectionAssert")]
+        [InlineData("StringAssert")]
+        [Theory]
+        public void ParameterWithLocalizableAttribute_SpecialCases_UnitTestApis_NoDiagnostic(string assertClassName)
+        {
+            VerifyCSharp($@"
+using System.ComponentModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting
+{{
+    public class {assertClassName}
+    {{
+        public static bool IsTrue(bool condition, string message) => true;
+    }}
+}}
+
+public class Test
+{{
+    public void M1()
+    {{
+        string str = ""a"";
+        var result = {assertClassName}.IsTrue(false, str);
+    }}
+}}
+");
+
+            VerifyBasic($@"
+Imports System.ComponentModel
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+Namespace Microsoft.VisualStudio.TestTools.UnitTesting
+    Public Class {assertClassName}
+        Public Shared Function IsTrue(condition As Boolean, message As String) As Boolean
+            Return True
+        End Function
+    End Class
+End Namespace
+
+Public Class Test
+    Public Sub M1()
+        Dim str = ""a""
+        Dim result = {assertClassName}.IsTrue(False, str)
+    End Sub
+End Class
+");
+        }
+
+        [InlineData("message")]
+        [InlineData("text")]
+        [InlineData("caption")]
+        [InlineData("Message")]
+        [InlineData("Text")]
+        [InlineData("Caption")]
+        [Theory]
+        public void ParameterWithLocalizableName_StringLiteralArgument_Method_Diagnostic(string parameterName)
+        {
+            VerifyCSharp($@"
+public class C
+{{
+    public void M(string {parameterName})
+    {{
+    }}
+}}
+
+public class Test
+{{
+    public void M1(C c)
+    {{
+        var str = ""a"";
+        c.M(str);
+    }}
+}}
+",
+            // Test0.cs(14,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(14, 13, "void Test.M1(C c)", parameterName, $"void C.M(string {parameterName})", "a"));
+
+            VerifyBasic($@"
+Public Class C
+    Public Sub M({parameterName} As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.M(str)
+    End Sub
+End Class
+",
+            // Test0.vb(10,13): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(10, 13, "Sub Test.M1(c As C)", parameterName, $"Sub C.M({parameterName} As String)", "a"));
+        }
+
+        [InlineData("message")]
+        [InlineData("text")]
+        [InlineData("caption")]
+        [InlineData("Message")]
+        [InlineData("Text")]
+        [InlineData("Caption")]
+        [Theory]
+        public void PropertyWithLocalizableName_StringLiteralArgument_Diagnostic(string propertyName)
+        {
+            VerifyCSharp($@"
+public class C
+{{
+    public string {propertyName} {{ get; set; }}
+}}
+
+public class Test
+{{
+    public void M1(C c)
+    {{
+        var str = ""a"";
+        c.{propertyName} = str;
+    }}
+}}
+",
+
+            // Test0.cs(12,9): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'value' of a call to 'void C.caption.set'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(12, 9, "void Test.M1(C c)", "value", $"void C.{propertyName}.set", "a"));
+
+            VerifyBasic($@"
+Public Class C
+    Public Property {propertyName} As String
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a""
+        c.{propertyName} = str
+    End Sub
+End Class
+",
+
+            // Test0.vb(9,9): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'AutoPropertyValue' of a call to 'Property Set C.caption(AutoPropertyValue As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(9, 9, "Sub Test.M1(c As C)", "AutoPropertyValue", $"Property Set C.{propertyName}(AutoPropertyValue As String)", "a"));
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Globalization/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Globalization/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -843,6 +843,51 @@ End Class
         }
 
         [Fact]
+        public void ParameterWithLocalizableAttribute_ConstantField_StringLiteralArgument_Method_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    private const string _field = ""a"";
+    public void M1(C c)
+    {
+        c.M(_field);
+    }
+}
+",
+            // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetCSharpResultAt(16, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"));
+
+            VerifyBasic(@"
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Private Const _field As String = ""a"" 
+
+    Public Sub M1(c As C)
+        c.M(_field)
+    End Sub
+End Class
+",
+            // Test0.vb(13,13): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a".
+            GetBasicResultAt(13, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String)", "a"));
+        }
+
+        [Fact]
         public void ParameterWithLocalizableAttribute_XmlStringLiteralArgument_NoDiagnostic()
         {
             VerifyCSharp(@"

--- a/src/Utilities/Extensions/DiagnosticExtensions.cs
+++ b/src/Utilities/Extensions/DiagnosticExtensions.cs
@@ -28,6 +28,14 @@ namespace Analyzer.Utilities.Extensions
             return node.GetLocation().CreateDiagnostic(rule, args);
         }
 
+        public static Diagnostic CreateDiagnostic(
+            this IOperation operation,
+            DiagnosticDescriptor rule,
+            params object[] args)
+        {
+            return operation.Syntax.CreateDiagnostic(rule, args);
+        }
+
         public static IEnumerable<Diagnostic> CreateDiagnostics(
             this IEnumerable<SyntaxToken> tokens,
             DiagnosticDescriptor rule,

--- a/src/Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -321,5 +321,18 @@ namespace Analyzer.Utilities.Extensions
 
             return null;
         }
+
+        public static int GetParameterIndex(this IMethodSymbol methodSymbol, IParameterSymbol parameterSymbol)
+        {
+            for (var i = 0; i < methodSymbol.Parameters.Length; i++)
+            {
+                if (parameterSymbol == methodSymbol.Parameters[i])
+                {
+                    return i;
+                }
+            }
+
+            throw new ArgumentException("Invalid paramater", nameof(parameterSymbol));
+        }
     }
 }

--- a/src/Utilities/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Utilities/Extensions/INamedTypeSymbolExtensions.cs
@@ -130,29 +130,6 @@ namespace Analyzer.Utilities.Extensions
         }
 
         /// <summary>
-        /// Returns a value indicating whether the specified symbol has the specified
-        /// attribute.
-        /// </summary>
-        /// <param name="symbol">
-        /// The symbol being examined.
-        /// </param>
-        /// <param name="attribute">
-        /// The attribute in question.
-        /// </param>
-        /// <returns>
-        /// <c>true</c> if <paramref name="symbol"/> has an attribute of type
-        /// <paramref name="attribute"/>; otherwise <c>false</c>.
-        /// </returns>
-        /// <remarks>
-        /// If <paramref name="symbol"/> is a type, this method does not find attributes
-        /// on its base types.
-        /// </remarks>
-        public static bool HasAttribute(this INamedTypeSymbol symbol, INamedTypeSymbol attribute)
-        {
-            return symbol.GetAttributes().Any(attr => attr.AttributeClass.Equals(attribute));
-        }
-
-        /// <summary>
         /// Returns a value indicating whether the specified symbol is a static
         /// holder type.
         /// </summary>

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -473,5 +473,28 @@ namespace Analyzer.Utilities.Extensions
                     return null;
             }
         }
+
+        /// <summary>
+        /// Returns a value indicating whether the specified symbol has the specified
+        /// attribute.
+        /// </summary>
+        /// <param name="symbol">
+        /// The symbol being examined.
+        /// </param>
+        /// <param name="attribute">
+        /// The attribute in question.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if <paramref name="symbol"/> has an attribute of type
+        /// <paramref name="attribute"/>; otherwise <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// If <paramref name="symbol"/> is a type, this method does not find attributes
+        /// on its base types.
+        /// </remarks>
+        public static bool HasAttribute(this ISymbol symbol, INamedTypeSymbol attribute)
+        {
+            return symbol.GetAttributes().Any(attr => attr.AttributeClass.Equals(attribute));
+        }
     }
 }

--- a/src/Utilities/WellKnownTypes.cs
+++ b/src/Utilities/WellKnownTypes.cs
@@ -141,6 +141,11 @@ namespace Analyzer.Utilities
             return compilation.GetTypeByMetadataName("System.Web.UI.Control");
         }
 
+        public static INamedTypeSymbol WebUILiteralControl(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Web.UI.LiteralControl");
+        }
+
         public static INamedTypeSymbol WinFormsUIControl(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.Windows.Forms.Control");
@@ -366,6 +371,11 @@ namespace Analyzer.Utilities
             return compilation.GetTypeByMetadataName("System.Composition.ExportAttribute");
         }
 
+        public static INamedTypeSymbol LocalizableAttribute(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.ComponentModel.LocalizableAttribute");
+        }
+
         public static INamedTypeSymbol FieldOffsetAttribute(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.Runtime.InteropServices.FieldOffsetAttribute");
@@ -405,6 +415,21 @@ namespace Analyzer.Utilities
         public static INamedTypeSymbol ExpectedException(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("Microsoft.VisualStudio.TestTools.UnitTesting.ExpectedExceptionAttribute");
+        }
+
+        public static INamedTypeSymbol UnitTestingAssert(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("Microsoft.VisualStudio.TestTools.UnitTesting.Assert");
+        }
+
+        public static INamedTypeSymbol UnitTestingCollectionAssert(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert");
+        }
+
+        public static INamedTypeSymbol UnitTestingCollectionStringAssert(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert");
         }
 
         public static INamedTypeSymbol XunitAssert(Compilation compilation)
@@ -475,6 +500,11 @@ namespace Analyzer.Utilities
         public static INamedTypeSymbol SystemDiagnosticContractsContract(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.Diagnostics.Contracts.Contract");
+        }
+
+        public static INamedTypeSymbol XmlWriter(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Xml.XmlWriter");
         }
         #endregion
     }


### PR DESCRIPTION
…low StringContentAnalysis

_A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable._

Rule documentation: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters

Fixes #411