### PR TITLE
Performance improvements for DFA

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
     /// <summary>
     /// Abstract copy value shared by a set of one of more <see cref="AnalysisEntity"/> instances tracked by <see cref="CopyAnalysis"/>.
     /// </summary>
-    internal class CopyAbstractValue : IEquatable<CopyAbstractValue>
+    internal class CopyAbstractValue : CacheBasedEquatable<CopyAbstractValue>
     {
         public static CopyAbstractValue NotApplicable = new CopyAbstractValue(CopyAbstractValueKind.NotApplicable);
         public static CopyAbstractValue Invalid = new CopyAbstractValue(CopyAbstractValueKind.Invalid);
@@ -53,34 +53,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.CopyAnalysis
         public ImmutableHashSet<AnalysisEntity> AnalysisEntities { get; }
         public CopyAbstractValueKind Kind { get; }
 
-        public static bool operator ==(CopyAbstractValue value1, CopyAbstractValue value2)
-        {
-            if ((object)value1 == null)
-            {
-                return (object)value2 == null;
-            }
-
-            return value1.Equals(value2);
-        }
-
-        public static bool operator !=(CopyAbstractValue value1, CopyAbstractValue value2)
-        {
-            return !(value1 == value2);
-        }
-
-        public bool Equals(CopyAbstractValue other)
-        {
-            return other != null &&
-                Kind == other.Kind &&
-                AnalysisEntities.SetEquals(other.AnalysisEntities);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as CopyAbstractValue);
-        }
-
-        public override int GetHashCode()
+        protected override int ComputeHashCode()
         {
             int hashCode = HashUtilities.Combine(Kind.GetHashCode(), AnalysisEntities.Count.GetHashCode());
             foreach (var location in AnalysisEntities)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
     /// It contains the set of <see cref="IOperation"/>s that dispose an associated disposable <see cref="AbstractLocation"/> and
     /// the dispose <see cref="Kind"/>.
     /// </summary>
-    internal class DisposeAbstractValue : IEquatable<DisposeAbstractValue>
+    internal class DisposeAbstractValue : CacheBasedEquatable<DisposeAbstractValue>
     {
         public static readonly DisposeAbstractValue NotDisposable = new DisposeAbstractValue(DisposeAbstractValueKind.NotDisposable);
         public static readonly DisposeAbstractValue NotDisposed = new DisposeAbstractValue(DisposeAbstractValueKind.NotDisposed);
@@ -71,34 +71,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
         public ImmutableHashSet<IOperation> DisposingOrEscapingOperations { get; }
         public DisposeAbstractValueKind Kind { get; }
 
-        public static bool operator ==(DisposeAbstractValue value1, DisposeAbstractValue value2)
-        {
-            if ((object)value1 == null)
-            {
-                return (object)value2 == null;
-            }
-
-            return value1.Equals(value2);
-        }
-
-        public static bool operator !=(DisposeAbstractValue value1, DisposeAbstractValue value2)
-        {
-            return !(value1 == value2);
-        }
-
-        public bool Equals(DisposeAbstractValue other)
-        {
-            return other != null &&
-                Kind == other.Kind &&
-                DisposingOrEscapingOperations.SetEquals(other.DisposingOrEscapingOperations);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as DisposeAbstractValue);
-        }
-
-        public override int GetHashCode()
+        protected override int ComputeHashCode()
         {
             int hashCode = HashUtilities.Combine(Kind.GetHashCode(), DisposingOrEscapingOperations.Count.GetHashCode());
             foreach (var operation in DisposingOrEscapingOperations)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
     /// Abstract PointsTo value for an <see cref="AnalysisEntity"/>/<see cref="IOperation"/> tracked by <see cref="PointsToAnalysis"/>.
     /// It contains the set of possible <see cref="AbstractLocation"/>s that the entity or the operation can point to and the <see cref="Kind"/> of the location(s).
     /// </summary>
-    internal class PointsToAbstractValue: IEquatable<PointsToAbstractValue>
+    internal class PointsToAbstractValue: CacheBasedEquatable<PointsToAbstractValue>
     {
         public static PointsToAbstractValue Undefined = new PointsToAbstractValue(PointsToAbstractValueKind.Undefined);
         public static PointsToAbstractValue NoLocation = new PointsToAbstractValue(PointsToAbstractValueKind.NoLocation);
@@ -46,34 +46,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
         public ImmutableHashSet<AbstractLocation> Locations { get; }
         public PointsToAbstractValueKind Kind { get; }
 
-        public static bool operator ==(PointsToAbstractValue value1, PointsToAbstractValue value2)
-        {
-            if ((object)value1 == null)
-            {
-                return (object)value2 == null;
-            }
-
-            return value1.Equals(value2);
-        }
-
-        public static bool operator !=(PointsToAbstractValue value1, PointsToAbstractValue value2)
-        {
-            return !(value1 == value2);
-        }
-
-        public bool Equals(PointsToAbstractValue other)
-        {
-            return other != null &&
-                Kind == other.Kind &&
-                Locations.SetEquals(other.Locations);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as PointsToAbstractValue);
-        }
-
-        public override int GetHashCode()
+        protected override int ComputeHashCode()
         {
             int hashCode = HashUtilities.Combine(Kind.GetHashCode(), Locations.Count.GetHashCode());
             foreach (var location in Locations)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
             public override PointsToAbstractValue VisitInstanceReference(IInstanceReferenceOperation operation, object argument)
             {
                 var _ = base.VisitInstanceReference(operation, argument);
-                IOperation currentInstanceOperation = operation.GetInstance();
+                IOperation currentInstanceOperation = operation.GetInstance(IsInsideObjectInitializer);
                 return currentInstanceOperation != null ?
                     GetCachedAbstractValue(currentInstanceOperation) :
                     ThisOrMePointsToAbstractValue;
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.PointsToAnalysis
                 var pointsToAbstractValue = new PointsToAbstractValue(location);
                 CacheAbstractValue(operation, pointsToAbstractValue);
 
-                var _ = VisitArray(operation.Initializers, argument);
+                var _ = base.VisitAnonymousObjectCreation(operation, argument);
                 return pointsToAbstractValue;
             }
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/StringContentAnalysis/StringContentAbstractValue.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
     /// <summary>
     /// Abstract string content data value for <see cref="AnalysisEntity"/>/<see cref="IOperation"/> tracked by <see cref="StringContentAnalysis"/>.
     /// </summary>
-    internal partial class StringContentAbstractValue : IEquatable<StringContentAbstractValue>
+    internal partial class StringContentAbstractValue : CacheBasedEquatable<StringContentAbstractValue>
     {
         public static readonly StringContentAbstractValue UndefinedState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.Undefined);
         public static readonly StringContentAbstractValue InvalidState = new StringContentAbstractValue(ImmutableHashSet<string>.Empty, StringContainsNonLiteralState.Invalid);
@@ -68,34 +68,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.StringContentAnalysis
         /// </summary>
         public ImmutableHashSet<string> LiteralValues { get; }
 
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as StringContentAbstractValue);
-        }
-
-        public static bool operator ==(StringContentAbstractValue value1, StringContentAbstractValue value2)
-        {
-            if ((object)value1 == null)
-            {
-                return (object)value2 == null;
-            }
-
-            return value1.Equals(value2);
-        }
-
-        public static bool operator !=(StringContentAbstractValue value1, StringContentAbstractValue value2)
-        {
-            return !(value1 == value2);
-        }
-
-        public bool Equals(StringContentAbstractValue other)
-        {
-            return other != null &&
-                NonLiteralState == other.NonLiteralState &&
-                LiteralValues.SetEquals(other.LiteralValues);
-        }
-
-        public override int GetHashCode()
+        protected override int ComputeHashCode()
         {
             var hashCode = NonLiteralState.GetHashCode();
             foreach (var literal in LiteralValues.OrderBy(s => s))

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractEquatable.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractEquatable.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Analyzer.Utilities;
+
+namespace Microsoft.CodeAnalysis.Operations.DataFlow
+{
+    /// <summary>
+    /// Abstract cache based equatable implementation for objects that are compared frequently and hence need a performance optimization of using a cached hash code.
+    /// </summary>
+    internal abstract class CacheBasedEquatable<T> : IEquatable<T>
+        where T: class
+    {
+        private readonly Lazy<int> _lazyHashCode;
+
+        protected CacheBasedEquatable()
+        {
+#pragma warning disable CA2214 // Do not call overridable methods in constructors
+                               // https://github.com/dotnet/roslyn-analyzers/issues/1652
+            _lazyHashCode = new Lazy<int>(() => HashUtilities.Combine(GetType().GetHashCode(), ComputeHashCode()));
+#pragma warning restore CA2214 // Do not call overridable methods in constructors
+        }
+
+        protected abstract int ComputeHashCode();
+
+        public sealed override int GetHashCode() => _lazyHashCode.Value;
+        public sealed override bool Equals(object obj) => Equals(obj as T);
+        public bool Equals(T other) => _lazyHashCode.Value == (other as CacheBasedEquatable<T>)?._lazyHashCode.Value;
+
+        public static bool operator ==(CacheBasedEquatable<T> value1, CacheBasedEquatable<T> value2)
+        {
+            if ((object)value1 == null)
+            {
+                return (object)value2 == null;
+            }
+
+            return value1.Equals(value2);
+        }
+
+        public static bool operator !=(CacheBasedEquatable<T> value1, CacheBasedEquatable<T> value2)
+        {
+            return !(value1 == value2);
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
@@ -15,16 +15,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
 
             public uint Index { get; }
 
-            public override bool Equals(AbstractIndex other)
-            {
-                return other is ConstantValueIndex otherIndex &&
-                    Index == otherIndex.Index;
-            }
-
-            public override int GetHashCode()
-            {
-                return HashUtilities.Combine(Index.GetHashCode(), nameof(ConstantValueIndex).GetHashCode());
-            }
+            protected override int ComputeHashCode() => HashUtilities.Combine(Index.GetHashCode(), nameof(ConstantValueIndex).GetHashCode());
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
@@ -17,16 +17,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
 
             public IOperation Operation { get; }
 
-            public override bool Equals(AbstractIndex other)
-            {
-                return other is OperationBasedIndex otherIndex &&
-                    Operation.Equals(otherIndex.Operation);
-            }
-
-            public override int GetHashCode()
-            {
-                return HashUtilities.Combine(Operation.GetHashCode(), nameof(OperationBasedIndex).GetHashCode());
-            }
+            protected override int ComputeHashCode() => HashUtilities.Combine(Operation.GetHashCode(), nameof(OperationBasedIndex).GetHashCode());
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
@@ -15,16 +15,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
 
             public AnalysisEntity AnalysisEntity { get; }
 
-            public override bool Equals(AbstractIndex other)
-            {
-                return other is AnalysisEntityBasedIndex otherIndex &&
-                    AnalysisEntity.Equals(otherIndex.AnalysisEntity);
-            }
-
-            public override int GetHashCode()
-            {
-                return HashUtilities.Combine(AnalysisEntity.GetHashCode(), nameof(AnalysisEntityBasedIndex).GetHashCode());
-            }
+            protected override int ComputeHashCode() => HashUtilities.Combine(AnalysisEntity.GetHashCode(), nameof(AnalysisEntityBasedIndex).GetHashCode());
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractIndex.cs
@@ -1,41 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.CodeAnalysis.Operations.DataFlow
 {
     /// <summary>
     /// Represents an abstract index into a location.
     /// It is used by an <see cref="AnalysisEntity"/> for operations such as an <see cref="IArrayElementReferenceOperation"/>, index access <see cref="IPropertyReferenceOperation"/>, etc.
     /// </summary>
-    internal abstract partial class AbstractIndex : IEquatable<AbstractIndex>
+    internal abstract partial class AbstractIndex : CacheBasedEquatable<AbstractIndex>
     {
         public static AbstractIndex Create(uint index) => new ConstantValueIndex(index);
         public static AbstractIndex Create(AnalysisEntity analysisEntity) => new AnalysisEntityBasedIndex(analysisEntity);
         public static AbstractIndex Create(IOperation operation) => new OperationBasedIndex(operation);
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AbstractIndex);
-        }
-
-        public static bool operator ==(AbstractIndex value1, AbstractIndex value2)
-        {
-            if ((object)value1 == null)
-            {
-                return (object)value2 == null;
-            }
-
-            return value1.Equals(value2);
-        }
-
-        public static bool operator !=(AbstractIndex value1, AbstractIndex value2)
-        {
-            return !(value1 == value2);
-        }
-
-        public abstract bool Equals(AbstractIndex other);
-
-        public override abstract int GetHashCode();
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
@@ -2,7 +2,6 @@
 
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
-using System;
 using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Operations.DataFlow
@@ -20,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     ///     3. Location created for certain symbols which do not have a declaration in executable code, i.e. no <see cref="IOperation"/> for declaration (such as parameter symbols, member symbols, etc. - <see cref="CreateSymbolLocation(ISymbol)"/>).
     /// </para>
     /// </summary>
-    internal sealed class AbstractLocation : IEquatable<AbstractLocation>
+    internal sealed class AbstractLocation : CacheBasedEquatable<AbstractLocation>
     {
         public static readonly AbstractLocation Null = new AbstractLocation(creationOpt: null, analysisEntityOpt: null, symbolOpt: null, locationTypeOpt: null);
 
@@ -59,41 +58,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             }
         }
 
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AbstractLocation);
-        }
-
-        public static bool operator ==(AbstractLocation value1, AbstractLocation value2)
-        {
-            if ((object)value1 == null)
-            {
-                return (object)value2 == null;
-            }
-
-            return value1.Equals(value2);
-        }
-
-        public static bool operator !=(AbstractLocation value1, AbstractLocation value2)
-        {
-            return !(value1 == value2);
-        }
-
-        public bool Equals(AbstractLocation other)
-        {
-            if (ReferenceEquals(this, other))
-            {
-                return true;
-            }
-
-            return other != null &&
-                CreationOpt == other.CreationOpt &&
-                AnalysisEntityOpt == other.AnalysisEntityOpt &&
-                SymbolOpt == other.SymbolOpt &&
-                LocationTypeOpt == other.LocationTypeOpt;
-        }
-
-        public override int GetHashCode()
+        protected override int ComputeHashCode()
         {
             return HashUtilities.Combine(CreationOpt?.GetHashCode() ?? 0,
                 HashUtilities.Combine(SymbolOpt?.GetHashCode() ?? 0,

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -13,17 +13,22 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
     /// <summary>
     /// Factory to create <see cref="AnalysisEntity"/> objects for operations, symbol declarations, etc.
     /// This factory also tracks analysis entities that share the same instance location (e.g. value type members).
+    /// NOTE: This factory must only be used from within an <see cref="OperationVisitor"/>, as it is tied to the visitor's state tracking via <see cref="_getIsInsideObjectInitializer"/> delegate.
     /// </summary>
     internal sealed class AnalysisEntityFactory
     {
         private readonly Dictionary<IOperation, AnalysisEntity> _analysisEntityMap;
         private readonly Dictionary<ISymbol, PointsToAbstractValue> _instanceLocationsForSymbols;
         private readonly Func<IOperation, PointsToAbstractValue> _getPointsToAbstractValueOpt;
-        
+        private readonly Func<bool> _getIsInsideObjectInitializer;
+
         public AnalysisEntityFactory(
-            Func<IOperation, PointsToAbstractValue> getPointsToAbstractValueOpt, INamedTypeSymbol containingTypeSymbol)
+            Func<IOperation, PointsToAbstractValue> getPointsToAbstractValueOpt,
+            Func<bool> getIsInsideObjectInitializer,
+            INamedTypeSymbol containingTypeSymbol)
         {
             _getPointsToAbstractValueOpt = getPointsToAbstractValueOpt;
+            _getIsInsideObjectInitializer = getIsInsideObjectInitializer;
             _analysisEntityMap = new Dictionary<IOperation, AnalysisEntity>();
             _instanceLocationsForSymbols = new Dictionary<ISymbol, PointsToAbstractValue>();
 
@@ -125,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 case IInstanceReferenceOperation instanceReference:
                     if (_getPointsToAbstractValueOpt != null)
                     {
-                        instanceOpt = instanceReference.GetInstance();
+                        instanceOpt = instanceReference.GetInstance(_getIsInsideObjectInitializer());
                         if (instanceOpt == null)
                         {
                             // Reference to this or base instance.

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -29,12 +29,14 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 return key.SymbolOpt != null ? ValueDomain.Merge(value, defaultValue) : defaultValue;
             }
 
-            var resultMap = new Dictionary<AnalysisEntity, TValue>();            
+            var resultMap = new Dictionary<AnalysisEntity, TValue>();
+            var map2LookupIgnoringInstanceLocation = map2.Keys.ToLookup(entity => entity.EqualsIgnoringInstanceLocationId);
             foreach (var entry1 in map1)
             {
                 AnalysisEntity key1 = entry1.Key;
                 TValue value1 = entry1.Value;
-                var equivalentKeys2 = map2.Keys.Where(key => key.EqualsIgnoringInstanceLocation(key1));
+                
+                var equivalentKeys2 = map2LookupIgnoringInstanceLocation[key1.EqualsIgnoringInstanceLocationId];
                 if (!equivalentKeys2.Any())
                 {
                     TValue mergedValue = GetMergedValueForEntityPresentInOneMap(key1, value1);


### PR DESCRIPTION
1. Cache the hash code of analysis values. GetHashCode shows up quite a bit on analysis perf traces.
2. Reduce merge invocations for binary operations.
3. Avoid walking the IOperation parent chain when attempting to compute the instance corresponding to an IInstanceOperation. For majority of cases we are not within an object initializer and don't need the associated perf hit.
4. Some other small misc improvements from perf traces.