### PR TITLE
Implement CA2215 (DisposeMethodsShouldCallBaseClassDispose)

### DIFF
--- a/nuget/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.props
+++ b/nuget/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.props
@@ -14,6 +14,7 @@
       -Microsoft.Reliability#CA2000;
       -Microsoft.Security#CA2100;
       -Microsoft.Usage#CA2213;
+      -Microsoft.Usage#CA2215;
     </CodeAnalysisRuleSetOverrides>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposeMethodsShouldCallBaseClassDispose.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/DisposeMethodsShouldCallBaseClassDispose.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.Usage
+{
+    /// <summary>
+    /// CA2215: Dispose methods should call base class dispose
+    /// 
+    /// A type that implements System.IDisposable inherits from a type that also implements IDisposable.
+    /// The Dispose method of the inheriting type does not call the Dispose method of the parent type.
+    /// To fix a violation of this rule, call base.Dispose in your Dispose method.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class DisposeMethodsShouldCallBaseClassDispose : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA2215";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftUsageAnalyzersResources.DisposeMethodsShouldCallBaseClassDisposeTitle), MicrosoftUsageAnalyzersResources.ResourceManager, typeof(MicrosoftUsageAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftUsageAnalyzersResources.DisposeMethodsShouldCallBaseClassDisposeMessage), MicrosoftUsageAnalyzersResources.ResourceManager, typeof(MicrosoftUsageAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftUsageAnalyzersResources.DisposeMethodsShouldCallBaseClassDisposeDescription), MicrosoftUsageAnalyzersResources.ResourceManager, typeof(MicrosoftUsageAnalyzersResources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
+                                                                             s_localizableTitle,
+                                                                             s_localizableMessage,
+                                                                             DiagnosticCategory.Usage,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             description: s_localizableDescription,
+                                                                             helpLinkUri: "https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2213-disposable-fields-should-be-disposed",
+                                                                             customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                if (!DisposeAnalysisHelper.TryGetOrCreate(compilationContext.Compilation, out DisposeAnalysisHelper disposeAnalysisHelper))
+                {
+                    return;
+                }
+
+                compilationContext.RegisterOperationBlockStartAction(operationBlockStartContext =>
+                {
+                    if (!(operationBlockStartContext.OwningSymbol is IMethodSymbol containingMethod) ||
+                        !containingMethod.IsOverride ||
+                        containingMethod.OverriddenMethod.IsAbstract)
+                    {
+                        return;
+                    }
+
+                    var disposeMethodKind = containingMethod.GetDisposeMethodKind(disposeAnalysisHelper.IDisposable);
+                    switch (disposeMethodKind)
+                    {
+                        case DisposeMethodKind.Dispose:
+                        case DisposeMethodKind.DisposeBool:
+                            break;
+
+                        case DisposeMethodKind.Close:
+                            // FxCop compat: Ignore Close methods due to high false positive rate.
+                            return;
+
+                        default:
+                            return;
+                    }
+
+                    var invokesBaseDispose = false;
+                    operationBlockStartContext.RegisterOperationAction(operationContext =>
+                    {
+                        if (invokesBaseDispose)
+                        {
+                            return;
+                        }
+
+                        var invocation = (IInvocationOperation)operationContext.Operation;
+                        if (invocation.TargetMethod == containingMethod.OverriddenMethod &&
+                            invocation.Instance.GetInstanceReferenceKind() == InstanceReferenceKind.Base)
+                        {
+                            Debug.Assert(invocation.TargetMethod.GetDisposeMethodKind(disposeAnalysisHelper.IDisposable) == disposeMethodKind);
+                            invokesBaseDispose = true;
+                        }
+                    }, OperationKind.Invocation);
+
+                    operationBlockStartContext.RegisterOperationBlockEndAction(operationEndContext =>
+                    {
+                        if (!invokesBaseDispose)
+                        {
+                            // Ensure that method '{0}' calls '{1}' in all possible control flow paths.
+                            var arg1 = containingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                            var baseKeyword = containingMethod.Language == LanguageNames.CSharp ? "base" : "MyBase";
+                            var disposeMethodParam = disposeMethodKind == DisposeMethodKind.Dispose ?
+                                string.Empty :
+                                containingMethod.Language == LanguageNames.CSharp ? "bool" : "Boolean";
+                            var arg2 = $"{baseKeyword}.Dispose({disposeMethodParam})";
+                            var diagnostic = containingMethod.CreateDiagnostic(Rule, arg1, arg2);
+                            operationEndContext.ReportDiagnostic(diagnostic);
+                        }
+                    });
+                });
+            });
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/MicrosoftUsageAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/MicrosoftUsageAnalyzersResources.resx
@@ -126,4 +126,13 @@
   <data name="DisposableFieldsShouldBeDisposedTitle" xml:space="preserve">
     <value>Disposable fields should be disposed</value>
   </data>
+  <data name="DisposeMethodsShouldCallBaseClassDisposeDescription" xml:space="preserve">
+    <value>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</value>
+  </data>
+  <data name="DisposeMethodsShouldCallBaseClassDisposeMessage" xml:space="preserve">
+    <value>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</value>
+  </data>
+  <data name="DisposeMethodsShouldCallBaseClassDisposeTitle" xml:space="preserve">
+    <value>Dispose methods should call base class dispose</value>
+  </data>
 </root>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.cs.xlf
@@ -17,6 +17,21 @@
         <target state="translated">{0} obsahuje pole {1}, které je typu IDisposable {2}, ale není vůbec jednoúčelové. Změňte metodu Dispose pro {0} tak, aby u tohoto pole volala Close nebo Dispose.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.de.xlf
@@ -17,6 +17,21 @@
         <target state="translated">"{0}" enthält das Feld "{1}" mit dem IDisposable-Typ "{2}", wird aber nie verworfen. Ändern Sie die Dispose-Methode für "{0}", um "Close" oder "Dispose" für dieses Feld aufzurufen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.es.xlf
@@ -17,6 +17,21 @@
         <target state="translated">"{0}" contiene el campo "{1}" que es de tipo IDisposable "{2}", pero no se descarta nunca. Cambie el método Dispose en "{0}" para llamar a Close o Dispose en este campo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.fr.xlf
@@ -17,6 +17,21 @@
         <target state="translated">'{0}' contient un champ '{1}' avec le type IDisposable '{2}', mais il n'est jamais supprimé. Changez la méthode Dispose sur '{0}' pour appeler Close ou Dispose sur ce champ.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.it.xlf
@@ -17,6 +17,21 @@
         <target state="translated">'{0}' contiene il campo '{1}' che è di tipo IDisposable '{2}', ma non viene mai eliminato. Modificare il metodo Dispose su '{0}' in modo che chiami Close o Dispose su questo campo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ja.xlf
@@ -17,6 +17,21 @@
         <target state="translated">'{0}' には IDisposable 型 '{2}' のフィールド '{1}' が含まれていますが、これは破棄されません。'{0}' の Dispose メソッドを変更し、このフィールドで Close または Dispose を呼び出してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ko.xlf
@@ -17,6 +17,21 @@
         <target state="translated">'{0}'에 IDisposable 형식 '{2}'인 '{1}' 필드가 포함되지만, 삭제되지 않습니다. '{0}'의 Dispose 메서드를 변경하여 이 필드에서 Close 또는 Dispose를 호출하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.pl.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Element „{0}” zawiera pole „{1}” z interfejsem IDisposable typu „{2}”, ale nie jest nigdy likwidowany. Zmień metodę Dispose w elemencie „{0}”, aby wywołać metodę Close lub Dispose dla tego pola.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.pt-BR.xlf
@@ -17,6 +17,21 @@
         <target state="translated">'{0}' contém o campo '{1}' que é do tipo IDisposable '{2}', mas ele nunca é descartado. Altere o método Dispose em '{0}' para chamar Close ou Dispose neste campo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.ru.xlf
@@ -17,6 +17,21 @@
         <target state="translated">"{0}" содержит поле "{1}" с типом IDisposable "{2}", но оно никогда не высвобождается. Измените метод Dispose в "{0}", чтобы вызвать Close или Dispose в этом поле.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.tr.xlf
@@ -17,6 +17,21 @@
         <target state="translated">'{0}', '{2}' IDisposable türünde olan '{1}' alanını içeriyor ancak hiç atılmamış. '{0}' öğesindeki Dispose metodunu bu alanda Close veya Dispose çağrısı yapacak şekilde değiştirin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.zh-Hans.xlf
@@ -17,6 +17,21 @@
         <target state="translated">“{0}”包含 IDisposable 类型“{2}”的字段“{1}”，但永远不会释放。更改“{0}”上的 Dispose 方法以在此字段上调用 Close 或 Dispose。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Usage/xlf/MicrosoftUsageAnalyzersResources.zh-Hant.xlf
@@ -17,6 +17,21 @@
         <target state="translated">'{0}' 包含 IDisposable 類型為 '{2}' 的欄位 '{1}'，但其從未處置。變更 '{0}' 的處置方法可關閉或處置此欄位。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeDescription">
+        <source>A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</source>
+        <target state="new">A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
+        <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeTitle">
+        <source>Dispose methods should call base class dispose</source>
+        <target state="new">Dispose methods should call base class dispose</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.md
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Microsoft.CodeQuality.Analyzers.Exp.md
@@ -57,3 +57,13 @@ Category: Usage
 Severity: Warning
 
 Help: [https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2213-disposable-fields-should-be-disposed](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2213-disposable-fields-should-be-disposed)
+
+### CA2215: Dispose methods should call base class dispose ###
+
+A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type.
+
+Category: Usage
+
+Severity: Warning
+
+Help: [https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2215-dispose-methods-should-call-base-class-dispose](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2215-dispose-methods-should-call-base-class-dispose)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposeMethodsShouldCallBaseClassDisposeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/UnitTests/Usage/DisposeMethodsShouldCallBaseClassDisposeTests.cs
@@ -1,0 +1,830 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeQuality.Analyzers.Exp.Usage;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeQuality.Analyzers.Exp.UnitTests.Usage
+{
+    public partial class DisposeMethodsShouldCallBaseClassDisposeTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new DisposeMethodsShouldCallBaseClassDispose();
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new DisposeMethodsShouldCallBaseClassDispose();
+
+        private new DiagnosticResult GetCSharpResultAt(int line, int column, string containingMethod, string baseDisposeSignature) =>
+            GetCSharpResultAt(line, column, DisposeMethodsShouldCallBaseClassDispose.Rule, containingMethod, baseDisposeSignature);
+
+        private new DiagnosticResult GetBasicResultAt(int line, int column, string containingMethod, string baseDisposeSignature) =>
+            GetBasicResultAt(line, column, DisposeMethodsShouldCallBaseClassDispose.Rule, containingMethod, baseDisposeSignature);
+
+        [Fact]
+        public void NoBaseDisposeImplementation_NoBaseDisposeCall_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A 
+{
+}
+
+class B : A, IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+End Class
+
+Class B
+    Inherits A
+    Implements IDisposable
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void NoBaseDisposeImplementation_NoBaseDisposeCall_02_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A 
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A, IDisposable
+{
+    public override void Dispose()
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Public Overridable Sub Dispose()
+    End Sub
+End Class
+
+Class B
+    Inherits A
+    Implements IDisposable
+
+    Public Overrides Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void BaseDisposeCall_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A
+{
+    public override void Dispose()
+    {
+        base.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose()
+        MyBase.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void NoBaseDisposeCall_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A
+{
+    public override void Dispose()
+    {
+    }
+}
+",
+            // Test0.cs(13,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
+            GetCSharpResultAt(13, 26, "void B.Dispose()", "base.Dispose()"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose()
+    End Sub
+End Class",
+            // Test0.vb(14,26): warning CA2215: Ensure that method 'Sub B.Dispose()' calls 'MyBase.Dispose()' in all possible control flow paths.
+            GetBasicResultAt(14, 26, "Sub B.Dispose()", "MyBase.Dispose()"));
+        }
+
+        [Fact]
+        public void BaseDisposeCall_IgnoreCase_VB_NoDiagnostic()
+        {
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose()
+        myBasE.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void BaseDisposeBoolCall_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose(bool b)
+    {
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}
+
+class B : A
+{
+    public override void Dispose(bool b)
+    {
+        base.Dispose(b);
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose(b As Boolean)
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Dispose(True)
+        GC.SuppressFinalize(Me)
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose(b As Boolean)
+        MyBase.Dispose(b)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void NoBaseDisposeBoolCall_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose(bool b)
+    {
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}
+
+class B : A
+{
+    public override void Dispose(bool b)
+    {
+    }
+}
+",
+            // Test0.cs(19,26): warning CA2215: Ensure that method 'void B.Dispose(bool b)' calls 'base.Dispose(bool)' in all possible control flow paths.
+            GetCSharpResultAt(19, 26, "void B.Dispose(bool b)", "base.Dispose(bool)"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose(b As Boolean)
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Dispose(True)
+        GC.SuppressFinalize(Me)
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose(b As Boolean)
+    End Sub
+End Class",
+            // Test0.vb(19,26): warning CA2215: Ensure that method 'Sub B.Dispose(b As Boolean)' calls 'MyBase.Dispose(Boolean)' in all possible control flow paths.
+            GetBasicResultAt(19, 26, "Sub B.Dispose(b As Boolean)", "MyBase.Dispose(Boolean)"));
+        }
+
+        [Fact]
+        public void NoBaseDisposeCloseCall_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Close()
+    {
+    }
+
+    public void Dispose()
+    {
+        Close();
+        GC.SuppressFinalize(this);
+    }
+}
+
+class B : A
+{
+    public override void Close()
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Close()
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Close()
+        GC.SuppressFinalize(Me)
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Close()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void AbstractBaseDisposeMethod_NoBaseDisposeCall_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+abstract class A : IDisposable
+{
+    public abstract void Dispose();
+}
+
+class B : A
+{
+    public override void Dispose()
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+MustInherit Class A
+    Implements IDisposable
+
+    Public MustOverride Sub Dispose() Implements IDisposable.Dispose
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void ShadowsBaseDisposeMethod_NoBaseDisposeCall_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A
+{
+    public new void Dispose()
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Shadows Sub Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void Multiple_BaseDisposeCalls_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A
+{
+    public override void Dispose()
+    {
+        base.Dispose();
+        base.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose()
+        MyBase.Dispose()
+        MyBase.Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void BaseDisposeCalls_AllPaths_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A
+{
+    private readonly bool flag;
+    public override void Dispose()
+    {
+        if (flag)
+        {
+            base.Dispose();
+        }
+        else
+        {
+            base.Dispose();
+        }
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Private ReadOnly flag As Boolean
+    Public Overrides Sub Dispose()
+        If flag Then
+            MyBase.Dispose()
+        Else 
+            MyBase.Dispose()
+        End If
+    End Sub
+End Class");
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1654"), WorkItem(1654, "https://github.com/dotnet/roslyn-analyzers/issues/1654")]
+        public void BaseDisposeCalls_SomePaths_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A
+{
+    private readonly A a;
+    public override void Dispose()
+    {
+        if (a != null)
+        {
+            base.Dispose();
+        }
+    }
+}
+",
+            // Test0.cs(14,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
+            GetCSharpResultAt(14, 26, "void B.Dispose()", "base.Dispose()"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Private ReadOnly a As A
+    Public Overrides Sub Dispose()
+        If a IsNot Nothing Then
+            MyBase.Dispose()
+        End If
+    End Sub
+End Class",
+            // Test0.vb(15,26): warning CA2215: Ensure that method 'Sub B.Dispose()' calls 'MyBase.Dispose()' in all possible control flow paths.
+            GetBasicResultAt(15, 26, "Sub B.Dispose()", "MyBase.Dispose()"));
+        }
+
+        [Fact]
+        public void BaseDisposeCall_GuardedWithBoolField_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A
+{
+    private bool disposed;
+
+    public override void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        base.Dispose();
+        disposed = true;
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Private disposed As Boolean
+
+    Public Overrides Sub Dispose()
+        If disposed Then
+            Return
+        End If
+
+        MyBase.Dispose()
+        disposed = True
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void BaseDisposeCall_DifferentOverload_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+
+    public void Dispose(int i)
+    {
+    }
+}
+
+class B : A
+{
+    public override void Dispose()
+    {
+        Dispose(0);
+    }
+}
+",
+            // Test0.cs(17,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
+            GetCSharpResultAt(17, 26, "void B.Dispose()", "base.Dispose()"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+
+    Public Overridable Sub Dispose(i As Integer)
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose()
+        Dispose(0)
+    End Sub
+End Class",
+            // Test0.vb(17,26): warning CA2215: Ensure that method 'Sub B.Dispose()' calls 'MyBase.Dispose()' in all possible control flow paths.
+            GetBasicResultAt(17, 26, "Sub B.Dispose()", "MyBase.Dispose()"));
+        }
+
+        [Fact]
+        public void DisposeCall_DifferentInstance_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A
+{
+    private readonly A a;
+    public override void Dispose()
+    {
+        a.Dispose();
+    }
+}
+",
+            // Test0.cs(14,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
+            GetCSharpResultAt(14, 26, "void B.Dispose()", "base.Dispose()"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Private ReadOnly a As A
+    Public Overrides Sub Dispose()
+        a.Dispose()
+    End Sub
+End Class",
+            // Test0.vb(15,26): warning CA2215: Ensure that method 'Sub B.Dispose()' calls 'MyBase.Dispose()' in all possible control flow paths.
+            GetBasicResultAt(15, 26, "Sub B.Dispose()", "MyBase.Dispose()"));
+        }
+
+        [Fact]
+        public void DisposeCall_StaticMethod_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+
+    public static void Dispose(bool b)
+    {
+    }
+}
+
+class B : A
+{
+    public override void Dispose()
+    {
+        A.Dispose(true);
+    }
+}
+",
+            // Test0.cs(17,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
+            GetCSharpResultAt(17, 26, "void B.Dispose()", "base.Dispose()"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+
+    Public Shared Sub Dispose(b As Boolean)
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose()
+        A.Dispose(True)
+    End Sub
+End Class",
+            // Test0.vb(17,26): warning CA2215: Ensure that method 'Sub B.Dispose()' calls 'MyBase.Dispose()' in all possible control flow paths.
+            GetBasicResultAt(17, 26, "Sub B.Dispose()", "MyBase.Dispose()"));
+        }
+
+        [Fact]
+        public void DisposeCall_ThisOrMeInstance_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public virtual void Dispose()
+    {
+    }
+}
+
+class B : A
+{
+    public override void Dispose()
+    {
+        this.Dispose();
+    }
+}
+",
+            // Test0.cs(13,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
+            GetCSharpResultAt(13, 26, "void B.Dispose()", "base.Dispose()"));
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+
+    Public Overridable Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Inherits A
+
+    Public Overrides Sub Dispose()
+        Me.Dispose()
+    End Sub
+End Class",
+            // Test0.vb(14,26): warning CA2215: Ensure that method 'Sub B.Dispose()' calls 'MyBase.Dispose()' in all possible control flow paths.
+            GetBasicResultAt(14, 26, "Sub B.Dispose()", "MyBase.Dispose()"));
+        }
+    }
+}

--- a/src/Utilities/Analyzer.Utilities.projitems
+++ b/src/Utilities/Analyzer.Utilities.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AbstractVersionCheckAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommonAccessibilityUtilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)InstanceReferenceKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DisposeMethodKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HashUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DiagnosticCategory.cs" />

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -459,7 +459,7 @@ namespace Analyzer.Utilities.Extensions
 
             var text = instance.Syntax.ToString();
 
-            // Ignore case for VB by converting ToLower.
+            // Ignore case for VB by converting ToUpperInvariant.
             if (instance.Language == LanguageNames.VisualBasic)
             {
                 text = text.ToUpperInvariant();

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -462,7 +462,7 @@ namespace Analyzer.Utilities.Extensions
             // Ignore case for VB by converting ToLower.
             if (instance.Language == LanguageNames.VisualBasic)
             {
-                text = text.ToLower();
+                text = text.ToUpperInvariant();
             }
 
             switch (text)
@@ -475,7 +475,7 @@ namespace Analyzer.Utilities.Extensions
 
                     break;
 
-                case "me":
+                case "ME":
                     if (instance.Language == LanguageNames.VisualBasic)
                     {
                         return InstanceReferenceKind.This;
@@ -491,7 +491,7 @@ namespace Analyzer.Utilities.Extensions
 
                     break;
 
-                case "mybase":
+                case "MYBASE":
                     if (instance.Language == LanguageNames.VisualBasic)
                     {
                         return InstanceReferenceKind.Base;
@@ -499,7 +499,7 @@ namespace Analyzer.Utilities.Extensions
 
                     break;
 
-                case "myclass":
+                case "MYCLASS":
                     if (instance.Language == LanguageNames.VisualBasic)
                     {
                         return InstanceReferenceKind.MyClass;

--- a/src/Utilities/InstanceReferenceKind.cs
+++ b/src/Utilities/InstanceReferenceKind.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Analyzer.Utilities
+{
+    /// <summary>
+    /// Describes different kinds of instance references for an operation used as instance.
+    /// </summary>
+    public enum InstanceReferenceKind
+    {
+        /// <summary>
+        /// Reference to no instance or an object instance through a symbol, i.e. instance is not an <see cref="IInstanceReferenceOperation"/>.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Reference to 'this' or 'Me' instance through an <see cref="IInstanceReferenceOperation"/>.
+        /// </summary>
+        This,
+
+        /// <summary>
+        /// Reference to 'base' or 'MyBase' instance through an <see cref="IInstanceReferenceOperation"/>.
+        /// </summary>
+        Base,
+
+        /// <summary>
+        /// Reference to 'MyClass' instance in VB through an <see cref="IInstanceReferenceOperation"/>.
+        /// </summary>
+        MyClass,
+
+        /// <summary>
+        /// Reference to object or anonymous type instance being created through an <see cref="IInstanceReferenceOperation"/>.
+        /// </summary>
+        Creation,
+    }
+}


### PR DESCRIPTION
_A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type._

**Rule Description:** https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2215-dispose-methods-should-call-base-class-dispose

Fixes #535

TODO: #1654 tracks improving the rule precision with dataflow analysis.