### PR TITLE
Only add getters and setters for type-forwarded properties to public API

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
@@ -508,6 +508,13 @@ namespace Roslyn.Diagnostics.Analyzers
                     return false;
                 }
 
+                // We don't consider properties to be public APIs. Instead, property getters and setters
+                // (which are IMethodSymbols) are considered as public APIs.
+                if (symbol is IPropertySymbol)
+                {
+                    return false;
+                }
+
                 return IsPublicApiCore(symbol);
             }
 

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
@@ -532,9 +532,8 @@ C.Method() -> void
                 GetAdditionalFileResultAt(7, 1, shippedFilePath, DeclarePublicAPIAnalyzer.RemoveDeletedApiRule, "C.Method() -> void"));
         }
 
-
         [Fact]
-        public void TypeForwardsAreProcessed()
+        public void TypeForwardsAreProcessed1()
         {
             var source = @"
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.StringComparison))]
@@ -548,6 +547,34 @@ System.StringComparison.InvariantCulture = 2 -> System.StringComparison (forward
 System.StringComparison.InvariantCultureIgnoreCase = 3 -> System.StringComparison (forwarded, contained in mscorlib)
 System.StringComparison.Ordinal = 4 -> System.StringComparison (forwarded, contained in mscorlib)
 System.StringComparison.OrdinalIgnoreCase = 5 -> System.StringComparison (forwarded, contained in mscorlib)
+";
+            string unshippedText = $@"";
+
+            VerifyCSharp(source, shippedText, unshippedText);
+        }
+
+        [Fact]
+        public void TypeForwardsAreProcessed2()
+        {
+            var source = @"
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.StringComparer))]
+";
+            string shippedText = $@"
+System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.InvariantCulture.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.InvariantCultureIgnoreCase.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.CurrentCulture.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.CurrentCultureIgnoreCase.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.Ordinal.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.OrdinalIgnoreCase.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.Create(System.Globalization.CultureInfo culture, bool ignoreCase) -> System.StringComparer (forwarded, contained in mscorlib)
+System.StringComparer.Compare(object x, object y) -> int (forwarded, contained in mscorlib)
+System.StringComparer.Equals(object x, object y) -> bool (forwarded, contained in mscorlib)
+System.StringComparer.GetHashCode(object obj) -> int (forwarded, contained in mscorlib)
+abstract System.StringComparer.Compare(string x, string y) -> int (forwarded, contained in mscorlib)
+abstract System.StringComparer.Equals(string x, string y) -> bool (forwarded, contained in mscorlib)
+abstract System.StringComparer.GetHashCode(string obj) -> int (forwarded, contained in mscorlib)
+System.StringComparer.StringComparer() -> void (forwarded, contained in mscorlib)
 ";
             string unshippedText = $@"";
 


### PR DESCRIPTION
During normal operation, properties are not added to the public API surface area because the analyzer does not register a symbol
action for `SymbolKind.Property`. This works fine, there is an action registered for `SymbolKind.Method`, which ensures that getters
and setters are added as expected. Things are a bit different for forwarded types.

In the case of a forwarded type, the public API surface area is discovered by recursively searching members and nested types. However,
this code adds both properties *and* accessors, resulting in the PublicAPI.Shipped.txt file needs to include an entry for the property
and the accessors, like so:

```
Microsoft.CodeAnalysis.FileTextLoader.Path.get -> string (forwarded, contained in Microsoft.CodeAnalysis.Workspaces)
Microsoft.CodeAnalysis.FileTextLoader.Path { get; } -> string (forwarded, contained in Microsoft.CodeAnalysis.Workspaces)
```

This change fixes the analyzer to not consider property symbols when recursively searching through forwarded types. However, it still
considers their accessors.