### PR TITLE
DeclarePublicAPI: Relax sorting logic

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DeclarePublicAPIAnalyzerTests.cs
@@ -1152,6 +1152,144 @@ C.Property.get -> int{expectedEndOfFile}";
             VerifyCSharpAdditionalFileFix(source, shippedText, unshippedText, fixedUnshippedText);
         }
 
+        [Fact]
+        public void MissingType_A()
+        {
+            var source = @"
+public class A { }
+public class B { }
+public class D { }
+";
+
+            var unshippedText = @"B
+B.B() -> void
+D
+D.D() -> void";
+
+            var expectedUnshippedText = @"A
+A.A() -> void
+B
+B.B() -> void
+D
+D.D() -> void";
+            VerifyCSharpAdditionalFileFix(source, shippedApiText: "", oldUnshippedApiText: unshippedText, newUnshippedApiText: expectedUnshippedText);
+        }
+
+        [Fact]
+        public void MissingType_C()
+        {
+            var source = @"
+public class B { }
+public class C { }
+public class D { }
+";
+
+            var unshippedText = @"B
+B.B() -> void
+D
+D.D() -> void";
+
+            var expectedUnshippedText = @"B
+B.B() -> void
+C
+C.C() -> void
+D
+D.D() -> void";
+            VerifyCSharpAdditionalFileFix(source, shippedApiText: "", oldUnshippedApiText: unshippedText, newUnshippedApiText: expectedUnshippedText);
+        }
+
+        [Fact]
+        public void MissingType_E()
+        {
+            var source = @"
+public class B { }
+public class D { }
+public class E { }
+";
+
+            var unshippedText = @"B
+B.B() -> void
+D
+D.D() -> void";
+
+            var expectedUnshippedText = @"B
+B.B() -> void
+D
+D.D() -> void
+E
+E.E() -> void";
+            VerifyCSharpAdditionalFileFix(source, shippedApiText: "", oldUnshippedApiText: unshippedText, newUnshippedApiText: expectedUnshippedText);
+        }
+
+        [Fact]
+        public void MissingType_Unordered_A()
+        {
+            var source = @"
+public class A { }
+public class B { }
+public class D { }
+";
+
+            var unshippedText = @"D
+D.D() -> void
+B
+B.B() -> void";
+
+            var expectedUnshippedText = @"A
+A.A() -> void
+D
+D.D() -> void
+B
+B.B() -> void";
+            VerifyCSharpAdditionalFileFix(source, shippedApiText: "", oldUnshippedApiText: unshippedText, newUnshippedApiText: expectedUnshippedText);
+        }
+
+        [Fact]
+        public void MissingType_Unordered_C()
+        {
+            var source = @"
+public class B { }
+public class C { }
+public class D { }
+";
+
+            var unshippedText = @"D
+D.D() -> void
+B
+B.B() -> void";
+
+            var expectedUnshippedText = @"C
+C.C() -> void
+D
+D.D() -> void
+B
+B.B() -> void";
+            VerifyCSharpAdditionalFileFix(source, shippedApiText: "", oldUnshippedApiText: unshippedText, newUnshippedApiText: expectedUnshippedText);
+        }
+
+        [Fact]
+        public void MissingType_Unordered_E()
+        {
+            var source = @"
+public class B { }
+public class D { }
+public class E { }
+";
+
+            var unshippedText = @"D
+D.D() -> void
+B
+B.B() -> void";
+
+            var expectedUnshippedText = @"D
+D.D() -> void
+B
+B.B() -> void
+E
+E.E() -> void";
+            VerifyCSharpAdditionalFileFix(source, shippedApiText: "", oldUnshippedApiText: unshippedText, newUnshippedApiText: expectedUnshippedText);
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Sorted unshipped files are nice for reviewing the entire file (infrequent), but they often make incremental reviews harder whenever the order was messed up by a merge.

This PR relaxes the sorting logic. When new entries are added, we scan from the top and find the first suitable place, with the rest of the file in its original order.

Relates to https://github.com/dotnet/roslyn/issues/26285