### PR TITLE
Move to the latest Microsoft.CodeAnalysis package from features/dataf…

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -19,8 +19,8 @@
     <CodecovVersion>1.0.3</CodecovVersion>
 
     <!-- Roslyn -->
-    <MicrosoftCodeAnalysisVersion>2.6.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftNetCompilersVersion>2.6.0</MicrosoftNetCompilersVersion>
+    <MicrosoftCodeAnalysisVersion>2.8.0-dataflow-62824-01</MicrosoftCodeAnalysisVersion>
+    <MicrosoftNetCompilersVersion>2.6.1</MicrosoftNetCompilersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyersVersion>2.6.1-beta1-62512-01</MicrosoftCodeAnalysisFXCopAnalyersVersion>
     <MicrosoftCodeAnalysisAnalyersVersion>2.6.1-beta1-62512-01</MicrosoftCodeAnalysisAnalyersVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/DoNotIgnoreMethodResults.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/DoNotIgnoreMethodResults.cs
@@ -240,14 +240,17 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 return false;
             }
 
-            // Get the enclosing block. If that block's parent isn't null (MSTest case) or an IAnonymousFunctionOperation (xUnit/NUnit), then
-            // we bail immediately
+            // Get the enclosing block.
             if (!(operationContext.Operation.Parent is IBlockOperation enclosingBlock))
             {
                 return false;
             }
 
-            if (enclosingBlock.Parent != null && enclosingBlock.Parent.Kind != OperationKind.AnonymousFunction)
+            // If enclosing block isn't the topmost IBlockOperation (MSTest case) or its parent isn't an IAnonymousFunctionOperation (xUnit/NUnit), then
+            // we bail immediately
+            var hasTopmostBlockParent = enclosingBlock == operationContext.Operation.GetTopmostParentBlock();
+            var hasAnonymousFunctionParent = enclosingBlock.Parent?.Kind == OperationKind.AnonymousFunction;
+            if (!hasTopmostBlockParent && !hasAnonymousFunctionParent)
             {
                 return false;
             }
@@ -269,8 +272,8 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 }
             }
 
-            // If the parent is Null, we're in the MSTest case. Otherwise, we're in the xUnit/NUnit case.
-            if (enclosingBlock.Parent == null)
+            // If enclosing block is the topmost block, we're in the MSTest case. Otherwise, we're in the xUnit/NUnit case.
+            if (hasTopmostBlockParent)
             {
                 if (expectedExceptionType == null)
                 {


### PR DESCRIPTION
…low branch in Roslyn and fix an analyzer that was broken by topmost IBlockOperation now being parented by an IMethodBodyOperation - this was discussed at the design meeting and was considered as an acceptable break.