### PR TITLE
Do not report CA1309 on == and != operators

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpUseOrdinalStringComparison.cs
+++ b/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpUseOrdinalStringComparison.cs
@@ -28,12 +28,5 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
 
             return invocation.GetLocation();
         }
-
-        protected override Location GetOperatorTokenLocation(SyntaxNode binaryOperationNode)
-        {
-            Debug.Assert(binaryOperationNode is BinaryExpressionSyntax);
-
-            return ((BinaryExpressionSyntax)binaryOperationNode).OperatorToken.GetLocation();
-        }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForEmptyStringsUsingStringLengthTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForEmptyStringsUsingStringLengthTests.cs
@@ -150,6 +150,56 @@ End Class
                 BasicResult(14, 9));
         }
 
+        [Fact]
+        public void CA1820OperatorOverloadTestCSharp()
+        {
+            VerifyCSharp(@"
+using System;
+
+class C
+{
+    void Method()
+    {
+        string a = null;
+        if (a == """") { }
+        if ("""" != a) { }
+        if (a == string.Empty) { }
+        if (string.Empty != a) { }
+    }
+}
+",
+                CSharpResult(9, 13),
+                CSharpResult(10, 13),
+                CSharpResult(11, 13),
+                CSharpResult(12, 13));
+        }
+
+        [Fact]
+        public void CA1820OperatorOverloadTestBasic()
+        {
+            VerifyBasic(@"
+Imports System
+
+Class C
+    Sub Method()
+        Dim a As String
+        If a = """" Then
+        End If
+        If """" <> a Then
+        End If
+        If a = String.Empty Then
+        End If
+        If String.Empty <> a Then
+        End If
+    End Sub
+End Class
+",
+                BasicResult(7, 12),
+                BasicResult(9, 12),
+                BasicResult(11, 12),
+                BasicResult(13, 12));
+        }
+
         #endregion
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/UseOrdinalStringComparisonTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/UseOrdinalStringComparisonTests.cs
@@ -230,7 +230,7 @@ End Class
         }
 
         [Fact]
-        public void CA1309OperatorOverloadTestCSharp()
+        public void CA1309OperatorOverloadTestCSharp_NoDiagnostic()
         {
             VerifyCSharp(@"
 using System;
@@ -240,21 +240,17 @@ class C
     void Method()
     {
         string a = null, b = null;
-        // not allowed
         if (a == b) { }
         if (a != b) { }
-        // this is allowed
         if (a == null) { }
         if (null == a) { }
     }
 }
-",
-                CSharpResult(10, 15),
-                CSharpResult(11, 15));
+");
         }
 
         [Fact]
-        public void CA1309OperatorOverloadTestBasic()
+        public void CA1309OperatorOverloadTestBasic_NoDiagnostic()
         {
             VerifyBasic(@"
 Imports System
@@ -262,12 +258,10 @@ Imports System
 Class C
     Sub Method()
         Dim a As String, b As String
-        ' not allowed
         If a = b Then
         End If
         If a <> b Then
         End If
-        ' this is allowed
         If a = Nothing Then
         End If
         If a Is Nothing Then
@@ -276,9 +270,7 @@ Class C
         End If
     End Sub
 End Class
-",
-                BasicResult(8, 14),
-                BasicResult(10, 14));
+");
         }
 
         [Fact]

--- a/src/Microsoft.NetCore.Analyzers/VisualBasic/Runtime/BasicUseOrdinalStringComparison.vb
+++ b/src/Microsoft.NetCore.Analyzers/VisualBasic/Runtime/BasicUseOrdinalStringComparison.vb
@@ -24,11 +24,5 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
 
             Return invocation.GetLocation()
         End Function
-
-        Protected Overrides Function GetOperatorTokenLocation(binaryOperationNode As SyntaxNode) As Location
-            Debug.Assert(TypeOf binaryOperationNode Is BinaryExpressionSyntax)
-
-            Return DirectCast(binaryOperationNode, BinaryExpressionSyntax).OperatorToken.GetLocation()
-        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #1661 and #1081
Also revert #1528 which removed the IBinaryOperation analysis from incorrect rule (CA1820 instead of CA1309).