### PR TITLE
Fix: CA1822 Mark Members As Static should not trigger for methods containing only NotImplementedException #1544

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
@@ -215,11 +215,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 // statement. The last two are implicit in these scenarios.
 
                 // Filter out operation roots with no IOperation API support (OperationKind.None)
-                var operationBlocks = context.OperationBlocks;
-                if (operationBlocks.Any(operation => operation.IsOperationNoneRoot()))
-                {
-                    operationBlocks = operationBlocks.Where(operation => !operation.IsOperationNoneRoot()).ToImmutableArray();
-                }
+                var operationBlocks = context.OperationBlocks.WhereAsArray(operation => !operation.IsOperationNoneRoot());
 
                 // In the presence of parameter initializers, there will be multiple operation blocks. We assume that there
                 // is only one IBlockOperation, and that the rest are something else

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
@@ -68,11 +68,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                     onSerializedAttribute,
                     onSerializingAttribute,
                     obsoleteAttribute);
-
-                ImmutableHashSet<INamedTypeSymbol> exceptionsToSkip = ImmutableHashSet.Create(
-                    WellKnownTypes.NotImplementedException(compilationStartContext.Compilation),
-                    WellKnownTypes.NotSupportedException(compilationStartContext.Compilation));
-
+                
                 UnusedParameterDictionary unusedMethodParameters = new ConcurrentDictionary<IMethodSymbol, ISet<IParameterSymbol>>();
                 ISet<IMethodSymbol> methodsUsedAsDelegates = new HashSet<IMethodSymbol>();
 
@@ -139,7 +135,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                     }
 
                     // Initialize local mutable state in the start action.
-                    var analyzer = new UnusedParametersAnalyzer(method, unusedMethodParameters, exceptionsToSkip);
+                    var analyzer = new UnusedParametersAnalyzer(method, unusedMethodParameters);
 
                     // Register an intermediate non-end action that accesses and modifies the state.
                     startOperationBlockContext.RegisterOperationAction(analyzer.AnalyzeOperation, OperationKind.ParameterReference);
@@ -166,8 +162,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         private class UnusedParametersAnalyzer
         {
             #region Per-CodeBlock mutable state
-
-            private readonly ImmutableHashSet<INamedTypeSymbol> _exceptionsToSkip;
+                       
             private readonly HashSet<IParameterSymbol> _unusedParameters;
             private readonly UnusedParameterDictionary _finalUnusedParameters;
             private readonly IMethodSymbol _method;
@@ -176,11 +171,10 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
             #region State intialization
 
-            public UnusedParametersAnalyzer(IMethodSymbol method, UnusedParameterDictionary finalUnusedParameters, ImmutableHashSet<INamedTypeSymbol> exceptionsToSkip)
+            public UnusedParametersAnalyzer(IMethodSymbol method, UnusedParameterDictionary finalUnusedParameters)
             {
                 // Initialization: Assume all parameters are unused.
-                _unusedParameters = new HashSet<IParameterSymbol>(method.Parameters);
-                _exceptionsToSkip = exceptionsToSkip;
+                _unusedParameters = new HashSet<IParameterSymbol>(method.Parameters);                
                 _finalUnusedParameters = finalUnusedParameters;
                 _method = method;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
@@ -247,20 +247,16 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             return builder?.ToImmutable() ?? ImmutableArray<INamedTypeSymbol>.Empty;
         }
 
-        private bool IsMethodNotImplemented(OperationBlockAnalysisContext context)
+        private static bool IsMethodNotImplemented(OperationBlockAnalysisContext context)
         {
             // Check to see if the method just throws a NotImplementedException
             // Mark Members as static should not trigger for methods containing only NotImplementedException 
-            
+
             // Note that VB method bodies with 1 action have 3 operations.
             // The first is the actual operation, the second is a label statement, and the third is a return
             // statement. The last two are implicit in these scenarios.
-                        
-            var operationBlocks = context.OperationBlocks;
-            if (operationBlocks.Any(operation => operation.IsOperationNoneRoot()))
-            {
-                operationBlocks = operationBlocks.Where(operation => !operation.IsOperationNoneRoot()).ToImmutableArray();
-            }
+
+            var operationBlocks = context.OperationBlocks.WhereAsArray(operation => !operation.IsOperationNoneRoot());
 
             IBlockOperation methodBlock = null;
             if (operationBlocks.Length == 1 && operationBlocks[0].Kind == OperationKind.Block)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
                     blockStartContext.RegisterOperationBlockEndAction(blockEndContext =>
                     {
-                        if (!isInstanceReferenced)
+                        if (!isInstanceReferenced && !IsMethodNotImplemented(blockEndContext))
                         {
                             ISymbol reportingSymbol = methodSymbol;
                             var isAccessor = methodSymbol.IsPropertyAccessor() || methodSymbol.IsEventAccessor();
@@ -245,6 +245,76 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             Add(WellKnownTypes.NunitTearDown(compilation));
 
             return builder?.ToImmutable() ?? ImmutableArray<INamedTypeSymbol>.Empty;
+        }
+
+        private bool IsMethodNotImplemented(OperationBlockAnalysisContext context)
+        {
+            // Check to see if the method just throws a NotImplementedException
+            // Mark Members as static should not trigger for methods containing only NotImplementedException 
+            
+            // Note that VB method bodies with 1 action have 3 operations.
+            // The first is the actual operation, the second is a label statement, and the third is a return
+            // statement. The last two are implicit in these scenarios.
+                        
+            var operationBlocks = context.OperationBlocks;
+            if (operationBlocks.Any(operation => operation.IsOperationNoneRoot()))
+            {
+                operationBlocks = operationBlocks.Where(operation => !operation.IsOperationNoneRoot()).ToImmutableArray();
+            }
+
+            IBlockOperation methodBlock = null;
+            if (operationBlocks.Length == 1 && operationBlocks[0].Kind == OperationKind.Block)
+            {
+                methodBlock = (IBlockOperation)operationBlocks[0];
+            }
+            else if (operationBlocks.Length > 1)
+            {
+                foreach (var block in operationBlocks)
+                {
+                    if (block.Kind == OperationKind.Block)
+                    {
+                        methodBlock = (IBlockOperation)block;
+                        break;
+                    }
+                }
+            }
+
+            if (methodBlock != null)
+            {
+                bool IsSingleStatementBody(IBlockOperation body)
+                {
+                    return body.Operations.Length == 1 ||
+                        (body.Operations.Length == 3 && body.Syntax.Language == LanguageNames.VisualBasic &&
+                         body.Operations[1] is ILabeledOperation labeledOp && labeledOp.IsImplicit &&
+                         body.Operations[2] is IReturnOperation returnOp && returnOp.IsImplicit);
+                }
+
+                if (IsSingleStatementBody(methodBlock))
+                {
+                    var innerOperation = methodBlock.Operations.First();
+
+                    // Because of https://github.com/dotnet/roslyn/issues/23152, there can be an expression-statement
+                    // wrapping expression-bodied throw operations. Compensate by unwrapping if necessary.
+                    if (innerOperation.Kind == OperationKind.ExpressionStatement &&
+                        innerOperation is IExpressionStatementOperation exprStatement)
+                    {
+                        innerOperation = exprStatement.Operation;
+                    }
+
+                    if (innerOperation.Kind == OperationKind.Throw &&
+                        innerOperation is IThrowOperation throwOperation &&
+                        throwOperation.Exception.Kind == OperationKind.ObjectCreation &&
+                        throwOperation.Exception is IObjectCreationOperation createdException)
+                    {
+                        if (WellKnownTypes.NotImplementedException(context.Compilation) == createdException.Type.OriginalDefinition)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
@@ -79,7 +79,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
                     blockStartContext.RegisterOperationBlockEndAction(blockEndContext =>
                     {
-                        if (!isInstanceReferenced && !IsMethodNotImplemented(blockEndContext))
+                        // Methods referenced by other non static methods 
+                        // and methods containing only NotImplementedException should not considered for marking them as static
+                        if (!isInstanceReferenced && !blockEndContext.IsMethodNotImplementedOrSupported())
                         {
                             ISymbol reportingSymbol = methodSymbol;
                             var isAccessor = methodSymbol.IsPropertyAccessor() || methodSymbol.IsEventAccessor();
@@ -245,72 +247,6 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             Add(WellKnownTypes.NunitTearDown(compilation));
 
             return builder?.ToImmutable() ?? ImmutableArray<INamedTypeSymbol>.Empty;
-        }
-
-        private static bool IsMethodNotImplemented(OperationBlockAnalysisContext context)
-        {
-            // Check to see if the method just throws a NotImplementedException
-            // Mark Members as static should not trigger for methods containing only NotImplementedException 
-
-            // Note that VB method bodies with 1 action have 3 operations.
-            // The first is the actual operation, the second is a label statement, and the third is a return
-            // statement. The last two are implicit in these scenarios.
-
-            var operationBlocks = context.OperationBlocks.WhereAsArray(operation => !operation.IsOperationNoneRoot());
-
-            IBlockOperation methodBlock = null;
-            if (operationBlocks.Length == 1 && operationBlocks[0].Kind == OperationKind.Block)
-            {
-                methodBlock = (IBlockOperation)operationBlocks[0];
-            }
-            else if (operationBlocks.Length > 1)
-            {
-                foreach (var block in operationBlocks)
-                {
-                    if (block.Kind == OperationKind.Block)
-                    {
-                        methodBlock = (IBlockOperation)block;
-                        break;
-                    }
-                }
-            }
-
-            if (methodBlock != null)
-            {
-                bool IsSingleStatementBody(IBlockOperation body)
-                {
-                    return body.Operations.Length == 1 ||
-                        (body.Operations.Length == 3 && body.Syntax.Language == LanguageNames.VisualBasic &&
-                         body.Operations[1] is ILabeledOperation labeledOp && labeledOp.IsImplicit &&
-                         body.Operations[2] is IReturnOperation returnOp && returnOp.IsImplicit);
-                }
-
-                if (IsSingleStatementBody(methodBlock))
-                {
-                    var innerOperation = methodBlock.Operations.First();
-
-                    // Because of https://github.com/dotnet/roslyn/issues/23152, there can be an expression-statement
-                    // wrapping expression-bodied throw operations. Compensate by unwrapping if necessary.
-                    if (innerOperation.Kind == OperationKind.ExpressionStatement &&
-                        innerOperation is IExpressionStatementOperation exprStatement)
-                    {
-                        innerOperation = exprStatement.Operation;
-                    }
-
-                    if (innerOperation.Kind == OperationKind.Throw &&
-                        innerOperation is IThrowOperation throwOperation &&
-                        throwOperation.Exception.Kind == OperationKind.ObjectCreation &&
-                        throwOperation.Exception is IObjectCreationOperation createdException)
-                    {
-                        if (WellKnownTypes.NotImplementedException(context.Compilation) == createdException.Type.OriginalDefinition)
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-
-            return false;
-        }
+        }       
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -331,6 +331,8 @@ public class MembersTests
     public int GetterOnlyAutoProp { get; }
 
     public void SomeEventHandler(object sender, System.EventArgs args) { }
+
+    public void SomeNotImplementedMethod() => throw new System.NotImplementedException();
 }
 
 public class Generic<T>
@@ -381,6 +383,10 @@ Public Class MembersTests
     Public ReadOnly Property GetterOnlyAutoProp As Integer
 
     Public Sub SomeEventHandler(sender As Object, args As System.EventArgs)
+    End Sub
+
+    Public Sub SomeNotImplementedMethod()
+        Throw New System.NotImplementedException()
     End Sub
 End Class
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -333,6 +333,8 @@ public class MembersTests
     public void SomeEventHandler(object sender, System.EventArgs args) { }
 
     public void SomeNotImplementedMethod() => throw new System.NotImplementedException();
+
+    public void SomeNotSupportedMethod() => throw new System.NotSupportedException();
 }
 
 public class Generic<T>
@@ -387,6 +389,10 @@ Public Class MembersTests
 
     Public Sub SomeNotImplementedMethod()
         Throw New System.NotImplementedException()
+    End Sub
+
+    Public Sub SomeNotSupportedMethod()
+        Throw New System.NotSupportedException()
     End Sub
 End Class
 

--- a/src/Utilities/Analyzer.Utilities.projitems
+++ b/src/Utilities/Analyzer.Utilities.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AbstractVersionCheckAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommonAccessibilityUtilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\OperationBlockAnalysisContextExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InstanceReferenceKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DisposeMethodKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HashUtilities.cs" />

--- a/src/Utilities/Extensions/OperationBlockAnalysisContextExtension.cs
+++ b/src/Utilities/Extensions/OperationBlockAnalysisContextExtension.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Analyzer.Utilities.Extensions
+{
+    public static class OperationBlockAnalysisContextExtension
+    {
+        public static bool IsMethodNotImplementedOrSupported(this OperationBlockAnalysisContext context)
+        {
+            // Note that VB method bodies with 1 action have 3 operations.
+            // The first is the actual operation, the second is a label statement, and the third is a return
+            // statement. The last two are implicit in these scenarios.
+
+            var operationBlocks = context.OperationBlocks.WhereAsArray(operation => !operation.IsOperationNoneRoot());
+
+            IBlockOperation methodBlock = null;
+            if (operationBlocks.Length == 1 && operationBlocks[0].Kind == OperationKind.Block)
+            {
+                methodBlock = (IBlockOperation)operationBlocks[0];
+            }
+            else if (operationBlocks.Length > 1)
+            {
+                foreach (var block in operationBlocks)
+                {
+                    if (block.Kind == OperationKind.Block)
+                    {
+                        methodBlock = (IBlockOperation)block;
+                        break;
+                    }
+                }
+            }
+
+            if (methodBlock != null)
+            {
+                bool IsSingleStatementBody(IBlockOperation body)
+                {
+                    return body.Operations.Length == 1 ||
+                        (body.Operations.Length == 3 && body.Syntax.Language == LanguageNames.VisualBasic &&
+                         body.Operations[1] is ILabeledOperation labeledOp && labeledOp.IsImplicit &&
+                         body.Operations[2] is IReturnOperation returnOp && returnOp.IsImplicit);
+                }
+
+                if (IsSingleStatementBody(methodBlock))
+                {
+                    var innerOperation = methodBlock.Operations.First();
+
+                    // Because of https://github.com/dotnet/roslyn/issues/23152, there can be an expression-statement
+                    // wrapping expression-bodied throw operations. Compensate by unwrapping if necessary.
+                    if (innerOperation.Kind == OperationKind.ExpressionStatement &&
+                        innerOperation is IExpressionStatementOperation exprStatement)
+                    {
+                        innerOperation = exprStatement.Operation;
+                    }
+
+                    if (innerOperation.Kind == OperationKind.Throw &&
+                        innerOperation is IThrowOperation throwOperation &&
+                        throwOperation.Exception.Kind == OperationKind.ObjectCreation &&
+                        throwOperation.Exception is IObjectCreationOperation createdException)
+                    {
+                        if (WellKnownTypes.NotImplementedException(context.Compilation) == createdException.Type.OriginalDefinition
+                            || WellKnownTypes.NotSupportedException(context.Compilation) == createdException.Type.OriginalDefinition)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1544

This updates CA1822 to be aware of method bodies that are only throw NotImplementedException() and makes sure that diagnostics aren't registered for them.