### PR TITLE
Account for parameter RefKind while identifying alternate overloads.

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyCultureInfoTests.cs
@@ -106,6 +106,33 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
+        public void CA1304_MethodOverloadHasCultureInfoAsFirstArgument_RefKindRef_CSharp()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Globalization;
+
+public class CultureInfoTestClass2
+{
+    public static void Method()
+    {
+        MethodOverloadHasCultureInfoAsFirstArgument(""Foo"");
+    }
+
+    public static void MethodOverloadHasCultureInfoAsFirstArgument(string format)
+    {
+        var provider = CultureInfo.CurrentCulture;
+        MethodOverloadHasCultureInfoAsFirstArgument(ref provider, format);
+    }
+
+    public static void MethodOverloadHasCultureInfoAsFirstArgument(ref CultureInfo provider, string format)
+    {
+        Console.WriteLine(string.Format(provider, format));
+    }
+}");
+        }
+
+        [Fact]
         public void CA1304_MethodOverloadHasCultureInfoAsLastArgument_CSharp()
         {
             VerifyCSharp(@"
@@ -135,6 +162,34 @@ public class CultureInfoTestClass2
     }
 }",
             GetCSharpResultAt(9, 9, SpecifyCultureInfoAnalyzer.Rule, "CultureInfoTestClass2.MethodOverloadHasCultureInfoAsLastArgument(string)", "CultureInfoTestClass2.Method()", "CultureInfoTestClass2.MethodOverloadHasCultureInfoAsLastArgument(string, CultureInfo)"));
+        }
+
+        [Fact]
+        public void CA1304_MethodOverloadHasCultureInfoAsLastArgument_RefKindOut_CSharp()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Globalization;
+
+public class CultureInfoTestClass2
+{
+    public static void Method()
+    {
+        MethodOverloadHasCultureInfoAsLastArgument(""Foo"");
+    }
+
+    public static void MethodOverloadHasCultureInfoAsLastArgument(string format)
+    {
+        CultureInfo provider;
+        MethodOverloadHasCultureInfoAsLastArgument(format, out provider);
+    }
+
+    public static void MethodOverloadHasCultureInfoAsLastArgument(string format, out CultureInfo provider)
+    {
+        provider = CultureInfo.CurrentCulture;
+        Console.WriteLine(string.Format(provider, format));
+    }
+}");
         }
 
         [Fact]
@@ -299,6 +354,8 @@ public class CultureInfoTestClass2
         MethodOverloadHasMoreThanCultureInfo(""Foo"");
         // No Diag - Since the CultureInfo parameter is neither as the first parameter nor as the last parameter
         MethodOverloadWithJustCultureInfoAsInbetweenParameter("""", """");
+        // No Diag - Since the non-CultureInfo parameter in the overload has RefKind != RefKind.None
+        MethodOverloadHasNonCultureInfoWithRefKindRef("""");
     }
 
     public static void MethodOverloadHasInheritedCultureInfo(string format)
@@ -329,6 +386,16 @@ public class CultureInfoTestClass2
     public static void MethodOverloadWithJustCultureInfoAsInbetweenParameter(string a, CultureInfo provider, string b)
     {
         Console.WriteLine(string.Format(provider, """"));
+    }
+
+    public static void MethodOverloadHasNonCultureInfoWithRefKindRef(string format)
+    {
+        MethodOverloadHasNonCultureInfoWithRefKindRef(ref format, CultureInfo.CurrentCulture);
+    }
+
+    public static void MethodOverloadHasNonCultureInfoWithRefKindRef(ref string format, CultureInfo provider)
+    {
+        Console.WriteLine(string.Format(provider, format));
     }
 }
 

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyCultureInfoTests.cs
@@ -106,6 +106,33 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
+        public void CA1304_MethodOverloadHasCultureInfoAsFirstAndSecondArgument_CSharp()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Globalization;
+
+public class CultureInfoTestClass2
+{
+    public static void Method(CultureInfo provider)
+    {
+        MethodOverloadHasCultureInfoAsFirstAndSecondArgument(ref provider);
+    }
+
+    public static void MethodOverloadHasCultureInfoAsFirstAndSecondArgument(ref CultureInfo provider)
+    {
+        MethodOverloadHasCultureInfoAsFirstAndSecondArgument(ref provider, CultureInfo.CurrentCulture);
+    }
+
+    public static void MethodOverloadHasCultureInfoAsFirstAndSecondArgument(ref CultureInfo provider, CultureInfo provider2)
+    {
+    }
+}",
+            // Test0.cs(9,9): warning CA1304: The behavior of 'CultureInfoTestClass2.MethodOverloadHasCultureInfoAsFirstAndSecondArgument(ref CultureInfo)' could vary based on the current user's locale settings. Replace this call in 'CultureInfoTestClass2.Method(CultureInfo)' with a call to 'CultureInfoTestClass2.MethodOverloadHasCultureInfoAsFirstAndSecondArgument(ref CultureInfo, CultureInfo)'.
+            GetCSharpResultAt(9, 9, SpecifyCultureInfoAnalyzer.Rule, "CultureInfoTestClass2.MethodOverloadHasCultureInfoAsFirstAndSecondArgument(ref CultureInfo)", "CultureInfoTestClass2.Method(CultureInfo)", "CultureInfoTestClass2.MethodOverloadHasCultureInfoAsFirstAndSecondArgument(ref CultureInfo, CultureInfo)"));
+        }
+
+        [Fact]
         public void CA1304_MethodOverloadHasCultureInfoAsFirstArgument_RefKindRef_CSharp()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
@@ -147,6 +147,11 @@ public static class IFormatProviderStringTest
     {
         IFormatProviderOverloads.UserDefinedParamsMismatchMethodOverload(""Bar"");
     }
+
+    public static void SpecifyIFormatProvider8()
+    {
+        IFormatProviderOverloads.MethodOverloadWithMismatchRefKind(""Bar"");
+    }
 }
 
 internal static class IFormatProviderOverloads
@@ -168,6 +173,22 @@ internal static class IFormatProviderOverloads
 
     public static string UserDefinedParamsMismatchMethodOverload(IFormatProvider provider, string format, params object[] objs)
     {
+        return null;
+    }
+
+    public static string MethodOverloadWithMismatchRefKind(string format)
+    {
+        return null;
+    }
+
+    public static string MethodOverloadWithMismatchRefKind(IFormatProvider provider, ref string format)
+    {
+        return null;
+    }
+
+    public static string MethodOverloadWithMismatchRefKind(out IFormatProvider provider, string format)
+    {
+        provider = null;
         return null;
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyStringComparisonTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyStringComparisonTests.cs
@@ -163,6 +163,40 @@ GetCA1307CSharpResultsAt(9, 9, "StringComparisonTests.DoNothing(string)",
         }
 
         [Fact]
+        public void CA1307_OverloadWithMismatchRefKind_CSharp()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Globalization;
+
+public class StringComparisonTests
+{
+    public void MyMethod()
+    {
+        M("""");
+    }
+
+    public void M(string str)
+    {
+    }
+
+    public void M(string str, out StringComparison strCompare)
+    {
+        strCompare = StringComparison.Ordinal;
+    }
+
+    public void M(ref StringComparison strCompare, string str)
+    {
+        strCompare = StringComparison.Ordinal;
+    }
+
+    public void M(ref string str, StringComparison strCompare)
+    {
+    }
+}");
+        }
+
+        [Fact]
         public void CA1307_StringCompareTests_VisualBasic()
         {
             VerifyBasic(@"

--- a/src/Utilities/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
+++ b/src/Utilities/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
@@ -48,20 +48,31 @@ namespace Analyzer.Utilities.Extensions
 
                 if (!trailingOnly && candidateMethod.Parameters.First().Type.Equals(expectedParameterType))
                 {
+                    // Bail out if RefKind of first parameter is not None.
+                    if (candidateMethod.Parameters[0].RefKind != RefKind.None)
+                    {
+                        return false;
+                    }
+
                     // If expectedParameterType is the first parameter then the parameters to compare in candidateMethod against selectedOverload
                     // is offset by 1
                     j = 1;
                 }
-                else if (!candidateMethod.Parameters.Last().Type.Equals(expectedParameterType))
+                else
                 {
-                    // expectedParameterType is neither the first parameter nor the last parameter
-                    return false;
+                    var lastParameter = candidateMethod.Parameters.Last();
+                    if (!lastParameter.Type.Equals(expectedParameterType) || lastParameter.RefKind != RefKind.None)
+                    {
+                        // expectedParameterType is neither the first parameter nor the last parameter
+                        return false;
+                    }
                 }
 
                 for (int i = 0; i < selectedOverload.Parameters.Count(); i++, j++)
                 {
                     if (!selectedOverload.Parameters[i].Type.Equals(candidateMethod.Parameters[j].Type) ||
-                        selectedOverload.Parameters[i].IsParams != candidateMethod.Parameters[j].IsParams)
+                        selectedOverload.Parameters[i].IsParams != candidateMethod.Parameters[j].IsParams ||
+                        selectedOverload.Parameters[i].RefKind != candidateMethod.Parameters[j].RefKind)
                     {
                         return false;
                     }

--- a/src/Utilities/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
+++ b/src/Utilities/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
@@ -46,14 +46,8 @@ namespace Analyzer.Utilities.Extensions
                 // in candidateMethod to compare against selectedOverload's parameter is set to 0
                 int j = 0;
 
-                if (!trailingOnly && candidateMethod.Parameters.First().Type.Equals(expectedParameterType))
+                if (!trailingOnly && candidateMethod.Parameters.First().Type.Equals(expectedParameterType) && candidateMethod.Parameters[0].RefKind == RefKind.None)
                 {
-                    // Bail out if RefKind of first parameter is not None.
-                    if (candidateMethod.Parameters[0].RefKind != RefKind.None)
-                    {
-                        return false;
-                    }
-
                     // If expectedParameterType is the first parameter then the parameters to compare in candidateMethod against selectedOverload
                     // is offset by 1
                     j = 1;


### PR DESCRIPTION
Affected rules: CA1304, CA1305 and CA1307
Fixes #1734