### PR TITLE
Only consider namespaces with externally visible types for CA1724

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
@@ -99,8 +99,8 @@ public class Sdk
                         CSharpDefaultResultAt(2, 14, "Sdk", "Xunit.Sdk"));
         }
 
-        [Fact]
-        public void CA1724CSharpDeterministicDiagnosticOnA()
+        [Fact, WorkItem(1673,"https://github.com/dotnet/roslyn-analyzers/issues/1673")]
+        public void CA1724CSharp_NoDiagnostic_NamespaceWithNoTypes()
         {
             VerifyCSharp(@"
 namespace A.B
@@ -110,8 +110,132 @@ namespace A.B
 namespace D
 {
     public class A {}
+}");
+        }
+
+        [Fact, WorkItem(1673, "https://github.com/dotnet/roslyn-analyzers/issues/1673")]
+        public void CA1724CSharp_NoDiagnostic_NamespaceWithNoExternallyVisibleTypes()
+        {
+            VerifyCSharp(@"
+namespace A
+{
+    internal class C { }
+}
+
+namespace D
+{
+    public class A {}
+}");
+        }
+
+        [Fact, WorkItem(1673, "https://github.com/dotnet/roslyn-analyzers/issues/1673")]
+        public void CA1724CSharp_NoDiagnostic_NamespaceWithNoExternallyVisibleTypes_02()
+        {
+            VerifyCSharp(@"
+namespace A
+{
+    namespace B
+    {
+        internal class C { }
+    }
+}
+
+namespace D
+{
+    public class A {}
+}");
+        }
+
+        [Fact, WorkItem(1673, "https://github.com/dotnet/roslyn-analyzers/issues/1673")]
+        public void CA1724CSharp_NoDiagnostic_ClashingTypeIsNotExternallyVisible()
+        {
+            VerifyCSharp(@"
+namespace A
+{
+    namespace B
+    {
+        public class C { }
+    }
+}
+
+namespace D
+{
+    internal class A {}
+}");
+        }
+
+        [Fact, WorkItem(1673, "https://github.com/dotnet/roslyn-analyzers/issues/1673")]
+        public void CA1724CSharp_Diagnostic_NamespaceWithExternallyVisibleTypeMember()
+        {
+            VerifyCSharp(@"
+namespace A
+{
+    public class C { }
+}
+
+namespace D
+{
+    public class A {}
 }",
-            CSharpDefaultResultAt(8, 18, "A", "A"));
+            // Test0.cs(9,18): warning CA1724: The type name A conflicts in whole or in part with the namespace name 'A'. Change either name to eliminate the conflict.
+            CSharpDefaultResultAt(9, 18, "A", "A"));
+        }
+
+        [Fact, WorkItem(1673, "https://github.com/dotnet/roslyn-analyzers/issues/1673")]
+        public void CA1724CSharp_Diagnostic_NamespaceWithExternallyVisibleTypeMember_02()
+        {
+            VerifyCSharp(@"
+namespace B
+{
+    namespace A
+    {
+        public class C { }
+    }
+}
+
+namespace D
+{
+    public class A {}
+}",
+            // Test0.cs(12,18): warning CA1724: The type name A conflicts in whole or in part with the namespace name 'B.A'. Change either name to eliminate the conflict.
+            CSharpDefaultResultAt(12, 18, "A", "B.A"));
+        }
+
+        [Fact, WorkItem(1673, "https://github.com/dotnet/roslyn-analyzers/issues/1673")]
+        public void CA1724CSharp_Diagnostic_NamespaceWithExternallyVisibleTypeMember_InChildNamespace()
+        {
+            VerifyCSharp(@"
+namespace A
+{
+    namespace B
+    {
+        public class C { }
+    }
+}
+
+namespace D
+{
+    public class A {}
+}",
+            // Test0.cs(12,18): warning CA1724: The type name A conflicts in whole or in part with the namespace name 'A'. Change either name to eliminate the conflict.
+            CSharpDefaultResultAt(12, 18, "A", "A"));
+        }
+
+        [Fact, WorkItem(1673, "https://github.com/dotnet/roslyn-analyzers/issues/1673")]
+        public void CA1724CSharp_Diagnostic_NamespaceWithExternallyVisibleTypeMember_InChildNamespace_02()
+        {
+            VerifyCSharp(@"
+namespace A.B
+{
+    public class C { }
+}
+
+namespace D
+{
+    public class A {}
+}",
+            // Test0.cs(9,18): warning CA1724: The type name A conflicts in whole or in part with the namespace name 'A'. Change either name to eliminate the conflict.
+            CSharpDefaultResultAt(9, 18, "A", "A"));
         }
 
         [Fact]


### PR DESCRIPTION
The implementation becomes more stricter then legacy implementation, which considers all namespaces at least one type, externally or non-externally visible. However, given the intent of the rule to help design a consumable public library, the stricter implementation seems less noisy as the library clients would only care about externally visible types.

Fixes #1673