### PR TITLE
Enable FixAll testing by default for all code fix tests

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpUseLiteralsWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpUseLiteralsWhereAppropriate.Fixer.cs
@@ -22,7 +22,10 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines
                 syntaxNode = syntaxNode.Parent;
             }
 
-            return syntaxNode as FieldDeclarationSyntax;
+            var field = (FieldDeclarationSyntax)syntaxNode;
+
+            // Multiple declarators are not supported, as one of them may not be constant.
+            return field?.Declaration.Variables.Count > 1 ? null : field;
         }
 
         protected override bool IsStaticKeyword(SyntaxToken syntaxToken)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.Fixer.cs
@@ -175,7 +175,8 @@ public class C
     }
 }
 ";
-            VerifyCSharpFix(code, fixedCode);
+            // Skip FixAll as the resultant document is different, but difference is not critical due to broken code scenario.
+            VerifyCSharpFix(code, fixedCode, testFixAllScope: null);
         }
 
         [Fact]
@@ -205,7 +206,8 @@ Public Class C
     End Function
 End Class
 ";
-            VerifyBasicFix(code, fixedCode);
+            // Skip FixAll as the resultant document is different, but difference is not critical due to broken code scenario.
+            VerifyBasicFix(code, fixedCode, testFixAllScope: null);
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHaveZeroValueTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHaveZeroValueTests.Fixer.cs
@@ -31,6 +31,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             return new CSharpEnumsShouldHaveZeroValueFixer();
         }
 
+        // No trivial way to FixAll diagnostics for this code fix.
+        protected override bool TestFixAllByDefault => false;
+
         [Fact]
         public void CSharp_EnumsShouldZeroValueFlagsRename()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Microsoft.CodeQuality.Analyzers.UnitTests.csproj
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Microsoft.CodeQuality.Analyzers.UnitTests.csproj
@@ -13,7 +13,4 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Globalization\" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.Fixer.cs
@@ -74,6 +74,8 @@ End Class
         [Fact]
         public void CSharp_CodeFixForMultiDeclaration()
         {
+            // Fixers are disabled on multiple fields, because it may introduce compile error.
+
             VerifyCSharpFix(@"
 class C
 {
@@ -85,11 +87,9 @@ class C
 class C
 {
     /*leading*/
-    const /*intermediate*/  /*trailing*/ string f3, f4 = ""Message is shown only for f4"";
+    readonly /*intermediate*/ static /*trailing*/ string f3, f4 = ""Message is shown only for f4"";
 }
 ");
-            // VB-fixer is disabled on multiple fields, because it would introduce compile error.
-            // Error BC30438: Constants must have a value.
             VerifyBasicFix(@"
 Class C
     Shared ReadOnly f3 As String, f4 As String = ""Message is shown only for f4""

--- a/src/Test.Utilities/CodeFixTestBase.cs
+++ b/src/Test.Utilities/CodeFixTestBase.cs
@@ -22,42 +22,55 @@ namespace Test.Utilities
 
         protected abstract CodeFixProvider GetBasicCodeFixProvider();
 
-        protected void VerifyCSharpUnsafeCodeFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false)
+        protected virtual bool TestFixAllByDefault => true;
+
+        protected void VerifyCSharpUnsafeCodeFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false, FixAllScope? testFixAllScope = FixAllScope.Document)
         {
-            VerifyFix(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, allowUnsafeCode: true, validationMode: DefaultTestValidationMode);
+            VerifyFix(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, testFixAllScope, allowUnsafeCode: true, validationMode: DefaultTestValidationMode);
         }
 
-        protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false, TestValidationMode validationMode = DefaultTestValidationMode)
+        protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false, FixAllScope? testFixAllScope = FixAllScope.Document, TestValidationMode validationMode = DefaultTestValidationMode)
         {
-            VerifyFix(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, allowUnsafeCode: false, validationMode: validationMode);
+            VerifyFix(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, testFixAllScope, allowUnsafeCode: false, validationMode: validationMode);
         }
 
-        protected void VerifyCSharpFix(string[] oldSources, string[] newSources, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false, TestValidationMode validationMode = DefaultTestValidationMode)
+        protected void VerifyCSharpFix(string[] oldSources, string[] newSources, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false, FixAllScope? testFixAllScope = FixAllScope.Project, TestValidationMode validationMode = DefaultTestValidationMode)
         {
-            VerifyFix(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), oldSources, newSources, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, allowUnsafeCode: false, validationMode: validationMode);
+            VerifyFix(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), oldSources, newSources, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, testFixAllScope, allowUnsafeCode: false, validationMode: validationMode);
         }
 
-        protected void VerifyCSharpFixAll(string oldSource, string newSource, bool allowNewCompilerDiagnostics = false, TestValidationMode validationMode = DefaultTestValidationMode)
+        protected void VerifyCSharpFixAll(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, TestValidationMode validationMode = DefaultTestValidationMode)
         {
-            VerifyFixAll(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, allowNewCompilerDiagnostics, allowUnsafeCode: false, validationMode: validationMode);
+            VerifyFixAll(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, FixAllScope.Document, codeFixIndex, allowNewCompilerDiagnostics, allowUnsafeCode: false, validationMode: validationMode);
         }
 
-        protected void VerifyBasicFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false, TestValidationMode validationMode = DefaultTestValidationMode)
+        protected void VerifyBasicFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false, FixAllScope? testFixAllScope = FixAllScope.Document, TestValidationMode validationMode = DefaultTestValidationMode)
         {
-            VerifyFix(LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), GetBasicCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, allowUnsafeCode: false, validationMode: validationMode);
+            VerifyFix(LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), GetBasicCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, testFixAllScope, allowUnsafeCode: false, validationMode: validationMode);
         }
 
-        protected void VerifyBasicFix(string[] oldSources, string[] newSources, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false, TestValidationMode validationMode = DefaultTestValidationMode)
+        protected void VerifyBasicFix(string[] oldSources, string[] newSources, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool onlyFixFirstFixableDiagnostic = false, FixAllScope? testFixAllScope = FixAllScope.Project, TestValidationMode validationMode = DefaultTestValidationMode)
         {
-            VerifyFix(LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), GetBasicCodeFixProvider(), oldSources, newSources, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, allowUnsafeCode: false, validationMode: validationMode);
+            VerifyFix(LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), GetBasicCodeFixProvider(), oldSources, newSources, codeFixIndex, allowNewCompilerDiagnostics, onlyFixFirstFixableDiagnostic, testFixAllScope, allowUnsafeCode: false, validationMode: validationMode);
         }
 
-        protected void VerifyBasicFixAll(string oldSource, string newSource, bool allowNewCompilerDiagnostics = false, TestValidationMode validationMode = DefaultTestValidationMode)
+        protected void VerifyBasicFixAll(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, TestValidationMode validationMode = DefaultTestValidationMode)
         {
-            VerifyFixAll(LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), GetBasicCodeFixProvider(), new[] { oldSource }, new[] { newSource }, allowNewCompilerDiagnostics, allowUnsafeCode: false, validationMode: validationMode);
+            VerifyFixAll(LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), GetBasicCodeFixProvider(), new[] { oldSource }, new[] { newSource }, FixAllScope.Document, codeFixIndex, allowNewCompilerDiagnostics, allowUnsafeCode: false, validationMode: validationMode);
         }
 
-        private void VerifyFix(string language, DiagnosticAnalyzer analyzerOpt, CodeFixProvider codeFixProvider, string[] oldSources, string[] newSources, int? codeFixIndex, bool allowNewCompilerDiagnostics, bool onlyFixFirstFixableDiagnostic, bool allowUnsafeCode, TestValidationMode validationMode)
+        private void VerifyFix(
+            string language,
+            DiagnosticAnalyzer analyzerOpt,
+            CodeFixProvider codeFixProvider,
+            string[] oldSources,
+            string[] newSources,
+            int? codeFixIndex,
+            bool allowNewCompilerDiagnostics,
+            bool onlyFixFirstFixableDiagnostic,
+            FixAllScope? testFixAllScope,
+            bool allowUnsafeCode,
+            TestValidationMode validationMode)
         {
             var runner = new CodeFixRunner(analyzerOpt, codeFixProvider, validationMode);
             Assert.True(oldSources.Length == newSources.Length, "Length of expected and actual sources arrays must match.");
@@ -65,24 +78,32 @@ namespace Test.Utilities
 
             var project = documents.First().Project;
             Solution newSolution;
-            if (onlyFixFirstFixableDiagnostic || codeFixIndex.HasValue)
+            if (onlyFixFirstFixableDiagnostic)
             {
-                newSolution = runner.ApplySingleFix(project, ImmutableArray<TestAdditionalDocument>.Empty, codeFixIndex.HasValue ? codeFixIndex.Value : 0, fixableDiagnosticIndex: 0);
+                newSolution = runner.ApplySingleFix(project, ImmutableArray<TestAdditionalDocument>.Empty, codeFixIndex.HasValue ? codeFixIndex.Value : 0);
+                testFixAllScope = null;
             }
             else
             {
-                newSolution = runner.ApplyFixesOneByOne(project.Solution, ImmutableArray<TestAdditionalDocument>.Empty, allowNewCompilerDiagnostics);
+                newSolution = runner.ApplyFixesOneByOne(project.Solution, ImmutableArray<TestAdditionalDocument>.Empty, allowNewCompilerDiagnostics, codeFixIndex.HasValue ? codeFixIndex.Value : 0);
             }
 
             VerifyDocuments(newSolution, documents, newSources);
+
+            if (TestFixAllByDefault && testFixAllScope.HasValue)
+            {
+                VerifyFixAll(runner, documents, newSources, testFixAllScope.Value, codeFixIndex, allowNewCompilerDiagnostics);
+            }
         }
 
         private void VerifyFixAll(
-            string language, 
+            string language,
             DiagnosticAnalyzer analyzerOpt, 
             CodeFixProvider codeFixProvider, 
             string[] oldSources, 
-            string[] newSources, 
+            string[] newSources,
+            FixAllScope fixAllScope,
+            int? codeFixIndex,
             bool allowNewCompilerDiagnostics, 
             bool allowUnsafeCode,
             TestValidationMode validationMode)
@@ -90,9 +111,14 @@ namespace Test.Utilities
             var runner = new CodeFixRunner(analyzerOpt, codeFixProvider, validationMode);
             Assert.True(oldSources.Length == newSources.Length, "Length of expected and actual sources arrays must match.");
             Document[] documents = CreateDocuments(oldSources, language, allowUnsafeCode: allowUnsafeCode);
+            VerifyFixAll(runner, documents, newSources, fixAllScope, codeFixIndex, allowNewCompilerDiagnostics);
+        }
+
+        private static void VerifyFixAll(CodeFixRunner runner, Document[] documents, string[] newSources, FixAllScope fixAllScope, int? codeFixIndex, bool allowNewCompilerDiagnostics)
+        {
             var solution = documents.First().Project.Solution;
-            solution = runner.ApplyFixAll(solution, ImmutableArray<TestAdditionalDocument>.Empty, allowNewCompilerDiagnostics);
-            VerifyDocuments(solution, documents, newSources);
+            var newSolution = runner.ApplyFixAll(solution, fixAllScope, allowNewCompilerDiagnostics, codeFixIndex.HasValue ? codeFixIndex.Value : 0);
+            VerifyDocuments(newSolution, documents, newSources);
         }
 
         protected static void VerifyAdditionalFileFix(
@@ -126,23 +152,27 @@ namespace Test.Utilities
             var runner = new CodeFixRunner(analyzerOpt, codeFixProvider, validationMode);
             if (onlyFixFirstFixableDiagnostic || codeFixIndex.HasValue)
             {
-                newSolution = runner.ApplySingleFix(document.Project, additionalFiles, codeFixIndex.HasValue ? codeFixIndex.Value : 0, fixableDiagnosticIndex: 0);
+                newSolution = runner.ApplySingleFix(document.Project, additionalFiles, codeFixIndex.HasValue ? codeFixIndex.Value : 0);
             }
             else
             {
-                newSolution = runner.ApplyFixesOneByOne(document.Project.Solution, additionalFiles, allowNewCompilerDiagnostics);
+                newSolution = runner.ApplyFixesOneByOne(document.Project.Solution, additionalFiles, allowNewCompilerDiagnostics, codeFixIndex.HasValue ? codeFixIndex.Value : 0);
             }
 
             Assert.Equal(additionalFileText, GetActualTextForNewDocument(newSolution.GetDocument(document.Id), newAdditionalFileToVerify.Name).ToString());
         }
 
-        private void VerifyDocuments(Solution solution, Document[] documents, string[] newSources)
+        private static void VerifyDocuments(Solution solution, Document[] documents, string[] newSources)
         {
             for (int i = 0; i < documents.Length; i++)
             {
+                var expectedText = newSources[i].Trim();
                 var document = solution.GetDocument(documents[i].Id);
-                var actualText = GetActualTextForNewDocument(document, documents[i].Name);
-                Assert.Equal(newSources[i], actualText.ToString());
+                var actualText = GetActualTextForNewDocument(document, documents[i].Name).ToString().Trim();
+                if (expectedText != actualText)
+                {
+                    Assert.False(false, $"Expected:\n{expectedText}\n\nActual:\n{actualText}\n");
+                }
             }
         }
 


### PR DESCRIPTION
All the VerifyXXXFix test helpers now take an optional FixAllScope, which defaults to document/project based on whether the test verifies a single document or multiple documents. After validating the individual diagnostic code fix, the test framework also invokes the FixAll and verifies the result is identical.

For unit tests which have multiple fixable diagnostics in the original source code, they should explicitly disable FixAll testing in the VerifyXXXFix call by passing a null FixAllScope and have a separate FixAll test with appropriate baseline.

For code fixers which have no FixAll support, they can override the `TestFixAllByDefault` property to turn off FixAll testing for all it's unit tests.

Fixes #1420