### PR TITLE
Enable generating code metrics in legacy mode

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,7 @@
     <NoWarn>$(NoWarn);xUnit1004;xUnit2000;xUnit2003;xUnit2004;xUnit2009;xUnit2010;xUnit1013</NoWarn>
 
     <DefineConstants Condition="'$(BUILDING_VSIX)' == 'true'">$(DefineConstants),BUILDING_VSIX</DefineConstants>
+    <DefineConstants Condition="'$(LEGACY_CODE_METRICS_MODE)' == 'true'">$(DefineConstants),LEGACY_CODE_METRICS_MODE</DefineConstants>
   </PropertyGroup>
 
   <!-- Test runner configuration -->

--- a/src/Utilities/CodeMetrics/ComputationalComplexityMetrics.cs
+++ b/src/Utilities/CodeMetrics/ComputationalComplexityMetrics.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -97,6 +98,14 @@ namespace Microsoft.CodeAnalysis.CodeMetrics
                 {
                     continue;
                 }
+
+#if LEGACY_CODE_METRICS_MODE
+                // Legacy mode does not account for code within lambdas/local functions for code metrics.
+                if (operation.IsWithinLambdaOrLocalFunction())
+                {
+                    continue;
+                }
+#endif
 
                 if (operation.ConstantValue.HasValue)
                 {

--- a/src/Utilities/CodeMetrics/MetricsHelper.cs
+++ b/src/Utilities/CodeMetrics/MetricsHelper.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.CodeMetrics
@@ -179,6 +179,14 @@ namespace Microsoft.CodeAnalysis.CodeMetrics
                         // Add used types within executable code in the operation tree.
                         foreach (var operation in operationBlock.DescendantsAndSelf())
                         {
+#if LEGACY_CODE_METRICS_MODE
+                            // Legacy mode does not account for code within lambdas/local functions for code metrics.
+                            if (operation.IsWithinLambdaOrLocalFunction())
+                            {
+                                continue;
+                            }
+#endif
+
                             if (!operation.IsImplicit && hasConditionalLogic(operation))
                             {
                                 cyclomaticComplexity += 1;
@@ -217,7 +225,6 @@ namespace Microsoft.CodeAnalysis.CodeMetrics
                 switch (operation.Kind)
                 {
                     case OperationKind.CaseClause:
-                    case OperationKind.CatchClause:
                     case OperationKind.Coalesce:
                     case OperationKind.Conditional:
                     case OperationKind.ConditionalAccess:

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -513,5 +513,9 @@ namespace Analyzer.Utilities.Extensions
 
             return InstanceReferenceKind.Creation;
         }
+
+        public static bool IsWithinLambdaOrLocalFunction(this IOperation operation)
+            => operation.GetAncestor<IAnonymousFunctionOperation>(OperationKind.AnonymousFunction) != null ||
+               operation.GetAncestor<ILocalFunctionOperation>(OperationKind.LocalFunction) != null;
     }
 }


### PR DESCRIPTION
Define a new preprocessor directive to generate code metrics based on legacy mode heuristics (FxCop based MSIL analysis). This is done as part of customer requests for compat. Note that majority of these heursitics are very specific to IL analysis and hence are not included in the default code metrics mode.

Fixes #1840

@jgold6 Once this PR is merged in, customers can get code metrics data using legacy/compat mode by compiling the Metrics.csproj with following command: 

`msbuild /m /v:m /t:rebuild /p:LEGACY_CODE_METRICS_MODE=true Metrics.csproj`

I have attached the new code metrics reported generated by Metrics.exe for MobileApp/XamarinCRM in the new legacy mode. The numbers match a lot more with the legacy code metrics generation in VS. Please verify: [output.zip](https://github.com/dotnet/roslyn-analyzers/files/2446841/output.zip)


