### PR TITLE
Fix NRE in DiagnosticAnalyzerApiUsageAnalyzer when processi…

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAPIUsageAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAPIUsageAnalyzer.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 var syntax = decl.GetSyntax(cancellationToken);
 
                 // GetSyntax for VB returns the StatementSyntax instead of BlockSyntax node.
-                syntax = syntax.FirstAncestorOrSelf<SyntaxNode>(node => IsNamedTypeDeclarationBlock(node), ascendOutOfTrivia: false);
+                syntax = syntax.FirstAncestorOrSelf<SyntaxNode>(node => IsNamedTypeDeclarationBlock(node), ascendOutOfTrivia: false) ?? syntax;
 
                 var semanticModel = compilation.GetSemanticModel(syntax.SyntaxTree);
                 var nodesToProcess = new Queue<(SyntaxNode node, bool inExecutableCode)>();

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticAnalyzerApiUsageAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticAnalyzerApiUsageAnalyzerTests.cs
@@ -28,9 +28,13 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 interface I<T> { }
 
+internal delegate void MyDelegateGlobal();
+
 class MyAnalyzer : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics=> throw new NotImplementedException();
+
+    internal delegate void MyDelegateInType();
 
     public override void Initialize(AnalysisContext context)
     {
@@ -66,8 +70,11 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Interface I(Of T)
 End Interface
 
+Friend Delegate Sub MyDelegateGlobal()
+
 Class MyAnalyzer
     Inherits DiagnosticAnalyzer
+    Friend Delegate Sub MyDelegateInType()
 
     Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
         Get


### PR DESCRIPTION
…ng globally declared delegate types.

Fixes #1803 

Tagging @sharwell @shyamnamboodiripad - this fixes NRE in RS1022 seen in stylecop and testimpact repos.