### PR TITLE
ImplementIDisposableCorrectly should only analyze externally visible type

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                             CheckDisposeSignatureRule(disposeMethod, type, context);
                             CheckRenameDisposeRule(disposeMethod, type, context);
 
-                            if (!type.IsSealed && type.DeclaredAccessibility != Accessibility.Private)
+                            if (!type.IsSealed)
                             {
                                 IMethodSymbol disposeBoolMethod = FindDisposeBoolMethod(type);
                                 if (disposeBoolMethod != null)
@@ -244,7 +244,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 {
                     INamedTypeSymbol type = method.ContainingType;
                     if (type != null && type.TypeKind == TypeKind.Class &&
-                        !type.IsSealed && type.DeclaredAccessibility != Accessibility.Private)
+                        !type.IsSealed && type.IsExternallyVisible())
                     {
                         if (ImplementsDisposableDirectly(type))
                         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
@@ -1026,6 +1026,37 @@ public class C : IDisposable
         }
 
         [Fact]
+        public void CSharp_CA1063_DisposeImplementation_NoDiagnostic_ConditionalStatement_Internal()
+        {
+            VerifyCSharp(@"
+using System;
+
+internal class C : IDisposable
+{
+    private bool disposed;
+
+    public void Dispose()
+    {
+        if (!disposed)
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    ~C()
+    {
+        Dispose(false);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+    }
+}
+");
+        }
+
+        [Fact]
         public void CSharp_CA1063_DisposeImplementation_Diagnostic_CallDisposeBoolTwice()
         {
             VerifyCSharp(@"
@@ -2279,6 +2310,36 @@ Public Class C
 End Class
 ",
             GetCA1063BasicDisposeImplementationResultAt(9, 16, "C", "Dispose"));
+        }
+
+        [Fact]
+        public void Basic_CA1063_DisposeImplementation_NoDiagnostic_ConditionalStatement_Internal()
+        {
+            VerifyBasic(@"
+Imports System
+
+Friend Class C
+    Implements IDisposable
+
+    Private disposed As Boolean
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        If Not disposed Then
+            Dispose(True)
+            GC.SuppressFinalize(Me)
+        End If
+    End Sub
+
+    Protected Overrides Sub Finalize()
+        Dispose(False)
+        MyBase.Finalize()
+    End Sub
+
+    Protected Overridable Sub Dispose(disposing As Boolean)
+    End Sub
+
+End Class
+");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1795

"Implement IDisposable Correctly" was still fired, when type was internal and not inherited from base type.