### PR TITLE
Don't trigger ca1052 for abstract classes

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/StaticHolderTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/StaticHolderTypes.cs
@@ -75,7 +75,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             var symbol = (INamedTypeSymbol)context.Symbol;
             if (!symbol.IsStatic &&
                 symbol.IsExternallyVisible() &&
-                symbol.IsStaticHolderType())
+                symbol.IsStaticHolderType() &&
+                !symbol.IsAbstract)
             {
                 context.ReportDiagnostic(symbol.CreateDiagnostic(Rule, symbol.Name));
             }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -815,5 +815,17 @@ Public Class B29
 End Class
 ");
         }
+
+        [Fact]
+        public void CA1052NoDiagnosticForAbstractNonStaticClassCSharp()
+        {
+            VerifyCSharp(@"
+public abstract class C1
+{
+    internal class C2 : C1 {
+    }
+}
+");
+        }
     }
 }


### PR DESCRIPTION
Fixes issue #1820 Base class is should not be detected as a static holder type