### PR TITLE
Fix for assert from analysis involving lValue flow captures (address …

### DIFF
--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -344,18 +344,5 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         protected IDictionary<AnalysisEntity, TAbstractAnalysisValue> GetClonedAnalysisDataHelper(IDictionary<AnalysisEntity, TAbstractAnalysisValue> analysisData)
             => new Dictionary<AnalysisEntity, TAbstractAnalysisValue>(analysisData);
-
-        #region Visitor methods
-        protected override TAbstractAnalysisValue VisitAssignmentOperation(IAssignmentOperation operation, object argument)
-        {
-            var value = base.VisitAssignmentOperation(operation, argument);
-            if (AnalysisEntityFactory.TryCreate(operation.Target, out AnalysisEntity targetEntity))
-            {
-                value = GetAbstractValue(targetEntity);
-            }
-
-            return value;
-        }
-        #endregion
     }
 }


### PR DESCRIPTION
…taken varaibles)

Fixes #1855

Base implementation already did the right thing by returing the data value computed for right side of assignment, so deleted the override in AnalysisEntityBasedOperationVisitor.

I wish all bug fixes involved just deleting code :-)