### PR TITLE
Ensure that we get the same CFG for a given interprocedural target me…

### DIFF
--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -57,6 +57,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         /// Dictionary storing context sensitive interprocedural analysis results for each callsite.
         /// </summary>
         private readonly ImmutableDictionary<IOperation, IDataFlowAnalysisResult<TAbstractAnalysisValue>>.Builder _interproceduralResultsBuilder;
+
+        /// <summary>
+        /// Dictionary from interprocedural method symbols invoked to their corresponding <see cref="ControlFlowGraph"/>.
+        /// </summary>
+        private readonly Dictionary<IMethodSymbol, ControlFlowGraph> _interproceduralMethodToCfgMapOpt;
         #endregion
 
         protected abstract TAbstractAnalysisValue GetAbstractDefaultValue(ITypeSymbol type);
@@ -148,6 +153,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 }
 
                 _addressSharedEntitiesBuilder.AddRange(analysisContext.InterproceduralAnalysisDataOpt.AddressSharedEntities);
+                _interproceduralMethodToCfgMapOpt = null;
+            }
+            else
+            {
+                _interproceduralMethodToCfgMapOpt = new Dictionary<IMethodSymbol, ControlFlowGraph>();
             }
 
             AnalysisEntity thisOrMeInstanceFromCalleeOpt;
@@ -1549,7 +1559,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     _addressSharedEntitiesBuilder.ToImmutable(),
                     ImmutableStack.CreateRange(_interproceduralCallStack),
                     newMethodsBeingAnalyzed,
-                    getCachedAbstractValueFromCaller: GetCachedAbstractValue);
+                    getCachedAbstractValueFromCaller: GetCachedAbstractValue,
+                    getInterproceduralControlFlowGraph: GetInterproceduralControlFlowGraph);
 
                 (AnalysisEntity, PointsToAbstractValue)? GetInvocationInstance()
                 {
@@ -2256,14 +2267,27 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             IOperation originalOperation,
             TAbstractAnalysisValue defaultValue)
         {
-            Func<ControlFlowGraph> getCfg = () =>
-            {
-                var operation = method.GetTopmostOperationBlock(WellKnownTypeProvider.Compilation);
-                return operation?.GetEnclosingControlFlowGraph();
-            };
+            Func<ControlFlowGraph> getCfg = () => GetInterproceduralControlFlowGraph(method);
 
             return PerformInterproceduralAnalysis(getCfg, method, visitedInstance,
                 visitedArguments, originalOperation, defaultValue, isLambdaOrLocalFunction: false);
+        }
+
+        private ControlFlowGraph GetInterproceduralControlFlowGraph(IMethodSymbol method)
+        {
+            if (DataFlowAnalysisContext.InterproceduralAnalysisDataOpt != null)
+            {
+                return DataFlowAnalysisContext.InterproceduralAnalysisDataOpt.GetInterproceduralControlFlowGraph(method);
+            }
+
+            if (!_interproceduralMethodToCfgMapOpt.TryGetValue(method, out var cfg))
+            {
+                var operation = method.GetTopmostOperationBlock(WellKnownTypeProvider.Compilation);
+                cfg = operation?.GetEnclosingControlFlowGraph();
+                _interproceduralMethodToCfgMapOpt.Add(method, cfg);
+            }
+
+            return cfg;
         }
 
         public virtual TAbstractAnalysisValue VisitInvocation_LocalFunction(

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
@@ -32,7 +32,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             ImmutableDictionary<AnalysisEntity, CopyAbstractValue> addressSharedEntities,
             ImmutableStack<IOperation> callStack,
             ImmutableHashSet<TAnalysisContext> methodsBeingAnalyzed,
-            Func<IOperation, TAbstractAnalysisValue> getCachedAbstractValueFromCaller)
+            Func<IOperation, TAbstractAnalysisValue> getCachedAbstractValueFromCaller,
+            Func<IMethodSymbol, ControlFlowGraph> getInterproceduralControlFlowGraph)
         {
             Debug.Assert(initialAnalysisData != null);
             Debug.Assert(!arguments.IsDefault);
@@ -40,6 +41,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Debug.Assert(callStack != null);
             Debug.Assert(methodsBeingAnalyzed != null);
             Debug.Assert(getCachedAbstractValueFromCaller != null);
+            Debug.Assert(getInterproceduralControlFlowGraph != null);
 
             InitialAnalysisData = initialAnalysisData;
             InvocationInstanceOpt = invocationInstanceOpt;
@@ -49,6 +51,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             CallStack = callStack;
             MethodsBeingAnalyzed = methodsBeingAnalyzed;
             GetCachedAbstractValueFromCaller = getCachedAbstractValueFromCaller;
+            GetInterproceduralControlFlowGraph = getInterproceduralControlFlowGraph;
         }
 
         public TAnalysisData InitialAnalysisData { get; }
@@ -59,6 +62,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public ImmutableStack<IOperation> CallStack { get; }
         public ImmutableHashSet<TAnalysisContext> MethodsBeingAnalyzed { get; }
         public Func<IOperation, TAbstractAnalysisValue> GetCachedAbstractValueFromCaller { get; }
+        public Func<IMethodSymbol, ControlFlowGraph> GetInterproceduralControlFlowGraph { get; }
 
         protected sealed override int ComputeHashCode()
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/MapAbstractDomain.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/MapAbstractDomain.cs
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 var value = kvp.Value;
                 if (!newValue.TryGetValue(key, out TValue otherValue))
                 {
+                    Debug.Fail("Non-monotonic Merge function");
                     return 1;
                 }
 
@@ -54,6 +55,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                 if (result > 0)
                 {
+                    Debug.Fail("Non-monotonic Merge function");
                     return 1;
                 }
                 else if (result < 0)


### PR DESCRIPTION
…thod

Generating different CFGs for same method has both performance and functional implications:
1. Performance: we are computing CFG multiple times for the same operation block, potentially also leading to duplicate dataflow analysis.
2. Functional: PointsTo values for allocations from interprodedural calls contain the interprocedural call stack of operations, and we want these to be identical for same call stack across different fix point iterations of dataflow analysis over the same basic block, which is only possible if we use the same CFG across these iterations.

We now hold a strong reference from each interprocedural target method symbol to corresponding CFG in the DataFlowOperationVisitor to guarantee the above.
Additionally, we also have ConditionalWeakTables based off Compilation to cache topmost block operation for method symbols and CFGs for operation blocks so that interprocedural flow analysis across analyzers or analyzer callbacks also re-use the same CFGs if possible (this is purely a performance optimization).

Fixes #1870