### PR TITLE
Fix GetChildAnalysisEntities to not return the original given entity

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3438,5 +3438,31 @@ using System.Reflection;
             // Test0.cs(14,36): warning CA1062: In externally visible method 'IInterface PropConvert.ToSettings(object o)', validate parameter 'o' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(14, 36, "IInterface PropConvert.ToSettings(object o)", "o"));
         }
+
+        [Fact, WorkItem(1870, "https://github.com/dotnet/roslyn-analyzers/issues/1870")]
+        public void Issue1870_02()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Collections.Generic;
+
+namespace ANamespace
+{
+    public static class SomeExtensions
+    {
+        public static Dictionary<string, string> Merge(this Dictionary<string, string> dictionary, Dictionary<string, string> dictionaryToMerge) {
+            if (dictionaryToMerge == null)
+                return dictionary;
+
+            var newDictionary = new Dictionary<string, string>(dictionary);
+
+            foreach (var valueDictionary in dictionaryToMerge)
+                newDictionary[valueDictionary.Key] = valueDictionary.Value;
+
+            return newDictionary;
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -193,12 +193,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                HashUtilities.Combine(Type.GetHashCode(),
                HashUtilities.Combine(ParentOpt?.GetHashCode() ?? 0, IsThisOrMeInstance.GetHashCode()))))));
 
-        public bool HasAncestorOrSelf(AnalysisEntity ancestor)
+        public bool HasAncestor(AnalysisEntity ancestor)
         {
             Debug.Assert(ancestor != null);
 
-            AnalysisEntity current = this;
-            do
+            AnalysisEntity current = this.ParentOpt;
+            while (current != null)
             {
                 if (current == ancestor)
                 {
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 }
 
                 current = current.ParentOpt;
-            } while (current != null);
+            }
 
             return false;
         }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Debug.Assert(analysisEntity.Type.HasValueCopySemantics());
 
             IEnumerable<AnalysisEntity> dependantAnalysisEntities = GetChildAnalysisEntities(analysisEntity);
-            ResetInstanceAnalysisDataCore(dependantAnalysisEntities);
+            ResetInstanceAnalysisDataCore(dependantAnalysisEntities.Concat(analysisEntity));
         }
 
         protected override void ResetReferenceTypeInstanceAnalysisData(PointsToAbstractValue pointsToValue)
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             var hasValueCopySemantics = analysisEntity.Type.HasValueCopySemantics();
             foreach (var entity in GetChildAnalysisEntities(analysisEntity.InstanceLocation))
             {
-                if (!hasValueCopySemantics || entity.HasAncestorOrSelf(analysisEntity))
+                if (!hasValueCopySemantics || entity.HasAncestor(analysisEntity))
                 {
                     yield return entity;
                 }


### PR DESCRIPTION
This fixes the assert in CopyAnalysis identified by @dotpaul in https://github.com/dotnet/roslyn-analyzers/issues/1870#issuecomment-435544389