### PR TITLE
Fix couple of asserts in PointsToAnalysis

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3464,5 +3464,203 @@ namespace ANamespace
     }
 }");
         }
+
+        [Fact, WorkItem(1886, "https://github.com/dotnet/roslyn-analyzers/issues/1886")]
+        public void Issue1886()
+        {
+            VerifyCSharp(@"
+public enum Status
+{
+    Status1,
+    Status2,
+}
+
+public class C1
+{
+    public Status MyStatus { get; set; }
+}
+
+public class C2
+{
+    public static void M(C1 c, bool f)
+    {
+        if (c== null)
+        {
+            return;
+        }
+
+        c.MyStatus = f ? Status.Status1 : Status.Status2;
+    }
+}");
+        }
+
+        [Fact, WorkItem(1891, "https://github.com/dotnet/roslyn-analyzers/issues/1891")]
+        public void Issue1891()
+        {
+            VerifyCSharp(@"
+using System;
+using System.IO;
+using System.Threading;
+using System.Web;
+
+public interface IContext
+{
+    HttpContext HttpContext { get; }
+}
+
+public class CaptureStream : Stream
+{
+    public CaptureStream(Stream innerStream)
+    {
+        _innerStream = innerStream;
+        _captureStream = new MemoryStream();
+    }
+
+    private readonly Stream _innerStream;
+    private readonly MemoryStream _captureStream;
+
+    public override bool CanRead
+    {
+        get { return _innerStream.CanRead; }
+    }
+
+    public override bool CanSeek
+    {
+        get { return _innerStream.CanSeek; }
+    }
+
+    public override bool CanWrite
+    {
+        get { return _innerStream.CanWrite; }
+    }
+
+    public override long Length
+    {
+        get { return _innerStream.Length; }
+    }
+
+    public override long Position
+    {
+        get { return _innerStream.Position; }
+        set { _innerStream.Position = value; }
+    }
+
+    public override long Seek(long offset, SeekOrigin direction)
+    {
+        return _innerStream.Seek(offset, direction);
+    }
+
+    public override void SetLength(long length)
+    {
+        _innerStream.SetLength(length);
+    }
+
+    public override void Close()
+    {
+        _innerStream.Close();
+    }
+
+    public override void Flush()
+    {
+        if (_captureStream.Length > 0)
+        {
+            OnCaptured();
+            _captureStream.SetLength(0);
+        }
+
+        _innerStream.Flush();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        return _innerStream.Read(buffer, offset, count);
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _captureStream.Write(buffer, offset, count);
+        _innerStream.Write(buffer, offset, count);
+    }
+
+    public event Action<byte[]> Captured;
+
+    protected virtual void OnCaptured()
+    {
+        Captured(_captureStream.ToArray());
+    }
+}
+
+public class Class1
+{
+    private string AField;
+    private bool ASwitch;
+
+    public void Method(IContext aContext)
+    {
+        var captureHandlerIsAttached = false;
+
+        try
+        {
+            if (!ASwitch)
+                return;
+
+            Console.WriteLine(AField);
+
+            if (!HasUrl(aContext))
+            {
+                return;
+            }
+
+            var response = aContext.HttpContext.Response;
+            var captureStream = new CaptureStream(null);
+            response.Filter = captureStream;
+
+            captureStream.Captured += (output) => {
+                try
+                {
+                    if (response.StatusCode != 200)
+                    {
+                        Console.WriteLine(AField);
+                        return;
+                    }
+
+                    Console.WriteLine(aContext.HttpContext.Request.Url.AbsolutePath);
+                }
+                finally
+                {
+                    ReleaseTheLock();
+                }
+            };
+
+            captureHandlerIsAttached = true;
+        }
+        finally
+        {
+            if (!captureHandlerIsAttached)
+                ReleaseTheLock();
+        }
+    }
+
+    private void ReleaseTheLock()
+    {
+        if (AField != null && Monitor.IsEntered(AField))
+        {
+            Monitor.Exit(AField);
+            AField = null;
+        }
+    }
+
+    protected virtual bool HasUrl(IContext filterContext)
+    {
+        if (filterContext.HttpContext.Request.Url == null)
+        {
+            return false;
+        }
+        return true;
+    }
+}",
+            // Test0.cs(115,28): warning CA1062: In externally visible method 'void Class1.Method(IContext aContext)', validate parameter 'aContext' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(115, 28, "void Class1.Method(IContext aContext)", "aContext"));
+        }
     }
 }

--- a/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
@@ -41,6 +41,7 @@ namespace Test.Utilities
         private static readonly MetadataReference s_immutableCollectionsReference = MetadataReference.CreateFromFile(typeof(ImmutableArray<int>).Assembly.Location);
         private static readonly MetadataReference s_systemDiagnosticsDebugReference = MetadataReference.CreateFromFile(typeof(Debug).Assembly.Location);
         private static readonly MetadataReference s_systemDataReference = MetadataReference.CreateFromFile(typeof(System.Data.DataSet).Assembly.Location);
+        private static readonly MetadataReference s_systemWebReference = MetadataReference.CreateFromFile(typeof(System.Web.HttpRequest).Assembly.Location);
         private static readonly MetadataReference s_systemXmlLinq = MetadataReference.CreateFromFile(typeof(System.Xml.Linq.XAttribute).Assembly.Location);
         protected static readonly CompilationOptions s_CSharpDefaultOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
         protected static readonly CompilationOptions s_CSharpUnsafeCodeDefaultOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithAllowUnsafe(true);
@@ -428,6 +429,7 @@ namespace Test.Utilities
                 .AddMetadataReference(projectId, SystemThreadingTaskFacadeRef)
                 .AddMetadataReference(projectId, s_workspacesReference)
                 .AddMetadataReference(projectId, s_systemDiagnosticsDebugReference)
+                .AddMetadataReference(projectId, s_systemWebReference)
                 .AddMetadataReference(projectId, s_systemXmlLinq)
                 .WithProjectCompilationOptions(projectId, options)
                 .WithProjectParseOptions(projectId, parseOptions)

--- a/src/Test.Utilities/Test.Utilities.csproj
+++ b/src/Test.Utilities/Test.Utilities.csproj
@@ -16,5 +16,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary" Version="$(MicrosoftCodeAnalysisTestResourcesProprietaryVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Web" />
+  </ItemGroup>
   <Import Project="..\Utilities\Analyzer.Utilities.projitems" Label="Shared" />
 </Project>

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             return new PointsToAbstractValue(lValueCapturedOperations);
         }
 
-        public PointsToAbstractValue MakeNonNull(IOperation operation, PointsToAnalysisContext analysisContext)
+        public PointsToAbstractValue MakeNonNull(IOperation operation, PointsToAnalysisContext analysisContext, AnalysisEntity analysisEntityForOperationOpt)
         {
             Debug.Assert(Kind != PointsToAbstractValueKind.KnownLValueCaptures);
 
@@ -105,7 +105,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             if (Kind != PointsToAbstractValueKind.KnownLocations)
             {
-                return Create(AbstractLocation.CreateAllocationLocation(operation, operation.Type, analysisContext), mayBeNull: false);
+                var location = analysisEntityForOperationOpt != null ?
+                    AbstractLocation.CreateAnalysisEntityDefaultLocation(analysisEntityForOperationOpt) :
+                    AbstractLocation.CreateAllocationLocation(operation, operation.Type, analysisContext);
+                return Create(location, mayBeNull: false);
             }
 
             var locations = Locations.Where(location => !location.IsNull).ToImmutableHashSet();

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                         break;
 
                     case NullAbstractValue.NotNull:
-                        newPointsToValue = existingValue.MakeNonNull(operation, analysisContext);
+                        newPointsToValue = existingValue.MakeNonNull(operation, analysisContext, analysisEntity);
                         break;
 
                     case NullAbstractValue.Invalid:
@@ -640,7 +640,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 switch (nullState)
                 {
                     case NullAbstractValue.NotNull:
-                        return defaultValue.MakeNonNull(operation, DataFlowAnalysisContext);
+                        if (!AnalysisEntityFactory.TryCreate(operation, out var analysisEntityOpt))
+                        {
+                            analysisEntityOpt = null;
+                        }
+
+                        return defaultValue.MakeNonNull(operation, DataFlowAnalysisContext, analysisEntityOpt);
 
                     case NullAbstractValue.Null:
                         return defaultValue.MakeNull();

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
         private static PointsToAnalysisResult GetOrComputeResultForAnalysisContext(PointsToAnalysisContext analysisContext)
         {
-            var defaultPointsToValueGenerator = new DefaultPointsToValueGenerator();
+            var defaultPointsToValueGenerator = new DefaultPointsToValueGenerator(analysisContext.ControlFlowGraph);
             var analysisDomain = new PointsToAnalysisDomain(defaultPointsToValueGenerator);
             var operationVisitor = new PointsToDataFlowOperationVisitor(defaultPointsToValueGenerator, analysisDomain, analysisContext);
             var pointsToAnalysis = new PointsToAnalysis(analysisDomain, operationVisitor);


### PR DESCRIPTION
1) Fixes #1886: Loosen the assert in DefaultPointsToValueGenerator to account for lvalue flow captures. We already handle flow captures in the method implementation. I was able to find a minimal repro for this assert and used it in the added test.
2) Fixes #1891: PointsToAbstractValue.MakeNonNull should attempt to use analysis entity based location if the underlying operation binds to an entity. I was unable to create a smaller repro then what @dotpaul provided in the issue.