### PR TITLE
Fix bunch of asserts from interprocedural analysis

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3757,5 +3757,29 @@ internal class C2
     }
 }");
         }
+
+        [Fact]
+        public void GetValueOrDefaultAssert()
+        {
+            VerifyCSharp(@"
+public struct S
+{
+    public bool Flag;
+    public object Old;
+    public object New;
+
+    public bool Equals(S other)
+    {
+        return this.Flag == other.Flag
+            && (this.Old == null ? other.Old == null : this.Old.Equals(other.Old))
+            && (this.New == null ? other.New == null : this.New.Equals(other.New));
+    }
+ 
+    public override bool Equals(object obj)
+    {
+        return obj is S && Equals((S)obj);
+    }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3819,5 +3819,29 @@ public struct S2
     }
 }");
         }
+
+        [Fact]
+        public void SameFlowCaptureIdAcrossInterproceduralMethod()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public bool Flag;
+    public void M(C c, bool flag)
+    {
+        c = c ?? Create(flag);
+    }
+
+    public C Create(bool flag)
+    {
+        if (Flag == flag)
+        {
+            return this;
+        }
+
+        return new C() { Flag = flag };
+    }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3781,5 +3781,43 @@ public struct S
     }
 }");
         }
+
+        [Fact]
+        public void GetValueOrDefaultAssert_02()
+        {
+            VerifyCSharp(@"
+public struct S
+{
+    public object Node;
+    public int Index;
+    public S2 Token;
+
+    public bool Equals(S other)
+    {
+        return Node == other.Node && Index == other.Index && Token.Equals(other.Token);
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is S && Equals((S)obj);
+    }
+}
+
+public struct S2
+{
+    public object Parent { get; } 
+    internal object Node { get; } 
+    internal int Index { get; } 
+    internal int Position { get; }
+
+    public bool Equals(S2 other)
+    {
+        return Parent == other.Parent &&
+            Node == other.Node &&
+            Position == other.Position &&
+            Index == other.Index;
+    }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3663,5 +3663,65 @@ public class Class1
             // Test0.cs(115,28): warning CA1062: In externally visible method 'void Class1.Method(IContext aContext)', validate parameter 'aContext' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(115, 28, "void Class1.Method(IContext aContext)", "aContext"));
         }
+
+        [Fact, WorkItem(1891, "https://github.com/dotnet/roslyn-analyzers/issues/1891")]
+        public void MakeNullAndMakeMayBeNullAssert()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class Class1
+{
+    public virtual void M1(Class1 node, bool flag1, bool flag2)
+    {
+        foreach (var child in node.M2())
+        {
+            if (flag1)
+            {
+                if (flag2)
+                {
+                    M1(child);
+                }
+            }
+            else if (flag2)
+            {
+                if (!flag1)
+                {
+                    M3(child);
+                }
+            }
+        }
+    }
+
+    public virtual void M1(Class1 node)
+    {
+    }
+
+    private Enumerator M2() => default(Enumerator);
+
+    private void M3(object o) { }
+
+    private struct Enumerator : IReadOnlyList<Class1>
+    {
+        public Class1 this[int index] => throw new NotImplementedException();
+
+        public int Count => throw new NotImplementedException();
+
+        public IEnumerator<Class1> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}",
+            // Test0.cs(10,31): warning CA1062: In externally visible method 'void Class1.M1(Class1 node, bool flag1, bool flag2)', validate parameter 'node' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(10, 31, "void Class1.M1(Class1 node, bool flag1, bool flag2)", "node"));
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3664,7 +3664,7 @@ public class Class1
             GetCSharpResultAt(115, 28, "void Class1.Method(IContext aContext)", "aContext"));
         }
 
-        [Fact, WorkItem(1891, "https://github.com/dotnet/roslyn-analyzers/issues/1891")]
+        [Fact]
         public void MakeNullAndMakeMayBeNullAssert()
         {
             VerifyCSharp(@"
@@ -3722,6 +3722,40 @@ public class Class1
 }",
             // Test0.cs(10,31): warning CA1062: In externally visible method 'void Class1.M1(Class1 node, bool flag1, bool flag2)', validate parameter 'node' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(10, 31, "void Class1.M1(Class1 node, bool flag1, bool flag2)", "node"));
+        }
+
+        [Fact]
+        public void OutParameterAssert()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public void M(string s, bool b)
+    {
+        C2.M(s, b);
+    }
+}
+
+internal class C2
+{
+    public static void M(string s, bool b)
+    {
+        char? unused;
+        M(s, b, out unused);
+    }
+
+    public static void M(string s, bool b, out char? ch)
+    {
+        ch = null;
+        while (b)
+        {
+            if (!string.IsNullOrEmpty(s))
+            {
+                ch = s[0];
+            }
+        }
+    }
+}");
         }
     }
 }

--- a/src/Utilities/Analyzer.Utilities.projitems
+++ b/src/Utilities/Analyzer.Utilities.projitems
@@ -108,6 +108,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\ValueContentAnalysis\ValueContentBlockAnalysisResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractAnalysisDomain.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractBlockAnalysisResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\InterproceduralCaptureId.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\ArgumentInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\InterproceduralAnalysisKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\InterproceduralAnalysisData.cs" />

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
@@ -24,15 +24,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
         public PointsToAbstractValue GetOrCreateDefaultValue(AnalysisEntity analysisEntity)
         {
-            // Must be one of the following:
-            //  1. A reference type OR
-            //  2. A nullable value type OR
-            //  3. ThisOrMeInstance of a non-nullable value type OR
-            //  4. An lvalue capture of a non-nullable value type
-            Debug.Assert(analysisEntity.Type.IsReferenceTypeOrNullableValueType() ||
-                         analysisEntity.IsThisOrMeInstance ||
-                         (analysisEntity.CaptureIdOpt != null &&
-                          LValueFlowCapturesProvider.GetOrCreateLValueFlowCaptures(_controlFlowGraph).Contains(analysisEntity.CaptureIdOpt.Value)));
             Debug.Assert(_lazyDefaultPointsToValueMap == null);
 
             if (!_defaultPointsToValueMapBuilder.TryGetValue(analysisEntity, out PointsToAbstractValue value))
@@ -43,8 +34,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 {
                     return PointsToAbstractValue.Undefined;
                 }
-                else if (analysisEntity.IsThisOrMeInstance &&
-                    !analysisEntity.Type.IsReferenceTypeOrNullableValueType())
+                else if (!analysisEntity.Type.IsReferenceTypeOrNullableValueType())
                 {
                     return PointsToAbstractValue.NoLocation;
                 }

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.CorePointsToAnalysisDataDomain.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.CorePointsToAnalysisDataDomain.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                                 break;
 
                             case NullAbstractValue.NotNull:
-                                if (backEdgeValue.MakeMayBeNull() != forwardEdgeValue)
+                                if (backEdgeValue.MakeMayBeNull(key) != forwardEdgeValue)
                                 {
                                     if (forwardEdgeValue.NullState == NullAbstractValue.NotNull)
                                     {

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             private static bool ShouldBeTracked(ITypeSymbol typeSymbol) => typeSymbol.IsReferenceTypeOrNullableValueType();
 
             private bool ShouldBeTracked(AnalysisEntity analysisEntity) => ShouldBeTracked(analysisEntity.Type) ||
-                analysisEntity.CaptureIdOpt.HasValue && IsLValueFlowCapture(analysisEntity.CaptureIdOpt.Value);
+                analysisEntity.CaptureIdOpt.HasValue && IsLValueFlowCapture(analysisEntity.CaptureIdOpt.Value.Id);
 
             protected override void AddTrackedEntities(ImmutableArray<AnalysisEntity>.Builder builder)
             {

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -114,10 +114,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             {
                 if (ShouldBeTracked(analysisEntity))
                 {
-                    if (!CurrentAnalysisData.HasAbstractValue(analysisEntity) &&
-                        value.Kind == PointsToAbstractValueKind.Undefined)
+                    if (value.Kind == PointsToAbstractValueKind.Undefined)
                     {
                         Debug.Assert(value == _defaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity));
+                        Debug.Assert(!CurrentAnalysisData.TryGetValue(analysisEntity, out var currentValue) ||
+                                     currentValue == PointsToAbstractValue.Unknown &&         
+                                     (analysisEntity.SymbolOpt as IParameterSymbol)?.RefKind == RefKind.Out);
                         return;
                     }
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             ISymbol symbolOpt,
             ImmutableArray<AbstractIndex> indices,
             SyntaxNode instanceReferenceOperationSyntaxOpt,
-            CaptureId? captureIdOpt,
+            InterproceduralCaptureId? captureIdOpt,
             PointsToAbstractValue location,
             ITypeSymbol type,
             AnalysisEntity parentOpt,
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Debug.Assert(instanceReferenceOperation != null);
         }
 
-        private AnalysisEntity(CaptureId captureId, ITypeSymbol capturedType)
+        private AnalysisEntity(InterproceduralCaptureId captureId, ITypeSymbol capturedType)
             : this(symbolOpt: null, indices: ImmutableArray<AbstractIndex>.Empty, instanceReferenceOperationSyntaxOpt: null,
                   captureIdOpt: captureId, location: PointsToAbstractValue.NoLocation, type: capturedType, parentOpt: null, isThisOrMeInstance: false)
         {
@@ -105,18 +105,20 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             return new AnalysisEntity(instanceReferenceOperation, instanceLocation);
         }
 
-        public static AnalysisEntity Create(IFlowCaptureOperation flowCaptureOperation)
+        public static AnalysisEntity Create(IFlowCaptureOperation flowCaptureOperation, ControlFlowGraph controlFlowGraph)
         {
             Debug.Assert(flowCaptureOperation != null);
 
-            return new AnalysisEntity(flowCaptureOperation.Id, flowCaptureOperation.Value.Type);
+            var captureId = new InterproceduralCaptureId(flowCaptureOperation.Id, controlFlowGraph);
+            return new AnalysisEntity(captureId, flowCaptureOperation.Value.Type);
         }
 
-        public static AnalysisEntity Create(IFlowCaptureReferenceOperation flowCaptureReferenceOperation)
+        public static AnalysisEntity Create(IFlowCaptureReferenceOperation flowCaptureReferenceOperation, ControlFlowGraph controlFlowGraph)
         {
             Debug.Assert(flowCaptureReferenceOperation != null);
 
-            return new AnalysisEntity(flowCaptureReferenceOperation.Id, flowCaptureReferenceOperation.Type);
+            var captureId = new InterproceduralCaptureId(flowCaptureReferenceOperation.Id, controlFlowGraph);
+            return new AnalysisEntity(captureId, flowCaptureReferenceOperation.Type);
         }
 
         public static AnalysisEntity CreateThisOrMeInstance(INamedTypeSymbol typeSymbol, PointsToAbstractValue instanceLocation)
@@ -173,7 +175,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public ISymbol SymbolOpt { get; }
         public ImmutableArray<AbstractIndex> Indices { get; }
         public SyntaxNode InstanceReferenceOperationSyntaxOpt { get; }
-        public CaptureId? CaptureIdOpt { get; }
+        public InterproceduralCaptureId? CaptureIdOpt { get; }
         public PointsToAbstractValue InstanceLocation { get; }
         public ITypeSymbol Type { get; }
         public AnalysisEntity ParentOpt { get; }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
     /// </summary>
     internal sealed class AnalysisEntityFactory
     {
+        private readonly ControlFlowGraph _controlFlowGraph;
         private readonly Dictionary<IOperation, AnalysisEntity> _analysisEntityMap;
         private readonly Dictionary<ISymbol, PointsToAbstractValue> _instanceLocationsForSymbols;
         private readonly Func<IOperation, PointsToAbstractValue> _getPointsToAbstractValueOpt;
@@ -25,6 +26,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         private readonly ImmutableStack<IOperation> _interproceduralCallStackOpt;
 
         public AnalysisEntityFactory(
+            ControlFlowGraph controlFlowGraph,
             Func<IOperation, PointsToAbstractValue> getPointsToAbstractValueOpt,
             Func<bool> getIsInsideAnonymousObjectInitializer,
             INamedTypeSymbol containingTypeSymbol,
@@ -32,6 +34,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             ImmutableStack<IOperation> interproceduralCallStackOpt,
             IEnumerable<KeyValuePair<ISymbol, PointsToAbstractValue>> instanceLocationsFromCallee)
         {
+            _controlFlowGraph = controlFlowGraph;
             _getPointsToAbstractValueOpt = getPointsToAbstractValueOpt;
             _getIsInsideAnonymousObjectInitializer = getIsInsideAnonymousObjectInitializer;
             _interproceduralCallStackOpt = interproceduralCallStackOpt;
@@ -175,11 +178,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     return TryCreate(argument.Value, out analysisEntity);
 
                 case IFlowCaptureOperation flowCapture:
-                    analysisEntity = AnalysisEntity.Create(flowCapture);
+                    analysisEntity = AnalysisEntity.Create(flowCapture, _controlFlowGraph);
                     break;
 
                 case IFlowCaptureReferenceOperation flowCaptureReference:
-                    analysisEntity = AnalysisEntity.Create(flowCaptureReference);
+                    analysisEntity = AnalysisEntity.Create(flowCaptureReference, _controlFlowGraph);
                     break;
 
                 case IDeclarationExpressionOperation declarationExpression:

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -196,6 +196,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             if (_returnValueOperationsOpt == null ||
                 _returnValueOperationsOpt.Count == 0)
             {
+                if (OwningSymbol is IMethodSymbol method &&
+                    !method.ReturnsVoid)
+                {
+                    // Non-void method without any return statements
+                    return (GetAbstractDefaultValue(method.ReturnType), PredicateValueKind.Unknown);
+                }
+
                 return null;
             }
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -174,6 +174,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
 
             AnalysisEntityFactory = new AnalysisEntityFactory(
+                DataFlowAnalysisContext.ControlFlowGraph,
                 getPointsToAbstractValueOpt: (analysisContext.PointsToAnalysisResultOpt != null || IsPointsToAnalysis) ?
                     GetPointsToAbstractValue :
                     (Func<IOperation, PointsToAbstractValue>)null,

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralCaptureId.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralCaptureId.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Analyzer.Utilities;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
+{
+    /// <summary>
+    /// Unique flow capture Id across interprocedural flow graph.
+    /// This type essentially wraps each <see cref="CaptureId"/>, which is unique for each control flow graph,
+    /// with its owning <see cref="ControlFlowGraph"/>.
+    /// </summary>
+    internal struct InterproceduralCaptureId : IEquatable<InterproceduralCaptureId>
+    {
+        public InterproceduralCaptureId(CaptureId captureId, ControlFlowGraph controlFlowGraph)
+        {
+            Id = captureId;
+            ControlFlowGraph = controlFlowGraph;
+        }
+
+        public CaptureId Id { get; }
+        public ControlFlowGraph ControlFlowGraph { get; }
+
+        public bool Equals(InterproceduralCaptureId other)
+            => Id.Equals(other.Id) && ControlFlowGraph == other.ControlFlowGraph;
+
+        public override bool Equals(object obj)
+            => obj is InterproceduralCaptureId && Equals((InterproceduralCaptureId)obj);
+
+        public override int GetHashCode()
+            => HashUtilities.Combine(Id.GetHashCode(), ControlFlowGraph.GetHashCode());
+    }
+}


### PR DESCRIPTION
Fixed few asserts found while dogfooding the interprocedural analysis based DFA rule on real world code. I expect few more such PRs to get us clean on interprocedural analysis.

Each commit has an associated unit test that caused the original assert to fire.