### PR TITLE
Fix CacheBasedEquatable to handle hash code clashes

### DIFF
--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
@@ -62,6 +62,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
         public ImmutableHashSet<AnalysisEntity> AnalysisEntities { get; }
         public CopyAbstractValueKind Kind { get; }
 
-        protected override int ComputeHashCode() => HashUtilities.Combine(AnalysisEntities, Kind.GetHashCode());
+        protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
+        {
+            builder.Add(HashUtilities.Combine(AnalysisEntities));
+            builder.Add(Kind.GetHashCode());
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
@@ -60,6 +61,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                 PessimisticAnalysis, pointsToAnalysisResultOpt, GetOrComputeAnalysisResult, ControlFlowGraph, interproceduralAnalysisData);
         }
 
-        protected override int GetHashCode(int hashCode) => hashCode;
+        protected override void ComputeHashCodePartsSpecific(ImmutableArray<int>.Builder builder)
+        {
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
@@ -71,7 +71,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
         public ImmutableHashSet<IOperation> DisposingOrEscapingOperations { get; }
         public DisposeAbstractValueKind Kind { get; }
 
-        protected override int ComputeHashCode()
-            => HashUtilities.Combine(DisposingOrEscapingOperations, Kind.GetHashCode());
+        protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
+        {
+            builder.Add(HashUtilities.Combine(DisposingOrEscapingOperations));
+            builder.Add(Kind.GetHashCode());
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
 
             public override int GetHashCode()
             {
-                return HashUtilities.Combine(_trackedInstanceFieldLocationsOpt?.GetHashCode() ?? 0, base.GetHashCode());
+                return HashUtilities.Combine(_trackedInstanceFieldLocationsOpt.GetHashCodeOrDefault(), base.GetHashCode());
             }
 
             public ImmutableDictionary<IFieldSymbol, PointsToAbstractValue> TrackedInstanceFieldPointsToMap

--- a/src/Utilities/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisContext.cs
@@ -86,8 +86,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
         public ImmutableHashSet<INamedTypeSymbol> DisposeOwnershipTransferLikelyTypes { get; }
         public bool TrackInstanceFields { get; }
 
-        protected override int GetHashCode(int hashCode)
-            => HashUtilities.Combine(TrackInstanceFields.GetHashCode(),
-               HashUtilities.Combine(DisposeOwnershipTransferLikelyTypes, hashCode));
+        protected override void ComputeHashCodePartsSpecific(ImmutableArray<int>.Builder builder)
+        {
+            builder.Add(TrackInstanceFields.GetHashCode());
+            builder.Add(HashUtilities.Combine(DisposeOwnershipTransferLikelyTypes));
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
 
             public override int GetHashCode()
             {
-                return HashUtilities.Combine(_hazardousParameterUsageBuilderOpt?.GetHashCode() ?? 0, base.GetHashCode());
+                return HashUtilities.Combine(_hazardousParameterUsageBuilderOpt.GetHashCodeOrDefault(), base.GetHashCode());
             }
 
             public ImmutableDictionary<IParameterSymbol, SyntaxNode> HazardousParameterUsages

--- a/src/Utilities/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysisContext.cs
@@ -2,8 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 
@@ -83,7 +83,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
                 InterproceduralAnalysisDataOpt, trackHazardousParameterUsages: true);
 
         public bool TrackHazardousParameterUsages { get; }
-        protected override int GetHashCode(int hashCode)
-            => HashUtilities.Combine(TrackHazardousParameterUsages.GetHashCode(), hashCode);
+
+        protected override void ComputeHashCodePartsSpecific(ImmutableArray<int>.Builder builder)
+        {
+            builder.Add(TrackHazardousParameterUsages.GetHashCode());
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -183,9 +183,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         public PointsToAbstractValueKind Kind { get; }
         public NullAbstractValue NullState { get; }
 
-        protected override int ComputeHashCode()
-            => HashUtilities.Combine(Locations,
-               HashUtilities.Combine(LValueCapturedOperations,
-               HashUtilities.Combine(Kind.GetHashCode(), NullState.GetHashCode())));
+        protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
+        {
+            builder.Add(HashUtilities.Combine(Locations));
+            builder.Add(HashUtilities.Combine(LValueCapturedOperations));
+            builder.Add(Kind.GetHashCode());
+            builder.Add(NullState.GetHashCode());
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 
@@ -62,6 +63,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 PessimisticAnalysis, copyAnalysisResultOpt, GetOrComputeAnalysisResult, ControlFlowGraph, interproceduralAnalysisData);
         }
 
-        protected override int GetHashCode(int hashCode) => hashCode;
+        protected override void ComputeHashCodePartsSpecific(ImmutableArray<int>.Builder builder)
+        {
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisContext.cs
@@ -134,13 +134,14 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         public ImmutableHashSet<string> MethodNamesToCheckForFlaggedUsage { get; }
 
 #pragma warning disable CA1307 // Specify StringComparison - string.GetHashCode(StringComparison) not available in all projects that reference this shared project
-        protected override int GetHashCode(int hashCode) =>
-            HashUtilities.Combine(this.TypeToTrackMetadataName.GetHashCode(),
-                HashUtilities.Combine(this.IsNewInstanceFlagged.GetHashCode(),
-                    HashUtilities.Combine(this.PropertyToSetFlag.GetHashCode(),
-                        HashUtilities.Combine(this.IsNullPropertyFlagged.GetHashCode(),
-                            HashUtilities.Combine(this.MethodNamesToCheckForFlaggedUsage,
-                                hashCode)))));
+        protected override void ComputeHashCodePartsSpecific(ImmutableArray<int>.Builder builder)
+        {
+            builder.Add(TypeToTrackMetadataName.GetHashCode());
+            builder.Add(IsNewInstanceFlagged.GetHashCode());
+            builder.Add(PropertyToSetFlag.GetHashCode());
+            builder.Add(IsNullPropertyFlagged.GetHashCode());
+            builder.Add(HashUtilities.Combine(MethodNamesToCheckForFlaggedUsage));
+        }
 #pragma warning restore CA1307 // Specify StringComparison
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/SymbolAccess.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/SymbolAccess.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 
@@ -46,11 +47,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public ISymbol AccessingMethod { get; }
 
-        protected override int ComputeHashCode()
+        protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
         {
-            return HashUtilities.Combine(this.Location.GetHashCode(),
-                HashUtilities.Combine(this.Symbol.GetHashCode(),
-                this.AccessingMethod.GetHashCode()));
+            builder.Add(Location.GetHashCode());
+            builder.Add(Symbol.GetHashCode());
+            builder.Add(AccessingMethod.GetHashCode());
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAbstractValue.cs
@@ -32,9 +32,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public ImmutableHashSet<SymbolAccess> SourceOrigins { get; }
 
-        protected override int ComputeHashCode()
+        protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
         {
-            return HashUtilities.Combine(this.SourceOrigins, this.Kind.GetHashCode());
+            builder.Add(HashUtilities.Combine(SourceOrigins));
+            builder.Add(Kind.GetHashCode());
         }
 
         /// <summary>

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
@@ -121,12 +122,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public TaintedDataSymbolMap<SinkInfo> SinkInfos { get; }
 
-        protected override int GetHashCode(int hashCode)
+        protected override void ComputeHashCodePartsSpecific(ImmutableArray<int>.Builder builder)
         {
-            return HashUtilities.Combine(this.SourceInfos.GetHashCode(),
-                HashUtilities.Combine(this.SanitizerInfos.GetHashCode(),
-                HashUtilities.Combine(this.SinkInfos.GetHashCode(),
-                hashCode)));
+            builder.Add(SourceInfos.GetHashCode());
+            builder.Add(SanitizerInfos.GetHashCode());
+            builder.Add(SinkInfos.GetHashCode());
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
@@ -130,8 +130,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
         /// </summary>
         public ImmutableHashSet<object> LiteralValues { get; }
 
-        protected override int ComputeHashCode()
-            => HashUtilities.Combine(LiteralValues, NonLiteralState.GetHashCode());
+        protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
+        {
+            builder.Add(HashUtilities.Combine(LiteralValues));
+            builder.Add(NonLiteralState.GetHashCode());
+        }
 
         /// <summary>
         /// Performs the union of this state and the other state 

--- a/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 
@@ -66,6 +67,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
                 PessimisticAnalysis, copyAnalysisResultOpt, pointsToAnalysisResultOpt, GetOrComputeAnalysisResult, ControlFlowGraph, interproceduralAnalysisData);
         }
 
-        protected override int GetHashCode(int hashCode) => hashCode;
+        protected override void ComputeHashCodePartsSpecific(ImmutableArray<int>.Builder builder)
+        {
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
@@ -99,19 +100,20 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
         }
 
-        protected abstract int GetHashCode(int hashCode);
+        protected abstract void ComputeHashCodePartsSpecific(ImmutableArray<int>.Builder builder);
 
-        protected sealed override int ComputeHashCode()
+        protected sealed override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
         {
-            var hashCode = HashUtilities.Combine(ValueDomain.GetHashCode(),
-                HashUtilities.Combine(OwningSymbol.GetHashCode(),
-                HashUtilities.Combine(ControlFlowGraph.OriginalOperation.GetHashCode(),
-                HashUtilities.Combine(InterproceduralAnalysisKind.GetHashCode(),
-                HashUtilities.Combine(PessimisticAnalysis.GetHashCode(),
-                HashUtilities.Combine(PredicateAnalysis.GetHashCode(),
-                HashUtilities.Combine(CopyAnalysisResultOpt?.GetHashCode() ?? 0,
-                HashUtilities.Combine(PointsToAnalysisResultOpt?.GetHashCode() ?? 0, InterproceduralAnalysisDataOpt?.GetHashCode() ?? 0))))))));
-            return GetHashCode(hashCode);
+            builder.Add(ValueDomain.GetHashCode());
+            builder.Add(OwningSymbol.GetHashCode());
+            builder.Add(ControlFlowGraph.OriginalOperation.GetHashCode());
+            builder.Add(InterproceduralAnalysisKind.GetHashCode());
+            builder.Add(PessimisticAnalysis.GetHashCode());
+            builder.Add(PredicateAnalysis.GetHashCode());
+            builder.Add(CopyAnalysisResultOpt.GetHashCodeOrDefault());
+            builder.Add(PointsToAnalysisResultOpt.GetHashCodeOrDefault());
+            builder.Add(InterproceduralAnalysisDataOpt.GetHashCodeOrDefault());
+            ComputeHashCodePartsSpecific(builder);
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
@@ -16,7 +16,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             public int Index { get; }
 
 #pragma warning disable CA1307 // Specify StringComparison - string.GetHashCode(StringComparison) not available in all projects that reference this shared project
-            protected override int ComputeHashCode() => HashUtilities.Combine(Index.GetHashCode(), nameof(ConstantValueIndex).GetHashCode());
+            protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
+            {
+                builder.Add(Index.GetHashCode());
+                builder.Add(nameof(ConstantValueIndex).GetHashCode());
+            }
 #pragma warning restore CA1307 // Specify StringComparison
         }
     }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
-using Analyzer.Utilities;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
@@ -19,7 +18,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             public IOperation Operation { get; }
 
 #pragma warning disable CA1307 // Specify StringComparison - string.GetHashCode(StringComparison) not available in all projects that reference this shared project
-            protected override int ComputeHashCode() => HashUtilities.Combine(Operation.GetHashCode(), nameof(OperationBasedIndex).GetHashCode());
+            protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
+            {
+                builder.Add(Operation.GetHashCode());
+                builder.Add(nameof(OperationBasedIndex).GetHashCode());
+            }
 #pragma warning restore CA1307 // Specify StringComparison
         }
     }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
@@ -16,7 +16,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             public AnalysisEntity AnalysisEntity { get; }
 
 #pragma warning disable CA1307 // Specify StringComparison - string.GetHashCode(StringComparison) not available in all projects that reference this shared project
-            protected override int ComputeHashCode() => HashUtilities.Combine(AnalysisEntity.GetHashCode(), nameof(AnalysisEntityBasedIndex).GetHashCode());
+            protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
+            {
+                builder.Add(AnalysisEntity.GetHashCode());
+                builder.Add(nameof(AnalysisEntityBasedIndex).GetHashCode());
+            }
 #pragma warning restore CA1307 // Specify StringComparison
         }
     }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
@@ -68,13 +68,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public bool IsNull => ReferenceEquals(this, Null);
         public bool IsNoLocation => ReferenceEquals(this, NoLocation);
 
-        protected override int ComputeHashCode()
-            => HashUtilities.Combine(CreationOpt?.GetHashCode() ?? 0,
-               HashUtilities.Combine(CreationCallStack,
-               HashUtilities.Combine(SymbolOpt?.GetHashCode() ?? 0,
-               HashUtilities.Combine(AnalysisEntityOpt?.GetHashCode() ?? 0,
-               HashUtilities.Combine(LocationTypeOpt?.GetHashCode() ?? 0,
-               HashUtilities.Combine(_isSpecialSingleton.GetHashCode(), IsNull.GetHashCode()))))));
+        protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
+        {
+            builder.Add(CreationOpt.GetHashCodeOrDefault());
+            builder.Add(HashUtilities.Combine(CreationCallStack));
+            builder.Add(SymbolOpt.GetHashCodeOrDefault());
+            builder.Add(AnalysisEntityOpt.GetHashCodeOrDefault());
+            builder.Add(LocationTypeOpt.GetHashCodeOrDefault());
+            builder.Add(_isSpecialSingleton.GetHashCode());
+            builder.Add(IsNull.GetHashCode());
+        }
 
         public SyntaxNode GetNodeToReportDiagnostic(PointsToAnalysisResult pointsToAnalysisResultOpt)
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -50,6 +50,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                 foreach (AnalysisEntity key2 in equivalentKeys2)
                 {
+                    // Confirm that key2 and key1 are indeed EqualsIgnoringInstanceLocation
+                    // This ensures that we handle hash code clashes of EqualsIgnoringInstanceLocationId.
+                    if (!key1.EqualsIgnoringInstanceLocation(key2))
+                    {
+                        continue;
+                    }
+
                     TValue value2 = map2[key2];
                     TValue mergedValue = ValueDomain.Merge(value1, value2);
                     Debug.Assert(ValueDomain.Compare(value1, mergedValue) <= 0);

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/ArgumentInfo.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/ArgumentInfo.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Collections.Immutable;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 
@@ -29,9 +29,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public PointsToAbstractValue InstanceLocation { get; }
         public TAbstractAnalysisValue Value { get; }
 
-        protected override int ComputeHashCode()
-            => HashUtilities.Combine(Operation.GetHashCode(),
-               HashUtilities.Combine(AnalysisEntityOpt?.GetHashCode() ?? 0,
-               HashUtilities.Combine(InstanceLocation.GetHashCode(), Value.GetHashCode())));
+        protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
+        {
+            builder.Add(Operation.GetHashCode());
+            builder.Add(AnalysisEntityOpt.GetHashCodeOrDefault());
+            builder.Add(InstanceLocation.GetHashCode());
+            builder.Add(Value.GetHashCode());
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/CacheBasedEquatable.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/CacheBasedEquatable.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
+using System.Linq;
 using Analyzer.Utilities;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
@@ -11,21 +13,48 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
     internal abstract class CacheBasedEquatable<T> : IEquatable<T>
         where T: class
     {
+        private readonly Lazy<ImmutableArray<int>> _lazyHashCodeParts;
         private readonly Lazy<int> _lazyHashCode;
 
         protected CacheBasedEquatable()
         {
 #pragma warning disable CA2214 // Do not call overridable methods in constructors
-                               // https://github.com/dotnet/roslyn-analyzers/issues/1652
-            _lazyHashCode = new Lazy<int>(() => HashUtilities.Combine(GetType().GetHashCode(), ComputeHashCode()));
+            // https://github.com/dotnet/roslyn-analyzers/issues/1652
+            _lazyHashCodeParts = new Lazy<ImmutableArray<int>>(() => ComputeHashCodeParts());
+            _lazyHashCode = new Lazy<int>(ComputeHashCode);
 #pragma warning restore CA2214 // Do not call overridable methods in constructors
         }
 
-        protected abstract int ComputeHashCode();
+        private int ComputeHashCode() => HashUtilities.Combine(_lazyHashCodeParts.Value, GetType().GetHashCode());
+
+        private ImmutableArray<int> ComputeHashCodeParts()
+        {
+            var builder = ImmutableArray.CreateBuilder<int>();
+            ComputeHashCodeParts(builder);
+            return builder.ToImmutable();
+        }
+
+        protected abstract void ComputeHashCodeParts(ImmutableArray<int>.Builder builder);
 
         public sealed override int GetHashCode() => _lazyHashCode.Value;
         public sealed override bool Equals(object obj) => Equals(obj as T);
-        public bool Equals(T other) => _lazyHashCode.Value == (other as CacheBasedEquatable<T>)?._lazyHashCode.Value;
+        public bool Equals(T other)
+        {
+            // Perform fast equality checks first.
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            var otherEquatable = other as CacheBasedEquatable<T>;
+            if (otherEquatable == null || _lazyHashCode.Value != otherEquatable._lazyHashCode.Value)
+            {
+                return false;
+            }
+
+            // Now perform slow check that compares individual hash code parts sequences.
+            return _lazyHashCodeParts.Value.SequenceEqual(otherEquatable._lazyHashCodeParts.Value);
+        }
 
         public static bool operator ==(CacheBasedEquatable<T> value1, CacheBasedEquatable<T> value2)
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
@@ -64,21 +64,21 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public Func<IOperation, TAbstractAnalysisValue> GetCachedAbstractValueFromCaller { get; }
         public Func<IMethodSymbol, ControlFlowGraph> GetInterproceduralControlFlowGraph { get; }
 
-        protected sealed override int ComputeHashCode()
+        protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
         {
-            var hashCode = InitialAnalysisData?.GetHashCode() ?? 0;
+            builder.Add(InitialAnalysisData.GetHashCodeOrDefault());
 
             if (InvocationInstanceOpt.HasValue)
             {
-                hashCode = HashUtilities.Combine(InvocationInstanceOpt.Value.Instance.GetHashCode(),
-                           HashUtilities.Combine(InvocationInstanceOpt.Value.PointsToValue.GetHashCode(), hashCode));
+                builder.Add(InvocationInstanceOpt.Value.Instance.GetHashCode());
+                builder.Add(InvocationInstanceOpt.Value.PointsToValue.GetHashCode());
             }
 
-            return HashUtilities.Combine(Arguments,
-                   HashUtilities.Combine(CapturedVariablesMap,
-                   HashUtilities.Combine(AddressSharedEntities,
-                   HashUtilities.Combine(CallStack,
-                   HashUtilities.Combine(MethodsBeingAnalyzed, hashCode)))));
+            builder.Add(HashUtilities.Combine(Arguments));
+            builder.Add(HashUtilities.Combine(CapturedVariablesMap));
+            builder.Add(HashUtilities.Combine(AddressSharedEntities));
+            builder.Add(HashUtilities.Combine(CallStack));
+            builder.Add(HashUtilities.Combine(MethodsBeingAnalyzed));
         }
     }
 }


### PR DESCRIPTION
We now do a quick pass that compares reference equality and hash codes, which if required is followed by a slow pass that compares individual part hash codes. If this still turns out to cause hash code clashes, we will implement the true equality checks on an even slower equality compare path.