### PR TITLE
Asserts continued - interprocedural analysis

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3995,6 +3995,42 @@ public class C
         }
 
         [Fact]
+        public void AssignmentInTry_CatchWithThrow()
+        {
+            VerifyCSharp(@"
+using System;
+using System.IO;
+
+public class C
+{
+    private C2 _c;
+
+    private readonly Func<C2> _createC2;
+
+    public void M1(C2 c1, bool flag)
+    {
+        C2 c2;
+        try
+        {
+            c2 = (_createC2 != null) ? _createC2() : null;
+        }
+        catch (IOException ex) when (ex != null)
+        {
+            var message = flag ? null : """";
+            throw new Exception(message);
+        }
+
+        _c = c2;
+    }
+}
+
+public class C2
+{
+}
+");
+        }
+
+        [Fact]
         public void AnalysisEntityWithIndexAssert()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3993,5 +3993,36 @@ public class C
     }
 }");
         }
+
+        [Fact]
+        public void AnalysisEntityWithIndexAssert()
+        {
+            VerifyCSharp(@"
+public struct C1
+{
+    public void M1(int index, C2 c2)
+    {
+        for (int i = 0; i < index; i++)
+        {
+            c2.M2(this[i]);
+        }
+    }
+
+    public S this[int i]
+    {
+        get { return new S(); }
+    }
+}
+
+public class C2
+{
+    public void M2(S s) { }
+}
+
+public struct S { }
+",
+            // Test0.cs(8,13): warning CA1062: In externally visible method 'void C1.M1(int index, C2 c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(8, 13, "void C1.M1(int index, C2 c2)", "c2"));
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3863,6 +3863,44 @@ public struct S2
         }
 
         [Fact]
+        public void GetValueAssert()
+        {
+            VerifyCSharp(@"
+public struct S
+{
+    public int Major { get; }
+    public int Minor { get; }
+    public static S None = new S();
+    
+    public bool Equals(S other)
+    {
+        return this.Major == other.Major && this.Minor == other.Minor;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is S && Equals((S)obj);
+    }
+
+    public bool IsValid => true;
+}
+
+public struct S2
+{
+    public S s { get; private set; }
+
+    public bool IsNone(object o)
+    {
+        if (!s.Equals(S.None) && !s.IsValid)
+        {
+        }
+
+        return true;
+    }
+}");
+        }
+
+        [Fact]
         public void SameFlowCaptureIdAcrossInterproceduralMethod()
         {
             VerifyCSharp(@"

--- a/src/Utilities/Extensions/BasicBlockExtensions.cs
+++ b/src/Utilities/Extensions/BasicBlockExtensions.cs
@@ -10,7 +10,7 @@ namespace Analyzer.Utilities.Extensions
 {
     internal static class BasicBlockExtensions
     {
-        public static IEnumerable<(BasicBlock predecessorBlock, BranchWithInfo branchWithInfo)> GetPredecessorsWithBranches(this BasicBlock basicBlock, Dictionary<int, BasicBlock> ordinalToBlockMap)
+        public static IEnumerable<(BasicBlock predecessorBlock, BranchWithInfo branchWithInfo)> GetPredecessorsWithBranches(this BasicBlock basicBlock, ControlFlowGraph cfg)
         {
             foreach (ControlFlowBranch predecessorBranch in basicBlock.Predecessors)
             {
@@ -18,7 +18,7 @@ namespace Analyzer.Utilities.Extensions
                 if (predecessorBranch.FinallyRegions.Length > 0)
                 {
                     var lastFinally = predecessorBranch.FinallyRegions[predecessorBranch.FinallyRegions.Length - 1];
-                    yield return (predecessorBlock: ordinalToBlockMap[lastFinally.LastBlockOrdinal], branchWithInfo);
+                    yield return (predecessorBlock: cfg.Blocks[lastFinally.LastBlockOrdinal], branchWithInfo);
                 }
                 else
                 {

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
             AssertValidCopyAnalysisData(coreAnalysisData);
         }
 
-        public override void Reset(CopyAbstractValue resetValue)
+        public override void Reset(CopyAbstractValue resetValue, Func<AnalysisEntity, bool> shouldResetOpt = null)
         {
             throw new NotImplementedException("Use the other overload of Reset");
         }

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
@@ -160,27 +160,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
             AssertValidCopyAnalysisData(coreAnalysisData);
         }
 
-        public override void Reset(CopyAbstractValue resetValue, Func<AnalysisEntity, bool> shouldResetOpt = null)
+        public override void Reset(Func<AnalysisEntity, CopyAbstractValue, CopyAbstractValue> getResetValue)
         {
-            throw new NotImplementedException("Use the other overload of Reset");
-        }
-
-        public void Reset(Func<AnalysisEntity, CopyAbstractValue> getDefaultCopyValue)
-        {
-            if (CoreAnalysisData.Count > 0)
-            {
-                var keys = CoreAnalysisData.Keys.ToImmutableArray();
-                foreach (var key in keys)
-                {
-                    if (CoreAnalysisData[key].AnalysisEntities.Count > 1)
-                    {
-                        CoreAnalysisData[key] = getDefaultCopyValue(key);
-                    }
-                }
-            }
-
-            ResetPredicatedData();
-
+            base.Reset(getResetValue);
             this.AssertValidCopyAnalysisData();
         }
 
@@ -209,7 +191,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
         [Conditional("DEBUG")]
         private static void AssertValidCopyAnalysisEntity(AnalysisEntity analysisEntity)
         {
-            Debug.Assert(!analysisEntity.HasUnknownInstanceLocation, "Don't track entities if do not know about it's instance location");
+            Debug.Assert(!analysisEntity.HasUnknownInstanceLocationWithEmptyLocations, "Don't track entities if do not know about it's instance location");
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             {
                 if (!ShouldBeTracked(analysisEntity))
                 {
-                    Debug.Assert(!CurrentAnalysisData.HasAbstractValue(analysisEntity));
+                    Debug.Assert(!CurrentAnalysisData.TryGetValue(analysisEntity, out var existingValue) || existingValue == PointsToAbstractValue.NoLocation);
                     return PointsToAbstractValue.NoLocation;
                 }
 

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 // Ensure PointsTo value is set for the "this" or "Me" instance.
                 if (input != null && !HasAbstractValue(AnalysisEntityFactory.ThisOrMeInstance))
                 {
-                    input.SetAbstractValue(AnalysisEntityFactory.ThisOrMeInstance, ThisOrMePointsToAbstractValue);
+                    input.SetAbstractValue(AnalysisEntityFactory.ThisOrMeInstance, ThisOrMePointsToAbstractValue, IsLValueFlowCaptureEntity);
                 }
 
                 var output = base.Flow(statement, block, input);
@@ -59,8 +59,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             private static bool ShouldBeTracked(ITypeSymbol typeSymbol) => typeSymbol.IsReferenceTypeOrNullableValueType();
 
-            private bool ShouldBeTracked(AnalysisEntity analysisEntity) => ShouldBeTracked(analysisEntity.Type) ||
-                analysisEntity.CaptureIdOpt.HasValue && IsLValueFlowCapture(analysisEntity.CaptureIdOpt.Value.Id);
+            private bool ShouldBeTracked(AnalysisEntity analysisEntity) => ShouldBeTracked(analysisEntity.Type) || IsLValueFlowCaptureEntity(analysisEntity);
 
             protected override void AddTrackedEntities(ImmutableArray<AnalysisEntity>.Builder builder)
             {
@@ -123,7 +122,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                         return;
                     }
 
-                    CurrentAnalysisData.SetAbstractValue(analysisEntity, value);
+                    CurrentAnalysisData.SetAbstractValue(analysisEntity, value, IsLValueFlowCaptureEntity);
                 }
             }
 
@@ -134,7 +133,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 DefaultPointsToValueGenerator defaultPointsToValueGenerator,
                 PointsToAnalysisData sourceAnalysisData,
                 PointsToAnalysisData targetAnalysisData,
-                PointsToAnalysisContext analysisContext)
+                PointsToAnalysisContext analysisContext,
+                Func<AnalysisEntity, bool> isLValueFlowCaptureEntity)
             {
                 AssertValidPointsToAnalysisData(sourceAnalysisData);
                 AssertValidPointsToAnalysisData(targetAnalysisData);
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                         throw new InvalidProgramException();
                 }
 
-                targetAnalysisData.SetAbstractValue(analysisEntity, newPointsToValue);
+                targetAnalysisData.SetAbstractValue(analysisEntity, newPointsToValue, isLValueFlowCaptureEntity);
                 AssertValidPointsToAnalysisData(targetAnalysisData);
             }
 
@@ -182,7 +182,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 // Do not escape the PointsTo value for parameter at exit.
             }
 
-            protected override void ResetCurrentAnalysisData() => CurrentAnalysisData.Reset(ValueDomain.UnknownOrMayBeValue);
+            protected override void ResetCurrentAnalysisData() => CurrentAnalysisData.Reset(ValueDomain.UnknownOrMayBeValue, ShouldReset);
+            private bool ShouldReset(AnalysisEntity analysisEntity)
+            {
+                Debug.Assert(CurrentAnalysisData.HasAbstractValue(analysisEntity));
+                return !IsLValueFlowCaptureEntity(analysisEntity);
+            }
 
             protected override PointsToAbstractValue ComputeAnalysisValueForReferenceOperation(IOperation operation, PointsToAbstractValue defaultValue)
             {
@@ -298,7 +303,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                             SetValueFromPredicate(analysisEntity, value, equals, inferInTargetAnalysisData,
                                 target, ref predicateValueKind, _defaultPointsToValueGenerator,
                                 sourceAnalysisData: CurrentAnalysisData, targetAnalysisData: targetAnalysisData,
-                                analysisContext: DataFlowAnalysisContext);
+                                analysisContext: DataFlowAnalysisContext,
+                                isLValueFlowCaptureEntity: IsLValueFlowCaptureEntity);
                         }
                     }
                     else
@@ -306,7 +312,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                         SetValueFromPredicate(targetEntity, value, equals, inferInTargetAnalysisData,
                             target, ref predicateValueKind, _defaultPointsToValueGenerator,
                             sourceAnalysisData: CurrentAnalysisData, targetAnalysisData: targetAnalysisData,
-                            analysisContext: DataFlowAnalysisContext);
+                            analysisContext: DataFlowAnalysisContext,
+                            isLValueFlowCaptureEntity: IsLValueFlowCaptureEntity);
                     }
 
                     return true;
@@ -325,7 +332,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 DefaultPointsToValueGenerator defaultPointsToValueGenerator,
                 PointsToAnalysisData sourceAnalysisData,
                 PointsToAnalysisData targetAnalysisData,
-                PointsToAnalysisContext analysisContext)
+                PointsToAnalysisContext analysisContext,
+                Func<AnalysisEntity, bool> isLValueFlowCaptureEntity)
             {
                 // Compute the negated value.
                 NullAbstractValue negatedValue = NegatePredicateValue(value);
@@ -370,7 +378,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 if (inferInTargetAnalysisData)
                 {
                     // Set value for the CurrentAnalysisData.
-                    SetAbstractValueFromPredicate(key, target, value, defaultPointsToValueGenerator, sourceAnalysisData, targetAnalysisData, analysisContext);
+                    SetAbstractValueFromPredicate(key, target, value, defaultPointsToValueGenerator,
+                        sourceAnalysisData, targetAnalysisData, analysisContext, isLValueFlowCaptureEntity);
                 }
             }
 

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -65,7 +66,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
         public override void SetAbstractValue(AnalysisEntity key, PointsToAbstractValue value)
         {
+            throw new NotImplementedException("Use the other overload of Reset");
+        }
+
+        public void SetAbstractValue(AnalysisEntity key, PointsToAbstractValue value, Func<AnalysisEntity, bool> isLValueFlowCaptureEntity)
+        {
             Debug.Assert(value.Kind != PointsToAbstractValueKind.Undefined);
+            Debug.Assert(!isLValueFlowCaptureEntity(key) || value.Kind == PointsToAbstractValueKind.KnownLValueCaptures);
             base.SetAbstractValue(key, value);
         }
 

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
@@ -66,14 +66,36 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
         public override void SetAbstractValue(AnalysisEntity key, PointsToAbstractValue value)
         {
-            throw new NotImplementedException("Use the other overload of Reset");
+            throw new NotImplementedException($"Use the supported overload of {nameof(SetAbstractValue)}");
         }
 
-        public void SetAbstractValue(AnalysisEntity key, PointsToAbstractValue value, Func<AnalysisEntity, bool> isLValueFlowCaptureEntity)
+        public void SetAbstractValue(
+            AnalysisEntity key,
+            PointsToAbstractValue value,
+            AbstractValueDomain<PointsToAbstractValue> valueDomain,
+            Func<AnalysisEntity, bool> isLValueFlowCaptureEntity)
         {
             Debug.Assert(value.Kind != PointsToAbstractValueKind.Undefined);
             Debug.Assert(!isLValueFlowCaptureEntity(key) || value.Kind == PointsToAbstractValueKind.KnownLValueCaptures);
+
+            // PointsToAbstractValueKind.Unknown value might point to some known locations.
+            // If we are setting to PointsToAbstractValue.Unknown, 
+            // ensure we don't lose those these locations, as that would a non-monotonic operation.
+            if (value == PointsToAbstractValue.Unknown &&
+                TryGetValue(key, out var currentValue) &&
+                currentValue.Kind == PointsToAbstractValueKind.Unknown &&
+                currentValue != PointsToAbstractValue.Unknown)
+            {
+                value = valueDomain.Merge(value, currentValue);
+            }
+
             base.SetAbstractValue(key, value);
+        }
+
+        public override void Reset(Func<AnalysisEntity, PointsToAbstractValue, PointsToAbstractValue> getResetValue)
+        {
+            base.Reset(getResetValue);
+            AssertValidPointsToAnalysisData();
         }
 
         [Conditional("DEBUG")]

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisData.cs
@@ -43,5 +43,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         {
             return new TaintedDataAnalysisData(this, (TaintedDataAnalysisData) data, coreDataAnalysisDomain);
         }
+
+        public void Reset(TaintedDataAbstractValue resetValue)
+        {
+            base.Reset((analysisEntity, currentValue) => resetValue);
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisData.cs
@@ -50,5 +50,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
 
         public override AnalysisEntityBasedPredicateAnalysisData<ValueContentAbstractValue> WithMergedData(AnalysisEntityBasedPredicateAnalysisData<ValueContentAbstractValue> data, MapAbstractDomain<AnalysisEntity, ValueContentAbstractValue> coreDataAnalysisDomain)
             => new ValueContentAnalysisData(this, (ValueContentAnalysisData)data, coreDataAnalysisDomain);
+
+        public void Reset(ValueContentAbstractValue resetValue)
+        {
+            base.Reset((analysisEntity, currentValue) => resetValue);
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
@@ -67,6 +67,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public ITypeSymbol LocationTypeOpt { get; }
         public bool IsNull => ReferenceEquals(this, Null);
         public bool IsNoLocation => ReferenceEquals(this, NoLocation);
+        public bool IsAnalysisEntityDefaultLocation => AnalysisEntityOpt != null;
 
         protected override void ComputeHashCodeParts(ImmutableArray<int>.Builder builder)
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public AnalysisEntity ParentOpt { get; }
         public bool IsThisOrMeInstance { get; }
 
-        public bool HasUnknownInstanceLocation => InstanceLocation.Kind == PointsToAbstractValueKind.Unknown;
+        public bool HasUnknownInstanceLocationWithEmptyLocations => InstanceLocation == PointsToAbstractValue.Unknown;
 
         public bool EqualsIgnoringInstanceLocation(AnalysisEntity other)
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Debug.Assert(symbolOpt != null || !indices.IsEmpty || instanceReferenceOperationSyntaxOpt != null || captureIdOpt.HasValue);
             Debug.Assert(location != null);
             Debug.Assert(type != null);
-            Debug.Assert(parentOpt == null || parentOpt.Type.HasValueCopySemantics());
+            Debug.Assert(parentOpt == null || parentOpt.Type.HasValueCopySemantics() || !indices.IsEmpty);
 
             SymbolOpt = symbolOpt;
             Indices = indices;

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 EqualsHelper(CoreAnalysisData, other.CoreAnalysisData);
         }
 
-        public virtual void Reset(TValue resetValue, Func<AnalysisEntity, bool> shouldResetOpt = null)
+        public virtual void Reset(Func<AnalysisEntity, TValue, TValue> getResetValue)
         {
             // Reset the current analysis data, while ensuring that we don't violate the monotonicity, i.e. we cannot remove any existing key from currentAnalysisData.
             // Just set the values for existing keys to ValueDomain.UnknownOrMayBeValue.
@@ -115,10 +115,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 var keys = CoreAnalysisData.Keys.ToImmutableArray();
                 foreach (var key in keys)
                 {
-                    if (shouldResetOpt == null || shouldResetOpt(key))
-                    {
-                        CoreAnalysisData[key] = resetValue;
-                    }
+                    CoreAnalysisData[key] = getResetValue(key, CoreAnalysisData[key]);
                 }
             }
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -105,7 +106,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 EqualsHelper(CoreAnalysisData, other.CoreAnalysisData);
         }
 
-        public virtual void Reset(TValue resetValue)
+        public virtual void Reset(TValue resetValue, Func<AnalysisEntity, bool> shouldResetOpt = null)
         {
             // Reset the current analysis data, while ensuring that we don't violate the monotonicity, i.e. we cannot remove any existing key from currentAnalysisData.
             // Just set the values for existing keys to ValueDomain.UnknownOrMayBeValue.
@@ -114,7 +115,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 var keys = CoreAnalysisData.Keys.ToImmutableArray();
                 foreach (var key in keys)
                 {
-                    CoreAnalysisData[key] = resetValue;
+                    if (shouldResetOpt == null || shouldResetOpt(key))
+                    {
+                        CoreAnalysisData[key] = resetValue;
+                    }
                 }
             }
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -121,6 +121,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         protected bool IsInsideAnonymousObjectInitializer { get; private set; }
 
         protected bool IsLValueFlowCapture(CaptureId captureId) => _lValueFlowCaptures.Contains(captureId);
+        protected bool IsLValueFlowCaptureEntity(AnalysisEntity analysisEntity)
+            => analysisEntity.CaptureIdOpt != null && IsLValueFlowCapture(analysisEntity.CaptureIdOpt.Value.Id);
 
         protected virtual int GetAllowedInterproceduralCallChain() => MaxInterproceduralCallChain;
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 {
                     IParameterSymbol parameter = parameters[i];
                     PointsToAbstractValue instanceLocation = interproceduralAnalysisData.Arguments[i].InstanceLocation;
-                    if (parameter.RefKind != RefKind.None && instanceLocation.Kind != PointsToAbstractValueKind.Unknown)
+                    if (parameter.RefKind != RefKind.None && instanceLocation != PointsToAbstractValue.Unknown)
                     {
                         yield return new KeyValuePair<ISymbol, PointsToAbstractValue>(parameter, instanceLocation);
                     }


### PR DESCRIPTION
Fix some more asserts from dogfooding interprocedural rule. https://github.com/dotnet/roslyn-analyzers/commit/6c1df8331f3b36126a3530414b653d19c1401606 is the primary bulky commit that changes PointsToAbstractValue merging logic.