### PR TITLE
Fix couple more asserts in PointsToAbstractValue merge

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -4160,5 +4160,91 @@ public class C<T> where T : class
     }
 }");
         }
+
+        [Fact]
+        public void YieldReturn_WithinLoop()
+        {
+            VerifyCSharp(@"
+using System.Collections.Generic;
+
+public class C
+{
+    public string Path;
+    public C[] Array;
+
+    public IEnumerable<object> M(object o)
+    {
+        foreach (C item in Array)
+        {
+            yield return M2(item, o) ?? (C)new E(item.Path);
+        }
+    }
+
+    private D M2(C item, object o)
+    {
+        var resolved = item.Path;
+        if (resolved != null)
+        {
+            return new D();
+        }
+
+        return null;
+    }
+}
+
+public class D : C
+{
+}
+
+public class E : C
+{
+    public E(string s)
+    {
+        if (s == null)
+        {
+            throw new System.ArgumentNullException(nameof(s));
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void NonMonotonicMergeAssert_UnknownValueMerge()
+        {
+            VerifyCSharp(@"
+using System.Collections.Generic;
+using System.IO;
+
+public class B
+{
+    internal C Node;
+
+    public void WriteTo(TextWriter writer)
+    {
+        Node?.WriteTo(writer);
+    }
+}
+
+public class C
+{
+    internal void WriteTo(TextWriter writer)
+    {
+        var stack = new Stack<(C node, bool leading, bool trailing)>();
+        ProcessStack(writer, stack);
+    }
+
+    private static void ProcessStack(TextWriter writer, Stack<(C node, bool leading, bool trailing)> stack)
+    {
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            var currentNode = current.node;
+            var currentLeading = current.leading;
+            var currentTrailing = current.trailing;
+        }
+    }
+}
+");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -4130,5 +4130,35 @@ public struct S { }
             // Test0.cs(11,13): warning CA1062: In externally visible method 'void C1.M1(int index, int index2, C2 c2, S[] items)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(11, 13, "void C1.M1(int index, int index2, C2 c2, S[] items)", "c2"));
         }
+
+        [Fact]
+        public void NonMonotonicMergeAssert_LValueFlowCatpure_ResetAcrossInterproceduralCall()
+        {
+            VerifyCSharp(@"
+using System.Threading;
+
+public class C<T> where T : class
+{
+    internal delegate T Factory();
+    private readonly Factory _factory;
+
+    public void M(string s, object o)
+    {
+        o = o ?? new object();
+        AllocateSlow(s);
+        var x = s.Length;
+    }
+
+    private T AllocateSlow(string s)
+    {
+        if (s != null)
+        {
+            return null;
+        }
+
+        return _factory();
+    }
+}");
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValueKind.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValueKind.cs
@@ -29,7 +29,19 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         KnownLValueCaptures,
 
         /// <summary>
-        /// Points to unknown set of locations.
+        /// Points to unknown set of locations, which is known to be null.
+        /// Note that this value kind is theoretically not needed, as the underlying
+        /// value is null, but it has been added to ensure monotonicity of value merge.
+        /// </summary>
+        UnknownNull,
+
+        /// <summary>
+        /// Points to unknown set of locations, which is known to be non-null.
+        /// </summary>
+        UnknownNotNull,
+
+        /// <summary>
+        /// Points to unknown set of locations, which may or may not be null.
         /// </summary>
         Unknown,
     }

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.CorePointsToAnalysisDataDomain.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.CorePointsToAnalysisDataDomain.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             protected override PointsToAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => DefaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity);
             protected override bool CanSkipNewEntry(AnalysisEntity analysisEntity, PointsToAbstractValue value)
-                => value == PointsToAbstractValue.Unknown ||
+                => value.Kind == PointsToAbstractValueKind.Unknown ||
                     !DefaultPointsToValueGenerator.IsTrackedEntity(analysisEntity) ||
                     value == GetDefaultValue(analysisEntity);
 
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                                 break;
 
                             case NullAbstractValue.NotNull:
-                                if (backEdgeValue.MakeMayBeNull(key) != forwardEdgeValue)
+                                if (backEdgeValue.MakeMayBeNull() != forwardEdgeValue)
                                 {
                                     if (forwardEdgeValue.NullState == NullAbstractValue.NotNull)
                                     {
@@ -86,19 +86,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
                         void stopTrackingAnalysisDataForEntity(AnalysisEntity entity)
                         {
-                            var mergedValue = PointsToAbstractValue.Unknown;
-                            if (forwardEdgeAnalysisData.TryGetValue(entity, out var currentValue))
+                            if (forwardEdgeAnalysisData.ContainsKey(entity))
                             {
-                                mergedValue = ValueDomain.Merge(mergedValue, currentValue);
+                                forwardEdgeAnalysisData[entity] = PointsToAbstractValue.Unknown;
                             }
-
-                            if (backEdgeAnalysisData.TryGetValue(entity, out currentValue))
-                            {
-                                mergedValue = ValueDomain.Merge(mergedValue, currentValue);
-                            }
-
-                            Debug.Assert(mergedValue.Kind == PointsToAbstractValueKind.Unknown);
-                            forwardEdgeAnalysisData[entity] = mergedValue;
                         }
                     }
                 }

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
@@ -72,22 +72,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         public void SetAbstractValue(
             AnalysisEntity key,
             PointsToAbstractValue value,
-            AbstractValueDomain<PointsToAbstractValue> valueDomain,
             Func<AnalysisEntity, bool> isLValueFlowCaptureEntity)
         {
             Debug.Assert(value.Kind != PointsToAbstractValueKind.Undefined);
             Debug.Assert(!isLValueFlowCaptureEntity(key) || value.Kind == PointsToAbstractValueKind.KnownLValueCaptures);
-
-            // PointsToAbstractValueKind.Unknown value might point to some known locations.
-            // If we are setting to PointsToAbstractValue.Unknown, 
-            // ensure we don't lose those these locations, as that would a non-monotonic operation.
-            if (value == PointsToAbstractValue.Unknown &&
-                TryGetValue(key, out var currentValue) &&
-                currentValue.Kind == PointsToAbstractValueKind.Unknown &&
-                currentValue != PointsToAbstractValue.Unknown)
-            {
-                value = valueDomain.Merge(value, currentValue);
-            }
 
             base.SetAbstractValue(key, value);
         }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public AnalysisEntity ParentOpt { get; }
         public bool IsThisOrMeInstance { get; }
 
-        public bool HasUnknownInstanceLocationWithEmptyLocations => InstanceLocation == PointsToAbstractValue.Unknown;
+        public bool HasUnknownInstanceLocationWithEmptyLocations => InstanceLocation.Kind == PointsToAbstractValueKind.Unknown;
 
         public bool EqualsIgnoringInstanceLocation(AnalysisEntity other)
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -107,19 +107,25 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             return new AnalysisEntity(instanceReferenceOperation, instanceLocation);
         }
 
-        public static AnalysisEntity Create(IFlowCaptureOperation flowCaptureOperation, ControlFlowGraph controlFlowGraph)
+        public static AnalysisEntity Create(
+            IFlowCaptureOperation flowCaptureOperation,
+            ControlFlowGraph controlFlowGraph,
+            Func<CaptureId, bool> getIsLValueFlowCapture)
         {
             Debug.Assert(flowCaptureOperation != null);
 
-            var captureId = new InterproceduralCaptureId(flowCaptureOperation.Id, controlFlowGraph);
+            var captureId = new InterproceduralCaptureId(flowCaptureOperation.Id, controlFlowGraph, getIsLValueFlowCapture(flowCaptureOperation.Id));
             return new AnalysisEntity(captureId, flowCaptureOperation.Value.Type);
         }
 
-        public static AnalysisEntity Create(IFlowCaptureReferenceOperation flowCaptureReferenceOperation, ControlFlowGraph controlFlowGraph)
+        public static AnalysisEntity Create(
+            IFlowCaptureReferenceOperation flowCaptureReferenceOperation,
+            ControlFlowGraph controlFlowGraph,
+            Func<CaptureId, bool> getIsLValueFlowCapture)
         {
             Debug.Assert(flowCaptureReferenceOperation != null);
 
-            var captureId = new InterproceduralCaptureId(flowCaptureReferenceOperation.Id, controlFlowGraph);
+            var captureId = new InterproceduralCaptureId(flowCaptureReferenceOperation.Id, controlFlowGraph, getIsLValueFlowCapture(flowCaptureReferenceOperation.Id));
             return new AnalysisEntity(captureId, flowCaptureReferenceOperation.Type);
         }
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -23,12 +23,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         private readonly Dictionary<ISymbol, PointsToAbstractValue> _instanceLocationsForSymbols;
         private readonly Func<IOperation, PointsToAbstractValue> _getPointsToAbstractValueOpt;
         private readonly Func<bool> _getIsInsideAnonymousObjectInitializer;
+        private readonly Func<CaptureId, bool> _getIsLValueFlowCapture;
         private readonly ImmutableStack<IOperation> _interproceduralCallStackOpt;
 
         public AnalysisEntityFactory(
             ControlFlowGraph controlFlowGraph,
             Func<IOperation, PointsToAbstractValue> getPointsToAbstractValueOpt,
             Func<bool> getIsInsideAnonymousObjectInitializer,
+            Func<CaptureId, bool> getIsLValueFlowCapture,
             INamedTypeSymbol containingTypeSymbol,
             AnalysisEntity thisOrMeInstanceFromCalleeOpt,
             ImmutableStack<IOperation> interproceduralCallStackOpt,
@@ -37,6 +39,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             _controlFlowGraph = controlFlowGraph;
             _getPointsToAbstractValueOpt = getPointsToAbstractValueOpt;
             _getIsInsideAnonymousObjectInitializer = getIsInsideAnonymousObjectInitializer;
+            _getIsLValueFlowCapture = getIsLValueFlowCapture;
             _interproceduralCallStackOpt = interproceduralCallStackOpt;
 
             _analysisEntityMap = new Dictionary<IOperation, AnalysisEntity>();
@@ -178,11 +181,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     return TryCreate(argument.Value, out analysisEntity);
 
                 case IFlowCaptureOperation flowCapture:
-                    analysisEntity = AnalysisEntity.Create(flowCapture, _controlFlowGraph);
+                    analysisEntity = AnalysisEntity.Create(flowCapture, _controlFlowGraph, _getIsLValueFlowCapture);
                     break;
 
                 case IFlowCaptureReferenceOperation flowCaptureReference:
-                    analysisEntity = AnalysisEntity.Create(flowCaptureReference, _controlFlowGraph);
+                    analysisEntity = AnalysisEntity.Create(flowCaptureReference, _controlFlowGraph, _getIsLValueFlowCapture);
                     break;
 
                 case IDeclarationExpressionOperation declarationExpression:

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         protected AbstractAnalysisDomain<TAnalysisData> AnalysisDomain { get; }
         protected DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue> OperationVisitor { get; }
-        private Dictionary<ControlFlowRegion, TAnalysisData> MergedInputAnalysisDataForFinallyRegions { get; set; }
 
         protected TAnalysisResult GetOrComputeResultCore(TAnalysisContext analysisContext, bool cacheResult)
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         protected bool IsLValueFlowCapture(CaptureId captureId) => _lValueFlowCaptures.Contains(captureId);
         protected bool IsLValueFlowCaptureEntity(AnalysisEntity analysisEntity)
-            => analysisEntity.CaptureIdOpt != null && IsLValueFlowCapture(analysisEntity.CaptureIdOpt.Value.Id);
+            => analysisEntity.CaptureIdOpt != null && analysisEntity.CaptureIdOpt.Value.IsLValueFlowCapture;
 
         protected virtual int GetAllowedInterproceduralCallChain() => MaxInterproceduralCallChain;
 
@@ -181,6 +181,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     GetPointsToAbstractValue :
                     (Func<IOperation, PointsToAbstractValue>)null,
                 getIsInsideAnonymousObjectInitializer: () => IsInsideAnonymousObjectInitializer,
+                getIsLValueFlowCapture: IsLValueFlowCapture,
                 containingTypeSymbol: analysisContext.OwningSymbol.ContainingType,
                 thisOrMeInstanceFromCalleeOpt: thisOrMeInstanceFromCalleeOpt,
                 interproceduralCallStackOpt: analysisContext.InterproceduralAnalysisDataOpt?.CallStack,

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 {
                     IParameterSymbol parameter = parameters[i];
                     PointsToAbstractValue instanceLocation = interproceduralAnalysisData.Arguments[i].InstanceLocation;
-                    if (parameter.RefKind != RefKind.None && instanceLocation != PointsToAbstractValue.Unknown)
+                    if (parameter.RefKind != RefKind.None && instanceLocation.Kind != PointsToAbstractValueKind.Unknown)
                     {
                         yield return new KeyValuePair<ISymbol, PointsToAbstractValue>(parameter, instanceLocation);
                     }
@@ -519,8 +519,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 case ControlFlowBranchSemantics.Throw:
                 case ControlFlowBranchSemantics.Rethrow:
                     // Update the tracked merged analysis data at throw branches.
-                    var exceptionType = branch.BranchValueOpt?.GetThrowExceptionType(CurrentBasicBlock) as INamedTypeSymbol;
-                    if (exceptionType != null &&
+                    if (branch.BranchValueOpt?.GetThrowExceptionType(CurrentBasicBlock) is INamedTypeSymbol exceptionType &&
                         exceptionType.DerivesFrom(WellKnownTypeProvider.Exception, baseTypesOnly: true))
                     {
                         AnalysisDataForUnhandledThrowOperations = AnalysisDataForUnhandledThrowOperations ?? new Dictionary<ThrowBranchWithExceptionType, TAnalysisData>();

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralCaptureId.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralCaptureId.cs
@@ -12,14 +12,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
     /// </summary>
     internal struct InterproceduralCaptureId : IEquatable<InterproceduralCaptureId>
     {
-        public InterproceduralCaptureId(CaptureId captureId, ControlFlowGraph controlFlowGraph)
+        public InterproceduralCaptureId(CaptureId captureId, ControlFlowGraph controlFlowGraph, bool isLValueFlowCapture)
         {
             Id = captureId;
             ControlFlowGraph = controlFlowGraph;
+            IsLValueFlowCapture = isLValueFlowCapture;
         }
 
         public CaptureId Id { get; }
         public ControlFlowGraph ControlFlowGraph { get; }
+        public bool IsLValueFlowCapture { get; }
 
         public bool Equals(InterproceduralCaptureId other)
             => Id.Equals(other.Id) && ControlFlowGraph == other.ControlFlowGraph;


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn-analyzers/commit/b519d7e7d4bc914c4361e8842e700de3bd845816: Fix implementation of `IsLValueFlowCapture(AnalysisEntity)` computation for Interprocedural capture ID across method calls.

2. https://github.com/dotnet/roslyn-analyzers/commit/a3de3e54b9c33d597f347f3620a0120b2c2de43b: Fix merging of PointsToAbstractValue by inserting new `PointsToAbstractValueKind.UnknownNull` and `PointsToAbstractValueKind.UnknownNotNull` to track values with unknown locations but known null state from predicate analysis. For example, points to value of a `field` in if statment below:
```
class C
{
  private object field;
  void M()
  {
    if (field != null)
    {
        // 'field' has unknown, but non-null PointsTo value here
    }
  }
}
```