### PR TITLE
Fix NRE in banned API analyzer when symbol null

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -245,7 +245,7 @@ namespace Roslyn.Diagnostics.Analyzers
                 {
                     VerifyType(reportDiagnostic, typeSymbol, syntaxNode);
                 }
-                else
+                else if (symbol != null)
                 {
                     VerifySymbol(reportDiagnostic, symbol, syntaxNode);
                 }


### PR DESCRIPTION
The documentation verifier could receive `null` from `GetDeclaredOrReferencedSymbol`, which resulted in a NRE. This change protects against that.