### PR TITLE
Locking DFA invocation when caching a result

### DIFF
--- a/src/Utilities/Analyzer.Utilities.projitems
+++ b/src/Utilities/Analyzer.Utilities.projitems
@@ -147,6 +147,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\SetAbstractDomain.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\StackGuard.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\ThrowBranchWithExceptionType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SingleThreadedConcurrentDictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WellKnownTypeProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HashUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DiagnosticCategory.cs" />

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         where TAnalysisResult : DataFlowAnalysisResult<TBlockAnalysisResult, TAbstractAnalysisValue>
         where TBlockAnalysisResult : AbstractBlockAnalysisResult
     {
-        private static readonly ConditionalWeakTable<IOperation, ConcurrentDictionary<DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>, TAnalysisResult>> s_resultCache =
-            new ConditionalWeakTable<IOperation, ConcurrentDictionary<DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>, TAnalysisResult>>();
+        private static readonly ConditionalWeakTable<IOperation, SingleThreadedConcurrentDictionary<DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>, TAnalysisResult>> s_resultCache =
+            new ConditionalWeakTable<IOperation, SingleThreadedConcurrentDictionary<DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>, TAnalysisResult>>();
 
         protected DataFlowAnalysis(AbstractAnalysisDomain<TAnalysisData> analysisDomain, DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue> operationVisitor)
         {

--- a/src/Utilities/SingleThreadedConcurrentDictionary.cs
+++ b/src/Utilities/SingleThreadedConcurrentDictionary.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Analyzer.Utilities
+{
+    /// <summary>
+    /// Like ConcurrentDictionary, but single threaded valueFactory execution in GetOrAdd.
+    /// </summary>
+    /// <remarks>Useful for long running valueFactory functions, like say performing 
+    /// dataflow analysis.  This way DFA is invoked only once per key, even if multiple
+    /// threads simultaneously request the same key.</remarks>
+    internal class SingleThreadedConcurrentDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// Holds the real values.
+        /// </summary>
+        private ConcurrentDictionary<TKey, TValue> BackingDictionary = new ConcurrentDictionary<TKey, TValue>();
+
+        /// <summary>
+        /// Holds the locks for when creating a value to be inserted.
+        /// </summary>
+        private ConcurrentDictionary<TKey, object> LockDictionary = new ConcurrentDictionary<TKey, object>();
+
+        /// <summary>
+        /// Adds a key/value pair using the specified function if the key does not already exist.  Returns the new value, or the existing value if the key exists.
+        /// </summary>
+        /// <param name="key">Key to add.</param>
+        /// <param name="valueFactory">Function to be invoked to generate the key, if necessary.</param>
+        /// <returns>Value of the key, which will either be the existing value, or new value if the key was not in the dictionary.</returns>
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+        {
+            if (this.BackingDictionary.TryGetValue(key, out TValue value))
+            {
+                return value;
+            }
+
+            // The return value of ConcurrentDictionary.GetOrAdd() is
+            // consistent, i.e. the same instance no matter how many times
+            // this valueFactory gets executed.  So for a given key, we'll
+            // always get back the same lockObject instance.
+            object lockObject = this.LockDictionary.GetOrAdd(key, (_) => new object());
+            lock (lockObject)
+            {
+                if (this.BackingDictionary.TryGetValue(key, out value))
+                {
+                    return value;
+                }
+
+                value = valueFactory(key);
+
+                TValue getOrAddedValue = this.BackingDictionary.GetOrAdd(key, value);
+                Debug.Assert(Object.ReferenceEquals(getOrAddedValue, value), "Unexpected race condition");
+                return getOrAddedValue;
+            }
+        }
+    }
+}


### PR DESCRIPTION
So that if multiple threads request the same result, only one invokes DFA and the others are blocked.