### PR TITLE
Fix banning generic symbols

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -101,17 +101,17 @@ namespace Roslyn.Diagnostics.Analyzers
                     {
                         case IObjectCreationOperation objectCreation:
                             VerifySymbol(context.ReportDiagnostic, objectCreation.Constructor, context.Operation.Syntax);
-                            VerifyType(context.ReportDiagnostic, objectCreation.Type.OriginalDefinition, context.Operation.Syntax);
+                            VerifyType(context.ReportDiagnostic, objectCreation.Type, context.Operation.Syntax);
                             break;
 
                         case IInvocationOperation invocation:
                             VerifySymbol(context.ReportDiagnostic, invocation.TargetMethod, context.Operation.Syntax);
-                            VerifyType(context.ReportDiagnostic, invocation.TargetMethod.ContainingType.OriginalDefinition, context.Operation.Syntax);
+                            VerifyType(context.ReportDiagnostic, invocation.TargetMethod.ContainingType, context.Operation.Syntax);
                             break;
 
                         case IMemberReferenceOperation memberReference:
                             VerifySymbol(context.ReportDiagnostic, memberReference.Member, context.Operation.Syntax);
-                            VerifyType(context.ReportDiagnostic, memberReference.Member.ContainingType.OriginalDefinition, context.Operation.Syntax);
+                            VerifyType(context.ReportDiagnostic, memberReference.Member.ContainingType, context.Operation.Syntax);
                             break;
                     }
                 },
@@ -207,7 +207,9 @@ namespace Roslyn.Diagnostics.Analyzers
 
             void VerifyType(Action<Diagnostic> reportDiagnostic, ITypeSymbol type, SyntaxNode syntaxNode)
             {
-                while (!(type is null))
+                type = type.OriginalDefinition;
+
+                do
                 {
                     if (messageByBannedSymbol.TryGetValue(type, out var message))
                     {
@@ -222,10 +224,13 @@ namespace Roslyn.Diagnostics.Analyzers
 
                     type = type.ContainingType;
                 }
+                while (!(type is null));
             }
 
             void VerifySymbol(Action<Diagnostic> reportDiagnostic, ISymbol symbol, SyntaxNode syntaxNode)
             {
+                symbol = symbol.OriginalDefinition;
+
                 if (messageByBannedSymbol.TryGetValue(symbol, out var message))
                 {
                     reportDiagnostic(

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -485,27 +485,67 @@ namespace N
     {
         public void Banned() {}
         public void Banned(int i) {}
+        public void Banned<T>(T t) {}
 
         void M()
         {
             Banned();
             Banned(1);
+            Banned<string>("""");
+        }
+    }
+
+    class D<T>
+    {
+        public void Banned() {}
+        public void Banned(int i) {}
+        public void Banned<U>(U u) {}
+
+        void M()
+        {
+            Banned();
+            Banned(1);
+            Banned<string>("""");
         }
     }
 }";
 
             var bannedText1 = @"M:N.C.Banned";
             var bannedText2 = @"M:N.C.Banned(System.Int32)";
+            var bannedText3 = @"M:N.C.Banned``1(``0)";
+            var bannedText4 = @"M:N.D`1.Banned()";
+            var bannedText5 = @"M:N.D`1.Banned(System.Int32)";
+            var bannedText6 = @"M:N.D`1.Banned``1(``0)";
 
             VerifyCSharp(
                 source,
                 bannedText1,
-                GetCSharpResultAt(11, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C.Banned()", ""));
+                GetCSharpResultAt(12, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C.Banned()", ""));
 
             VerifyCSharp(
                 source,
                 bannedText2,
-                GetCSharpResultAt(12, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C.Banned(int)", ""));
+                GetCSharpResultAt(13, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C.Banned(int)", ""));
+
+            VerifyCSharp(
+                source,
+                bannedText3,
+                GetCSharpResultAt(14, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C.Banned<T>(T)", ""));
+
+            VerifyCSharp(
+                source,
+                bannedText4,
+                GetCSharpResultAt(26, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "D<T>.Banned()", ""));
+
+            VerifyCSharp(
+                source,
+                bannedText5,
+                GetCSharpResultAt(27, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "D<T>.Banned(int)", ""));
+
+            VerifyCSharp(
+                source,
+                bannedText6,
+                GetCSharpResultAt(28, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "D<T>.Banned<U>(U)", ""));
         }
 
         [Fact]

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -73,7 +73,26 @@ T:System.Console";
                 GetResultAt(
                     SymbolIsBannedAnalyzer.BannedSymbolsFileName,
                     SymbolIsBannedAnalyzer.DuplicateBannedSymbolRule.Id,
-                    string.Format(SymbolIsBannedAnalyzer.DuplicateBannedSymbolRule.MessageFormat.ToString(), "T:System.Console"),
+                    string.Format(SymbolIsBannedAnalyzer.DuplicateBannedSymbolRule.MessageFormat.ToString(), "System.Console"),
+                    "(3,1)", "(2,1)"));
+        }
+
+        [Fact]
+        public void DiagnosticReportedForDuplicateBannedApiLinesWithDifferentIds()
+        {
+            // The colon in the documentation ID is optional.
+            // Verify that it doesn't cause exceptions when building look ups.
+
+            var source = @"";
+            var bannedText = @"
+T:System.Console;Message 1
+TSystem.Console;Message 2";
+
+            VerifyCSharp(source, bannedText,
+                GetResultAt(
+                    SymbolIsBannedAnalyzer.BannedSymbolsFileName,
+                    SymbolIsBannedAnalyzer.DuplicateBannedSymbolRule.Id,
+                    string.Format(SymbolIsBannedAnalyzer.DuplicateBannedSymbolRule.MessageFormat.ToString(), "System.Console"),
                     "(3,1)", "(2,1)"));
         }
 


### PR DESCRIPTION
Some fixes to the banned symbol analyzer.

- Ensure symbol comparison is done on unconstrained generic forms where required (for https://github.com/dotnet/project-system/pull/4390)
- Simplify and optimise collection building
- Fix an (unlikely, but possible) exception based on contents of `BannedSymbols.txt` (as part of the above simplification)
