### PR TITLE
Fix some more asserts and also implement support for IsPatternOperation

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidDeadConditionalCode.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidDeadConditionalCode.cs
@@ -66,7 +66,8 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                 (op as IInvocationOperation)?.TargetMethod.ReturnType.SpecialType == SpecialType.System_Boolean ||
                                 op.Kind == OperationKind.Coalesce ||
                                 op.Kind == OperationKind.ConditionalAccess ||
-                                op.Kind == OperationKind.IsNull;
+                                op.Kind == OperationKind.IsNull ||
+                                op.Kind == OperationKind.IsPattern;
 
                         if (operationRoot.HasAnyOperationDescendant(ShouldAnalyze))
                         {
@@ -100,6 +101,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                         break;
 
                                     case OperationKind.Invocation:
+                                    case OperationKind.IsPattern:
                                         predicateKind = GetPredicateKind(operation);
                                         if (predicateKind != PredicateValueKind.Unknown)
                                         {
@@ -136,7 +138,10 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
                             PredicateValueKind GetPredicateKind(IOperation operation)
                             {
-                                Debug.Assert(operation.Kind == OperationKind.BinaryOperator || operation.Kind == OperationKind.Invocation || operation.Kind == OperationKind.IsNull);
+                                Debug.Assert(operation.Kind == OperationKind.BinaryOperator ||
+                                             operation.Kind == OperationKind.Invocation ||
+                                             operation.Kind == OperationKind.IsNull ||
+                                             operation.Kind == OperationKind.IsPattern);
 
                                 if (operation is IBinaryOperation binaryOperation &&
                                     binaryOperation.IsComparisonOperator() ||

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
@@ -1459,5 +1459,101 @@ class Test
             // Test0.cs(11,56): warning CA1508: 's4 == s6' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(11, 56, "s4 == s6", "true"));
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_IsConstantPattern_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1_IsConstantPattern_AlwaysTrue(int c1)
+    {
+        c1 = 5;
+        if (c1 is 5)
+        {
+            return;
+        }
+    }
+
+    void M1_IsConstantPattern_AlwaysFalse(int c2)
+    {
+        c2 = 10;
+        if (c2 is 5)
+        {
+            return;
+        }
+    }
+
+    void M1_IsConstantPattern_Conversion_AlwaysTrue(short c3)
+    {
+        c3 = (short)5;
+        if (c3 is 5)
+        {
+            return;
+        }
+    }
+}
+",
+            // Test0.cs(15,13): warning CA1508: 'c1 is 5' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(15, 13, "c1 is 5", "true"),
+            // Test0.cs(24,13): warning CA1508: 'c2 is 5' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(24, 13, "c2 is 5", "false"),
+            // Test0.cs(33,13): warning CA1508: 'c3 is 5' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(33, 13, "c3 is 5", "true"));
+
+            // VB does not support patterns.
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_IsConstantPattern_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+}
+
+class D: C
+{
+}
+
+class Test
+{
+    void M1_IsConstantPattern(int c1)
+    {
+        if (c1 is 5)
+        {
+            return;
+        }
+    }
+
+    void M1_IsConstantPattern_02(int c2, bool flag)
+    {
+        if (flag)
+        {
+            c2 = 5;
+        }
+
+        if (c2 is 5)
+        {
+            return;
+        }
+    }
+}
+");
+
+            // VB does not support patterns.
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -4678,5 +4678,33 @@ public class C
     }
 }");
         }
+
+        [Fact]
+        public void RecursiveLocalFunctionInvocation()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Collections.Generic;
+
+public class C
+{
+    public int Field;
+    public object M(C c)
+    {
+        c = LocalFunction(c);
+        return c;
+
+        C LocalFunction(C c2)
+        {
+            if (c2.Field > 0)
+            {
+                c2 = LocalFunction(new C());
+            }
+
+            return c2;
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -4639,5 +4639,44 @@ public class C
             // Test0.cs(10,12): warning CA1062: In externally visible method 'void C.M(object o, int param)', validate parameter 'o' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(10, 12, "void C.M(object o, int param)", "o"));
         }
+
+        [Fact]
+        public void CopyValueTrackingEntityWithUnknownInstanceLocationAssert()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Collections.Generic;
+
+public struct S { }
+public class D
+{
+    public S S;
+}
+
+public class C
+{
+    public D D;
+    private List<C> list;
+
+    public void M(object o)
+    {
+        foreach (C c in list)
+        {
+            LocalFunction(ref c.D);
+        }
+
+        return;
+
+        void LocalFunction(ref D d)
+        {
+            LocalFunction2(ref d.S);
+        }
+
+        void LocalFunction2(ref S s)
+        {
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -4706,5 +4706,74 @@ public class C
     }
 }");
         }
+
+        [Fact]
+        public void MultiChainedLocalFunctionInvocations()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Collections.Generic;
+
+public class C
+{
+    public int Field;
+    public object M(C c)
+    {
+        c = LocalFunction1(c);
+        return c;
+
+        C LocalFunction1(C c2)
+        {
+            return LocalFunction2(c2);
+        }
+
+        C LocalFunction2(C c2)
+        {
+            return LocalFunction3(c2);
+        }
+
+        C LocalFunction3(C c2)
+        {
+            if (c2.Field > 0)
+            {
+                c2 = LocalFunction3(new C());
+            }
+
+            return c2;
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void MultiChainedLambdaInvocations()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public object M(C c)
+    {
+        Func<C, C> lambda1 = (C c2) =>
+        {
+            return c2;
+        };
+
+        Func<C, C> lambda2 = (C c2) =>
+        {
+            return lambda1(c2);
+        };
+
+        Func<C, C> lambda3 = (C c2) =>
+        {
+            return lambda2(c2);
+        };
+
+        c = lambda3(c);
+        return c;
+    }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -4775,5 +4775,29 @@ public class C
     }
 }");
         }
+
+        [Fact]
+        public void IsPatterExpression_UndefinedValueAssert()
+        {
+            VerifyCSharp(@"
+using System;
+public class C
+{
+    public void M(C c)
+    {
+        if (c is D d)
+        {
+            M2(d);
+        }
+    }
+
+    private void M2(D d)
+    {
+    }
+}
+
+public class D : C { }
+");
+        }
     }
 }

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -580,8 +580,19 @@ namespace Analyzer.Utilities.Extensions
                operation.GetAncestor<ILocalFunctionOperation>(OperationKind.LocalFunction) != null;
 
         public static ITypeSymbol GetPatternType(this IPatternOperation pattern)
-            => pattern is IDeclarationPatternOperation declarationPattern ?
-                ((ILocalSymbol)declarationPattern.DeclaredSymbol).Type :
-                pattern.Type;
+        {
+            switch (pattern)
+            {
+                case IDeclarationPatternOperation declarationPattern:
+                    return ((ILocalSymbol)declarationPattern.DeclaredSymbol).Type;
+
+                case IConstantPatternOperation constantPattern:
+                    return constantPattern.Value.Type;
+
+                default:
+                    Debug.Fail($"Unhandled pattern kind '{pattern.Kind}'");
+                    return null;
+            }
+        }
     }
 }

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -578,5 +578,10 @@ namespace Analyzer.Utilities.Extensions
         public static bool IsWithinLambdaOrLocalFunction(this IOperation operation)
             => operation.GetAncestor<IAnonymousFunctionOperation>(OperationKind.AnonymousFunction) != null ||
                operation.GetAncestor<ILocalFunctionOperation>(OperationKind.LocalFunction) != null;
+
+        public static ITypeSymbol GetPatternType(this IPatternOperation pattern)
+            => pattern is IDeclarationPatternOperation declarationPattern ?
+                ((ILocalSymbol)declarationPattern.DeclaredSymbol).Type :
+                pattern.Type;
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
         private sealed class ParameterValidationDataFlowOperationVisitor :
             AbstractLocationDataFlowOperationVisitor<ParameterValidationAnalysisData, ParameterValidationAnalysisContext, ParameterValidationAnalysisResult, ParameterValidationAbstractValue>
         {
-            private const int MaxInterproceduralCallChain = 1;
+            private const int MaxInterproceduralMethodCallChain = 1;
             private readonly ImmutableDictionary<IParameterSymbol, SyntaxNode>.Builder _hazardousParameterUsageBuilderOpt;
 
             public ParameterValidationDataFlowOperationVisitor(ParameterValidationAnalysisContext analysisContext)
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
             }
 
             // We only want to track method calls one level down.
-            protected override int GetAllowedInterproceduralCallChain() => MaxInterproceduralCallChain;
+            protected override int GetAllowedInterproceduralMethodCallChain() => MaxInterproceduralMethodCallChain;
 
             protected override ParameterValidationAbstractValue GetAbstractDefaultValue(ITypeSymbol type) => ValueDomain.Bottom;
 

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValueKind.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValueKind.cs
@@ -45,20 +45,4 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         /// </summary>
         Unknown,
     }
-
-    internal static class PointsToAbstractValueExtensions
-    {
-        public static bool IsInvalidOrUndefined(this PointsToAbstractValueKind kind)
-        {
-            switch (kind)
-            {
-                case PointsToAbstractValueKind.Invalid:
-                case PointsToAbstractValueKind.Undefined:
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-    }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.CorePointsToAnalysisDataDomain.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.CorePointsToAnalysisDataDomain.cs
@@ -26,10 +26,21 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             public DefaultPointsToValueGenerator DefaultPointsToValueGenerator { get; }
 
             protected override PointsToAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => DefaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity);
+
             protected override bool CanSkipNewEntry(AnalysisEntity analysisEntity, PointsToAbstractValue value)
                 => value.Kind == PointsToAbstractValueKind.Unknown ||
                     !DefaultPointsToValueGenerator.IsTrackedEntity(analysisEntity) ||
                     value == GetDefaultValue(analysisEntity);
+
+            protected override void AssertValidEntryForMergedMap(AnalysisEntity analysisEntity, PointsToAbstractValue value)
+            {
+                PointsToAnalysisData.AssertValidPointsToAnalysisKeyValuePair(analysisEntity, value);
+            }
+
+            protected override void AssertValidAnalysisData(CorePointsToAnalysisData map)
+            {
+                PointsToAnalysisData.AssertValidPointsToAnalysisData(map);
+            }
 
             public CorePointsToAnalysisData MergeCoreAnalysisDataForBackEdge(
                 PointsToAnalysisData forwardEdgeAnalysisData,

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAbstractValueDomain.cs
@@ -77,11 +77,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 }
                 else if (value1.Kind == PointsToAbstractValueKind.Invalid)
                 {
-                    result = value2;
+                    result = value2.Kind == PointsToAbstractValueKind.Undefined ?
+                        PointsToAbstractValue.Unknown :
+                        value2;
                 }
                 else if (value2.Kind == PointsToAbstractValueKind.Invalid)
                 {
-                    result = value1;
+                    result = value1.Kind == PointsToAbstractValueKind.Undefined ?
+                        PointsToAbstractValue.Unknown :
+                        value1;
                 }
                 else if (value1.Kind == PointsToAbstractValueKind.Undefined)
                 {

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -729,7 +729,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             public override PointsToAbstractValue GetAssignedValueForPattern(IIsPatternOperation operation, PointsToAbstractValue operandValue)
             {
-                if (operandValue.NullState == NullAbstractValue.NotNull)
+                if (operandValue.NullState == NullAbstractValue.NotNull &&
+                    ShouldBeTracked(operation.Value.Type))
                 {
                     if (TryInferConversion(operation, out bool alwaysSucceed, out bool alwaysFail))
                     {

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         }
 
         [Conditional("DEBUG")]
-        private static void AssertValidPointsToAnalysisData(CorePointsToAnalysisData map)
+        public static void AssertValidPointsToAnalysisData(CorePointsToAnalysisData map)
         {
             foreach (var kvp in map)
             {
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         }
 
         [Conditional("DEBUG")]
-        private static void AssertValidPointsToAnalysisKeyValuePair(
+        public static void AssertValidPointsToAnalysisKeyValuePair(
             AnalysisEntity key,
             PointsToAbstractValue value)
         {

--- a/src/Utilities/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
@@ -22,7 +22,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         private sealed class PropertySetDataFlowOperationVisitor :
             AbstractLocationDataFlowOperationVisitor<PropertySetAnalysisData, PropertySetAnalysisContext, PropertySetAnalysisResult, PropertySetAbstractValue>
         {
-            private const int MaxInterproceduralCallChain = 1;
+            private const int MaxInterproceduralMethodCallChain = 1;
             private readonly ImmutableDictionary<(Location Location, IMethodSymbol Method), PropertySetAbstractValue>.Builder _hazardousUsageBuilder;
             private INamedTypeSymbol DeserializerTypeSymbol;
 
@@ -50,7 +50,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
             }
 
             // We only want to track method calls one level down.
-            protected override int GetAllowedInterproceduralCallChain() => MaxInterproceduralCallChain;
+            protected override int GetAllowedInterproceduralMethodCallChain() => MaxInterproceduralMethodCallChain;
 
             protected override PropertySetAbstractValue GetAbstractDefaultValue(ITypeSymbol type) => ValueDomain.Bottom;
 

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.CoreTaintedDataAnalysisDataDomain.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.CoreTaintedDataAnalysisDataDomain.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
@@ -22,6 +23,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             protected override TaintedDataAbstractValue GetDefaultValue(AnalysisEntity analysisEntity)
             {
                 return TaintedDataAbstractValue.NotTainted;
+            }
+
+            protected override void AssertValidEntryForMergedMap(AnalysisEntity analysisEntity, TaintedDataAbstractValue value)
+            {
+                Debug.Assert(value.Kind == TaintedDataAbstractValueKind.Tainted);
             }
         }
     }

--- a/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.CoreAnalysisDataDomain.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.CoreAnalysisDataDomain.cs
@@ -24,6 +24,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
 
             protected override ValueContentAbstractValue GetDefaultValue(AnalysisEntity analysisEntity) => ValueContentAbstractValue.MayBeContainsNonLiteralState;
             protected override bool CanSkipNewEntry(AnalysisEntity analysisEntity, ValueContentAbstractValue value) => value.NonLiteralState == ValueContainsNonLiteralState.Maybe;
+            protected override void AssertValidEntryForMergedMap(AnalysisEntity analysisEntity, ValueContentAbstractValue value)
+            {
+                // No validation.
+            }
 
             public CoreValueContentAnalysisData MergeAnalysisDataForBackEdge(CoreValueContentAnalysisData forwardEdgeAnalysisData, CoreValueContentAnalysisData backEdgeAnalysisData)
             {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
@@ -82,9 +82,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             InterproceduralAnalysisData<TAnalysisData, TAnalysisContext, TAbstractAnalysisValue> interproceduralAnalysisData);
 
         public ControlFlowGraph GetLocalFunctionControlFlowGraph(IMethodSymbol localFunction)
-            => ControlFlowGraph.LocalFunctions.Contains(localFunction) ?
-                ControlFlowGraph.GetLocalFunctionControlFlowGraph(localFunction):
+        {
+            if (localFunction == OwningSymbol)
+            {
+                return ControlFlowGraph;
+            }
+
+            return ControlFlowGraph.LocalFunctions.Contains(localFunction) ?
+                ControlFlowGraph.GetLocalFunctionControlFlowGraph(localFunction) :
                 ParentControlFlowGraphOpt?.GetLocalFunctionControlFlowGraph(localFunction);
+        }
 
         public ControlFlowGraph GetAnonymousFunctionControlFlowGraph(IFlowAnonymousFunctionOperation lambda)
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         private readonly Func<CaptureId, bool> _getIsLValueFlowCapture;
         private readonly AnalysisEntity _interproceduralThisOrMeInstanceForCallerOpt;
         private readonly ImmutableStack<IOperation> _interproceduralCallStackOpt;
+        private readonly Func<IOperation, AnalysisEntity> _interproceduralGetAnalysisEntityForFlowCaptureOpt;
 
         public AnalysisEntityFactory(
             ControlFlowGraph controlFlowGraph,
@@ -37,7 +38,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             AnalysisEntity interproceduralInvocationInstanceOpt,
             AnalysisEntity interproceduralThisOrMeInstanceForCallerOpt,
             ImmutableStack<IOperation> interproceduralCallStackOpt,
-            ImmutableDictionary<ISymbol, PointsToAbstractValue> interproceduralCapturedVariablesMapOpt)
+            ImmutableDictionary<ISymbol, PointsToAbstractValue> interproceduralCapturedVariablesMapOpt,
+            Func<IOperation, AnalysisEntity> interproceduralGetAnalysisEntityForFlowCaptureOpt)
         {
             _controlFlowGraph = controlFlowGraph;
             _getPointsToAbstractValueOpt = getPointsToAbstractValueOpt;
@@ -45,6 +47,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             _getIsLValueFlowCapture = getIsLValueFlowCapture;
             _interproceduralThisOrMeInstanceForCallerOpt = interproceduralThisOrMeInstanceForCallerOpt;
             _interproceduralCallStackOpt = interproceduralCallStackOpt;
+            _interproceduralGetAnalysisEntityForFlowCaptureOpt = interproceduralGetAnalysisEntityForFlowCaptureOpt;
 
             _analysisEntityMap = new Dictionary<IOperation, AnalysisEntity>();
             _captureIdEntityMap = new Dictionary<CaptureId, AnalysisEntity>();
@@ -191,11 +194,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     return TryCreate(argument.Value, out analysisEntity);
 
                 case IFlowCaptureOperation flowCapture:
-                    analysisEntity = GetOrCreateForFlowCapture(flowCapture.Id, flowCapture.Value.Type);
+                    analysisEntity = GetOrCreateForFlowCapture(flowCapture.Id, flowCapture.Value.Type, flowCapture);
+                    Debug.Assert(analysisEntity.Type == null || analysisEntity.Type.Equals(flowCapture.Value.Type));
                     break;
 
                 case IFlowCaptureReferenceOperation flowCaptureReference:
-                    analysisEntity = GetOrCreateForFlowCapture(flowCaptureReference.Id, flowCaptureReference.Type);
+                    analysisEntity = GetOrCreateForFlowCapture(flowCaptureReference.Id, flowCaptureReference.Type, flowCaptureReference);
+                    Debug.Assert(analysisEntity.Type == null || analysisEntity.Type.Equals(flowCaptureReference.Type));
                     break;
 
                 case IDeclarationExpressionOperation declarationExpression:
@@ -291,8 +296,20 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public bool TryGetForFlowCapture(CaptureId captureId, out AnalysisEntity analysisEntity)
             => _captureIdEntityMap.TryGetValue(captureId, out analysisEntity);
 
-        private AnalysisEntity GetOrCreateForFlowCapture(CaptureId captureId, ITypeSymbol type)
+        public bool TryGetForInterproceduralAnalysis(IOperation operation, out AnalysisEntity analysisEntity)
+            => _analysisEntityMap.TryGetValue(operation, out analysisEntity);
+
+        private AnalysisEntity GetOrCreateForFlowCapture(CaptureId captureId, ITypeSymbol type, IOperation flowCaptureOrReference)
         {
+            var interproceduralFlowCaptureEntityOpt = _interproceduralGetAnalysisEntityForFlowCaptureOpt?.Invoke(flowCaptureOrReference);
+            if (interproceduralFlowCaptureEntityOpt != null)
+            {
+                Debug.Assert(!_controlFlowGraph.DescendantOperations().Contains(flowCaptureOrReference));
+                Debug.Assert(_interproceduralCallStackOpt.Last().Descendants().Contains(flowCaptureOrReference));
+                return interproceduralFlowCaptureEntityOpt;
+            }
+
+            Debug.Assert(_controlFlowGraph.DescendantOperations().Contains(flowCaptureOrReference));
             if (!_captureIdEntityMap.TryGetValue(captureId, out var entity))
             {
                 entity = AnalysisEntity.Create(captureId, type, _controlFlowGraph, _getIsLValueFlowCapture(captureId));

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -217,6 +217,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     type = variableDeclarator.Symbol.Type;
                     break;
 
+                case IDeclarationPatternOperation declarationPattern:
+                    symbolOpt = declarationPattern.DeclaredSymbol;
+                    type = ((ILocalSymbol)symbolOpt).Type;
+                    break;
+
                 default:
                     break;
             }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -127,7 +127,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                             newKeys.Add(mergedKey);
                         }
 
-
                         AssertValidEntryForMergedMap(mergedKey, mergedValue);
                         resultMap[mergedKey] = mergedValue;
                     }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -19,10 +19,23 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         protected abstract TValue GetDefaultValue(AnalysisEntity analysisEntity);
         protected abstract bool CanSkipNewEntry(AnalysisEntity analysisEntity, TValue value);
 
+        protected abstract void AssertValidEntryForMergedMap(AnalysisEntity analysisEntity, TValue value);
+        protected virtual void AssertValidAnalysisData(IDictionary<AnalysisEntity, TValue> map)
+        {
+#if DEBUG
+            foreach (var kvp in map)
+            {
+                AssertValidEntryForMergedMap(kvp.Key, kvp.Value);
+            }
+#endif
+        }
+
         public override IDictionary<AnalysisEntity, TValue> Merge(IDictionary<AnalysisEntity, TValue> map1, IDictionary<AnalysisEntity, TValue> map2)
         {
             Debug.Assert(map1 != null);
+            AssertValidAnalysisData(map1);
             Debug.Assert(map2 != null);
+            AssertValidAnalysisData(map2);
 
             TValue GetMergedValueForEntityPresentInOneMap(AnalysisEntity key, TValue value)
             {
@@ -44,6 +57,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     TValue mergedValue = GetMergedValueForEntityPresentInOneMap(key1, value1);
                     Debug.Assert(!map2.ContainsKey(key1));
                     Debug.Assert(ValueDomain.Compare(value1, mergedValue) <= 0);
+                    AssertValidEntryForMergedMap(key1, mergedValue);
                     resultMap.Add(key1, mergedValue);
                     continue;
                 }
@@ -64,6 +78,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                     if (key1.InstanceLocation.Equals(key2.InstanceLocation))
                     {
+                        AssertValidEntryForMergedMap(key1, mergedValue);
                         resultMap[key1] = mergedValue;
                     }
                     else
@@ -112,6 +127,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                             newKeys.Add(mergedKey);
                         }
 
+
+                        AssertValidEntryForMergedMap(mergedKey, mergedValue);
                         resultMap[mergedKey] = mergedValue;
                     }
                 }
@@ -120,6 +137,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 {
                     TValue mergedValue = GetMergedValueForEntityPresentInOneMap(key1, value1);
                     Debug.Assert(ValueDomain.Compare(value1, mergedValue) <= 0);
+                    AssertValidEntryForMergedMap(key1, mergedValue);
                     resultMap.Add(key1, mergedValue);
                 }
             }
@@ -132,6 +150,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 {
                     TValue mergedValue = GetMergedValueForEntityPresentInOneMap(key2, value2);
                     Debug.Assert(ValueDomain.Compare(value2, mergedValue) <= 0);
+                    AssertValidEntryForMergedMap(key2, mergedValue);
                     resultMap.Add(key2, mergedValue);
                 }
             }
@@ -148,6 +167,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
             Debug.Assert(Compare(map1, resultMap) <= 0);
             Debug.Assert(Compare(map2, resultMap) <= 0);
+            AssertValidAnalysisData(resultMap);
 
             return resultMap;
         }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/CacheBasedEquatable.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/CacheBasedEquatable.cs
@@ -79,6 +79,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             {
                 return (object)value2 == null;
             }
+            else if ((object)value2 == null)
+            {
+                return false;
+            }
 
             return value1.Equals(value2);
         }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/IDataFlowAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/IDataFlowAnalysisContext.cs
@@ -10,5 +10,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
     {
         ControlFlowGraph ControlFlowGraph { get; }
         ISymbol OwningSymbol { get; }
+        ControlFlowGraph GetLocalFunctionControlFlowGraph(IMethodSymbol localFunction);
+        ControlFlowGraph GetAnonymousFunctionControlFlowGraph(IFlowAnonymousFunctionOperation lambda);
     }
 }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
@@ -34,7 +34,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             ImmutableStack<IOperation> callStack,
             ImmutableHashSet<TAnalysisContext> methodsBeingAnalyzed,
             Func<IOperation, TAbstractAnalysisValue> getCachedAbstractValueFromCaller,
-            Func<IMethodSymbol, ControlFlowGraph> getInterproceduralControlFlowGraph)
+            Func<IMethodSymbol, ControlFlowGraph> getInterproceduralControlFlowGraph,
+            Func<IOperation, AnalysisEntity> getAnalysisEntityForFlowCapture)
         {
             Debug.Assert(initialAnalysisData != null);
             Debug.Assert(!arguments.IsDefault);
@@ -43,6 +44,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Debug.Assert(methodsBeingAnalyzed != null);
             Debug.Assert(getCachedAbstractValueFromCaller != null);
             Debug.Assert(getInterproceduralControlFlowGraph != null);
+            Debug.Assert(getAnalysisEntityForFlowCapture != null);
 
             InitialAnalysisData = initialAnalysisData;
             InvocationInstanceOpt = invocationInstanceOpt;
@@ -54,6 +56,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             MethodsBeingAnalyzed = methodsBeingAnalyzed;
             GetCachedAbstractValueFromCaller = getCachedAbstractValueFromCaller;
             GetInterproceduralControlFlowGraph = getInterproceduralControlFlowGraph;
+            GetAnalysisEntityForFlowCapture = getAnalysisEntityForFlowCapture;
         }
 
         public TAnalysisData InitialAnalysisData { get; }
@@ -66,6 +69,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public ImmutableHashSet<TAnalysisContext> MethodsBeingAnalyzed { get; }
         public Func<IOperation, TAbstractAnalysisValue> GetCachedAbstractValueFromCaller { get; }
         public Func<IMethodSymbol, ControlFlowGraph> GetInterproceduralControlFlowGraph { get; }
+        public Func<IOperation, AnalysisEntity> GetAnalysisEntityForFlowCapture { get; }
 
         protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
         {


### PR DESCRIPTION
Each commit has a description of the fix, but high level changes:

1. Fixes related to address shared entities (i.e. ref/out parameter) to ensure the analysis values are tracked properly across inter-procedural calls, especially copy analysis values.
2. Fixes related to recursive and chained invocations of lambda/local functions
3. Support for handling flow analysis values for pattern operations (see #1571).
4. Fixes related to accessing flow captures and flow capture references across inter-procedural calls
5. General improvements to CopyAnalysis with lot more stronger asserts to help catch non-monotonic updates upfront.