### PR TITLE
Removing TaintedDataAnalysis assert

### DIFF
--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.CoreTaintedDataAnalysisDataDomain.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.CoreTaintedDataAnalysisDataDomain.cs
@@ -27,7 +27,6 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
             protected override void AssertValidEntryForMergedMap(AnalysisEntity analysisEntity, TaintedDataAbstractValue value)
             {
-                Debug.Assert(value.Kind == TaintedDataAbstractValueKind.Tainted);
             }
         }
     }


### PR DESCRIPTION
TaintedDataAnalysis still tracks sanitized entities, so it seems possible that for mappings to contain NotTainted abstract values.

But I still need to look into the root cause of the assert I saw.

Just removing the assert for now.