### PR TITLE
Avoid immutable dictionary allocations

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
@@ -144,7 +144,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                     PointsToAbstractValue pointsToValue = fieldWithPointsToValue.Value;
 
                                     Debug.Assert(field.Type.IsDisposable(disposeAnalysisHelper.IDisposable));
-                                    ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[exitBlock].OutputData;
+                                    var disposeDataAtExit = disposeAnalysisResult[exitBlock].OutputData;
                                     var disposed = false;
                                     foreach (var location in pointsToValue.Locations)
                                     {

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeObjectsBeforeLosingScope.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeObjectsBeforeLosingScope.cs
@@ -57,7 +57,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockContext.OperationBlocks, containingMethod, out var disposeAnalysisResult, out var pointsToAnalysisResult))
                     {
                         BasicBlock exitBlock = disposeAnalysisResult.ControlFlowGraph.GetExit();
-                        ImmutableDictionary<AbstractLocation, DisposeAbstractValue> disposeDataAtExit = disposeAnalysisResult[exitBlock].OutputData;
+                        var disposeDataAtExit = disposeAnalysisResult[exitBlock].OutputData;
                         foreach (var kvp in disposeDataAtExit)
                         {
                             AbstractLocation location = kvp.Key;

--- a/src/Utilities/Analyzer.Utilities.projitems
+++ b/src/Utilities/Analyzer.Utilities.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\OperationBlockAnalysisContextExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\WellKnownDiagnosticTagsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractAnalysisData.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractBlockAnalysisResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\DictionaryAnalysisData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AddressSharedEntitiesProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PropertySetAnalysis\PropertySetAbstractValue.cs" />
@@ -116,7 +117,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\ValueContentAnalysis\ValueContentAnalysisData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\ValueContentAnalysis\ValueContentBlockAnalysisResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractAnalysisDomain.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractBlockAnalysisResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractBlockAnalysisResult`2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\InterproceduralCaptureId.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\ArgumentInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\InterproceduralAnalysisKind.cs" />

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyBlockAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyBlockAnalysisResult.cs
@@ -1,25 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
 {
     /// <summary>
     /// Result from execution of <see cref="CopyAnalysis"/> on a basic block.
     /// It store copy values for each <see cref="AnalysisEntity"/> at the start and end of the basic block.
     /// </summary>
-    internal sealed class CopyBlockAnalysisResult : AbstractBlockAnalysisResult
+    internal sealed class CopyBlockAnalysisResult : AbstractBlockAnalysisResult<AnalysisEntity, CopyAbstractValue>
     {
         public CopyBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<CopyAnalysisData> blockAnalysisData)
-            : base (basicBlock)
+            : base(basicBlock, blockAnalysisData.Input?.CoreAnalysisData, blockAnalysisData.Output?.CoreAnalysisData)
         {
-            InputData = blockAnalysisData.Input?.CoreAnalysisData.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, CopyAbstractValue>.Empty;
-            OutputData = blockAnalysisData.Output?.CoreAnalysisData.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, CopyAbstractValue>.Empty;
             IsReachable = blockAnalysisData.Input?.IsReachableBlockData ?? true;
         }
 
-        public ImmutableDictionary<AnalysisEntity, CopyAbstractValue> InputData { get; }
-        public ImmutableDictionary<AnalysisEntity, CopyAbstractValue> OutputData { get; }
         public bool IsReachable { get; }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/DisposeAnalysis/DisposeBlockAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/DisposeAnalysis/DisposeBlockAnalysisResult.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
 {
     using DisposeAnalysisData = DictionaryAnalysisData<AbstractLocation, DisposeAbstractValue>;
@@ -10,16 +8,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
     /// Result from execution of <see cref="DisposeAnalysis"/> on a basic block.
     /// It store dispose values for each <see cref="AbstractLocation"/> at the start and end of the basic block.
     /// </summary>
-    internal class DisposeBlockAnalysisResult : AbstractBlockAnalysisResult
+    internal class DisposeBlockAnalysisResult : AbstractBlockAnalysisResult<AbstractLocation, DisposeAbstractValue>
     {
         public DisposeBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<DisposeAnalysisData> blockAnalysisData)
-            : base (basicBlock)
+            : base(basicBlock, blockAnalysisData.Input, blockAnalysisData.Output)
         {
-            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<AbstractLocation, DisposeAbstractValue>.Empty;
-            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<AbstractLocation, DisposeAbstractValue>.Empty;
         }
-
-        public ImmutableDictionary<AbstractLocation, DisposeAbstractValue> InputData { get; }
-        public ImmutableDictionary<AbstractLocation, DisposeAbstractValue> OutputData { get; }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationBlockAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationBlockAnalysisResult.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
-
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalysis
 {
     using ParameterValidationAnalysisData = DictionaryAnalysisData<AbstractLocation, ParameterValidationAbstractValue>;
@@ -11,16 +8,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
     /// Result from execution of <see cref="ParameterValidationAnalysis"/> on a basic block.
     /// It stores ParameterValidation values for each <see cref="AbstractLocation"/> at the start and end of the basic block.
     /// </summary>
-    internal class ParameterValidationBlockAnalysisResult : AbstractBlockAnalysisResult
+    internal class ParameterValidationBlockAnalysisResult : AbstractBlockAnalysisResult<AbstractLocation, ParameterValidationAbstractValue>
     {
         public ParameterValidationBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<ParameterValidationAnalysisData> blockAnalysisData)
-            : base (basicBlock)
+            : base(basicBlock, blockAnalysisData.Input, blockAnalysisData.Output)
         {
-            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<AbstractLocation, ParameterValidationAbstractValue>.Empty;
-            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<AbstractLocation, ParameterValidationAbstractValue>.Empty;
         }
-
-        public ImmutableDictionary<AbstractLocation, ParameterValidationAbstractValue> InputData { get; }
-        public ImmutableDictionary<AbstractLocation, ParameterValidationAbstractValue> OutputData { get; }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToBlockAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PointsToAnalysis/PointsToBlockAnalysisResult.cs
@@ -1,27 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 {
     /// <summary>
     /// Result from execution of <see cref="PointsToAnalysis"/> on a basic block.
     /// It stores the PointsTo value for each <see cref="AnalysisEntity"/> at the start and end of the basic block.
     /// </summary>
-    internal class PointsToBlockAnalysisResult : AbstractBlockAnalysisResult
+    internal class PointsToBlockAnalysisResult : AbstractBlockAnalysisResult<AnalysisEntity, PointsToAbstractValue>
     {
-        public PointsToBlockAnalysisResult(
-            BasicBlock basicBlock,
-            DataFlowAnalysisInfo<PointsToAnalysisData> blockAnalysisData)
-            : base (basicBlock)
+        public PointsToBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<PointsToAnalysisData> blockAnalysisData)
+            : base(basicBlock, blockAnalysisData.Input?.CoreAnalysisData, blockAnalysisData.Output?.CoreAnalysisData)
         {
-            InputData = blockAnalysisData.Input?.CoreAnalysisData.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, PointsToAbstractValue>.Empty;
-            OutputData = blockAnalysisData.Output?.CoreAnalysisData.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, PointsToAbstractValue>.Empty;
             IsReachable = blockAnalysisData.Input?.IsReachableBlockData ?? true;
         }
 
-        public ImmutableDictionary<AnalysisEntity, PointsToAbstractValue> InputData { get; }
-        public ImmutableDictionary<AnalysisEntity, PointsToAbstractValue> OutputData { get; }
         public bool IsReachable { get; }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetBlockAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetBlockAnalysisResult.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 
@@ -14,16 +11,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
     /// Result from execution of <see cref="PropertySetAnalysis"/> on a basic block.
     /// It stores BinaryFormatter values for each <see cref="AbstractLocation"/> at the start and end of the basic block.
     /// </summary>
-    internal class PropertySetBlockAnalysisResult : AbstractBlockAnalysisResult
+    internal class PropertySetBlockAnalysisResult : AbstractBlockAnalysisResult<AbstractLocation, PropertySetAbstractValue>
     {
         public PropertySetBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<PropertySetAnalysisData> blockAnalysisData)
-            : base(basicBlock)
+            : base(basicBlock, blockAnalysisData.Input, blockAnalysisData.Output)
         {
-            InputData = blockAnalysisData.Input?.ToImmutableDictionary() ?? ImmutableDictionary<AbstractLocation, PropertySetAbstractValue>.Empty;
-            OutputData = blockAnalysisData.Output?.ToImmutableDictionary() ?? ImmutableDictionary<AbstractLocation, PropertySetAbstractValue>.Empty;
         }
-
-        public ImmutableDictionary<AbstractLocation, PropertySetAbstractValue> InputData { get; }
-        public ImmutableDictionary<AbstractLocation, PropertySetAbstractValue> OutputData { get; }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataBlockAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataBlockAnalysisResult.cs
@@ -1,26 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
+
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {
-    using System.Collections.Immutable;
-    using Microsoft.CodeAnalysis.FlowAnalysis;
-    using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
-
     /// <summary>
     /// Result from execution of <see cref="TaintedDataAnalysis"/> on a basic block.
     /// </summary>
-    internal class TaintedDataBlockAnalysisResult : AbstractBlockAnalysisResult
+    internal class TaintedDataBlockAnalysisResult : AbstractBlockAnalysisResult<AnalysisEntity, TaintedDataAbstractValue>
     {
-        public ImmutableDictionary<AnalysisEntity, TaintedDataAbstractValue> InputData { get; }
-        public ImmutableDictionary<AnalysisEntity, TaintedDataAbstractValue> OutputData { get; }
-        public bool IsReachable { get; }
-
         public TaintedDataBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<TaintedDataAnalysisData> blockAnalysisData)
-            : base(basicBlock)
+            : base(basicBlock, blockAnalysisData.Input?.CoreAnalysisData, blockAnalysisData.Output?.CoreAnalysisData)
         {
-            InputData = blockAnalysisData.Input?.CoreAnalysisData.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, TaintedDataAbstractValue>.Empty;
-            OutputData = blockAnalysisData.Output?.CoreAnalysisData.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, TaintedDataAbstractValue>.Empty;
             IsReachable = blockAnalysisData.Input?.IsReachableBlockData ?? true;
         }
+
+        public bool IsReachable { get; }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentBlockAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentBlockAnalysisResult.cs
@@ -1,26 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
 {
     /// <summary>
     /// Result from execution of <see cref="ValueContentAnalysis"/> on a basic block.
     /// It stores data values for each <see cref="AnalysisEntity"/> at the start and end of the basic block.
     /// </summary>
-    internal class ValueContentBlockAnalysisResult : AbstractBlockAnalysisResult
+    internal class ValueContentBlockAnalysisResult : AbstractBlockAnalysisResult<AnalysisEntity, ValueContentAbstractValue>
     {
         public ValueContentBlockAnalysisResult(BasicBlock basicBlock, DataFlowAnalysisInfo<ValueContentAnalysisData> blockAnalysisData)
-            : base(basicBlock)
+            : base(basicBlock, blockAnalysisData.Input?.CoreAnalysisData, blockAnalysisData.Output?.CoreAnalysisData)
         {
-            InputData = blockAnalysisData.Input?.CoreAnalysisData.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, ValueContentAbstractValue>.Empty;
-            OutputData = blockAnalysisData.Output?.CoreAnalysisData.ToImmutableDictionary() ?? ImmutableDictionary<AnalysisEntity, ValueContentAbstractValue>.Empty;
             IsReachable = blockAnalysisData.Input?.IsReachableBlockData ?? true;
         }
 
-        public ImmutableDictionary<AnalysisEntity, ValueContentAbstractValue> InputData { get; }
-
-        public ImmutableDictionary<AnalysisEntity, ValueContentAbstractValue> OutputData { get; }
         public bool IsReachable { get; }
     }
 }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractBlockAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractBlockAnalysisResult.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
     /// <summary>
     /// Result from execution of a <see cref="DataFlowAnalysis"/> on a basic block.
     /// </summary>
-    internal abstract class AbstractBlockAnalysisResult
+    internal abstract class AbstractBlockAnalysisResult : IDisposable
     {
         protected AbstractBlockAnalysisResult(BasicBlock basicBlock)
         {
@@ -13,5 +15,27 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         }
 
         public BasicBlock BasicBlock { get; }
+
+        #region IDisposable Support
+        public bool IsDisposed { get; private set; }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+        }
+
+#pragma warning disable CA1063 // Implement IDisposable Correctly - We want to ensure that we cleanup managed resources even when object was not explicitly disposed.
+        ~AbstractBlockAnalysisResult()
+#pragma warning restore CA1063 // Implement IDisposable Correctly
+        {
+            Dispose(true);  // We want to explicitly cleanup managed resources, so pass 'true'
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
     }
 }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractBlockAnalysisResult`2.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AbstractBlockAnalysisResult`2.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
+{
+    /// <summary>
+    /// Result from execution of a <see cref="DataFlowAnalysis"/> on a basic block.
+    /// </summary>
+    internal abstract class AbstractBlockAnalysisResult<TKey, TValue> : AbstractBlockAnalysisResult
+    {
+        private readonly DictionaryAnalysisData<TKey, TValue> _inputDataOpt;
+        private readonly DictionaryAnalysisData<TKey, TValue> _outputDataOpt;
+
+        protected AbstractBlockAnalysisResult(
+            BasicBlock basicBlock,
+            DictionaryAnalysisData<TKey, TValue> inputDataOpt,
+            DictionaryAnalysisData<TKey, TValue> outputDataOpt)
+            : base (basicBlock)
+        {
+            _inputDataOpt = inputDataOpt != null ? new DictionaryAnalysisData<TKey, TValue>(inputDataOpt) : null;
+            _outputDataOpt = outputDataOpt != null ? new DictionaryAnalysisData<TKey, TValue>(outputDataOpt) : null;
+        }
+
+        public IDictionary<TKey, TValue> InputData => _inputDataOpt ?? (IDictionary<TKey, TValue>)ImmutableDictionary<TKey, TValue>.Empty;
+        public IDictionary<TKey, TValue> OutputData => _outputDataOpt ?? (IDictionary<TKey, TValue>)ImmutableDictionary<TKey, TValue>.Empty;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _inputDataOpt?.Dispose();
+                _outputDataOpt?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
@@ -20,12 +18,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public DictionaryAnalysisData(IDictionary<TKey, TValue> initializer)
         {
             _coreAnalysisData = PooledDictionary<TKey, TValue>.GetInstance(initializer);
-        }
-
-        public ImmutableDictionary<TKey, TValue> ToImmutableDictionary()
-        {
-            Debug.Assert(!IsDisposed);
-            return _coreAnalysisData.ToImmutableDictionary();
         }
 
         public TValue this[TKey key]


### PR DESCRIPTION
Make AbstractBlockAnalysisResult disposable and switch to using cloned pooled dictionary instead of immutable dictionary. There will be a follow up change to even make DataflowAnalysisResult disposable(which is for the whole CFG).

This reduces large number of immutable dictionary allocations seen during profiling.