### PR TITLE
Remove a perf optimization in core DataFlow analysis walker that was …

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
@@ -893,6 +893,24 @@ class Test
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
+        [Fact]
+        public void IntegralValueCompare_ForLoop_02()
+        {
+            VerifyCSharp(@"
+class Test
+{
+    void M(int param, string param2, string param3)
+    {
+        for (int i = 0; i < param; i++)
+        {
+            var x = i == 0 ? param2 : param3;
+        }
+    }
+}
+");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
         public void StringCompare_CopyAnalysis()

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -1957,9 +1957,7 @@ class Test
 }
 ",
             // Test0.cs(16,20): warning CA2000: In method 'void Test.M1(A a)', call System.IDisposable.Dispose on object created by 'new A()' before all references to it are out of scope.
-            GetCSharpResultAt(16, 20, "void Test.M1(A a)", "new A()"),
-            // Test0.cs(20,20): warning CA2000: In method 'void Test.M1(A a)', call System.IDisposable.Dispose on object created by 'new A()' before all references to it are out of scope.
-            GetCSharpResultAt(20, 20, "void Test.M1(A a)", "new A()"));
+            GetCSharpResultAt(16, 20, "void Test.M1(A a)", "new A()"));
 
             VerifyBasic(@"
 Imports System
@@ -1982,9 +1980,7 @@ Class Test
     End Sub
 End Class",
             // Test0.vb(13,28): warning CA2000: In method 'Sub Test.M1(a As A)', call System.IDisposable.Dispose on object created by 'New A()' before all references to it are out of scope.
-            GetBasicResultAt(13, 28, "Sub Test.M1(a As A)", "New A()"),
-            // Test0.vb(17,28): warning CA2000: In method 'Sub Test.M1(a As A)', call System.IDisposable.Dispose on object created by 'New A()' before all references to it are out of scope.
-            GetBasicResultAt(17, 28, "Sub Test.M1(a As A)", "New A()"));
+            GetBasicResultAt(13, 28, "Sub Test.M1(a As A)", "New A()"));
         }
 
         [Fact]

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -104,12 +104,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                     var block = cfg.Blocks[blockOrdinal];
 
-                    // Optimization: We process the block only if all its predecessor blocks have been processed once.
-                    if (HasUnprocessedPredecessorBlock(block))
-                    {
-                        continue;
-                    }
-
                     var needsAtLeastOnePass = pendingBlocksNeedingAtLeastOnePass.Remove(blockOrdinal);
                     var isUnreachableBlock = unreachableBlocks.Contains(block.Ordinal);
 


### PR DESCRIPTION
…done prior to us using a SortedList for the worklist. This was causing us to incorrectly mark certain blocks within a loop as unreachable.