### PR TITLE
Performance improvements for context-sensitive interprocedural analysis

### DIFF
--- a/src/Utilities/Extensions/PooledHashSetExtensions.cs
+++ b/src/Utilities/Extensions/PooledHashSetExtensions.cs
@@ -11,6 +11,14 @@ namespace Analyzer.Utilities.Extensions
 {
     internal static class PooledHashSetExtensions
     {
+        public static void AddRange<T>(this PooledHashSet<T> builder, IEnumerable<T> set2)
+        {
+            foreach (var item in set2)
+            {
+                builder.Add(item);
+            }
+        }
+
         // Just to make hardcoding SinkInfos more convenient.
         public static void AddSinkInfo(
             this PooledHashSet<SinkInfo> builder,

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
             return new CopyAbstractValue(AnalysisEntities.Remove(entityToRemove));
         }
 
-        public CopyAbstractValue WithEntitiesRemoved(ImmutableHashSet<AnalysisEntity> entitiesToRemove)
+        public CopyAbstractValue WithEntitiesRemoved(IEnumerable<AnalysisEntity> entitiesToRemove)
         {
             Debug.Assert(entitiesToRemove.All(entityToRemove => AnalysisEntities.Contains(entityToRemove)));
             Debug.Assert(AnalysisEntities.Count > 1);

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
@@ -65,18 +65,24 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
             protected override bool HasAnyAbstractValue(CopyAnalysisData data) => data.HasAnyAbstractValue;
 
             protected override void StopTrackingEntity(AnalysisEntity analysisEntity)
+                => StopTrackingEntity(analysisEntity, CurrentAnalysisData, GetDefaultCopyValue);
+
+            private static void StopTrackingEntity(
+                AnalysisEntity analysisEntity,
+                CopyAnalysisData analysisData,
+                Func<AnalysisEntity, CopyAbstractValue> getDefaultCopyValue)
             {
-                AssertValidCopyAnalysisData(CurrentAnalysisData);
+                analysisData.AssertValidCopyAnalysisData(getDefaultCopyValue);
 
                 // First set the value to unknown so we remove the entity from existing copy sets.
                 // Note that we pass 'tryGetAddressSharedCopyValue = null' to ensure that
                 // we do not reset the entries for address shared entities.
-                SetAbstractValue(CurrentAnalysisData, analysisEntity, CopyAbstractValue.Unknown, tryGetAddressSharedCopyValue: _ => null);
-                CurrentAnalysisData.AssertValidCopyAnalysisData(tryGetDefaultCopyValueOpt: null);
+                SetAbstractValue(analysisData, analysisEntity, CopyAbstractValue.Unknown, tryGetAddressSharedCopyValue: _ => null);
+                analysisData.AssertValidCopyAnalysisData(tryGetDefaultCopyValueOpt: null);
 
                 // Now it should be safe to remove the entry.
-                CurrentAnalysisData.RemoveEntries(analysisEntity);
-                AssertValidCopyAnalysisData(CurrentAnalysisData);
+                analysisData.RemoveEntries(analysisEntity);
+                analysisData.AssertValidCopyAnalysisData(getDefaultCopyValue);
             }
 
             protected override CopyAbstractValue GetAbstractValue(AnalysisEntity analysisEntity) => CurrentAnalysisData.TryGetValue(analysisEntity, out var value) ? value : CopyAbstractValue.Unknown;
@@ -328,6 +334,110 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                 => new CopyAnalysisData(analysisResult[block].OutputData);
             protected override bool Equals(CopyAnalysisData value1, CopyAnalysisData value2)
                 => value1.Equals(value2);
+
+            public override (CopyAbstractValue Value, PredicateValueKind PredicateValueKind)? GetReturnValueAndPredicateKind()
+            {
+                // Filter out all the local symbol and flow capture entities from the return value.
+                var returnValueAndPredicateKindOpt = base.GetReturnValueAndPredicateKind();
+                if (returnValueAndPredicateKindOpt.HasValue &&
+                    returnValueAndPredicateKindOpt.Value.Value.Kind == CopyAbstractValueKind.Known)
+                {
+                    var entitiesToFilterBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
+
+                    try
+                    {
+                        var copyValue = returnValueAndPredicateKindOpt.Value.Value;
+                        var copyValueEntities = copyValue.AnalysisEntities;
+                        foreach (var entity in copyValueEntities)
+                        {
+                            if (ShouldRemoveEntityAtExit(entity))
+                            {
+                                ProcessEntityToRemoveAtExit(entity, entitiesToFilterBuilder, copyValueEntities);
+                            }
+                        }
+
+                        if (entitiesToFilterBuilder.Count > 0)
+                        {
+                            copyValue = entitiesToFilterBuilder.Count == copyValueEntities.Count ?
+                                CopyAbstractValue.Unknown :
+                                copyValue.WithEntitiesRemoved(entitiesToFilterBuilder);
+                        }
+
+                        return (copyValue, returnValueAndPredicateKindOpt.Value.PredicateValueKind);
+                    }
+                    finally
+                    {
+                        entitiesToFilterBuilder.Free();
+                    }
+                }
+
+                return returnValueAndPredicateKindOpt;
+            }
+
+            private bool ShouldRemoveEntityAtExit(AnalysisEntity entity)
+            {
+                return entity.SymbolOpt?.Kind == SymbolKind.Local &&
+                    entity.SymbolOpt.ContainingSymbol.Equals(DataFlowAnalysisContext.OwningSymbol) ||
+                    entity.CaptureIdOpt.HasValue &&
+                    entity.CaptureIdOpt.Value.ControlFlowGraph == DataFlowAnalysisContext.ControlFlowGraph;
+            }
+
+            private void ProcessEntityToRemoveAtExit(
+                AnalysisEntity entity,
+                PooledHashSet<AnalysisEntity> entitiesToFilterBuilder,
+                IEnumerable<AnalysisEntity> allAnalysisEntities)
+            {
+                Debug.Assert(ShouldRemoveEntityAtExit(entity));
+
+                // Stop tracking entity that is now out of scope.
+                entitiesToFilterBuilder.Add(entity);
+                
+                // Additionally, stop tracking all the child entities if the entity type has value copy semantics.
+                if (entity.Type.HasValueCopySemantics())
+                {
+                    var childEntities = allAnalysisEntities.Where(e => IsChildAnalysisEntity(e, ancestorEntity: entity));
+                    entitiesToFilterBuilder.AddRange(childEntities);
+                }
+            }
+
+
+            public override CopyAnalysisData GetMergedDataForUnhandledThrowOperations()
+            {
+                var copyAnalysisData = base.GetMergedDataForUnhandledThrowOperations();
+                if (copyAnalysisData == null)
+                {
+                    return null;
+                }
+
+                // Filter out all the local symbol and flow capture entities from the returned analysis data.
+                var entitiesToFilterBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
+
+                try
+                {
+                    var allAnalysisEntities = copyAnalysisData.CoreAnalysisData.Keys;
+                    foreach (var entity in allAnalysisEntities)
+                    {
+                        if (ShouldRemoveEntityAtExit(entity))
+                        {
+                            ProcessEntityToRemoveAtExit(entity, entitiesToFilterBuilder, allAnalysisEntities);
+                        }
+                    }
+
+                    foreach (var entity in entitiesToFilterBuilder)
+                    {
+                        StopTrackingEntity(entity, copyAnalysisData, GetDefaultCopyValue);
+                    }
+                }
+                finally
+                {
+                    entitiesToFilterBuilder.Free();
+                }
+
+                return copyAnalysisData;
+            }
+
+            #region Interprocedural analysis
+
             protected override void ApplyInterproceduralAnalysisResultCore(CopyAnalysisData resultData)
             {
                 var processedEntities = PooledHashSet<AnalysisEntity>.GetInstance();
@@ -397,6 +507,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                 AssertValidCopyAnalysisData(initialAnalysisData);
                 return initialAnalysisData;
             }
+
+            #endregion
 
             #region Visitor overrides
             public override CopyAbstractValue DefaultVisit(IOperation operation, object argument)

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
 {
-    using System.Collections.Generic;
-    using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
     using CopyAnalysisDomain = PredicatedAnalysisDataDomain<CopyAnalysisData, CopyAbstractValue>;
     using CopyAnalysisResult = DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue>;
 
@@ -399,7 +399,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                     entitiesToFilterBuilder.AddRange(childEntities);
                 }
             }
-
 
             public override CopyAnalysisData GetMergedDataForUnhandledThrowOperations()
             {

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
@@ -55,14 +55,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
         /// We do not support the <see cref="SetAbstractValue(AnalysisEntity, CopyAbstractValue)"/> overload
         /// that updates copy value for each individual entity.
         /// </summary>
-        public void SetAbstactValueForEntities(CopyAbstractValue copyValue, AnalysisEntity entityBeingAssigned)
+        public void SetAbstactValueForEntities(CopyAbstractValue copyValue, AnalysisEntity entityBeingAssignedOpt)
         {
             foreach (var entity in copyValue.AnalysisEntities)
             {
                 // If we have any predicate data based on the previous value of this entity,
                 // and we are changing the copy value for an assigment (i.e. entity == entityBeingAssigned),
                 // we need to drop all the predicate data based on this entity.
-                if (entity == entityBeingAssigned && HasPredicatedDataForEntity(entity))
+                if (entity == entityBeingAssignedOpt && HasPredicatedDataForEntity(entity))
                 {
                     StopTrackingPredicatedData(entity);
                 }

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -44,7 +44,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 return builder.ToImmutableArray();
             }
 
-            protected override void AddTrackedEntities(PooledHashSet<AnalysisEntity> builder)
+            protected override void AddTrackedEntities(PooledHashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
                 => CurrentAnalysisData.AddTrackedEntities(builder);
 
             protected override bool Equals(TaintedDataAnalysisData value1, TaintedDataAnalysisData value2)
@@ -104,9 +104,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 {
                     // Only track tainted data, or sanitized data.
                     // If it's new, and it's untainted, we don't care.
-                    this.CurrentAnalysisData.SetAbstractValue(analysisEntity, value);
+                    SetAbstractValueCore(CurrentAnalysisData, analysisEntity, value);
                 }
             }
+
+            private static void SetAbstractValueCore(TaintedDataAnalysisData taintedAnalysisData, AnalysisEntity analysisEntity, TaintedDataAbstractValue value)
+                => taintedAnalysisData.SetAbstractValue(analysisEntity, value);
 
             protected override void StopTrackingEntity(AnalysisEntity analysisEntity)
             {
@@ -503,6 +506,13 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                              || a.Parameter.RefKind == RefKind.Ref
                              || a.Parameter.RefKind == RefKind.In));
             }
+
+            protected override void ApplyInterproceduralAnalysisResultCore(TaintedDataAnalysisData resultData)
+                => ApplyInterproceduralAnalysisResultHelper(resultData.CoreAnalysisData);
+
+            protected override TaintedDataAnalysisData GetTrimmedCurrentAnalysisData(IEnumerable<AnalysisEntity> withEntities)
+                => GetTrimmedCurrentAnalysisDataHelper(withEntities, CurrentAnalysisData.CoreAnalysisData, SetAbstractValueCore);
+
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
@@ -22,10 +23,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
             {
             }
 
-            protected override void AddTrackedEntities(PooledHashSet<AnalysisEntity> builder)
+            protected override void AddTrackedEntities(PooledHashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
                 => CurrentAnalysisData.AddTrackedEntities(builder);
 
-            protected override void SetAbstractValue(AnalysisEntity analysisEntity, ValueContentAbstractValue value) => SetAbstractValue(CurrentAnalysisData, analysisEntity, value);
+            protected override void SetAbstractValue(AnalysisEntity analysisEntity, ValueContentAbstractValue value)
+                => SetAbstractValue(CurrentAnalysisData, analysisEntity, value);
 
             private static void SetAbstractValue(ValueContentAnalysisData analysisData, AnalysisEntity analysisEntity, ValueContentAbstractValue value)
             {
@@ -132,6 +134,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
                 => new ValueContentAnalysisData(analysisResult[block].OutputData);
             protected override bool Equals(ValueContentAnalysisData value1, ValueContentAnalysisData value2)
                 => value1.Equals(value2);
+            protected override void ApplyInterproceduralAnalysisResultCore(ValueContentAnalysisData resultData)
+                => ApplyInterproceduralAnalysisResultHelper(resultData.CoreAnalysisData);
+            protected override ValueContentAnalysisData GetTrimmedCurrentAnalysisData(IEnumerable<AnalysisEntity> withEntities)
+                => GetTrimmedCurrentAnalysisDataHelper(withEntities, CurrentAnalysisData.CoreAnalysisData, SetAbstractValue);
 
             #region Visitor methods
             public override ValueContentAbstractValue DefaultVisit(IOperation operation, object argument)

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -177,7 +177,22 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public AnalysisEntity ParentOpt { get; }
         public bool IsThisOrMeInstance { get; }
 
-        public bool HasUnknownInstanceLocation => InstanceLocation.Kind == PointsToAbstractValueKind.Unknown;
+        public bool HasUnknownInstanceLocation
+        {
+            get
+            {
+                switch (InstanceLocation.Kind)
+                {
+                    case PointsToAbstractValueKind.Unknown:
+                    case PointsToAbstractValueKind.UnknownNull:
+                    case PointsToAbstractValueKind.UnknownNotNull:
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
+        }
 
         public bool IsLValueFlowCaptureEntity => CaptureIdOpt.HasValue && CaptureIdOpt.Value.IsLValueFlowCapture;
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -393,20 +393,21 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                 if (invocationInstanceOpt.HasValue)
                 {
-                    AddWorklistEntityValue(invocationInstanceOpt.Value.InstanceOpt);
+                    AddWorklistEntityAndPointsToValue(invocationInstanceOpt.Value.InstanceOpt);
                     AddWorklistPointsToValue(invocationInstanceOpt.Value.PointsToValue);
                 }
 
                 if (thisOrMeInstanceForCallerOpt.HasValue)
                 {
-                    AddWorklistEntityValue(thisOrMeInstanceForCallerOpt.Value.Instance);
+                    AddWorklistEntityAndPointsToValue(thisOrMeInstanceForCallerOpt.Value.Instance);
                     AddWorklistPointsToValue(thisOrMeInstanceForCallerOpt.Value.PointsToValue);
                 }
 
                 foreach (var argument in argumentValues)
                 {
-                    if (!AddWorklistEntityValue(argument.AnalysisEntityOpt))
+                    if (!AddWorklistEntityAndPointsToValue(argument.AnalysisEntityOpt))
                     {
+                        // For allocations passed as arguments.
                         AddWorklistPointsToValue(argument.InstanceLocation);
                     }
                 }
@@ -453,11 +454,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                     foreach (var childEntity in childWorklistEntities)
                     {
-                        AddWorklistEntityValue(childEntity);
-                        if (pointsToValuesOpt.TryGetValue(childEntity, out var pointsToValue))
-                        {
-                            AddWorklistPointsToValue(pointsToValue);
-                        }
+                        AddWorklistEntityAndPointsToValue(childEntity);
                     }
 
                     childWorklistEntities.Clear();
@@ -481,11 +478,17 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
 
             // Local functions.
-            bool AddWorklistEntityValue(AnalysisEntity analysisEntityOpt)
+            bool AddWorklistEntityAndPointsToValue(AnalysisEntity analysisEntityOpt)
             {
                 if (analysisEntityOpt != null && allTrackedEntitiesBuilder.Contains(analysisEntityOpt))
                 {
                     worklistEntities.Add(analysisEntityOpt);
+
+                    if (pointsToValuesOpt.TryGetValue(analysisEntityOpt, out var pointsToValue))
+                    {
+                        AddWorklistPointsToValue(pointsToValue);
+                    }
+
                     return true;
                 }
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -326,6 +326,18 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         protected abstract void StopTrackingDataForParameter(IParameterSymbol parameter, AnalysisEntity analysisEntity);
 
+        protected virtual void StopTrackingDataForParameters(ImmutableDictionary<IParameterSymbol, AnalysisEntity> parameterEntities)
+        {
+            foreach (var kvp in parameterEntities)
+            {
+                IParameterSymbol parameter = kvp.Key;
+                AnalysisEntity analysisEntity = kvp.Value;
+
+                // Stop tracking parameter values on exit.
+                StopTrackingDataForParameter(parameter, analysisEntity);
+            }
+        }
+
         private void OnStartEntryBlockAnalysis(BasicBlock entryBlock)
         {
             Debug.Assert(entryBlock.Kind == BasicBlockKind.Entry);
@@ -388,15 +400,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             {
                 // Reset address shared entities to caller's address shared entities.
                 _addressSharedEntitiesProvider.SetAddressSharedEntities(DataFlowAnalysisContext.InterproceduralAnalysisDataOpt?.AddressSharedEntities);
-
-                foreach (var kvp in _lazyParameterEntities)
-                {
-                    IParameterSymbol parameter = kvp.Key;
-                    AnalysisEntity analysisEntity = kvp.Value;
-
-                    // Stop tracking parameter values on exit.
-                    StopTrackingDataForParameter(parameter, analysisEntity);
-                }
+                StopTrackingDataForParameters(_lazyParameterEntities);
             }
         }
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -1439,6 +1439,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         #region Interprocedural analysis
 
+        /// <summary>
+        /// Gets a new instance of analysis data that should be passed as initial analysis data
+        /// for interprocedural analysis.
+        /// The default implementation returns cloned <see cref="CurrentAnalysisData"/>.
+        /// </summary>
         protected virtual TAnalysisData GetInitialInterproceduralAnalysisData(
             IMethodSymbol invokedMethod,
             (AnalysisEntity InstanceOpt, PointsToAbstractValue PointsToValue)? invocationInstanceOpt,
@@ -1449,6 +1454,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             bool isLambdaOrLocalFunction)
             => GetClonedCurrentAnalysisData();
 
+        /// <summary>
+        /// Apply the result data from interprocedural analysis to <see cref="CurrentAnalysisData"/>.
+        /// Default implementation is designed for the default implementation of
+        /// <see cref="GetInitialInterproceduralAnalysisData(IMethodSymbol, (AnalysisEntity InstanceOpt, PointsToAbstractValue PointsToValue)?, (AnalysisEntity Instance, PointsToAbstractValue PointsToValue)?, ImmutableArray{ArgumentInfo{TAbstractAnalysisValue}}, IDictionary{AnalysisEntity, PointsToAbstractValue}, IDictionary{AnalysisEntity, CopyAbstractValue}, bool)"/>
+        /// and overwrites the <see cref="CurrentAnalysisData"/> with the given <paramref name="resultData"/>.
+        /// </summary>
         protected virtual void ApplyInterproceduralAnalysisResult(TAnalysisData resultData, bool isLambdaOrLocalFunction)
             => CurrentAnalysisData = resultData;
 

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         protected CopyAbstractValue TryGetAddressSharedCopyValue(AnalysisEntity analysisEntity)
             => _addressSharedEntitiesProvider.TryGetAddressSharedCopyValue(analysisEntity);
 
-        public (TAbstractAnalysisValue, PredicateValueKind)? GetReturnValueAndPredicateKind()
+        public virtual (TAbstractAnalysisValue Value, PredicateValueKind PredicateValueKind)? GetReturnValueAndPredicateKind()
         {
             if (_returnValueOperationsOpt == null ||
                 _returnValueOperationsOpt.Count == 0)
@@ -243,6 +243,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
             return (mergedValue, mergedPredicateValueKind ?? PredicateValueKind.Unknown);
         }
+
         private static PointsToAbstractValue GetThisOrMeInstancePointsToValue(ISymbol owningSymbol)
         {
             if (!owningSymbol.IsStatic &&
@@ -590,7 +591,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         public ImmutableDictionary<IOperation, PredicateValueKind> GetPredicateValueKindMap() => _predicateValueKindCacheBuilder.ToImmutable();
 
-        public TAnalysisData GetMergedDataForUnhandledThrowOperations()
+        public virtual TAnalysisData GetMergedDataForUnhandledThrowOperations()
         {
             if (AnalysisDataForUnhandledThrowOperations == null)
             {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         }
 
         public TAnalysisData InitialAnalysisData { get; }
-        public (AnalysisEntity Instance, PointsToAbstractValue PointsToValue)? InvocationInstanceOpt { get; }
+        public (AnalysisEntity InstanceOpt, PointsToAbstractValue PointsToValue)? InvocationInstanceOpt { get; }
         public (AnalysisEntity Instance, PointsToAbstractValue PointsToValue)? ThisOrMeInstanceForCallerOpt { get; }
         public ImmutableArray<ArgumentInfo<TAbstractAnalysisValue>> Arguments { get; }
         public ImmutableDictionary<ISymbol, PointsToAbstractValue> CapturedVariablesMap { get; }
@@ -84,12 +84,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         }
 
         private static void AddHashCodeParts(
-            (AnalysisEntity Instance, PointsToAbstractValue PointsToValue)? instanceAndPointsToValueOpt,
+            (AnalysisEntity InstanceOpt, PointsToAbstractValue PointsToValue)? instanceAndPointsToValueOpt,
             ArrayBuilder<int> builder)
         {
             if (instanceAndPointsToValueOpt.HasValue)
             {
-                builder.Add(instanceAndPointsToValueOpt.Value.Instance.GetHashCode());
+                builder.Add(instanceAndPointsToValueOpt.Value.InstanceOpt.GetHashCodeOrDefault());
                 builder.Add(instanceAndPointsToValueOpt.Value.PointsToValue.GetHashCode());
             }
             else


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/1811

1. Filter the key-value pairs passed to interprocedural analysis to improve its performance:
https://github.com/dotnet/roslyn-analyzers/commit/bfe11f22610ef3ad82a003cff0446f0cba384f71 is the core commit, and significantly improves the performance for interprocedural analysis

2. https://github.com/dotnet/roslyn-analyzers/commit/aad10b5eececd6d28d8d4d83b5e248c2e4925fcb also does some more minor perf optimizations found from traces