### PR TITLE
Add .editorconfig based configuration support for analyzers

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -2,7 +2,7 @@
 
 Starting with version `2.6.3`, all the analyzer NuGet packages produced in this repo, including the FxCop Analyzers NuGet package, support _.editorconfig based analyzer configuration_. End users can configure the behavior of specific CA rule(s) OR all configurable CA rules by specifying supported key-value pair options in an `.editorconfig` file. You can read more about `.editorconfig` format [here](https://editorconfig.org/).
 
-## .editorconfig format:
+## .editorconfig format
 Analyzer configuration options from an .editorconfig file are parsed into _general_ and _specific_ configuration options. General configuration enables configuring the behavior of all CA rules for which the provided option is valid. Specific configuration enables configuring each CA rule ID or CA rules belonging to each rule category, such as 'Naming', 'Design', 'Performance', etc. Our options are _case-insensitive_. Below are the supported formats:
    1. General configuration option:
       1. `dotnet_code_quality.OptionName = OptionValue`
@@ -17,7 +17,10 @@ For example, end users can configure the analyzed API surface for analyzers usin
       1. `dotnet_code_quality.CA1040.api_surface = public`
       2. `dotnet_code_quality.Naming.api_surface = public`
 
-## Supported .editorconfig options:
+## Enabling .editorconfig based configuration for a project
+End users can enable .editorconfig based configuration for individual projects by just copying the .editorconfig file with the options to the project root directory. In future, we plan to support hierarchical directory based configuration with an .editorconfig file at the solution directory, repo root directory or even individual document directories.
+
+## Supported .editorconfig options
 This section documents the list of supported .editorconfig key-value options for CA rules.
 
 ### Analyzed API surface

--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -1,0 +1,33 @@
+# Analyzer Configuration
+
+Starting with version `2.6.3`, all the analyzer NuGet packages produced in this repo, including the FxCop Analyzers NuGet package, support _.editorconfig based analyzer configuration_. End users can configure the behavior of specific CA rule(s) OR all configurable CA rules by specifying supported key-value pair options in an `.editorconfig` file. You can read more about `.editorconfig` format [here](https://editorconfig.org/).
+
+## .editorconfig format:
+Analyzer configuration options from an .editorconfig file are parsed into _general_ and _specific_ configuration options. General configuration enables configuring the behavior of all CA rules for which the provided option is valid. Specific configuration enables configuring each CA rule ID or CA rules belonging to each rule category, such as 'Naming', 'Design', 'Performance', etc. Our options are _case-insensitive_. Below are the supported formats:
+   1. General configuration option:
+      1. `dotnet_code_quality.OptionName = OptionValue`
+   2. Specific configuration option:
+      1. `dotnet_code_quality.RuleId.OptionName = OptionValue`
+      2. `dotnet_code_quality.RuleCategory.OptionName = OptionValue`
+
+For example, end users can configure the analyzed API surface for analyzers using the below `api_surface` option specification:
+   1. General configuration option:
+      1. `dotnet_code_quality.api_surface = public`
+   2. Specific configuration option:
+      1. `dotnet_code_quality.CA1040.api_surface = public`
+      2. `dotnet_code_quality.Naming.api_surface = public`
+
+## Supported .editorconfig options:
+This section documents the list of supported .editorconfig key-value options for CA rules.
+
+### Analyzed API surface
+Option Name:  `api_surface`
+Option Values:
+| Option Value | Summary |
+| --- | --- |
+| `public` | Analyzes public APIs that are externally visible outside the assembly. |
+| `internal` | Analyzes internal APIs that are visible within the assembly and to assemblies with [InternalsVisibleToAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute) access. |
+| `private` | Analyzes private APIs that are only visible within the containing type. |
+| `all` | Analyzes all APIs, regardless of the symbol visibility. |
+
+Users can also provide a comma separated list of above option values. For example, `private, internal` configures analysis of the entire non-public API surface.

--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -18,7 +18,17 @@ For example, end users can configure the analyzed API surface for analyzers usin
       2. `dotnet_code_quality.Naming.api_surface = public`
 
 ## Enabling .editorconfig based configuration for a project
-End users can enable .editorconfig based configuration for individual projects by just copying the .editorconfig file with the options to the project root directory. In future, we plan to support hierarchical directory based configuration with an .editorconfig file at the solution directory, repo root directory or even individual document directories.
+1. Per-project .editorconfig file: End users can enable .editorconfig based configuration for individual projects by just copying the .editorconfig file with the options to the project root directory. In future, we plan to support hierarchical directory based configuration with an .editorconfig file at the solution directory, repo root directory or even individual document directories.
+2. Shared .editorconfig file: If you would like to share a common .editorconfig file between projects, say `<%PathToSharedEditorConfig%>\.editorconfig`, then you should add the following MSBuild property group and item group to a shared props file that is imported _before_ the FxCop analyzer props files (that come from the FxCop analyzer NuGet package reference):
+```
+  <PropertyGroup>
+    <SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
+  </PropertyGroup>
+  <ItemGroup Condition="Exists('<%PathToSharedEditorConfig%>\.editorconfig')" >
+    <AdditionalFiles Include="<%PathToSharedEditorConfig%>\.editorconfig" />
+  </ItemGroup>
+```
+Note that this is a temporary workaround that is needed until the dotnet compilers and project system start understanding and respecting .editorconfig files.
 
 ## Supported .editorconfig options
 This section documents the list of supported .editorconfig key-value options for CA rules.

--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -39,7 +39,7 @@ Option Values:
 | Option Value | Summary |
 | --- | --- |
 | `public` | Analyzes public APIs that are externally visible outside the assembly. |
-| `internal` | Analyzes internal APIs that are visible within the assembly and to assemblies with [InternalsVisibleToAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute) access. |
+| `internal` or `friend` | Analyzes internal APIs that are visible within the assembly and to assemblies with [InternalsVisibleToAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute) access. |
 | `private` | Analyzes private APIs that are only visible within the containing type. |
 | `all` | Analyzes all APIs, regardless of the symbol visibility. |
 

--- a/src/GenerateAnalyzerRulesets/Program.cs
+++ b/src/GenerateAnalyzerRulesets/Program.cs
@@ -256,7 +256,7 @@ namespace GenerateAnalyzerRulesets
 
                 var fileContents =
 $@"<Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  {getCodeAnalysisTreatWarningsNotAsErrors()}{getRulesetOverrides()}
+  {getEditorConfigAsAdditionalFile()}{getCodeAnalysisTreatWarningsNotAsErrors()}{getRulesetOverrides()}
 </Project>";
                 var directory = Directory.CreateDirectory(propsFileDir);
                 var fileWithPath = Path.Combine(directory.FullName, propsFileName);
@@ -319,6 +319,19 @@ $@"<Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/develo
                 }
 
                 return string.Empty;
+            }
+
+            string getEditorConfigAsAdditionalFile()
+            {
+                return $@"
+  <!-- 
+    This item group adds any .editorconfig file present at the project root directory
+    as an additional file.
+  -->  
+  <ItemGroup Condition=""'$(SkipDefaultEditorConfigAsAdditionalFile)' != 'true' And Exists('$(MSBuildProjectDirectory)\.editorconfig')"" >
+    <AdditionalFiles Include=""$(MSBuildProjectDirectory)\.editorconfig"" />
+  </ItemGroup>
+";
             }
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructors.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructors.cs
@@ -43,7 +43,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static void AnalyzeSymbol(SymbolAnalysisContext context)
         {
             var symbol = context.Symbol as INamedTypeSymbol;
-            if (symbol.IsAbstract && symbol.IsExternallyVisible())
+            if (symbol.IsAbstract &&
+                symbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
             {
                 bool hasAnyPublicConstructors =
                     symbol.InstanceConstructors.Any(

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AvoidEmptyInterfaces.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AvoidEmptyInterfaces.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             var symbol = (INamedTypeSymbol)context.Symbol;
 
             if (symbol.TypeKind == TypeKind.Interface &&
-                symbol.IsExternallyVisible() &&
+                symbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken) &&
                 symbol.GetMembers().IsEmpty &&
                 !symbol.AllInterfaces.SelectMany(s => s.GetMembers()).Any())
             {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionsShouldImplementGenericInterface.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionsShouldImplementGenericInterface.cs
@@ -92,12 +92,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
 
-            // FxCop compat: only fire on externally visible types.
-            if (!namedTypeSymbol.IsExternallyVisible())
+            // FxCop compat: only fire on externally visible types by default.
+            if (!namedTypeSymbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
             {
                 return;
             }
-
 
             var allInterfacesStatus = default(CollectionsInterfaceStatus);
             foreach (var @interface in namedTypeSymbol.AllInterfaces)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypes.cs
@@ -40,12 +40,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.RegisterSymbolAction(
                 symbolAnalysisContext =>
                 {
-                    // Fxcop compat: fire only on public static members within externally visible generic types.
+                    // Fxcop compat: fire only on public static members within externally visible generic types by default.
                     ISymbol symbol = symbolAnalysisContext.Symbol;
                     if (!symbol.IsStatic ||
                         symbol.DeclaredAccessibility != Accessibility.Public ||
                         !symbol.ContainingType.IsGenericType ||
-                        !symbol.ContainingType.IsExternallyVisible())
+                        !symbol.ContainingType.MatchesConfiguredVisibility(symbolAnalysisContext.Options, Rule, symbolAnalysisContext.CancellationToken))
                     {
                         return;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
@@ -38,17 +38,17 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            analysisContext.RegisterSymbolAction(obj =>
+            analysisContext.RegisterSymbolAction(symbolAnalysisContext =>
             {
-                var field = (IFieldSymbol)obj.Symbol;
+                var field = (IFieldSymbol)symbolAnalysisContext.Symbol;
 
                 // Only report diagnostic on non-static, non-const, public or protected or protected internal/friend fields.
-                // Additionally, only report on members within externally visible types for FxCop compat.
+                // Additionally, by default only report on members within externally visible types for FxCop compat.
                 if (!field.IsStatic &&
                     !field.IsConst &&
-                    field.IsExternallyVisible())
+                    field.MatchesConfiguredVisibility(symbolAnalysisContext.Options, Rule, symbolAnalysisContext.CancellationToken))
                 {
-                    obj.ReportDiagnostic(field.CreateDiagnostic(Rule));
+                    symbolAnalysisContext.ReportDiagnostic(field.CreateDiagnostic(Rule));
                 }
             }, SymbolKind.Field);
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 var field = (IFieldSymbol)symbolAnalysisContext.Symbol;
 
-                // Only report diagnostic on non-static, non-const, private fields.
+                // Only report diagnostic on non-static, non-const, non-private fields.
                 // Additionally, by default only report externally visible fields for FxCop compat.
                 if (!field.IsStatic &&
                     !field.IsConst &&

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
@@ -42,10 +42,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 var field = (IFieldSymbol)symbolAnalysisContext.Symbol;
 
-                // Only report diagnostic on non-static, non-const, public or protected or protected internal/friend fields.
-                // Additionally, by default only report on members within externally visible types for FxCop compat.
+                // Only report diagnostic on non-static, non-const, private fields.
+                // Additionally, by default only report externally visible fields for FxCop compat.
                 if (!field.IsStatic &&
                     !field.IsConst &&
+                    field.DeclaredAccessibility != Accessibility.Private && 
                     field.MatchesConfiguredVisibility(symbolAnalysisContext.Options, Rule, symbolAnalysisContext.CancellationToken))
                 {
                     symbolAnalysisContext.ReportDiagnostic(field.CreateDiagnostic(Rule));

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumStorageShouldBeInt32.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumStorageShouldBeInt32.cs
@@ -70,8 +70,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // If accessibility of enum is not public exit
-            if (!symbol.IsExternallyVisible())
+            // Check accessibility of enum matches configuration or is public if not configured
+            if (!symbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
@@ -79,39 +79,46 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                 compilationStartContext.RegisterSymbolAction(symbolContext =>
                 {
-                    AnalyzeSymbol((INamedTypeSymbol)symbolContext.Symbol, flagsAttributeType, symbolContext.ReportDiagnostic);
+                    AnalyzeSymbol(symbolContext, flagsAttributeType);
                 }, SymbolKind.NamedType);
             });
 
         }
 
-        private static void AnalyzeSymbol(INamedTypeSymbol symbol, INamedTypeSymbol flagsAttributeType, Action<Diagnostic> addDiagnostic)
+        private static void AnalyzeSymbol(SymbolAnalysisContext symbolContext, INamedTypeSymbol flagsAttributeType)
         {
+            var symbol = (INamedTypeSymbol)symbolContext.Symbol;
             if (symbol != null &&
-                symbol.TypeKind == TypeKind.Enum &&
-                symbol.IsExternallyVisible())
+                symbol.TypeKind == TypeKind.Enum)
             {
+                var reportCA1027 = symbol.MatchesConfiguredVisibility(symbolContext.Options, Rule1027, symbolContext.CancellationToken);
+                var reportCA2217 = symbol.MatchesConfiguredVisibility(symbolContext.Options, Rule2217, symbolContext.CancellationToken);
+                if (!reportCA1027 && !reportCA2217)
+                {
+                    return;
+                }
+
                 if (EnumHelpers.TryGetEnumMemberValues(symbol, out IList<ulong> memberValues))
                 {
                     bool hasFlagsAttribute = symbol.GetAttributes().Any(a => a.AttributeClass == flagsAttributeType);
                     if (hasFlagsAttribute)
                     {
                         // Check "CA2217: Do not mark enums with FlagsAttribute"
-                        if (!ShouldBeFlags(memberValues, out IEnumerable<ulong> missingValues))
+                        if (reportCA2217 && !ShouldBeFlags(memberValues, out IEnumerable<ulong> missingValues))
                         {
                             Debug.Assert(missingValues != null);
 
                             string missingValuesString = missingValues.Select(v => v.ToString()).Aggregate((i, j) => i + ", " + j);
-                            addDiagnostic(symbol.CreateDiagnostic(Rule2217, symbol.Name, missingValuesString));
+                            symbolContext.ReportDiagnostic(symbol.CreateDiagnostic(Rule2217, symbol.Name, missingValuesString));
                         }
                     }
                     else
                     {
                         // Check "CA1027: Mark enums with FlagsAttribute"
                         // Ignore contiguous value enums to reduce noise.
-                        if (!IsContiguous(memberValues) && ShouldBeFlags(memberValues))
+                        if (reportCA1027 && !IsContiguous(memberValues) && ShouldBeFlags(memberValues))
                         {
-                            addDiagnostic(symbol.CreateDiagnostic(Rule1027, symbol.Name));
+                            symbolContext.ReportDiagnostic(symbol.CreateDiagnostic(Rule1027, symbol.Name));
                         }
                     }
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
@@ -108,7 +108,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol flagsAttribute)
         {
             var symbol = (INamedTypeSymbol)context.Symbol;
-            if (symbol.TypeKind != TypeKind.Enum || !symbol.IsExternallyVisible())
+            if (symbol.TypeKind != TypeKind.Enum)
+            {
+                return;
+            }
+
+            var reportCA1714 = symbol.MatchesConfiguredVisibility(context.Options, Rule_CA1714, context.CancellationToken);
+            var reportCA1717 = symbol.MatchesConfiguredVisibility(context.Options, Rule_CA1717, context.CancellationToken);
+            if (!reportCA1714 && !reportCA1717)
             {
                 return;
             }
@@ -116,14 +123,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             bool hasFlagsAttribute = symbol.GetAttributes().Any(a => a.AttributeClass.Equals(flagsAttribute));
             if (hasFlagsAttribute)
             {
-                if (!symbol.Name.IsPlural()) // Checking Rule CA1714
+                if (reportCA1714 && !symbol.Name.IsPlural()) // Checking Rule CA1714
                 {
                     context.ReportDiagnostic(symbol.CreateDiagnostic(Rule_CA1714, symbol.OriginalDefinition.Locations.First(), symbol.Name));
                 }
             }
             else
             {
-                if (symbol.Name.IsPlural()) // Checking Rule CA1717
+                if (reportCA1717 && symbol.Name.IsPlural()) // Checking Rule CA1717
                 {
                     context.ReportDiagnostic(symbol.CreateDiagnostic(Rule_CA1717, symbol.OriginalDefinition.Locations.First(), symbol.Name));
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHaveZeroValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHaveZeroValue.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using System.Diagnostics;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
@@ -103,11 +104,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // FxCop compat: only fire on externally visible types.
-            if (!symbol.IsExternallyVisible())
+            // FxCop compat: only fire on externally visible types by default.
+            if (!symbol.MatchesConfiguredVisibility(context.Options, RuleMultipleZero, context.CancellationToken))
             {
                 return;
             }
+
+            Debug.Assert(symbol.MatchesConfiguredVisibility(context.Options, RuleNoZero, context.CancellationToken));
+            Debug.Assert(symbol.MatchesConfiguredVisibility(context.Options, RuleRename, context.CancellationToken));
 
             ImmutableArray<IFieldSymbol> zeroValuedFields = GetZeroValuedFields(symbol).ToImmutableArray();
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using System.Threading;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
@@ -48,26 +49,30 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             IEnumerable<INamedTypeSymbol> globalTypes = context.Compilation.GlobalNamespace.GetTypeMembers().Where(item =>
                     item.ContainingAssembly == context.Compilation.Assembly &&
-                    IsExternallyVisible(item));
+                    MatchesConfiguredVisibility(item, context.Options, context.CancellationToken));
 
             CheckTypeNames(globalTypes, context.ReportDiagnostic);
-            CheckNamespaceMembers(globalNamespaces, context.Compilation, context.ReportDiagnostic);
+            CheckNamespaceMembers(globalNamespaces, context);
         }
 
         private static void AnalyzeSymbol(SymbolAnalysisContext context)
         {
             var namedTypeSymbol = context.Symbol as INamedTypeSymbol;
-            // Do not descent into non-publicly visible types
+            
+            // Do not descent into non-publicly visible types by default
             // Note: This is the behavior of FxCop, it might be more correct to descend into internal but not private
             // types because "InternalsVisibleTo" could be set. But it might be bad for users to start seeing warnings
             // where they previously did not from FxCop.
-            if (!namedTypeSymbol.IsExternallyVisible())
+            // Note that end user can now override this default behavior via options.
+            if (!namedTypeSymbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
             {
                 return;
             }
 
             // Get externally visible members in the given type
-            IEnumerable<ISymbol> members = namedTypeSymbol.GetMembers().Where(item => !item.IsAccessorMethod() && IsExternallyVisible(item));
+            IEnumerable<ISymbol> members = namedTypeSymbol.GetMembers()
+                                                          .Where(item => !item.IsAccessorMethod() &&
+                                                                         MatchesConfiguredVisibility(item, context.Options, context.CancellationToken));
 
             if (members.Any())
             {
@@ -79,19 +84,19 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
         }
 
-        private static void CheckNamespaceMembers(IEnumerable<INamespaceSymbol> namespaces, Compilation compilation, Action<Diagnostic> addDiagnostic)
+        private static void CheckNamespaceMembers(IEnumerable<INamespaceSymbol> namespaces, CompilationAnalysisContext context)
         {
             HashSet<INamespaceSymbol> excludedNamespaces = new HashSet<INamespaceSymbol>();
             foreach (INamespaceSymbol @namespace in namespaces)
             {
                 // Get all the potentially externally visible types in the namespace
                 IEnumerable<INamedTypeSymbol> typeMembers = @namespace.GetTypeMembers().Where(item =>
-                    item.ContainingAssembly == compilation.Assembly &&
-                    IsExternallyVisible(item));
+                    item.ContainingAssembly == context.Compilation.Assembly &&
+                    MatchesConfiguredVisibility(item, context.Options, context.CancellationToken));
 
                 if (typeMembers.Any())
                 {
-                    CheckTypeNames(typeMembers, addDiagnostic);
+                    CheckTypeNames(typeMembers, context.ReportDiagnostic);
                 }
                 else
                 {
@@ -102,7 +107,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 IEnumerable<INamespaceSymbol> namespaceMembers = @namespace.GetNamespaceMembers();
                 if (namespaceMembers.Any())
                 {
-                    CheckNamespaceMembers(namespaceMembers, compilation, addDiagnostic);
+                    CheckNamespaceMembers(namespaceMembers, context);
 
                     // If there is a child namespace that has externally visible types, then remove the parent namespace from exclusion list
                     if (namespaceMembers.Any(item => !excludedNamespaces.Contains(item)))
@@ -115,7 +120,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             // Before name check, remove all namespaces that don't contain externally visible types in current scope
             namespaces = namespaces.Where(item => !excludedNamespaces.Contains(item));
 
-            CheckNamespaceNames(namespaces, addDiagnostic);
+            CheckNamespaceNames(namespaces, context);
         }
 
         private static void CheckTypeMembers(IEnumerable<ISymbol> members, Action<Diagnostic> addDiagnostic)
@@ -203,7 +208,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
         }
 
-        private static void CheckNamespaceNames(IEnumerable<INamespaceSymbol> namespaces, Action<Diagnostic> addDiagnostic)
+        private static void CheckNamespaceNames(IEnumerable<INamespaceSymbol> namespaces, CompilationAnalysisContext context)
         {
             // If there is only one namespace, then return
             if (!namespaces.Skip(1).Any())
@@ -215,7 +220,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             foreach (IGrouping<string, INamespaceSymbol> group in namespaceList)
             {
-                addDiagnostic(Diagnostic.Create(Rule, Location.None, Namespace, GetSymbolDisplayString(group)));
+                context.ReportDiagnostic(Diagnostic.Create(Rule, Location.None, Namespace, GetSymbolDisplayString(group)));
             }
         }
 
@@ -228,10 +233,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             return string.Join(", ", group.Select(s => s.ToDisplayString()).OrderBy(k => k, StringComparer.Ordinal));
         }
 
-        public static bool IsExternallyVisible(ISymbol symbol)
+        public static bool MatchesConfiguredVisibility(ISymbol symbol, AnalyzerOptions options, CancellationToken cancellationToken)
         {
-            SymbolVisibility visibility = symbol.GetResultantVisibility();
-            return visibility == SymbolVisibility.Public || visibility == SymbolVisibility.Internal;
+            var defaultAllowedVisibilties = SymbolVisibilityGroup.Public | SymbolVisibilityGroup.Internal;
+            var allowedVisibilities = options.GetSymbolVisibilityGroupOption(Rule, defaultAllowedVisibilties, cancellationToken);
+            return allowedVisibilities.Contains(symbol.GetResultantVisibility());
         }
 
         #endregion

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using System.Diagnostics;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
@@ -49,11 +50,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.RegisterSymbolAction(
                 (context) =>
             {
-                // FxCop compat: only analyze externally visible symbols
-                if (!context.Symbol.IsExternallyVisible())
+                // FxCop compat: only analyze externally visible symbols by default.
+                if (!context.Symbol.MatchesConfiguredVisibility(context.Options, InterfaceRule, context.CancellationToken))
                 {
+                    Debug.Assert(!context.Symbol.MatchesConfiguredVisibility(context.Options, TypeParameterRule, context.CancellationToken));
                     return;
                 }
+
+                Debug.Assert(context.Symbol.MatchesConfiguredVisibility(context.Options, TypeParameterRule, context.CancellationToken));
 
                 switch (context.Symbol.Kind)
                 {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
@@ -109,13 +109,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 context.RegisterSymbolAction((saContext) =>
                 {
                     var namedTypeSymbol = (INamedTypeSymbol)saContext.Symbol;
-                    if (!namedTypeSymbol.MatchesConfiguredVisibility(context.Options, DefaultRule, context.CancellationToken))
+                    if (!namedTypeSymbol.MatchesConfiguredVisibility(saContext.Options, DefaultRule, saContext.CancellationToken))
                     {
-                        Debug.Assert(!namedTypeSymbol.MatchesConfiguredVisibility(context.Options, SpecialCollectionRule, context.CancellationToken));
+                        Debug.Assert(!namedTypeSymbol.MatchesConfiguredVisibility(saContext.Options, SpecialCollectionRule, saContext.CancellationToken));
                         return;
                     }
 
-                    Debug.Assert(namedTypeSymbol.MatchesConfiguredVisibility(context.Options, SpecialCollectionRule, context.CancellationToken));
+                    Debug.Assert(namedTypeSymbol.MatchesConfiguredVisibility(saContext.Options, SpecialCollectionRule, saContext.CancellationToken));
 
                     var baseType = namedTypeSymbol.GetBaseTypes().FirstOrDefault(bt => baseTypeSuffixMap.ContainsKey(bt.OriginalDefinition));
                     if (baseType != null)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System;
 using System.Linq;
 using Analyzer.Utilities.Extensions;
+using System.Diagnostics;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
@@ -108,10 +109,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 context.RegisterSymbolAction((saContext) =>
                 {
                     var namedTypeSymbol = (INamedTypeSymbol)saContext.Symbol;
-                    if (!namedTypeSymbol.IsExternallyVisible())
+                    if (!namedTypeSymbol.MatchesConfiguredVisibility(context.Options, DefaultRule, context.CancellationToken))
                     {
+                        Debug.Assert(!namedTypeSymbol.MatchesConfiguredVisibility(context.Options, SpecialCollectionRule, context.CancellationToken));
                         return;
                     }
+
+                    Debug.Assert(namedTypeSymbol.MatchesConfiguredVisibility(context.Options, SpecialCollectionRule, context.CancellationToken));
 
                     var baseType = namedTypeSymbol.GetBaseTypes().FirstOrDefault(bt => baseTypeSuffixMap.ContainsKey(bt.OriginalDefinition));
                     if (baseType != null)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
@@ -123,8 +123,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static void AnalyzeSymbol(ISymbol symbol, SymbolAnalysisContext context)
         {
-            // FxCop compat: only analyze externally visible symbols.
-            if (!symbol.IsExternallyVisible())
+            // FxCop compat: only analyze externally visible symbols by default.
+            if (!symbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffix.cs
@@ -141,7 +141,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         (SymbolAnalysisContext symbolAnalysisContext) =>
                         {
                             var namedTypeSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
-                            if (!namedTypeSymbol.IsExternallyVisible())
+                            
+                            // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+                            // will always have identical configured visibility.
+                            if (!namedTypeSymbol.MatchesConfiguredVisibility(symbolAnalysisContext.Options, TypeNoAlternateRule, symbolAnalysisContext.CancellationToken))
                             {
                                 return;
                             }
@@ -201,7 +204,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 (SymbolAnalysisContext context) =>
                 {
                     var memberSymbol = context.Symbol;
-                    if (!memberSymbol.IsExternallyVisible())
+
+                    // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+                    // will always have identical configured visibility.
+                    if (!memberSymbol.MatchesConfiguredVisibility(context.Options, TypeNoAlternateRule, context.CancellationToken))
                     {
                         return;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywords.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywords.cs
@@ -28,15 +28,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.IdentifiersShouldNotMatchKeywordsDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
 
         // Properties common to all DiagnosticDescriptors for this rule:
-        private static readonly string s_category = DiagnosticCategory.Naming;
-        private const DiagnosticSeverity Severity = DiagnosticHelpers.DefaultDiagnosticSeverity;
         private const string HelpLinkUri = "https://docs.microsoft.com/visualstudio/code-quality/ca1716-identifiers-should-not-match-keywords";
         
         internal static DiagnosticDescriptor MemberParameterRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageMemberParameter,
-                                                                             s_category,
-                                                                             Severity,
+                                                                             DiagnosticCategory.Naming,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpLinkUri,
@@ -44,8 +42,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         internal static DiagnosticDescriptor MemberRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageMember,
-                                                                             s_category,
-                                                                             Severity,
+                                                                             DiagnosticCategory.Naming,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpLinkUri,
@@ -53,8 +51,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         internal static DiagnosticDescriptor TypeRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageType,
-                                                                             s_category,
-                                                                             Severity,
+                                                                             DiagnosticCategory.Naming,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpLinkUri,
@@ -62,8 +60,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         internal static DiagnosticDescriptor NamespaceRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageNamespace,
-                                                                             s_category,
-                                                                             Severity,
+                                                                             DiagnosticCategory.Naming,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpLinkUri,
@@ -112,7 +110,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
 
                 // Don't complain about a namespace unless it contains at least one public type.
-                if (!type.IsExternallyVisible())
+                if (!type.MatchesConfiguredVisibility(context.Options, NamespaceRule, context.CancellationToken))
                 {
                     return;
                 }
@@ -154,7 +152,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private void AnalyzeTypeRule(SymbolAnalysisContext context)
         {
             INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
-            if (!type.IsExternallyVisible())
+            if (!type.MatchesConfiguredVisibility(context.Options, TypeRule, context.CancellationToken))
             {
                 return;
             }
@@ -172,7 +170,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private void AnalyzeMemberRule(SymbolAnalysisContext context)
         {
             ISymbol symbol = context.Symbol;
-            if (!symbol.IsExternallyVisible())
+            if (!symbol.MatchesConfiguredVisibility(context.Options, MemberRule, context.CancellationToken))
             {
                 return;
             }
@@ -196,7 +194,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private void AnalyzeMemberParameterRule(SymbolAnalysisContext context)
         {
             var method = (IMethodSymbol)context.Symbol;
-            if (!method.IsExternallyVisible())
+            if (!method.MatchesConfiguredVisibility(context.Options, MemberParameterRule, context.CancellationToken))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
@@ -182,9 +182,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             private void AnalyzeNamedTypeSymbol(SymbolAnalysisContext context)
             {
+                // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+                // will always have identical configured visibility.
                 if (context.Symbol is INamedTypeSymbol type &&
                     type.TypeKind == TypeKind.Class &&
-                    type.IsExternallyVisible())
+                    type.MatchesConfiguredVisibility(context.Options, IDisposableReimplementationRule, context.CancellationToken))
                 {
                     bool implementsDisposableInBaseType = ImplementsDisposableInBaseType(type);
 
@@ -242,9 +244,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 bool isDisposeMethod = method.Name == DisposeMethodName;
                 if (isFinalizerMethod || isDisposeMethod)
                 {
+                    // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+                    // will always have identical configured visibility.
                     INamedTypeSymbol type = method.ContainingType;
                     if (type != null && type.TypeKind == TypeKind.Class &&
-                        !type.IsSealed && type.IsExternallyVisible())
+                        !type.IsSealed && type.MatchesConfiguredVisibility(context.Options, IDisposableReimplementationRule, context.CancellationToken))
                     {
                         if (ImplementsDisposableDirectly(type))
                         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NestedTypesShouldNotBeVisible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NestedTypesShouldNotBeVisible.cs
@@ -24,15 +24,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.NestedTypesShouldNotBeVisibleDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
 
         // Properties common to the descriptors defined by this analyzer.
-        private static readonly string s_category = DiagnosticCategory.Design;
-        private const DiagnosticSeverity Severity = DiagnosticHelpers.DefaultDiagnosticSeverity;
         private const string HelpLinkUrl = "https://docs.microsoft.com/visualstudio/code-quality/ca1034-nested-types-should-not-be-visible";
         
         internal static DiagnosticDescriptor DefaultRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageDefault,
-                                                                             s_category,
-                                                                             Severity,
+                                                                             DiagnosticCategory.Design,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpLinkUrl,
@@ -40,8 +38,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         internal static DiagnosticDescriptor VisualBasicModuleRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageVisualBasicModule,
-                                                                             s_category,
-                                                                             Severity,
+                                                                             DiagnosticCategory.Design,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: HelpLinkUrl,

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
@@ -85,8 +85,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             var methodSymbol = (IMethodSymbol)symbolContext.Symbol;
 
-            // FxCop compat: only analyze externally visible symbols.
-            if (!methodSymbol.IsExternallyVisible())
+            // FxCop compat: only analyze externally visible symbols by default.
+            // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+            // will always have identical configured visibility.
+            if (!methodSymbol.MatchesConfiguredVisibility(symbolContext.Options, DefaultRule, symbolContext.CancellationToken))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.cs
@@ -45,8 +45,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 var namedType = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
                 
-                // FxCop compat: only analyze externally visible symbols.
-                if (!namedType.IsExternallyVisible())
+                // FxCop compat: only analyze externally visible symbols by default.
+                if (!namedType.MatchesConfiguredVisibility(symbolAnalysisContext.Options, Rule, symbolAnalysisContext.CancellationToken))
                 {
                     return;
                 }
@@ -77,8 +77,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             foreach (var operator1 in operators1)
             {
-                // FxCop compat: only analyze externally visible symbols.
-                if (!operator1.IsExternallyVisible())
+                // FxCop compat: only analyze externally visible symbols by default.
+                if (!operator1.MatchesConfiguredVisibility(analysisContext.Options, Rule, analysisContext.CancellationToken))
                 {
                     return;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
                 if (namedTypeSymbol.IsValueType &&
-                    namedTypeSymbol.IsExternallyVisible() &&
+                    namedTypeSymbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken) &&
                     namedTypeSymbol.OverridesEquals() && 
                     !namedTypeSymbol.ImplementsEqualityOperators())
                 {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
@@ -23,13 +23,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static readonly LocalizableString s_localizableMessageOpEquality = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
         private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideEqualsAndOperatorEqualsOnValueTypesDescription), MicrosoftApiDesignGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
 
-        private static readonly string s_category = DiagnosticCategory.Performance;
         private const string s_helpLinkUri = "https://docs.microsoft.com/visualstudio/code-quality/ca1815-override-equals-and-operator-equals-on-value-types";
 
         internal static DiagnosticDescriptor EqualsRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageEquals,
-                                                                             s_category,
+                                                                             DiagnosticCategory.Performance,
                                                                              defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
@@ -39,7 +38,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         internal static DiagnosticDescriptor OpEqualityRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageOpEquality,
-                                                                             s_category,
+                                                                             DiagnosticCategory.Performance,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                                              description: s_localizableDescription,
@@ -66,9 +65,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     //  1. Do not fire for enums.
                     //  2. Do not fire for enumerators.
                     //  3. Do not fire for value types without members.
+                    //  4. Externally visible types by default.
+                    // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+                    // will always have identical configured visibility.
                     if (!namedType.IsValueType ||
                         namedType.TypeKind == TypeKind.Enum ||
-                        !namedType.IsExternallyVisible() ||
+                        !namedType.MatchesConfiguredVisibility(compilationStartContext.Options, EqualsRule, compilationStartContext.CancellationToken) ||
                         !namedType.GetMembers().Any(m => !m.IsConstructor()))
                     {
                         return;

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     // will always have identical configured visibility.
                     if (!namedType.IsValueType ||
                         namedType.TypeKind == TypeKind.Enum ||
-                        !namedType.MatchesConfiguredVisibility(compilationStartContext.Options, EqualsRule, compilationStartContext.CancellationToken) ||
+                        !namedType.MatchesConfiguredVisibility(context.Options, EqualsRule, context.CancellationToken) ||
                         !namedType.GetMembers().Any(m => !m.IsConstructor()))
                     {
                         return;

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideMethodsOnComparableTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideMethodsOnComparableTypes.cs
@@ -78,17 +78,20 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                 compilationContext.RegisterSymbolAction(context =>
                 {
-                    AnalyzeSymbol((INamedTypeSymbol)context.Symbol, comparableType, genericComparableType, context.ReportDiagnostic);
+                    AnalyzeSymbol(context, comparableType, genericComparableType);
                 },
                 SymbolKind.NamedType);
             });
         }
 
-        private static void AnalyzeSymbol(INamedTypeSymbol namedTypeSymbol, INamedTypeSymbol comparableType, INamedTypeSymbol genericComparableType, Action<Diagnostic> addDiagnostic)
+        private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol comparableType, INamedTypeSymbol genericComparableType)
         {
+            // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+            // will always have identical configured visibility.
+            var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
             if (namedTypeSymbol.TypeKind == TypeKind.Interface ||
                 namedTypeSymbol.TypeKind == TypeKind.Enum ||
-                !namedTypeSymbol.IsExternallyVisible())
+                !namedTypeSymbol.MatchesConfiguredVisibility(context.Options, RuleBoth, context.CancellationToken))
             {
                 return;
             }
@@ -100,15 +103,15 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                 if (!overridesEquals && comparisonOperatorsString.Length != 0)
                 {
-                    addDiagnostic(namedTypeSymbol.CreateDiagnostic(RuleBoth, namedTypeSymbol.Name, comparisonOperatorsString));
+                    context.ReportDiagnostic(namedTypeSymbol.CreateDiagnostic(RuleBoth, namedTypeSymbol.Name, comparisonOperatorsString));
                 }
                 else if (!overridesEquals)
                 {
-                    addDiagnostic(namedTypeSymbol.CreateDiagnostic(RuleEquals, namedTypeSymbol.Name));
+                    context.ReportDiagnostic(namedTypeSymbol.CreateDiagnostic(RuleEquals, namedTypeSymbol.Name));
                 }
                 else if (comparisonOperatorsString.Length != 0)
                 {
-                    addDiagnostic(namedTypeSymbol.CreateDiagnostic(RuleOperator, namedTypeSymbol.Name, comparisonOperatorsString));
+                    context.ReportDiagnostic(namedTypeSymbol.CreateDiagnostic(RuleOperator, namedTypeSymbol.Name, comparisonOperatorsString));
                 }
             }
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclaration.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclaration.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             var methodSymbol = (IMethodSymbol)analysisContext.Symbol;
 
-            if (!methodSymbol.IsExternallyVisible() ||
+            if (!methodSymbol.MatchesConfiguredVisibility(analysisContext.Options, Rule, analysisContext.CancellationToken) ||
                 !(methodSymbol.CanBeReferencedByName || methodSymbol.IsImplementationOfAnyExplicitInterfaceMember())
                 || !methodSymbol.Locations.Any(x => x.IsInSource)
                 || string.IsNullOrWhiteSpace(methodSymbol.Name))

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStrings.cs
@@ -107,9 +107,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     return;
                 }
 
-                if (!method.IsExternallyVisible())
+                if (!method.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
                 {
-                    // only apply to methods that are exposed outside
+                    // only apply to methods that are exposed outside by default
                     return;
                 }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using System.Diagnostics;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
@@ -70,11 +71,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // If property is not visible outside the assembly
-            if (!property.IsExternallyVisible())
+            // Only analyze externally visible properties by default
+            if (!property.MatchesConfiguredVisibility(context.Options, AddGetterRule, context.CancellationToken))
             {
+                Debug.Assert(!property.MatchesConfiguredVisibility(context.Options, MakeMoreAccessibleRule, context.CancellationToken));
                 return;
             }
+
+            Debug.Assert(property.MatchesConfiguredVisibility(context.Options, MakeMoreAccessibleRule, context.CancellationToken));
 
             // We handled the non-CA1044 cases earlier.  Now, we handle CA1044 cases
             // If there is no getter then it is not accessible

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotReturnArrays.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotReturnArrays.cs
@@ -46,7 +46,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             var symbol = (IPropertySymbol)context.Symbol;
             if (symbol.Type.TypeKind == TypeKind.Array && !symbol.IsOverride)
             {
-                if (symbol.IsExternallyVisible() && !symbol.ContainingType.IsAttribute())
+                if (symbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken) &&
+                    !symbol.ContainingType.IsAttribute())
                 {
                     context.ReportDiagnostic(symbol.CreateDiagnostic(Rule));
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
@@ -50,8 +50,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             string identifier;
             var symbol = context.Symbol;
 
-            // Bail out if the method/property is not exposed (public, protected, or protected internal)
-            if (!symbol.IsExternallyVisible())
+            // Bail out if the method/property is not exposed (public, protected, or protected internal) by default
+            var configuredVisibilities = context.Options.GetSymbolVisibilityGroupOption(Rule, SymbolVisibilityGroup.Public, context.CancellationToken);
+            if (!configuredVisibilities.Contains(symbol.GetResultantVisibility()))
             {
                 return;
             }
@@ -77,7 +78,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 Diagnostic diagnostic = null;
 
-                var exposedMembers = type.GetMembers(identifier).Where(member => member.IsExternallyVisible());
+                var exposedMembers = type.GetMembers(identifier).Where(member => configuredVisibilities.Contains(member.GetResultantVisibility()));
                 foreach (var member in exposedMembers)
                 {
                     // Ignore Object.GetType, as it's commonly seen and Type is a commonly-used property name.

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ProvideObsoleteAttributeMessage.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ProvideObsoleteAttributeMessage.cs
@@ -58,8 +58,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol obsoleteAttributeType)
         {
-            // FxCop compat: only analyze externally visible symbols
-            if (!context.Symbol.IsExternallyVisible())
+            // FxCop compat: only analyze externally visible symbols by default
+            if (!context.Symbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/StaticHolderTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/StaticHolderTypes.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             var symbol = (INamedTypeSymbol)context.Symbol;
             if (!symbol.IsStatic &&
-                symbol.IsExternallyVisible() &&
+                symbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken) &&
                 symbol.IsStaticHolderType() &&
                 !symbol.IsAbstract)
             {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriParametersShouldNotBeStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriParametersShouldNotBeStrings.cs
@@ -84,9 +84,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     return;
                 }
 
-                if (!method.IsExternallyVisible())
+                if (!method.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
                 {
-                    // only apply to methods that are exposed outside
+                    // only apply to methods that are exposed outside by default
                     return;
                 }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriPropertiesShouldNotBeStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriPropertiesShouldNotBeStrings.cs
@@ -80,9 +80,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     return;
                 }
 
-                if (!property.IsExternallyVisible())
+                if (!property.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
                 {
-                    // only apply to methods that are exposed outside
+                    // only apply to methods that are exposed outside by default
                     return;
                 }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriReturnValuesShouldNotBeStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UriReturnValuesShouldNotBeStrings.cs
@@ -80,9 +80,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     return;
                 }
 
-                if (!method.IsExternallyVisible())
+                if (!method.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
                 {
-                    // only apply to methods that are exposed outside
+                    // only apply to methods that are exposed outside by default
                     return;
                 }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseEventsWhereAppropriate.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseEventsWhereAppropriate.cs
@@ -56,13 +56,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 }
 
                 // FxCop compat: bail out for implicitly declared methods, overridden methods, interface implementations,
-                // constructors and finalizers and non-externally visible methods.
+                // constructors and finalizers and non-externally visible methods by default.
                 if (method.IsImplicitlyDeclared ||
                     method.IsOverride ||
                     method.IsImplementationOfAnyInterfaceMember() ||
                     method.IsConstructor() ||
                     method.IsFinalizer() ||
-                    !method.IsExternallyVisible())
+                    !method.MatchesConfiguredVisibility(symbolContext.Options, Rule, symbolContext.CancellationToken))
                 {
                     return;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseGenericEventHandlerInstances.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseGenericEventHandlerInstances.cs
@@ -122,8 +122,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                     context.RegisterSymbolAction(symbolContext =>
                     {
+                        // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+                        // will always have identical configured visibility.
                         var namedType = (INamedTypeSymbol)symbolContext.Symbol;
-                        if (namedType.IsExternallyVisible() &&
+                        if (namedType.MatchesConfiguredVisibility(symbolContext.Options, RuleForDelegates, symbolContext.CancellationToken) &&
                             IsDelegateTypeWithInvokeMethod(namedType) &&
                             IsValidNonGenericEventHandler(namedType.DelegateInvokeMethod))
                         {
@@ -142,8 +144,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         // NOTE: Legacy FxCop reports CA1009 for delegate type that handles a public or protected event and does not have the correct signature, return type, or parameter names.
                         //       which recommends fixing the signature to use a valid non-generic event handler.
                         //       We do not report CA1009, but instead report CA1003 and recommend using a generic event handler.
+                        // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+                        // will always have identical configured visibility.
                         var eventSymbol = (IEventSymbol)symbolContext.Symbol;
-                        if (eventSymbol.IsExternallyVisible() &&
+                        if (eventSymbol.MatchesConfiguredVisibility(symbolContext.Options, RuleForEvents, symbolContext.CancellationToken) &&
                             !eventSymbol.IsOverride &&
                             !eventSymbol.IsImplementationOfAnyInterfaceMember() &&
                             !ContainingTypeHasComSourceInterfacesAttribute(eventSymbol) &&

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexers.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexers.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             var symbol = (IPropertySymbol)context.Symbol;
             if (symbol.IsIndexer &&
                 !symbol.IsOverride &&
-                symbol.IsExternallyVisible())
+                symbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken))
             {
                 if (symbol.GetParameters().Length == 1)
                 {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     methodSymbol.ReturnsVoid ||
                     methodSymbol.ReturnType.Kind == SymbolKind.ArrayType ||
                     methodSymbol.Parameters.Length > 0 ||
-                    !methodSymbol.IsExternallyVisible() ||
+                    !methodSymbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken) ||
                     methodSymbol.IsAccessorMethod() ||
                     !IsPropertyLikeName(methodSymbol.Name))
                 {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/UseLiteralsWhereAppropriate.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/UseLiteralsWhereAppropriate.cs
@@ -56,10 +56,13 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 var fieldInitializer = saContext.Operation as IFieldInitializerOperation;
 
                 // Diagnostics are reported on the last initialized field to retain the previous FxCop behavior
+                // Note all the descriptors/rules for this analyzer have the same ID and category and hence
+                // will always have identical configured visibility.
                 var lastField = fieldInitializer?.InitializedFields.LastOrDefault();
                 var fieldInitializerValue = fieldInitializer?.Value;
                 if (fieldInitializerValue == null || lastField.IsConst ||
-                    lastField.IsExternallyVisible() || !lastField.IsStatic ||
+                    !lastField.MatchesConfiguredVisibility(saContext.Options, DefaultRule, saContext.CancellationToken, defaultRequiredVisibility: SymbolVisibilityGroup.Internal | SymbolVisibilityGroup.Private) ||
+                    !lastField.IsStatic ||
                     !lastField.IsReadOnly || !fieldInitializerValue.ConstantValue.HasValue)
                 {
                     return;

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
@@ -122,6 +122,110 @@ Public Interface IBase
 End Interface");
         }
 
+        [Theory]
+        // General analyzer option
+        [InlineData("public", "dotnet_code_quality.api_surface = public")]
+        [InlineData("public", "dotnet_code_quality.api_surface = private, internal, public")]
+        [InlineData("public", "dotnet_code_quality.api_surface = all")]
+        [InlineData("protected", "dotnet_code_quality.api_surface = public")]
+        [InlineData("protected", "dotnet_code_quality.api_surface = private, internal, public")]
+        [InlineData("protected", "dotnet_code_quality.api_surface = all")]
+        [InlineData("internal", "dotnet_code_quality.api_surface = internal")]
+        [InlineData("internal", "dotnet_code_quality.api_surface = private, internal")]
+        [InlineData("internal", "dotnet_code_quality.api_surface = all")]
+        [InlineData("private", "dotnet_code_quality.api_surface = private")]
+        [InlineData("private", "dotnet_code_quality.api_surface = private, public")]
+        [InlineData("private", "dotnet_code_quality.api_surface = all")]
+        // Specific analyzer option
+        [InlineData("internal", "dotnet_code_quality.CA1040.api_surface = all")]
+        [InlineData("internal", "dotnet_code_quality.Design.api_surface = all")]
+        // General + Specific analyzer option
+        [InlineData("internal", @"dotnet_code_quality.api_surface = private
+                                  dotnet_code_quality.CA1040.api_surface = all")]
+        // Case-insensitive analyzer option
+        [InlineData("internal", "DOTNET_code_quality.CA1040.API_SURFACE = ALL")]
+        // Invalid analyzer option ignored
+        [InlineData("internal", @"dotnet_code_quality.api_surface = all
+                                  dotnet_code_quality.CA1040.api_surface_2 = private")]
+        public void TestCSharpEmptyInterface_AnalyzerOptions_Diagnostic(string accessibility, string editorConfigText)
+        {
+            VerifyCSharp($@"
+public class C
+{{
+    {accessibility} interface I {{ }}
+}}",
+                GetAdditionalFile(editorConfigText),
+                CreateCSharpResult(4, 16 + accessibility.Length));
+        }
+
+        [Theory]
+        // General analyzer option
+        [InlineData("Public", "dotnet_code_quality.api_surface = Public")]
+        [InlineData("Public", "dotnet_code_quality.api_surface = Private, Friend, Public")]
+        [InlineData("Public", "dotnet_code_quality.api_surface = All")]
+        [InlineData("Protected", "dotnet_code_quality.api_surface = Public")]
+        [InlineData("Protected", "dotnet_code_quality.api_surface = Private, Friend, Public")]
+        [InlineData("Protected", "dotnet_code_quality.api_surface = All")]
+        [InlineData("Friend", "dotnet_code_quality.api_surface = Friend")]
+        [InlineData("Friend", "dotnet_code_quality.api_surface = Private, Friend")]
+        [InlineData("Friend", "dotnet_code_quality.api_surface = All")]
+        [InlineData("Private", "dotnet_code_quality.api_surface = Private")]
+        [InlineData("Private", "dotnet_code_quality.api_surface = Private, Public")]
+        [InlineData("Private", "dotnet_code_quality.api_surface = All")]
+        // Specific analyzer option
+        [InlineData("Friend", "dotnet_code_quality.CA1040.api_surface = All")]
+        [InlineData("Friend", "dotnet_code_quality.Design.api_surface = All")]
+        // General + Specific analyzer option
+        [InlineData("Friend", @"dotnet_code_quality.api_surface = Private
+                                dotnet_code_quality.CA1040.api_surface = All")]
+        // Case-insensitive analyzer option
+        [InlineData("Friend", "DOTNET_code_quality.CA1040.API_SURFACE = ALL")]
+        // Invalid analyzer option ignored
+        [InlineData("Friend", @"dotnet_code_quality.api_surface = All
+                                dotnet_code_quality.CA1040.api_surface_2 = Private")]
+        public void TestBasicEmptyInterface_AnalyzerOptions_Diagnostic(string accessibility, string editorConfigText)
+        {
+            VerifyBasic($@"
+Public Class C
+    {accessibility} Interface I
+    End Interface
+End Class",
+                GetAdditionalFile(editorConfigText),
+                CreateBasicResult(3, 16 + accessibility.Length));
+        }
+
+        [Theory]
+        [InlineData("public", "dotnet_code_quality.api_surface = private")]
+        [InlineData("public", "dotnet_code_quality.CA1040.api_surface = internal, private")]
+        [InlineData("public", "dotnet_code_quality.Design.api_surface = internal, private")]
+        [InlineData("public", @"dotnet_code_quality.api_surface = all
+                                  dotnet_code_quality.CA1040.api_surface = private")]
+        public void TestCSharpEmptyInterface_AnalyzerOptions_NoDiagnostic(string accessibility, string editorConfigText)
+        {
+            VerifyCSharp($@"
+public class C
+{{
+    {accessibility} interface I {{ }}
+}}",
+                GetAdditionalFile(editorConfigText));
+        }
+
+        [Theory]
+        [InlineData("Public", "dotnet_code_quality.api_surface = Private")]
+        [InlineData("Public", "dotnet_code_quality.CA1040.api_surface = Friend, Private")]
+        [InlineData("Public", "dotnet_code_quality.Design.api_surface = Friend, Private")]
+        [InlineData("Public", @"dotnet_code_quality.api_surface = All
+                                dotnet_code_quality.CA1040.api_surface = Private")]
+        public void TestBasicEmptyInterface_AnalyzerOptions_NoDiagnostic(string accessibility, string editorConfigText)
+        {
+            VerifyBasic($@"
+Public Class C
+    {accessibility} Interface I
+    End Interface
+End Class",
+                GetAdditionalFile(editorConfigText));
+        }
+
         private static DiagnosticResult CreateCSharpResult(int line, int col)
         {
             return GetCSharpResultAt(line, col, AvoidEmptyInterfacesAnalyzer.RuleId, MicrosoftApiDesignGuidelinesAnalyzersResources.AvoidEmptyInterfacesMessage);
@@ -131,5 +235,8 @@ End Interface");
         {
             return GetBasicResultAt(line, col, AvoidEmptyInterfacesAnalyzer.RuleId, MicrosoftApiDesignGuidelinesAnalyzersResources.AvoidEmptyInterfacesMessage);
         }
+
+        private static FileAndSource GetAdditionalFile(string source)
+            => new FileAndSource() { Source = source, FilePath = ".editorconfig" };
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/TypesShouldNotExtendCertainBaseTypes.cs
@@ -69,7 +69,7 @@ namespace Microsoft.NetFramework.Analyzers
 
                         if (namedTypeSymbol.BaseType != null &&
                             badBaseTypes.Contains(namedTypeSymbol.BaseType) &&
-                            namedTypeSymbol.IsExternallyVisible())
+                            namedTypeSymbol.MatchesConfiguredVisibility(saContext.Options, Rule, saContext.CancellationToken))
                         {
                             string baseTypeName = namedTypeSymbol.BaseType.ToDisplayString();
                             Debug.Assert(s_badBaseTypesToMessage.ContainsKey(baseTypeName));

--- a/src/Utilities/Analyzer.Utilities.projitems
+++ b/src/Utilities/Analyzer.Utilities.projitems
@@ -43,6 +43,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SymbolVisibility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SyntaxNodeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\UriExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\SymbolVisibilityGroup.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\AnalyzerOptionsExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\CategorizedAnalyzerConfigOptions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\EditorConfigParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SolutionChangeAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SymbolDisplayFormats.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxGeneratorExtensions.cs" />

--- a/src/Utilities/AnalyzerUtilitiesResources.resx
+++ b/src/Utilities/AnalyzerUtilitiesResources.resx
@@ -117,42 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CategoryDesign" xml:space="preserve">
-    <value>Design</value>
-  </data>
-  <data name="CategoryGlobalization" xml:space="preserve">
-    <value>Globalization</value>
-  </data>
-  <data name="CategoryInteroperability" xml:space="preserve">
-    <value>Interoperability</value>
-  </data>
-  <data name="CategoryLibrary" xml:space="preserve">
-    <value>Library</value>
-  </data>
-  <data name="CategoryNaming" xml:space="preserve">
-    <value>Naming</value>
-  </data>
-  <data name="CategoryPerformance" xml:space="preserve">
-    <value>Performance</value>
-  </data>
-  <data name="CategoryReliability" xml:space="preserve">
-    <value>Reliability</value>
-  </data>
-  <data name="CategoryUsage" xml:space="preserve">
-    <value>Usage</value>
-  </data>
-  <data name="CategoryMobility" xml:space="preserve">
-    <value>Mobility</value>
-  </data>
-  <data name="CategorySecurity" xml:space="preserve">
-    <value>Security</value>
-  </data>
-  <data name="CategoryDocumentation" xml:space="preserve">
-    <value>Documentation</value>
-  </data>
-  <data name="CategoryMaintainability" xml:space="preserve">
-    <value>Maintainability</value>
-  </data>
   <data name="VersionCheckDescription" xml:space="preserve">
     <value>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</value>
   </data>

--- a/src/Utilities/DiagnosticCategory.cs
+++ b/src/Utilities/DiagnosticCategory.cs
@@ -4,18 +4,18 @@ namespace Analyzer.Utilities
 {
     internal static class DiagnosticCategory
     {
-        public static readonly string Design = AnalyzerUtilitiesResources.CategoryDesign;
-        public static readonly string Globalization = AnalyzerUtilitiesResources.CategoryGlobalization;
-        public static readonly string Interoperability = AnalyzerUtilitiesResources.CategoryInteroperability;
-        public static readonly string Mobility = AnalyzerUtilitiesResources.CategoryMobility;
-        public static readonly string Performance = AnalyzerUtilitiesResources.CategoryPerformance;
-        public static readonly string Reliability = AnalyzerUtilitiesResources.CategoryReliability;
-        public static readonly string Security = AnalyzerUtilitiesResources.CategorySecurity;
-        public static readonly string Usage = AnalyzerUtilitiesResources.CategoryUsage;
-        public static readonly string Naming = AnalyzerUtilitiesResources.CategoryNaming;
-        public static readonly string Library = AnalyzerUtilitiesResources.CategoryLibrary;
-        public static readonly string Documentation = AnalyzerUtilitiesResources.CategoryDocumentation;
-        public static readonly string Maintainability = AnalyzerUtilitiesResources.CategoryMaintainability;
+        public const string Design = nameof(Design);
+        public const string Globalization = nameof(Globalization);
+        public const string Interoperability = nameof(Interoperability);
+        public const string Mobility = nameof(Mobility);
+        public const string Performance = nameof(Performance);
+        public const string Reliability = nameof(Reliability);
+        public const string Security = nameof(Security);
+        public const string Usage = nameof(Usage);
+        public const string Naming = nameof(Naming);
+        public const string Library = nameof(Library);
+        public const string Documentation = nameof(Documentation);
+        public const string Maintainability = nameof(Maintainability);
 
         public const string RoslyDiagnosticsDesign = nameof(RoslyDiagnosticsDesign);
         public const string RoslyDiagnosticsMaintainability = nameof(RoslyDiagnosticsMaintainability);

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Analyzer.Utilities.Extensions
 {
@@ -90,6 +91,24 @@ namespace Analyzer.Utilities.Extensions
                 (IMethodSymbol m) => m.Parameters,
                 (IPropertySymbol p) => p.Parameters,
                 _ => ImmutableArray.Create<IParameterSymbol>());
+        }
+
+        /// <summary>
+        /// Returns true if the given symbol has required visibility based on options:
+        ///   1. If user has explicitly configured candidate <see cref="SymbolVisibilityGroup"/> in editor config options and
+        ///      given symbol's visibility is one of the candidate visibilites.
+        ///   2. Otherwise, if user has not configured visibility, and given symbol's visibility
+        ///      matches the given default symbol visibility.
+        /// </summary>
+        public static bool MatchesConfiguredVisibility(
+            this ISymbol symbol,
+            AnalyzerOptions options,
+            DiagnosticDescriptor rule,
+            CancellationToken cancellationToken,
+            SymbolVisibilityGroup defaultRequiredVisibility = SymbolVisibilityGroup.Public)
+        {
+            var allowedVisibilities = options.GetSymbolVisibilityGroupOption(rule, defaultRequiredVisibility, cancellationToken);
+            return allowedVisibilities.Contains(symbol.GetResultantVisibility());
         }
 
         /// <summary>

--- a/src/Utilities/Extensions/SymbolVisibility.cs
+++ b/src/Utilities/Extensions/SymbolVisibility.cs
@@ -4,9 +4,10 @@ namespace Analyzer.Utilities.Extensions
 {
     internal enum SymbolVisibility
     {
-        Public,
-        Internal,
-        Private,
+        Public = 0,
+        Internal = 1,
+        Private = 2,
+        Friend = Internal,
     }
 
     /// <summary>

--- a/src/Utilities/Extensions/SymbolVisibility.cs
+++ b/src/Utilities/Extensions/SymbolVisibility.cs
@@ -37,5 +37,23 @@ namespace Analyzer.Utilities.Extensions
                     throw new ArgumentOutOfRangeException(nameof(typeVisibility), typeVisibility, null);
             }
         }
+
+        public static SymbolVisibilityGroup ToSymbolVisibilityGroup(this SymbolVisibility symbolVisibility)
+        {
+            switch (symbolVisibility)
+            {
+                case SymbolVisibility.Public:
+                    return SymbolVisibilityGroup.Public;
+
+                case SymbolVisibility.Internal:
+                    return SymbolVisibilityGroup.Internal;
+
+                case SymbolVisibility.Private:
+                    return SymbolVisibilityGroup.Private;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(symbolVisibility), symbolVisibility, null);
+            }
+        }
     }
 }

--- a/src/Utilities/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Options/AnalyzerOptionsExtensions.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+#pragma warning disable RS1012 // Start action has no registered actions.
+
+namespace Analyzer.Utilities
+{
+    internal static class AnalyzerOptionsExtensions
+    {
+        public static SymbolVisibilityGroup GetSymbolVisibilityGroupOption(
+            this AnalyzerOptions options,
+            DiagnosticDescriptor rule,
+            SymbolVisibilityGroup defaultValue,
+            CancellationToken cancellationToken)
+            => options.GetEnumOptionValue("visibility", rule, defaultValue, cancellationToken);
+
+        private static TEnum GetEnumOptionValue<TEnum>(
+            this AnalyzerOptions options,
+            string optionName,
+            DiagnosticDescriptor rule,
+            TEnum defaultValue,
+            CancellationToken cancellationToken)
+            where TEnum: struct
+        {
+            var analyzerConfigOptions = options.GetCategorizedAnalyzerConfigOptions(cancellationToken);
+            return analyzerConfigOptions.GetEnumOptionValue(optionName, rule, defaultValue);
+        }
+
+        private static CategorizedAnalyzerConfigOptions GetCategorizedAnalyzerConfigOptions(
+            this AnalyzerOptions options,
+            CancellationToken cancellationToken)
+        {
+            foreach (var additionalFile in options.AdditionalFiles)
+            {
+                if (additionalFile.Path.EndsWith(".editorconfig", StringComparison.OrdinalIgnoreCase))
+                {
+                    var text = additionalFile.GetText(cancellationToken);
+                    return EditorConfigParser.Parse(text);
+                }
+            }
+
+            return CategorizedAnalyzerConfigOptions.Empty;
+        }
+    }
+}

--- a/src/Utilities/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Options/AnalyzerOptionsExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -11,6 +13,9 @@ namespace Analyzer.Utilities
 {
     internal static class AnalyzerOptionsExtensions
     {
+        private static readonly ConditionalWeakTable<AnalyzerOptions, CategorizedAnalyzerConfigOptions> s_cachedOptions
+            = new ConditionalWeakTable<AnalyzerOptions, CategorizedAnalyzerConfigOptions>();
+
         public static SymbolVisibilityGroup GetSymbolVisibilityGroupOption(
             this AnalyzerOptions options,
             DiagnosticDescriptor rule,
@@ -26,24 +31,37 @@ namespace Analyzer.Utilities
             CancellationToken cancellationToken)
             where TEnum: struct
         {
-            var analyzerConfigOptions = options.GetCategorizedAnalyzerConfigOptions(cancellationToken);
+            var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(cancellationToken);
             return analyzerConfigOptions.GetEnumOptionValue(optionName, rule, defaultValue);
         }
 
-        private static CategorizedAnalyzerConfigOptions GetCategorizedAnalyzerConfigOptions(
-            this AnalyzerOptions options,
-            CancellationToken cancellationToken)
+        private static CategorizedAnalyzerConfigOptions GetOrComputeCategorizedAnalyzerConfigOptions(
+            this AnalyzerOptions options, CancellationToken cancellationToken)
         {
-            foreach (var additionalFile in options.AdditionalFiles)
+            // TryGetValue upfront to avoid allocating createValueCallback if the entry already exists. 
+            if (s_cachedOptions.TryGetValue(options, out var categorizedAnalyzerConfigOptions))
             {
-                if (additionalFile.Path.EndsWith(".editorconfig", StringComparison.OrdinalIgnoreCase))
-                {
-                    var text = additionalFile.GetText(cancellationToken);
-                    return EditorConfigParser.Parse(text);
-                }
+                return categorizedAnalyzerConfigOptions;
             }
 
-            return CategorizedAnalyzerConfigOptions.Empty;
+            var createValueCallback = new ConditionalWeakTable<AnalyzerOptions, CategorizedAnalyzerConfigOptions>.CreateValueCallback(_ => ComputeCategorizedAnalyzerConfigOptions());
+            return s_cachedOptions.GetValue(options, createValueCallback);
+
+            // Local functions.
+            CategorizedAnalyzerConfigOptions ComputeCategorizedAnalyzerConfigOptions()
+            {
+                foreach (var additionalFile in options.AdditionalFiles)
+                {
+                    var fileName = Path.GetFileName(additionalFile.Path);
+                    if (fileName.Equals(".editorconfig", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var text = additionalFile.GetText(cancellationToken);
+                        return EditorConfigParser.Parse(text);
+                    }
+                }
+
+                return CategorizedAnalyzerConfigOptions.Empty;
+            }
         }
     }
 }

--- a/src/Utilities/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Options/AnalyzerOptionsExtensions.cs
@@ -16,7 +16,7 @@ namespace Analyzer.Utilities
             DiagnosticDescriptor rule,
             SymbolVisibilityGroup defaultValue,
             CancellationToken cancellationToken)
-            => options.GetEnumOptionValue("visibility", rule, defaultValue, cancellationToken);
+            => options.GetEnumOptionValue("api_surface", rule, defaultValue, cancellationToken);
 
         private static TEnum GetEnumOptionValue<TEnum>(
             this AnalyzerOptions options,

--- a/src/Utilities/Options/CategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Options/CategorizedAnalyzerConfigOptions.cs
@@ -14,21 +14,23 @@ namespace Analyzer.Utilities
     /// 
     /// .editorconfig format:
     ///  1) General configuration option:
-    ///     (a) "OptionName = OptionValue"
+    ///     (a) "dotnet_code_quality.OptionName = OptionValue"
     ///  2) Specific configuration option:
-    ///     (a) "RuleId.OptionName = OptionValue"
-    ///     (b) "RuleCategory.OptionName = OptionValue"
+    ///     (a) "dotnet_code_quality.RuleId.OptionName = OptionValue"
+    ///     (b) "dotnet_code_quality.RuleCategory.OptionName = OptionValue"
     ///    
     /// .editorconfig examples to configure API surface analyzed by analyzers:
     ///  1) General configuration option:
-    ///     (a) "visibility = all"
+    ///     (a) "dotnet_code_quality.api_surface = all"
     ///  2) Specific configuration option:
-    ///     (a) "CA1040.visibility = public, internal"
-    ///     (b) "Naming.visibility = public"
+    ///     (a) "dotnet_code_quality.CA1040.api_surface = public, internal"
+    ///     (b) "dotnet_code_quality.Naming.api_surface = public"
     ///  See <see cref="SymbolVisibilityGroup"/> for allowed symbol visibility value combinations.
     /// </summary>
     internal sealed class CategorizedAnalyzerConfigOptions
     {
+        private const string KeyPrefix = "dotnet_code_quality.";
+
         public static readonly CategorizedAnalyzerConfigOptions Empty = new CategorizedAnalyzerConfigOptions(
             ImmutableDictionary<string, string>.Empty,
             ImmutableDictionary<string, ImmutableDictionary<string, string>>.Empty);
@@ -60,6 +62,12 @@ namespace Analyzer.Utilities
                 var key = kvp.Key;
                 var value = kvp.Value;
 
+                if (!key.StartsWith(KeyPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                key = key.Substring(KeyPrefix.Length);
                 var keyParts = key.Split('.').Select(s => s.Trim()).ToImmutableArray();
                 switch (keyParts.Length)
                 {

--- a/src/Utilities/Options/CategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Options/CategorizedAnalyzerConfigOptions.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Analyzer.Utilities
+{
+    /// <summary>
+    /// Analyzer configuration options from an .editorconfig file that are parsed into general
+    /// and specific configuration options.
+    /// 
+    /// .editorconfig format:
+    ///  1) General configuration option:
+    ///     (a) "OptionName = OptionValue"
+    ///  2) Specific configuration option:
+    ///     (a) "RuleId.OptionName = OptionValue"
+    ///     (b) "RuleCategory.OptionName = OptionValue"
+    ///    
+    /// .editorconfig examples to configure API surface analyzed by analyzers:
+    ///  1) General configuration option:
+    ///     (a) "visibility = all"
+    ///  2) Specific configuration option:
+    ///     (a) "CA1040.visibility = public, internal"
+    ///     (b) "Naming.visibility = public"
+    ///  See <see cref="SymbolVisibilityGroup"/> for allowed symbol visibility value combinations.
+    /// </summary>
+    internal sealed class CategorizedAnalyzerConfigOptions
+    {
+        public static readonly CategorizedAnalyzerConfigOptions Empty = new CategorizedAnalyzerConfigOptions(
+            ImmutableDictionary<string, string>.Empty,
+            ImmutableDictionary<string, ImmutableDictionary<string, string>>.Empty);
+
+        private CategorizedAnalyzerConfigOptions(
+            ImmutableDictionary<string, string> generalOptions,
+            ImmutableDictionary<string, ImmutableDictionary<string, string>> specificOptions)
+        {
+            GeneralOptions = generalOptions;
+            SpecificOptions = specificOptions;
+        }
+
+        public ImmutableDictionary<string, string> GeneralOptions { get; }
+        public ImmutableDictionary<string, ImmutableDictionary<string, string>> SpecificOptions { get; }
+
+        public static CategorizedAnalyzerConfigOptions Create(IDictionary<string, string> options)
+        {
+            options = options ?? throw new ArgumentNullException(nameof(options));
+
+            if (options.Count == 0)
+            {
+                return Empty;
+            }
+
+            var generalOptionsBuilder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+            var specificOptionsBuilder = ImmutableDictionary.CreateBuilder<string, ImmutableDictionary<string, string>.Builder>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in options)
+            {
+                var key = kvp.Key;
+                var value = kvp.Value;
+
+                var keyParts = key.Split('.').Select(s => s.Trim()).ToImmutableArray();
+                switch (keyParts.Length)
+                {
+                    case 1:
+                        generalOptionsBuilder.Add(keyParts[0], value);
+                        break;
+
+                    case 2:
+                        if (!specificOptionsBuilder.TryGetValue(keyParts[0], out var optionsForKeyBuilder))
+                        {
+                            optionsForKeyBuilder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+                            specificOptionsBuilder.Add(keyParts[0], optionsForKeyBuilder);
+                        }
+
+                        optionsForKeyBuilder[keyParts[1]] = value;
+                        break;
+                }
+            }
+
+            var generalOptions = generalOptionsBuilder.Count > 0 ?
+                generalOptionsBuilder.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase) :
+                ImmutableDictionary<string, string>.Empty;
+
+            var specificOptions = specificOptionsBuilder.Count > 0 ?
+                specificOptionsBuilder
+                    .Select(kvp => new KeyValuePair<string, ImmutableDictionary<string, string>>(kvp.Key, kvp.Value.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase)))
+                    .ToImmutableDictionary(StringComparer.OrdinalIgnoreCase) :
+                ImmutableDictionary<string, ImmutableDictionary<string, string>>.Empty;
+
+            return new CategorizedAnalyzerConfigOptions(generalOptions, specificOptions);
+        }
+
+        public TEnum GetEnumOptionValue<TEnum>(string optionName, DiagnosticDescriptor rule, TEnum defaultValue)
+            where TEnum : struct
+        {
+            if (TryGetSpecificOptionValue(rule.Id, out var optionValue) ||
+                TryGetSpecificOptionValue(rule.Category, out optionValue) ||
+                TryGetGeneralOptionValue(out optionValue))
+            {
+                return optionValue;
+            }
+
+            return defaultValue;
+
+            // Local functions.
+            bool TryGetSpecificOptionValue(string specificOptionKey, out TEnum specificOptionValue)
+            {
+                if (SpecificOptions.TryGetValue(specificOptionKey, out var specificRuleOptions) &&
+                    specificRuleOptions.TryGetValue(optionName, out var valueString))
+                {
+                    return TryParse(valueString, out specificOptionValue);
+                }
+
+                specificOptionValue = defaultValue;
+                return false;
+            }
+
+            bool TryGetGeneralOptionValue(out TEnum generalOptionValue)
+            {
+                if (GeneralOptions.TryGetValue(optionName, out var valueString))
+                {
+                    return TryParse(valueString, out generalOptionValue);
+                }
+
+                generalOptionValue = defaultValue;
+                return false;
+            }
+
+            bool TryParse(string value, out TEnum result)
+                => Enum.TryParse(value, ignoreCase: true, result: out result);
+        }
+
+        public int GetIntegralOptionValue(string optionName, DiagnosticDescriptor rule, int defaultValue)
+        {
+            if (TryGetSpecificOptionValue(rule.Id, out var optionValue) ||
+                TryGetSpecificOptionValue(rule.Category, out optionValue) ||
+                TryGetGeneralOptionValue(out optionValue))
+            {
+                return optionValue;
+            }
+
+            return defaultValue;
+
+            // Local functions.
+            bool TryGetSpecificOptionValue(string specificOptionKey, out int specificOptionValue)
+            {
+                if (SpecificOptions.TryGetValue(specificOptionKey, out var specificRuleOptions) &&
+                    specificRuleOptions.TryGetValue(optionName, out var valueString))
+                {
+                    return int.TryParse(valueString, out specificOptionValue);
+                }
+
+                specificOptionValue = defaultValue;
+                return false;
+            }
+
+            bool TryGetGeneralOptionValue(out int generalOptionValue)
+            {
+                if (GeneralOptions.TryGetValue(optionName, out var valueString))
+                {
+                    return int.TryParse(valueString, out generalOptionValue);
+                }
+
+                generalOptionValue = defaultValue;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Utilities/Options/EditorConfigParser.cs
+++ b/src/Utilities/Options/EditorConfigParser.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Analyzer.Utilities
+{
+    /// <summary>
+    /// Parses a given .editorconfig source text into <see cref="CategorizedAnalyzerConfigOptions"/>.
+    /// </summary>
+    internal static class EditorConfigParser
+    {
+        // Matches EditorConfig section header such as "[*.{js,py}]", see http://editorconfig.org for details
+        private static readonly Regex s_sectionMatcher = new Regex(@"^\s*\[(([^#;]|\\#|\\;)+)\]\s*([#;].*)?$", RegexOptions.Compiled);
+        // Matches EditorConfig property such as "indent_style = space", see http://editorconfig.org for details
+        private static readonly Regex s_propertyMatcher = new Regex(@"^\s*([\w\.\-_]+)\s*[=:]\s*(.*?)\s*([#;].*)?$", RegexOptions.Compiled);
+
+        private static readonly StringComparer s_keyComparer = CaseInsensitiveComparison.Comparer;
+
+        /// <summary>
+        /// A set of keys that are reserved for special interpretation for the editorconfig specification.
+        /// All values corresponding to reserved keys in a (key,value) property pair are always lowercased
+        /// during parsing.
+        /// </summary>
+        /// <remarks>
+        /// This list was retrieved from https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
+        /// at 2018-04-21 19:37:05Z. New keys may be added to this list in newer versions, but old ones will
+        /// not be removed.
+        /// </remarks>
+        private static readonly ImmutableHashSet<string> s_reservedKeys
+            = ImmutableHashSet.CreateRange(s_keyComparer, new[] {
+                "root",
+                "indent_style",
+                "indent_size",
+                "tab_width",
+                "end_of_line",
+                "charset",
+                "trim_trailing_whitespace",
+                "insert_final_newline",
+            });
+
+        /// <summary>
+        /// A set of values that are reserved for special use for the editorconfig specification
+        /// and will always be lower-cased by the parser.
+        /// </summary>
+        private static readonly ImmutableHashSet<string> s_reservedValues
+            = ImmutableHashSet.CreateRange(s_keyComparer, new[] { "unset" });
+
+        private static readonly ConditionalWeakTable<SourceText, CategorizedAnalyzerConfigOptions> s_cachedOptions
+            = new ConditionalWeakTable<SourceText, CategorizedAnalyzerConfigOptions>();
+
+        private static readonly ConditionalWeakTable<SourceText, CategorizedAnalyzerConfigOptions>.CreateValueCallback s_cachedOptionsCreateValueCallback
+            = new ConditionalWeakTable<SourceText, CategorizedAnalyzerConfigOptions>.CreateValueCallback(ParseCore);
+
+        public static CategorizedAnalyzerConfigOptions Parse(SourceText text)
+            => s_cachedOptions.GetValue(text, s_cachedOptionsCreateValueCallback);
+
+        private static CategorizedAnalyzerConfigOptions ParseCore(SourceText text)
+            => ParseCore(text, out _);
+
+        private static CategorizedAnalyzerConfigOptions ParseCore(SourceText text, out ImmutableArray<string> invalidLines)
+        {
+            var parsedOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var invalidLinesBuilder = ImmutableArray.CreateBuilder<string>();
+
+            foreach (var textLine in text.Lines)
+            {
+                var line = textLine.ToString();
+
+                if (string.IsNullOrWhiteSpace(line) || IsComment(line))
+                {
+                    continue;
+                }
+
+                var propMatches = s_propertyMatcher.Matches(line);
+                if (propMatches.Count > 0 && propMatches[0].Groups.Count > 1)
+                {
+                    var key = propMatches[0].Groups[1].Value;
+                    var value = propMatches[0].Groups[2].Value;
+
+                    Debug.Assert(!string.IsNullOrEmpty(key));
+                    Debug.Assert(key == key.Trim());
+                    Debug.Assert(value == value?.Trim());
+
+                    key = CaseInsensitiveComparison.ToLower(key);
+                    if (s_reservedKeys.Contains(key) || s_reservedValues.Contains(value))
+                    {
+                        value = CaseInsensitiveComparison.ToLower(value);
+                    }
+
+                    parsedOptions[key] = value ?? "";
+                    continue;
+                }
+                else if (s_sectionMatcher.IsMatch(line))
+                {
+                    // Ignore section line
+                    continue;
+                }
+
+                // Unable to parse this line
+                invalidLinesBuilder.Add(line);
+            }
+
+            invalidLines = invalidLinesBuilder.ToImmutable();
+            return CategorizedAnalyzerConfigOptions.Create(parsedOptions);
+        }
+
+        private static bool IsComment(string line)
+        {
+            foreach (char c in line)
+            {
+                if (!char.IsWhiteSpace(c))
+                {
+                    return c == '#' || c == ';';
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Utilities/Options/EditorConfigParser.cs
+++ b/src/Utilities/Options/EditorConfigParser.cs
@@ -16,8 +16,6 @@ namespace Analyzer.Utilities
     /// </summary>
     internal static class EditorConfigParser
     {
-        // Matches EditorConfig section header such as "[*.{js,py}]", see http://editorconfig.org for details
-        private static readonly Regex s_sectionMatcher = new Regex(@"^\s*\[(([^#;]|\\#|\\;)+)\]\s*([#;].*)?$", RegexOptions.Compiled);
         // Matches EditorConfig property such as "indent_style = space", see http://editorconfig.org for details
         private static readonly Regex s_propertyMatcher = new Regex(@"^\s*([\w\.\-_]+)\s*[=:]\s*(.*?)\s*([#;].*)?$", RegexOptions.Compiled);
 
@@ -62,12 +60,8 @@ namespace Analyzer.Utilities
             => s_cachedOptions.GetValue(text, s_cachedOptionsCreateValueCallback);
 
         private static CategorizedAnalyzerConfigOptions ParseCore(SourceText text)
-            => ParseCore(text, out _);
-
-        private static CategorizedAnalyzerConfigOptions ParseCore(SourceText text, out ImmutableArray<string> invalidLines)
         {
             var parsedOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            var invalidLinesBuilder = ImmutableArray.CreateBuilder<string>();
 
             foreach (var textLine in text.Lines)
             {
@@ -97,17 +91,8 @@ namespace Analyzer.Utilities
                     parsedOptions[key] = value ?? "";
                     continue;
                 }
-                else if (s_sectionMatcher.IsMatch(line))
-                {
-                    // Ignore section line
-                    continue;
-                }
-
-                // Unable to parse this line
-                invalidLinesBuilder.Add(line);
             }
 
-            invalidLines = invalidLinesBuilder.ToImmutable();
             return CategorizedAnalyzerConfigOptions.Create(parsedOptions);
         }
 

--- a/src/Utilities/Options/EditorConfigParser.cs
+++ b/src/Utilities/Options/EditorConfigParser.cs
@@ -50,16 +50,7 @@ namespace Analyzer.Utilities
         private static readonly ImmutableHashSet<string> s_reservedValues
             = ImmutableHashSet.CreateRange(s_keyComparer, new[] { "unset" });
 
-        private static readonly ConditionalWeakTable<SourceText, CategorizedAnalyzerConfigOptions> s_cachedOptions
-            = new ConditionalWeakTable<SourceText, CategorizedAnalyzerConfigOptions>();
-
-        private static readonly ConditionalWeakTable<SourceText, CategorizedAnalyzerConfigOptions>.CreateValueCallback s_cachedOptionsCreateValueCallback
-            = new ConditionalWeakTable<SourceText, CategorizedAnalyzerConfigOptions>.CreateValueCallback(ParseCore);
-
         public static CategorizedAnalyzerConfigOptions Parse(SourceText text)
-            => s_cachedOptions.GetValue(text, s_cachedOptionsCreateValueCallback);
-
-        private static CategorizedAnalyzerConfigOptions ParseCore(SourceText text)
         {
             var parsedOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Utilities/Options/SymbolVisibilityGroup.cs
+++ b/src/Utilities/Options/SymbolVisibilityGroup.cs
@@ -10,13 +10,17 @@ namespace Analyzer.Utilities
     /// </summary>
     [Flags]
 #pragma warning disable CA1714 // Flags enums should have plural names
-    internal enum SymbolVisibilityGroup
+    public enum SymbolVisibilityGroup
 #pragma warning restore CA1714 // Flags enums should have plural names
     {
+        // NOTE: Below fields names are used in the .editorconfig specification
+        //       for symbol visibility analyzer option. Hence the names should *not* be modified,
+        //       as that would be a breaking change for .editorconfig specification.
         None = 0x0,
         Public = 0x1,
         Internal = 0x2,
         Private = 0x4,
+        Friend = Internal,
         All = Public | Internal | Private
     }
 

--- a/src/Utilities/Options/SymbolVisibilityGroup.cs
+++ b/src/Utilities/Options/SymbolVisibilityGroup.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Analyzer.Utilities.Extensions;
+
+namespace Analyzer.Utilities
+{
+    /// <summary>
+    /// Describes a group of effective <see cref="SymbolVisibility"/> for symbols.
+    /// </summary>
+    [Flags]
+#pragma warning disable CA1714 // Flags enums should have plural names
+    internal enum SymbolVisibilityGroup
+#pragma warning restore CA1714 // Flags enums should have plural names
+    {
+        None = 0x0,
+        Public = 0x1,
+        Internal = 0x2,
+        Private = 0x4,
+        All = Public | Internal | Private
+    }
+
+    internal static class SymbolVisibilityGroupExtensions
+    {
+        public static bool Contains(this SymbolVisibilityGroup symbolVisibilityGroup, SymbolVisibility symbolVisibility)
+        {
+            switch (symbolVisibility)
+            {
+                case SymbolVisibility.Public:
+                    return (symbolVisibilityGroup & SymbolVisibilityGroup.Public) != 0;
+
+                case SymbolVisibility.Internal:
+                    return (symbolVisibilityGroup & SymbolVisibilityGroup.Internal) != 0;
+
+                case SymbolVisibility.Private:
+                    return (symbolVisibilityGroup & SymbolVisibilityGroup.Private) != 0;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(symbolVisibility), symbolVisibility, null);
+            }
+        }
+    }
+}

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.cs.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.cs.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">Design</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">Globalizace</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">Interoperabilita</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">Knihovna</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">Pojmenování</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">Výkon</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">Spolehlivost</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">Použití</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">Mobilita</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">Zabezpečení</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">Analyzátory v tomto balíčku jsou ve verzi Preview a jsou svázány s konkrétní verzí rozhraní API platformy Microsoft.CodeAnalysis. Mezi verzí analyzátoru a platformy Microsoft.CodeAnalysis došlo k nesouladu a měli byste přepnout VSIX nebo balíček NuGet analyzátoru na odpovídající verzi platformy Microsoft.CodeAnalysis.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">Nesoulad verze analyzátoru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Documentation</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Maintainability</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.de.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.de.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">Design</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">Globalisierung</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">Interoperabilität</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">Bibliothek</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">Benennung</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">Leistung</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">Zuverlässigkeit</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">Syntax</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">Mobilität</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">Sicherheit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">Analysen in diesem Paket befinden sich in der Vorschau und sind an eine bestimmte API-Version von Microsoft.CodeAnalysis gebunden. Die Version der Analyse und die von Microsoft.CodeAnalysis stimmen nicht überein. Stellen Sie das NuGet-Paket/die VSIX der Analyse auf eine übereinstimmende Microsoft.CodeAnalysis-Version um.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">Analyseversionskonflikt</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Dokumentation</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Wartbarkeit</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.es.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.es.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">Diseño</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">Globalización</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">Interoperabilidad</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">Biblioteca</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">Nomenclatura</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">Rendimiento</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">Confiabilidad</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">Uso</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">Movilidad</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">Seguridad</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">Los analizadores de este paquete están en versión preliminar y están asociados a una versión de la API específica de Microsoft.CodeAnalysis. Las versiones de Microsoft.CodeAnalysis y del analizador no coinciden. Cambie el paquete NuGet/VSIX del analizador a una versión coincidente de Microsoft.CodeAnalysis.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">La versión del analizador no coincide</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Documentación</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Mantenimiento</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.fr.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.fr.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">Design</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">Mondialisation</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">Interopérabilité</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">Bibliothèque</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">Nommage</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">Performances</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">Fiabilité</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">Utilisation</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">Mobilité</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">Sécurité</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">Les analyseurs de ce package sont en préversion et sont liés à une version d'API spécifique de Microsoft.CodeAnalysis. Il existe une incompatibilité entre l'analyseur et la version de Microsoft.CodeAnalysis. Vous devez remplacer le package NuGet/VSIX de votre analyseur par une version compatible de Microsoft.CodeAnalysis.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">Incompatibilité de version de l'analyseur</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Documentation</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Maintenabilité</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.it.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.it.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">Progettazione</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">Globalizzazione</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">Interoperabilità</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">Libreria</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">Denominazione</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">Prestazioni</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">Affidabilità</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">Sintassi</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">Mobilità</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">Sicurezza</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">Gli analizzatori in questo pacchetto sono disponibili in versione di anteprima e sono collegati a una versione API specifica di Microsoft.CodeAnalysis. La versione dell'analizzatore non corrisponde a quella di Microsoft.CodeAnalysis ed è necessario impostare il pacchetto NuGet o il file VSIX dell'analizzatore su una versione corrispondente di Microsoft.CodeAnalysis.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">Versione dell'analizzatore non corrispondente</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Documentation</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Maintainability</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.ja.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.ja.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">デザイン</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">グローバリゼーション</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">相互運用性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">ライブラリ</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">名前付け</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">パフォーマンス</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">信頼性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">使用法</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">モビリティ</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">セキュリティ</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">このパッケージのアナライザーはプレビュー バージョンであり、Microsoft.CodeAnalysis の特定の API バージョンに関連付けられています。アナライザーと Microsoft.CodeAnalysis のバージョンに不一致があるため、アナライザーの NuGet パッケージ/VSIX を、対応するバージョンの Microsoft.CodeAnalysis に切り替える必要があります。</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">アナライザーのバージョン不一致</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">ドキュメント</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">保守容易性</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.ko.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.ko.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">디자인</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">세계화</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">상호 운용성</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">라이브러리</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">명명</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">성능</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">안정성</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">사용법</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">이동성</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">보안</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">이 패키지의 분석기는 미리 보기 버전이며 Microsoft.CodeAnalysis의 특정 API 버전에 연결됩니다. 분석기와 Microsoft.CodeAnalysis 버전이 일치하지 않으며 분석기 NuGet 패키지/VSIX를 일치하는 Microsoft.CodeAnalysis 버전으로 전환해야 합니다.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">분석기 버전 불일치</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">문서</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">유지 관리</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.pl.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.pl.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">Projektowanie</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">Globalizacja</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">Międzyoperacyjność</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">Biblioteka</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">Nazewnictwo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">Wydajność</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">Niezawodność</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">Użycie</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">Mobilność</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">Zabezpieczenia</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">Analizatory w tym pakiecie są w wersji zapoznawczej i są związane z konkretną wersją interfejsu API metody Microsoft.CodeAnalysis. Między analizatorem a wersją metody Microsoft.CodeAnalysis występuje niezgodność. Przełącz analizator pakietu NuGet/VSIX do pasującej wersji metody Microsoft.CodeAnalysis.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">Niezgodność wersji analizatora</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Dokumentacja</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Łatwość utrzymania</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.pt-BR.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.pt-BR.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">Design</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">Globalização</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">Interoperabilidade</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">Biblioteca</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">Nomenclatura</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">Desempenho</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">Confiabilidade</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">Uso</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">Mobilidade</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">Segurança</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">Os analisadores neste pacote são uma versão prévia e estão associados a uma versão da API específica de Microsoft.CodeAnalysis. Você tem uma incompatibilidade entre o analisador e a versão de Microsoft.CodeAnalysis e deve mudar o VSIX/pacote NuGet do analisador para uma versão correspondente do Microsoft.CodeAnalysis.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">Incompatibilidade de versão do analisador</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Documentation</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Maintainability</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.ru.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.ru.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">Проектирование</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">Глобализация</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">Взаимодействие</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">Библиотека</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">Именование</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">Производительность</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">Надежность</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">Использование</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">Мобильность</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">Безопасность</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">Анализаторы в этом пакете находятся на этапе предварительной версии и привязаны к определенной версии API Microsoft.CodeAnalysis. Возникло несоответствие анализатора и версии Microsoft.CodeAnalysis, поэтому нужно переключить пакет NuGet/VSIX анализатора на подходящую версию Microsoft.CodeAnalysis.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">Несовпадение версии анализатора</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Documentation</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Maintainability</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.tr.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.tr.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">Tasarım</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">Küreselleşme</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">Birlikte çalışabilirlik</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">Kitaplık</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">Adlandırma</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">Performans</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">Güvenilirlik</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">Kullanım</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">Taşınabilirlik</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">Güvenlik</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">Bu paketteki çözümleyiciler önizleme sürümündedir ve belirli bir Microsoft.CodeAnalysis API sürümüne bağlıdır. Çözümleyici ve Microsoft.CodeAnalysis sürümü arasında bir uyuşmazlık var ve çözümleyicinizin NuGet paketini/VSIX’ini eşleşen bir Microsoft.CodeAnalysis sürümüne geçirmeniz gerekiyor.</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">Çözümleyici sürüm uyuşmazlığı</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Belgeler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Sürdürülebilirlik</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.zh-Hans.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.zh-Hans.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">设计</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">全球化</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">互操作性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">库</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">命名</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">性能</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">可靠性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">使用情况</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">移动性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">安全</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">此包中的分析器为预览版本，并绑定到 Microsoft.CodeAnalysis 的特定 API 版本。如果分析器与 Microsoft.CodeAnalysis 的版本不匹配，应将分析器 NuGet 包/VSIX 切换到匹配的 Microsoft.CodeAnalysis 版本。</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">分析器版本不匹配</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">Documentation</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">Maintainability</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Utilities/xlf/AnalyzerUtilitiesResources.zh-Hant.xlf
+++ b/src/Utilities/xlf/AnalyzerUtilitiesResources.zh-Hant.xlf
@@ -2,56 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../AnalyzerUtilitiesResources.resx">
     <body>
-      <trans-unit id="CategoryDesign">
-        <source>Design</source>
-        <target state="translated">設計</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryGlobalization">
-        <source>Globalization</source>
-        <target state="translated">全球化</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryInteroperability">
-        <source>Interoperability</source>
-        <target state="translated">互通性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryLibrary">
-        <source>Library</source>
-        <target state="translated">程式庫</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryNaming">
-        <source>Naming</source>
-        <target state="translated">命名</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryPerformance">
-        <source>Performance</source>
-        <target state="translated">效能</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryReliability">
-        <source>Reliability</source>
-        <target state="translated">可靠性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryUsage">
-        <source>Usage</source>
-        <target state="translated">使用方式</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMobility">
-        <source>Mobility</source>
-        <target state="translated">行動性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategorySecurity">
-        <source>Security</source>
-        <target state="translated">安全性</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionCheckDescription">
         <source>Analyzers in this package are preview version and are tied to a specific API version of Microsoft.CodeAnalysis. You have a mismatch between the analyzer and Microsoft.CodeAnalysis version and should switch your analyzer NuGet package/VSIX to a matching version of the Microsoft.CodeAnalysis.</source>
         <target state="translated">此套件中的分析器是預覽版本，且繫結至 Microsoft.CodeAnalysis 的特定 API 版本。您的分析器與 Microsoft.CodeAnalysis 之間的版本不符，請將您的分析器 NuGet 套件/VSIX 切換至相符的 Microsoft.CodeAnalysis 版本。</target>
@@ -65,16 +15,6 @@
       <trans-unit id="VersionCheckTitle">
         <source>Analyzer version mismatch</source>
         <target state="translated">分析器版本不符</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryDocumentation">
-        <source>Documentation</source>
-        <target state="translated">文件</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CategoryMaintainability">
-        <source>Maintainability</source>
-        <target state="translated">可維護性</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fixes #1850

![editorconfigbasedoptions](https://user-images.githubusercontent.com/10605811/50529230-4df20180-0aa8-11e9-8d9d-228f1854d5a9.gif)

**Additions in this PR:**
1. `EditorConfigParser`: Simple .editorconfig based parser to read "key = value" property values from an additional file with name _.editorconfig_. Note that this is a temporary parser that will be deleted once the compiler support for .editorconfig comes online.
2. `CategorizedAnalyzerConfigOptions`: Analyzer configuration options from an .editorconfig file that are parsed into general and specific configuration options.
  .editorconfig format:
   1. General configuration option:
      1. `dotnet_code_quality.OptionName = OptionValue`
   2. Specific configuration option:
      1. `dotnet_code_quality.RuleId.OptionName = OptionValue`
      2. `dotnet_code_quality.RuleCategory.OptionName = OptionValue`
   .editorconfig examples to configure API surface analyzed by analyzers:
   1. General configuration option:
      1. `dotnet_code_quality.api_surface = all`
   2. Specific configuration option:
      1. `dotnet_code_quality.CA1040.api_surface = public, internal`
      2. `dotnet_code_quality.Naming.api_surface = public`
3. `AnalyzerOptionsExtensions`: Extension methods on `AnalyzerOptions` to fetch .editorconfig based configuration options. This PR adds support for the most commonly requested configuration option: _analyzed API surface_.
4. Update all the analyzers that defaulted to `IsExternallyVisible` default visibility for FxCop compat to operate based on .editorconfig configuration, with `IsExternallyVisible` being the fallback check in absence of .editorconfig configuration for corresponding rule.
5. Update the default props file included with each analyzer NuGet package to tag .editorconfig at the root of the project directory as an additional file. This functionality is enabled by default, but is guarded by a property to enable end users to specify different custom .editorconfig. With this change, end users just need to drop a .editorconfig file at the root of their project directory, and the analyzers will automatically respect the configuration setting within it.

To support rule category based configuration, I also fixed #1468 as part of this PR.
Fixes #1468

**Follow-up work:**
1. ~~Add an analyzer that reports additional file diagnostics for unknown key and/or values in the .editorconfig file. Currently, we just drop them on the floor.~~ On second thought, we cannot really do this as the editorconfig is shared with other analyzer packages, for which the key/value pair might be an expected one.
2. Add support for more configuration options. For example, #1826 for dataflow analysis, #1859 for security analyzers, etc.
3. ~~Add sanity unit tests~~ Done with https://github.com/dotnet/roslyn-analyzers/pull/1952/commits/ac97a3e5e8be0d3a7682fe2ea533a4b73ea4905c
4. ~~Add documentation page for the supported configuration key/values and steps for end user to enable this.~~ Done with https://github.com/dotnet/roslyn-analyzers/pull/1952/commits/963d03fecad742a1d122932245c377222d1207b3