### PR TITLE
Fix CA1066 (Implement IEquatable<T> when overriding Object.Equals)

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             INamedTypeSymbol constructedEquatable = equatableType.Construct(namedType);
             INamedTypeSymbol implementation = namedType
-                .Interfaces
+                .AllInterfaces
                 .FirstOrDefault(x => x.Equals(constructedEquatable));
             bool implementsEquatable = implementation != null;
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
@@ -314,6 +314,27 @@ struct C : B
                 GetCSharpResultAt(12, 8, EquatableAnalyzer.ImplementIEquatableRuleId, expectedMessage2));
         }
 
+        [Fact, WorkItem(1914, "https://github.com/dotnet/roslyn-analyzers/issues/1914")]
+        public void NoDiagnosticForParentClassWithIEquatableImplementation()
+        {
+            var code = @"
+using System;
+
+public interface IValueObject<T> : IEquatable<T> { }
+
+public struct S : IValueObject<S>
+{
+    private readonly int value;
+
+    public override bool Equals(object obj) => obj is S other && Equals(other);
+
+    public bool Equals(S other) => value == other.value;
+
+    public override int GetHashCode() => value;
+}";
+            VerifyCSharp(code);
+        }
+
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
             => new EquatableAnalyzer();
 


### PR DESCRIPTION
Account for interfaces implemented by the base types.
Fixes #1914