### PR TITLE
Fixes for CA2227: Collection properties should be read only

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
@@ -57,19 +59,27 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 (context) =>
                 {
                     INamedTypeSymbol iCollectionType = WellKnownTypes.ICollection(context.Compilation);
+                    INamedTypeSymbol genericICollectionType = WellKnownTypes.GenericICollection(context.Compilation);
                     INamedTypeSymbol arrayType = WellKnownTypes.Array(context.Compilation);
                     INamedTypeSymbol dataMemberAttribute = WellKnownTypes.DataMemberAttribute(context.Compilation);
 
-                    if (iCollectionType == null || arrayType == null)
+                    if (iCollectionType == null ||
+                        genericICollectionType == null ||
+                        arrayType == null)
                     {
                         return;
                     }
 
-                    context.RegisterSymbolAction(c => AnalyzeSymbol(c, iCollectionType, arrayType, dataMemberAttribute), SymbolKind.Property);
+                    context.RegisterSymbolAction(c => AnalyzeSymbol(c, iCollectionType, genericICollectionType, arrayType, dataMemberAttribute), SymbolKind.Property);
                 });
         }
 
-        public static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol iCollectionType, INamedTypeSymbol arrayType, INamedTypeSymbol dataMemberAttribute)
+        public static void AnalyzeSymbol(
+            SymbolAnalysisContext context,
+            INamedTypeSymbol iCollectionType,
+            INamedTypeSymbol genericICollectionType,
+            INamedTypeSymbol arrayType,
+            INamedTypeSymbol dataMemberAttribute)
         {
             var property = (IPropertySymbol)context.Symbol;
 
@@ -80,8 +90,29 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // make sure this property is NOT indexer, return type is NOT array but implement ICollection
-            if (property.IsIndexer || Inherits(property.Type, arrayType) || !Inherits(property.Type, iCollectionType))
+            // make sure this property is NOT an indexer
+            if (property.IsIndexer)
+            {
+                return;
+            }
+
+            // make sure return type is NOT array
+            if (Inherits(property.Type, arrayType))
+            {
+                return;
+            }
+
+            // make sure property type implements ICollection or ICollection<T>
+            if (!Inherits(property.Type, iCollectionType) && !Inherits(property.Type, genericICollectionType))
+            {
+                return;
+            }
+            
+            // exclude Immutable collections
+            // see https://github.com/dotnet/roslyn-analyzers/issues/1900 for details
+            if (property.Type.IsSealed &&
+                property.Type.Name.StartsWith("Immutable", StringComparison.Ordinal) &&
+                property.Type.ContainingNamespace?.ToDisplayString() == "System.Collections.Immutable")
             {
                 return;
             }
@@ -101,7 +132,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static bool Inherits(ITypeSymbol symbol, ITypeSymbol baseType)
         {
-            return symbol == null ? false : symbol.Inherits(baseType);
+            Debug.Assert(baseType.Equals(baseType.OriginalDefinition));
+            return symbol == null ? false : symbol.OriginalDefinition.Inherits(baseType);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static bool Inherits(ITypeSymbol symbol, ITypeSymbol baseType)
         {
             Debug.Assert(baseType.Equals(baseType.OriginalDefinition));
-            return symbol == null ? false : symbol.OriginalDefinition.Inherits(baseType);
+            return symbol?.OriginalDefinition.Inherits(baseType) ?? false;
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
@@ -249,6 +249,153 @@ public class A
 ");
         }
 
+        [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
+        public void CSharp_CA2227_ImmutableCollection_02()
+        {
+            VerifyCSharp(@"
+using System.Collections.Immutable;
+
+public class A
+{
+    public IImmutableStack<byte> ImmStack { get; set; }
+    public IImmutableQueue<byte> ImmQueue { get; set; }
+    public IImmutableSet<string> ImmSet { get; set; }
+    public IImmutableList<int> ImmList { get; set; }
+    public IImmutableDictionary<A, int> ImmDictionary { get; set; }
+}
+");
+        }
+
+        [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
+        public void CSharp_CA2227_ImmutableCollection_03()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+public class A
+{
+    public CustomImmutableList ImmList { get; set; }
+}
+
+public class CustomImmutableList : IImmutableList<int>, ICollection<int>
+{
+    public int this[int index] => throw new NotImplementedException();
+
+    public int Count => throw new NotImplementedException();
+
+    public bool IsReadOnly => throw new NotImplementedException();
+
+    public IImmutableList<int> Add(int value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> AddRange(IEnumerable<int> items)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> Clear()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool Contains(int item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void CopyTo(int[] array, int arrayIndex)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IEnumerator<int> GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+
+    public int IndexOf(int item, int index, int count, IEqualityComparer<int> equalityComparer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> Insert(int index, int element)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> InsertRange(int index, IEnumerable<int> items)
+    {
+        throw new NotImplementedException();
+    }
+
+    public int LastIndexOf(int item, int index, int count, IEqualityComparer<int> equalityComparer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> Remove(int value, IEqualityComparer<int> equalityComparer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool Remove(int item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> RemoveAll(Predicate<int> match)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> RemoveAt(int index)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> RemoveRange(IEnumerable<int> items, IEqualityComparer<int> equalityComparer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> RemoveRange(int index, int count)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> Replace(int oldValue, int newValue, IEqualityComparer<int> equalityComparer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IImmutableList<int> SetItem(int index, int value)
+    {
+        throw new NotImplementedException();
+    }
+
+    void ICollection<int>.Add(int item)
+    {
+        throw new NotImplementedException();
+    }
+
+    void ICollection<int>.Clear()
+    {
+        throw new NotImplementedException();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+}
+");
+        }
+
         [Fact]
         public void CSharp_CA2227_DataMember()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
@@ -46,6 +46,19 @@ public class A
 ", GetCSharpResultAt(6, 43, "Col"));
         }
 
+        [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
+        public void CSharp_CA2227_Test_GenericCollection()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class A
+{
+    public System.Collections.Generic.ICollection<int> Col { get; set; }
+}
+", GetCSharpResultAt(6, 56, "Col"));
+        }
+
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
         public void CSharp_CA2227_Test_Internal()
         {
@@ -170,7 +183,7 @@ class A
             VerifyCSharp(@"
 using System;
 
-class A
+public class A
 {
     public int[] Col { get; set; }
 }
@@ -183,13 +196,55 @@ class A
             VerifyCSharp(@"
 using System;
 
-class A
+public class A
 {
     public System.Collections.ICollection this[int i]
     {
         get { throw new NotImplementedException(); }
         set { }
     }
+}
+");
+        }
+
+        [Fact]
+        public void CSharp_CA2227_NonCollection()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class A
+{
+    public string Name { get; set; }
+}
+");
+        }
+
+        [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
+        public void CSharp_CA2227_ReadOnlyCollection()
+        {
+            VerifyCSharp(@"
+using System.Collections.Generic;
+
+public class A
+{
+    public IReadOnlyCollection<byte> Col { get; set; }
+}
+");
+        }
+
+        [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
+        public void CSharp_CA2227_ImmutableCollection()
+        {
+            VerifyCSharp(@"
+using System.Collections.Immutable;
+
+public class A
+{
+    public ImmutableArray<byte> ImmArray { get; set; }
+    public ImmutableHashSet<string> ImmSet { get; set; }
+    public ImmutableList<int> ImmList { get; set; }
+    public ImmutableDictionary<A, int> ImmDictionary { get; set; }
 }
 ");
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
@@ -221,16 +221,25 @@ public class A
         }
 
         [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
-        public void CSharp_CA2227_ReadOnlyCollection()
+        public void CSharp_CA2227_ReadOnlyCollections()
         {
+            // NOTE: ReadOnlyCollection<T> and ReadOnlyDictionary<Key, Value> implement ICollection and hence are flagged.
+            //       IReadOnlyCollection<T> does not implement ICollection or ICollection<T>, hence is not flagged.
             VerifyCSharp(@"
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 public class A
 {
-    public IReadOnlyCollection<byte> Col { get; set; }
+    public IReadOnlyCollection<byte> P1 { get; set; }
+    public ReadOnlyCollection<byte> P2 { get; set; }
+    public ReadOnlyDictionary<string, byte> P3 { get; set; }
 }
-");
+",
+            // Test0.cs(8,37): warning CA2227: Change 'P2' to be read-only by removing the property setter.
+            GetCSharpResultAt(8, 37, "P2"),
+            // Test0.cs(9,45): warning CA2227: Change 'P3' to be read-only by removing the property setter.
+            GetCSharpResultAt(9, 45, "P3"));
         }
 
         [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]

--- a/src/Utilities/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Extensions/ITypeSymbolExtensions.cs
@@ -85,9 +85,19 @@ namespace Analyzer.Utilities.Extensions
                 return false;
             }
 
-            if (!baseTypesOnly && symbol.AllInterfaces.OfType<ITypeSymbol>().Contains(candidateBaseType))
+            if (!baseTypesOnly)
             {
-                return true;
+                var allInterfaces = symbol.AllInterfaces.OfType<ITypeSymbol>();
+                if (candidateBaseType.OriginalDefinition.Equals(candidateBaseType))
+                {
+                    // Candidate base type is not a constructed generic type, so use original definition for interfaces.
+                    allInterfaces = allInterfaces.Select(i => i.OriginalDefinition);
+                }
+
+                if (allInterfaces.Contains(candidateBaseType))
+                {
+                    return true;
+                }
             }
 
             if (checkTypeParameterConstraints && symbol.TypeKind == TypeKind.TypeParameter)

--- a/src/Utilities/WellKnownTypes.cs
+++ b/src/Utilities/WellKnownTypes.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 
 namespace Analyzer.Utilities
@@ -461,6 +462,51 @@ namespace Analyzer.Utilities
         public static INamedTypeSymbol HttpVerbs(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName("System.Web.Mvc.HttpVerbs");
+        }
+
+        public static INamedTypeSymbol IImmutableDictionary(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Collections.Immutable.IImmutableDictionary`2");
+        }
+
+        public static INamedTypeSymbol IImmutableList(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Collections.Immutable.IImmutableList`1");
+        }
+
+        public static INamedTypeSymbol IImmutableQueue(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Collections.Immutable.IImmutableQueue`1");
+        }
+
+        public static INamedTypeSymbol IImmutableSet(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Collections.Immutable.IImmutableSet`1");
+        }
+
+        public static INamedTypeSymbol IImmutableStack(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Collections.Immutable.IImmutableStack`1");
+        }
+
+        public static ImmutableHashSet<INamedTypeSymbol> IImmutableInterfaces(Compilation compilation)
+        {
+            var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>();
+            AddIfNotNull(IImmutableDictionary(compilation));
+            AddIfNotNull(IImmutableList(compilation));
+            AddIfNotNull(IImmutableQueue(compilation));
+            AddIfNotNull(IImmutableSet(compilation));
+            AddIfNotNull(IImmutableStack(compilation));
+            return builder.ToImmutable();
+
+            // Local functions.
+            void AddIfNotNull(INamedTypeSymbol type)
+            {
+                if (type != null)
+                {
+                    builder.Add(type);
+                }
+            }
         }
 
         #region Test Framework Types


### PR DESCRIPTION
1. Ensure that we fire for types implementing `ICollection<T>`. Currently implementation only checked for the non-generic `ICollection`.
2. Ensure that we don't fire for immutable collection types - the rule is only intended for properties of non-immutable types.

Fixes #1900