### PR TITLE
Fix CA1063 when implementing the dispose pattern for a derived class

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -638,28 +638,31 @@
     <value>All IDisposable types should implement the Dispose pattern correctly.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageIDisposableReimplementation" xml:space="preserve">
-    <value>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</value>
+    <value>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</value>
+  </data>
+  <data name="ImplementIDisposableCorrectlyMessageFinalizeOverride" xml:space="preserve">
+    <value>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageDisposeOverride" xml:space="preserve">
-    <value>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</value>
+    <value>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageDisposeSignature" xml:space="preserve">
-    <value>Ensure that {0} is declared as public and sealed.</value>
+    <value>Ensure that '{0}' is declared as public and sealed.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageRenameDispose" xml:space="preserve">
-    <value>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</value>
+    <value>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageDisposeBoolSignature" xml:space="preserve">
-    <value>Ensure that {0} is declared as protected, virtual, and unsealed.</value>
+    <value>Ensure that '{0}' is declared as protected, virtual, and unsealed.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageDisposeImplementation" xml:space="preserve">
-    <value>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</value>
+    <value>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageFinalizeImplementation" xml:space="preserve">
-    <value>Modify {0} so that it calls Dispose(false) and then returns.</value>
+    <value>Modify '{0}' so that it calls Dispose(false) and then returns.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageProvideDisposeBool" xml:space="preserve">
-    <value>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</value>
+    <value>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</value>
   </data>
   <data name="ExceptionsShouldBePublicTitle" xml:space="preserve">
     <value>Exceptions should be public</value>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -640,9 +640,6 @@
   <data name="ImplementIDisposableCorrectlyMessageIDisposableReimplementation" xml:space="preserve">
     <value>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</value>
   </data>
-  <data name="ImplementIDisposableCorrectlyMessageFinalizeOverride" xml:space="preserve">
-    <value>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</value>
-  </data>
   <data name="ImplementIDisposableCorrectlyMessageDisposeOverride" xml:space="preserve">
     <value>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</value>
   </data>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Neukládejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">Když je to možné, rozšiřte objekty CancellationToken.</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">Odeberte IDisposable ze seznamu rozhraní implementovaných pomocí {0}, protože se už implementuje pomocí základního typu {1}.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">Odeberte IDisposable ze seznamu rozhraní implementovaných pomocí {0}, protože se už implementuje pomocí základního typu {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">Odeberte {0}, přepište Dispose(likvidace logického typu) a vložte logiku likvidace do cesty kódu, kde disposing nabývá hodnoty true.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">Odeberte {0}, přepište Dispose(likvidace logického typu) a vložte logiku likvidace do cesty kódu, kde disposing nabývá hodnoty true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">Zajistěte, aby {0} bylo deklarované jako veřejné a zapečetěné.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">Zajistěte, aby {0} bylo deklarované jako veřejné a zapečetěné.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">Přejmenujte {0} na Dispose a zajistěte, aby bylo deklarované jako veřejné a zapečetěné.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">Přejmenujte {0} na Dispose a zajistěte, aby bylo deklarované jako veřejné a zapečetěné.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">Zajistěte, aby {0} bylo deklarované jako chráněné, virtuální na nezapečetěné.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">Zajistěte, aby {0} bylo deklarované jako chráněné, virtuální na nezapečetěné.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Změňte {0} tak, aby volalo Dispose(true), pak volalo GC.SuppressFinalize u aktuální instance objektu (this nebo Me ve Visual Basicu) a pak se vrátilo.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Změňte {0} tak, aby volalo Dispose(true), pak volalo GC.SuppressFinalize u aktuální instance objektu (this nebo Me ve Visual Basicu) a pak se vrátilo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Změňte {0} tak, aby volalo Dispose(false) a pak se vrátilo.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Změňte {0} tak, aby volalo Dispose(false) a pak se vrátilo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Zadejte u {0} přepisovatelnou implementaci Dispose(logický typ) nebo tento typ označte jako zapečetěný. Volání Dispose(false) by mělo vyčistit jenom nativní prostředky. Volání Dispose(true) by mělo vyčistit spravované i nativní prostředky.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Zadejte u {0} přepisovatelnou implementaci Dispose(logický typ) nebo tento typ označte jako zapečetěný. Volání Dispose(false) by mělo vyčistit jenom nativní prostředky. Volání Dispose(true) by mělo vyčistit spravované i nativní prostředky.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
@@ -842,11 +842,6 @@
         <target state="translated">Odeberte IDisposable ze seznamu rozhraní implementovaných pomocí {0}, protože se už implementuje pomocí základního typu {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">Odeberte finalizační metodu z typu {0}, přepište Dispose(likvidace logického typu) a vložte logiku finalizační metody do cesty kódu, kde disposing nabývá hodnoty false.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">Odeberte {0}, přepište Dispose(likvidace logického typu) a vložte logiku likvidace do cesty kódu, kde disposing nabývá hodnoty true.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Async-Lambdas nicht als "Void" zurückgebende Delegattypen speichern</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">Nach Möglichkeit CancellationTokens verteilen</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">Entfernen Sie IDisposable aus der Liste der von "{0}" implementierten Schnittstellen, da es bereits vom Basistyp "{1}" implementiert wird.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">Entfernen Sie IDisposable aus der Liste der von "{0}" implementierten Schnittstellen, da es bereits vom Basistyp "{1}" implementiert wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">Entfernen Sie "{0}", setzen Sie "Dispose(bool disposing)" außer Kraft, und fügen Sie die Dispose-Logik in den Codepfad ein, wobei "disposing" TRUE ist.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">Entfernen Sie "{0}", setzen Sie "Dispose(bool disposing)" außer Kraft, und fügen Sie die Dispose-Logik in den Codepfad ein, wobei "disposing" TRUE ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">Stellen Sie sicher, dass "{0}" als "public" und "sealed" deklariert ist.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">Stellen Sie sicher, dass "{0}" als "public" und "sealed" deklariert ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">Benennen Sie "{0}" in "Dispose" um, und stellen Sie sicher, dass die Deklaration "public" und "sealed" lautet.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">Benennen Sie "{0}" in "Dispose" um, und stellen Sie sicher, dass die Deklaration "public" und "sealed" lautet.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">Stellen Sie sicher, dass "{0}" als "protected", "virtual" und "unsealed" deklariert ist.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">Stellen Sie sicher, dass "{0}" als "protected", "virtual" und "unsealed" deklariert ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Ändern Sie "{0}", sodass "Dispose(true)" und dann "GC.SuppressFinalize" für die aktuelle Objektinstanz ("this" oder "Me" in Visual Basic) aufgerufen und anschließend ein Wert zurückgegeben wird.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Ändern Sie "{0}", sodass "Dispose(true)" und dann "GC.SuppressFinalize" für die aktuelle Objektinstanz ("this" oder "Me" in Visual Basic) aufgerufen und anschließend ein Wert zurückgegeben wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Ändern Sie "{0}", sodass "Dispose(false)" aufgerufen und anschließend ein Wert zurückgegeben wird.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Ändern Sie "{0}", sodass "Dispose(false)" aufgerufen und anschließend ein Wert zurückgegeben wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Geben Sie eine überschreibbare Implementierung von "Dispose(bool)" für "{0}" an, oder markieren Sie den Typ als versiegelt. Durch einen Aufruf von "Dispose(false)" dürfen nur native Ressourcen bereinigt werden. Durch einen Aufruf von "Dispose(true)" dürfen sowohl verwaltete als auch native Ressourcen bereinigt werden.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Geben Sie eine überschreibbare Implementierung von "Dispose(bool)" für "{0}" an, oder markieren Sie den Typ als versiegelt. Durch einen Aufruf von "Dispose(false)" dürfen nur native Ressourcen bereinigt werden. Durch einen Aufruf von "Dispose(true)" dürfen sowohl verwaltete als auch native Ressourcen bereinigt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
@@ -842,11 +842,6 @@
         <target state="translated">Entfernen Sie IDisposable aus der Liste der von "{0}" implementierten Schnittstellen, da es bereits vom Basistyp "{1}" implementiert wird.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">Entfernen Sie den Finalizer aus dem Typ "{0}", setzen Sie "Dispose(bool disposing)" außer Kraft, und fügen Sie die Finalisierungslogik in den Codepfad ein, wobei "disposing" FALSE ist.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">Entfernen Sie "{0}", setzen Sie "Dispose(bool disposing)" außer Kraft, und fügen Sie die Dispose-Logik in den Codepfad ein, wobei "disposing" TRUE ist.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
@@ -842,11 +842,6 @@
         <target state="translated">Quite IDisposable de la lista de interfaces que implementa {0} porque el tipo base {1} ya la ha implementado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">Quite el finalizador del tipo {0}, invalide Dispose(bool disposing) y coloque la lógica de finalización en la ruta de acceso del código donde “disposing” es false.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">Quite {0}, invalide Dispose(bool disposing) y coloque la lógica de Dispose en la ruta de acceso del código donde “disposing” es true.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
@@ -62,6 +62,11 @@
         <target state="translated">No almacenar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">Propagar elementos CancellationToken cuando sea posible</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">Quite IDisposable de la lista de interfaces que implementa {0} porque el tipo base {1} ya la ha implementado.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">Quite IDisposable de la lista de interfaces que implementa {0} porque el tipo base {1} ya la ha implementado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">Quite {0}, invalide Dispose(bool disposing) y coloque la lógica de Dispose en la ruta de acceso del código donde “disposing” es true.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">Quite {0}, invalide Dispose(bool disposing) y coloque la lógica de Dispose en la ruta de acceso del código donde “disposing” es true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">Asegúrese de que el elemento {0} se declara como público y sellado.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">Asegúrese de que el elemento {0} se declara como público y sellado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">Cambie el nombre de {0} a “Dispose” y asegúrese de que este elemento se declara como público y sellado.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">Cambie el nombre de {0} a “Dispose” y asegúrese de que este elemento se declara como público y sellado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">Asegúrese de que el elemento {0} se declara como protegido, virtual y no sellado.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">Asegúrese de que el elemento {0} se declara como protegido, virtual y no sellado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Modifique {0} de modo que llame a Dispose(true), después llame a GC.SuppressFinalize en la instancia de objeto actual (“this” o “Me” en Visual Basic) y, a continuación, vuelva.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Modifique {0} de modo que llame a Dispose(true), después llame a GC.SuppressFinalize en la instancia de objeto actual (“this” o “Me” en Visual Basic) y, a continuación, vuelva.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Modifique {0} para que llame a Dispose(false) y, a continuación, vuelva.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Modifique {0} para que llame a Dispose(false) y, a continuación, vuelva.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Proporcione una implementación reemplazable de Dispose(bool) en {0} o marque el tipo como sellado. Una llamada a Dispose(false) solo debe limpiar los recursos nativos. Una llamada a Dispose(true) debe limpiar tanto los recursos administrados como nativos.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Proporcione una implementación reemplazable de Dispose(bool) en {0} o marque el tipo como sellado. Una llamada a Dispose(false) solo debe limpiar los recursos nativos. Una llamada a Dispose(true) debe limpiar tanto los recursos administrados como nativos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
@@ -842,11 +842,6 @@
         <target state="translated">Supprimez IDisposable de la liste des interfaces implémentées par {0}, car il est déjà implémenté par le type de base {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">Supprimez le finaliseur du type {0}, remplacez Dispose(bool disposing) et placez la logique de finalisation dans le chemin de code où 'disposing' a la valeur false.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">Supprimez {0}, remplacez Dispose(bool disposing) et placez la logique de suppression dans le chemin de code où 'disposing' a la valeur true.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Ne pas stocker de lambdas asynchrones en tant que types délégués retournant void</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">Propager CancellationTokens quand cela est possible</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">Supprimez IDisposable de la liste des interfaces implémentées par {0}, car il est déjà implémenté par le type de base {1}.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">Supprimez IDisposable de la liste des interfaces implémentées par {0}, car il est déjà implémenté par le type de base {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">Supprimez {0}, remplacez Dispose(bool disposing) et placez la logique de suppression dans le chemin de code où 'disposing' a la valeur true.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">Supprimez {0}, remplacez Dispose(bool disposing) et placez la logique de suppression dans le chemin de code où 'disposing' a la valeur true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">Vérifiez que {0} est déclaré comme étant public et sealed.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">Vérifiez que {0} est déclaré comme étant public et sealed.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">Renommez {0} en 'Dispose' et vérifiez qu'il est déclaré comme étant public et sealed.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">Renommez {0} en 'Dispose' et vérifiez qu'il est déclaré comme étant public et sealed.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">Vérifiez que {0} est déclaré comme étant protected, virtual et unsealed.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">Vérifiez que {0} est déclaré comme étant protected, virtual et unsealed.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Modifiez {0} pour qu'il appelle Dispose(true), puis GC.SuppressFinalize sur l'instance d'objet actuelle ('this' ou 'Me' en Visual Basic), et qu'il retourne ensuite une valeur.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Modifiez {0} pour qu'il appelle Dispose(true), puis GC.SuppressFinalize sur l'instance d'objet actuelle ('this' ou 'Me' en Visual Basic), et qu'il retourne ensuite une valeur.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Modifiez {0} pour qu'il appelle Dispose(false) et retourne ensuite une valeur.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Modifiez {0} pour qu'il appelle Dispose(false) et retourne ensuite une valeur.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Fournissez une implémentation pouvant être remplacée de Dispose(bool) sur {0}, ou marquez le type comme étant sealed. Un appel à Dispose(false) doit nettoyer uniquement les ressources natives. Un appel à Dispose(true) doit nettoyer les ressources managées et natives.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Fournissez une implémentation pouvant être remplacée de Dispose(bool) sur {0}, ou marquez le type comme étant sealed. Un appel à Dispose(false) doit nettoyer uniquement les ressources natives. Un appel à Dispose(true) doit nettoyer les ressources managées et natives.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
@@ -842,11 +842,6 @@
         <target state="translated">Rimuovere IDisposable dall'elenco delle interfacce implementate da {0} perché è già implementato dal tipo di base {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">Rimuovere il finalizzatore dal tipo {0}, eseguire l'override di Dispose(bool disposing) e inserire la logica di finalizzazione nel percorso del codice in cui 'disposing' è false.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">Rimuovere {0}, eseguire l'override di Dispose(bool disposing) e inserire la logica di Dispose nel percorso del codice in cui 'disposing' è true.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Non archiviare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">Propagare parametri CancellationToken quando possibile</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">Rimuovere IDisposable dall'elenco delle interfacce implementate da {0} perché è già implementato dal tipo di base {1}.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">Rimuovere IDisposable dall'elenco delle interfacce implementate da {0} perché è già implementato dal tipo di base {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">Rimuovere {0}, eseguire l'override di Dispose(bool disposing) e inserire la logica di Dispose nel percorso del codice in cui 'disposing' è true.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">Rimuovere {0}, eseguire l'override di Dispose(bool disposing) e inserire la logica di Dispose nel percorso del codice in cui 'disposing' è true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">Verificare che {0} sia dichiarato come public e sealed.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">Verificare che {0} sia dichiarato come public e sealed.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">Rinominare {0} in 'Dispose' e verificare che sia dichiarato come public e sealed.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">Rinominare {0} in 'Dispose' e verificare che sia dichiarato come public e sealed.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">Verificare che {0} sia dichiarato come protected, virtual e unsealed.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">Verificare che {0} sia dichiarato come protected, virtual e unsealed.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Modificare {0} in modo che chiami Dispose(true), quindi GC.SuppressFinalize nell'istanza dell'oggetto corrente ('this' o 'Me' in Visual Basic) e quindi esca dalla funzione.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Modificare {0} in modo che chiami Dispose(true), quindi GC.SuppressFinalize nell'istanza dell'oggetto corrente ('this' o 'Me' in Visual Basic) e quindi esca dalla funzione.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Modificare {0} in modo che chiami Dispose(false) e quindi esca dalla funzione.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Modificare {0} in modo che chiami Dispose(false) e quindi esca dalla funzione.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Fornire un'implementazione sottoponibile a override di Dispose(bool) su {0} o contrassegnare il tipo come sealed. Una chiamata a Dispose(false) pulisce solo le risorse native. Una chiamata a Dispose(true) pulisce le risorse native e quelle gestite.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Fornire un'implementazione sottoponibile a override di Dispose(bool) su {0} o contrassegnare il tipo come sealed. Una chiamata a Dispose(false) pulisce solo le risorse native. Una chiamata a Dispose(true) pulisce le risorse native e quelle gestite.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
@@ -62,6 +62,11 @@
         <target state="translated">デリゲート型を返す Void として非同期ラムダを格納しないでください</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">可能な場合は CancellationToken を伝達してください</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">IDisposable は、基本型 {1} で既に実装されているため、{0} によって実装されたインターフェイスのリストから削除します。</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">IDisposable は、基本型 {1} で既に実装されているため、{0} によって実装されたインターフェイスのリストから削除します。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">{0} を削除し、Dispose(bool disposing) をオーバーライドして、'disposing' が true であるコード パスに dispose 論理を入れます。</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">{0} を削除し、Dispose(bool disposing) をオーバーライドして、'disposing' が true であるコード パスに dispose 論理を入れます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">{0} が public および sealed として宣言されていることを確認してください。</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">{0} が public および sealed として宣言されていることを確認してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">{0} の名前を 'Dispose' に変更し、public および sealed として宣言されていることを確認してください。</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">{0} の名前を 'Dispose' に変更し、public および sealed として宣言されていることを確認してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">{0} が protected、virtual、および unsealed として宣言されていることを確認してください。</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">{0} が protected、virtual、および unsealed として宣言されていることを確認してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Dispose(true) を呼び出してから、現在のオブジェクトのインスタンス (Visual Basic では 'this' または 'Me') で GC.SuppressFinalize を呼び出し、その後戻り値を返すように、{0} を変更してください。</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Dispose(true) を呼び出してから、現在のオブジェクトのインスタンス (Visual Basic では 'this' または 'Me') で GC.SuppressFinalize を呼び出し、その後戻り値を返すように、{0} を変更してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Dispose(false) を呼び出してから、戻り値を返すように、{0} を変更してください。</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Dispose(false) を呼び出してから、戻り値を返すように、{0} を変更してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Dispose(bool) のオーバーライド可能な実装を {0} で指定するか、または型をシールドに設定します。Dispose(false) への呼び出しは、ネイティブ リソースのみをクリーンアップしなければなりません。Dispose(true) への呼び出しは、マネージおよびネイティブの両方のリソースをクリーンアップしなければなりません。</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Dispose(bool) のオーバーライド可能な実装を {0} で指定するか、または型をシールドに設定します。Dispose(false) への呼び出しは、ネイティブ リソースのみをクリーンアップしなければなりません。Dispose(true) への呼び出しは、マネージおよびネイティブの両方のリソースをクリーンアップしなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
@@ -842,11 +842,6 @@
         <target state="translated">IDisposable は、基本型 {1} で既に実装されているため、{0} によって実装されたインターフェイスのリストから削除します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">型 {0} からファイナライザーを削除し、Dispose(bool disposing) をオーバーライドして、'disposing' が false であるコード パスに finalization 論理を入れます。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">{0} を削除し、Dispose(bool disposing) をオーバーライドして、'disposing' が true であるコード パスに dispose 論理を入れます。</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
@@ -62,6 +62,11 @@
         <target state="translated">비동기 람다를 Void 반환 대리자 형식으로 저장하지 마세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">가능한 경우 취소 토큰을 전파하세요.</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">기본 형식 {1}에서 이미 구현되었으므로 {0}에서 구현된 인터페이스 목록의 IDisposable을 제거하세요.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">기본 형식 {1}에서 이미 구현되었으므로 {0}에서 구현된 인터페이스 목록의 IDisposable을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">{0}을(를) 제거하고 Dispose(bool disposing)를 재정의한 후 삭제 논리를 'disposing'이 true인 코드 경로에 추가하세요.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">{0}을(를) 제거하고 Dispose(bool disposing)를 재정의한 후 삭제 논리를 'disposing'이 true인 코드 경로에 추가하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">{0}이(가) public 및 sealed로 선언되었는지 확인하세요.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">{0}이(가) public 및 sealed로 선언되었는지 확인하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">{0}의 이름을 'Dispose'로 바꾸고 public 및 sealed로 선언되었는지 확인하세요.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">{0}의 이름을 'Dispose'로 바꾸고 public 및 sealed로 선언되었는지 확인하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">{0}이(가) protected, virtual 및 unsealed로 선언되었는지 확인하세요.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">{0}이(가) protected, virtual 및 unsealed로 선언되었는지 확인하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Dispose(true)를 호출한 다음 현재 개체 인스턴스(Visual Basic의 경우 'this' 또는 'Me')에서 GC.SuppressFinalize를 호출한 후 반환하도록 {0}을(를) 수정하세요.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Dispose(true)를 호출한 다음 현재 개체 인스턴스(Visual Basic의 경우 'this' 또는 'Me')에서 GC.SuppressFinalize를 호출한 후 반환하도록 {0}을(를) 수정하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Dispose(false)를 호출한 다음 반환하도록 {0}을(를) 수정하세요.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Dispose(false)를 호출한 다음 반환하도록 {0}을(를) 수정하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">{0}에 Dispose(bool)의 재정의 가능한 구현을 제거하거나 형식을 sealed로 표시하세요. Dispose(false)에 대한 호출은 네이티브 리소스만 정리해야 합니다. Dispose(true)에 대한 호출은 관리되는 리소스와 네이티브 리소스를 모두 정리해야 합니다.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">{0}에 Dispose(bool)의 재정의 가능한 구현을 제거하거나 형식을 sealed로 표시하세요. Dispose(false)에 대한 호출은 네이티브 리소스만 정리해야 합니다. Dispose(true)에 대한 호출은 관리되는 리소스와 네이티브 리소스를 모두 정리해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
@@ -842,11 +842,6 @@
         <target state="translated">기본 형식 {1}에서 이미 구현되었으므로 {0}에서 구현된 인터페이스 목록의 IDisposable을 제거하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">{0} 형식에서 종료자를 제거하고 Dispose(bool disposing)를 재정의한 후 종료 논리를 'disposing'이 false인 코드 경로에 추가하세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">{0}을(를) 제거하고 Dispose(bool disposing)를 재정의한 후 삭제 논리를 'disposing'이 true인 코드 경로에 추가하세요.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Nie przechowuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">Propaguj elementy CancellationToken, jeśli to możliwe</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">Usuń interfejs IDisposable z listy interfejsów implementowanych przez typ {0}, ponieważ jest już implementowany przez typ bazowy {1}.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">Usuń interfejs IDisposable z listy interfejsów implementowanych przez typ {0}, ponieważ jest już implementowany przez typ bazowy {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">Usuń metodę {0}, przesłoń metodę Dispose(bool disposing) i umieść logikę likwidowania w ścieżce kodu wykonywanej, gdy parametr „disposing” ma wartość true.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">Usuń metodę {0}, przesłoń metodę Dispose(bool disposing) i umieść logikę likwidowania w ścieżce kodu wykonywanej, gdy parametr „disposing” ma wartość true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">Upewnij się, że element {0} jest zadeklarowany jako publiczny i zapieczętowany.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">Upewnij się, że element {0} jest zadeklarowany jako publiczny i zapieczętowany.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">Zmień nazwę elementu {0} na „Dispose” i upewnij się, że jest on zadeklarowany jako publiczny i zapieczętowany.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">Zmień nazwę elementu {0} na „Dispose” i upewnij się, że jest on zadeklarowany jako publiczny i zapieczętowany.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">Upewnij się, że metoda {0} jest zadeklarowana jako chroniona, wirtualna i niezapieczętowana.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">Upewnij się, że metoda {0} jest zadeklarowana jako chroniona, wirtualna i niezapieczętowana.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Zmodyfikuj metodę {0} tak, aby wywoływała metodę Dispose(true), następnie metodę GC.SuppressFinalize dla bieżącego wystąpienia obiektu („this” lub „Me” w języku Visual Basic), po czym kończyła pracę.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Zmodyfikuj metodę {0} tak, aby wywoływała metodę Dispose(true), następnie metodę GC.SuppressFinalize dla bieżącego wystąpienia obiektu („this” lub „Me” w języku Visual Basic), po czym kończyła pracę.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Zmodyfikuj metodę {0} tak, aby wywoływała metodę Dispose(false) i kończyła pracę.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Zmodyfikuj metodę {0} tak, aby wywoływała metodę Dispose(false) i kończyła pracę.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Określ w klasie {0} implementację metody Dispose(bool), którą można przesłonić, lub oznacz typ jako zapieczętowany. Wywołanie metody Dispose(false) powinno czyścić tylko zasoby natywne. Wywołanie metody Dispose(true) powinno czyścić zasoby zarządzane i natywne.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Określ w klasie {0} implementację metody Dispose(bool), którą można przesłonić, lub oznacz typ jako zapieczętowany. Wywołanie metody Dispose(false) powinno czyścić tylko zasoby natywne. Wywołanie metody Dispose(true) powinno czyścić zasoby zarządzane i natywne.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
@@ -842,11 +842,6 @@
         <target state="translated">Usuń interfejs IDisposable z listy interfejsów implementowanych przez typ {0}, ponieważ jest już implementowany przez typ bazowy {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">Usuń finalizator z typu {0}, przesłoń metodę Dispose(bool disposing) i umieść logikę finalizacji w ścieżce kodu wykonywanej, gdy parametr „disposing” ma wartość false.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">Usuń metodę {0}, przesłoń metodę Dispose(bool disposing) i umieść logikę likwidowania w ścieżce kodu wykonywanej, gdy parametr „disposing” ma wartość true.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Não armazenar lambdas assíncronas como tipos delegados que retornam void</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">Propagar CancellationTokens quando possível</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">Remova IDisposable da lista de interfaces implementadas por {0}, pois ele já foi implementado pelo tipo base {1}.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">Remova IDisposable da lista de interfaces implementadas por {0}, pois ele já foi implementado pelo tipo base {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">Remova {0}, substitua Dispose(bool disposing) e coloque a lógica de descarte no caminho do código em que 'disposing' é true.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">Remova {0}, substitua Dispose(bool disposing) e coloque a lógica de descarte no caminho do código em que 'disposing' é true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">Verifique se {0} está declarado como público e selado.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">Verifique se {0} está declarado como público e selado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">Renomeie {0} como 'Dispose' e verifique se ele está declarado como público e selado.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">Renomeie {0} como 'Dispose' e verifique se ele está declarado como público e selado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">Verifique se {0} está declarado como protegido, virtual e não selado.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">Verifique se {0} está declarado como protegido, virtual e não selado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Modifique {0} para chamar Dispose(true), depois chamar GC.SuppressFinalize na instância de objeto atual ('this' ou 'Me' no Visual Basic) e retornar.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Modifique {0} para chamar Dispose(true), depois chamar GC.SuppressFinalize na instância de objeto atual ('this' ou 'Me' no Visual Basic) e retornar.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Modifique {0} de forma a chamar Dispose(false) e retornar.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Modifique {0} de forma a chamar Dispose(false) e retornar.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Forneça uma implementação substituível de Dispose(bool) em {0} ou marque o tipo como selado. Uma chamada para Dispose(false) deve limpar somente os recursos nativos. Uma chamada para Dispose(true) deve limpar os recursos gerenciados e os nativos.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Forneça uma implementação substituível de Dispose(bool) em {0} ou marque o tipo como selado. Uma chamada para Dispose(false) deve limpar somente os recursos nativos. Uma chamada para Dispose(true) deve limpar os recursos gerenciados e os nativos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
@@ -842,11 +842,6 @@
         <target state="translated">Remova IDisposable da lista de interfaces implementadas por {0}, pois ele já foi implementado pelo tipo base {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">Remova o finalizador do tipo {0}, substitua Dispose(bool disposing) e coloque a lógica de finalização no caminho do código em que 'disposing' é false.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">Remova {0}, substitua Dispose(bool disposing) e coloque a lógica de descarte no caminho do código em que 'disposing' é true.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
@@ -842,11 +842,6 @@
         <target state="translated">Удалите IDisposable из списка интерфейсов, реализованных с помощью {0}, так как он уже реализован базовым типом {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">Удалите метод завершения из типа {0}, переопределите Dispose(bool disposing) и поместите логику завершения в путь кода, где значение "disposing" равно false.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">Удалите метод {0}, переопределите Dispose(bool disposing) и поместите логику высвобождения в путь кода, где значение "disposing" равно true.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Не храните асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">По мере возможности распространяйте токены CancellationToken</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">Удалите IDisposable из списка интерфейсов, реализованных с помощью {0}, так как он уже реализован базовым типом {1}.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">Удалите IDisposable из списка интерфейсов, реализованных с помощью {0}, так как он уже реализован базовым типом {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">Удалите метод {0}, переопределите Dispose(bool disposing) и поместите логику высвобождения в путь кода, где значение "disposing" равно true.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">Удалите метод {0}, переопределите Dispose(bool disposing) и поместите логику высвобождения в путь кода, где значение "disposing" равно true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">Убедитесь, что {0} объявлен как общий и запечатанный.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">Убедитесь, что {0} объявлен как общий и запечатанный.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">Измените имя {0} на "Dispose" и убедитесь, что он объявлен как общий и запечатанный.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">Измените имя {0} на "Dispose" и убедитесь, что он объявлен как общий и запечатанный.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">Убедитесь, что {0} объявлен как защищенный, виртуальный и незапечатанный.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">Убедитесь, что {0} объявлен как защищенный, виртуальный и незапечатанный.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">Измените {0}, чтобы он вызывал Dispose(true), затем вызывал GC.SuppressFinalize для текущего экземпляра объекта ("this" или "Me" в Visual Basic), а затем возвращал результат.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">Измените {0}, чтобы он вызывал Dispose(true), затем вызывал GC.SuppressFinalize для текущего экземпляра объекта ("this" или "Me" в Visual Basic), а затем возвращал результат.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">Измените {0}, чтобы он вызывал Dispose(false) и затем возвращал результат.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">Измените {0}, чтобы он вызывал Dispose(false) и затем возвращал результат.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Предоставьте перегружаемую реализацию Dispose(bool) для {0} или отметьте тип как запечатанный. При вызове Dispose(false) должны очищаться только машинные ресурсы. При вызове Dispose(true) должны очищаться и управляемые, и машинные ресурсы.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Предоставьте перегружаемую реализацию Dispose(bool) для {0} или отметьте тип как запечатанный. При вызове Dispose(false) должны очищаться только машинные ресурсы. При вызове Dispose(true) должны очищаться и управляемые, и машинные ресурсы.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Depolamayın</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">Mümkün Olduğunda CancellationToken’ları Yay</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">IDisposable zaten {1} temel türü tarafından uygulandığından, {0} tarafından uygulanan arabirim listesinden bunu kaldırın.</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">IDisposable zaten {1} temel türü tarafından uygulandığından, {0} tarafından uygulanan arabirim listesinden bunu kaldırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">{0} türünü kaldırın, Dispose(bool disposing) öğesini geçersiz kılın ve atma mantığını 'disposing' değerinin true olduğu kod yoluna koyun.</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">{0} türünü kaldırın, Dispose(bool disposing) öğesini geçersiz kılın ve atma mantığını 'disposing' değerinin true olduğu kod yoluna koyun.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">{0} öğesinin genel ve mühürlü olarak bildirildiğinden emin olun.</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">{0} öğesinin genel ve mühürlü olarak bildirildiğinden emin olun.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">{0} yöntemini 'Dispose' olarak yeniden adlandırıp genel ve mühürlü olarak bildirildiğinden emin olun.</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">{0} yöntemini 'Dispose' olarak yeniden adlandırıp genel ve mühürlü olarak bildirildiğinden emin olun.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">{0} türünün korumalı, sanal ve mühürsüz olarak bildirildiğinden emin olun.</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">{0} türünün korumalı, sanal ve mühürsüz olarak bildirildiğinden emin olun.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">{0} öğesini önce Dispose(true) yöntemini, sonra geçerli nesne örneğinde ('this' veya Visual Basic'te 'Me') GC.SuppressFinalize'ı çağıracak ve sonra dönecek biçimde değiştirin.</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">{0} öğesini önce Dispose(true) yöntemini, sonra geçerli nesne örneğinde ('this' veya Visual Basic'te 'Me') GC.SuppressFinalize'ı çağıracak ve sonra dönecek biçimde değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">{0} öğesini Dispose(false) yöntemini çağıracak ve sonra dönecek şekilde değiştirin.</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">{0} öğesini Dispose(false) yöntemini çağıracak ve sonra dönecek şekilde değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">{0} türünde Dispose(bool) yönteminin geçersiz kılınabilecek bir uygulamasını sağlayın veya türü mühürlü olarak işaretleyin. Dispose(false) yöntemine yapılan bir çağrı yalnızca yerel kaynakları temizlemelidir. Dispose(true) yöntemine yapılan bir çağrı hem yönetilen hem yerel kaynakları temizlemelidir.</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">{0} türünde Dispose(bool) yönteminin geçersiz kılınabilecek bir uygulamasını sağlayın veya türü mühürlü olarak işaretleyin. Dispose(false) yöntemine yapılan bir çağrı yalnızca yerel kaynakları temizlemelidir. Dispose(true) yöntemine yapılan bir çağrı hem yönetilen hem yerel kaynakları temizlemelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
@@ -842,11 +842,6 @@
         <target state="translated">IDisposable zaten {1} temel türü tarafından uygulandığından, {0} tarafından uygulanan arabirim listesinden bunu kaldırın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">{0} türünden sonlandırıcıyı kaldırın, Dispose(bool disposing) yöntemini geçersiz kılın ve sonlandırma mantığını 'disposing' değerinin false olduğu kod yoluna koyun.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">{0} türünü kaldırın, Dispose(bool disposing) öğesini geçersiz kılın ve atma mantığını 'disposing' değerinin true olduğu kod yoluna koyun.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="translated">不要将异步 Lambda 作为 Void 返回委托类型存储</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">如有可能，传播 CancellationTokens</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">从 {0} 实现的接口列表中删除 IDisposable，因为它已由基类型 {1} 实现。</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">从 {0} 实现的接口列表中删除 IDisposable，因为它已由基类型 {1} 实现。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">移除 {0}，重写 Dispose(bool disposing)，并在 "disposing" 为 true 的代码路径中加入释放逻辑。</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">移除 {0}，重写 Dispose(bool disposing)，并在 "disposing" 为 true 的代码路径中加入释放逻辑。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">确保将 {0} 声明为 public 和 sealed。</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">确保将 {0} 声明为 public 和 sealed。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">将 {0} 重命名为 "Dispose"，并确保将其声明为 public 和 sealed。</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">将 {0} 重命名为 "Dispose"，并确保将其声明为 public 和 sealed。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">确保将 {0} 声明为 protected、virtual 和 unsealed。</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">确保将 {0} 声明为 protected、virtual 和 unsealed。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">修改 {0}，使它先调用 Dispose(true)，然后对当前对象实例(在 Visual Basic 中为 "this" 或 "Me")调用 GC.SuppressFinalize，最后返回。</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">修改 {0}，使它先调用 Dispose(true)，然后对当前对象实例(在 Visual Basic 中为 "this" 或 "Me")调用 GC.SuppressFinalize，最后返回。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">修改 {0} 以便它可以调用 Dispose(false)，然后返回。</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">修改 {0} 以便它可以调用 Dispose(false)，然后返回。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">对 {0} 提供 Dispose(bool) 的可重写实现或将该类型标记为 sealed。对 Dispose(false) 的调用应仅清理本机资源。对 Dispose(true) 的调用应既清理托管资源又清理本机资源。</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">对 {0} 提供 Dispose(bool) 的可重写实现或将该类型标记为 sealed。对 Dispose(false) 的调用应仅清理本机资源。对 Dispose(true) 的调用应既清理托管资源又清理本机资源。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
@@ -842,11 +842,6 @@
         <target state="translated">从 {0} 实现的接口列表中删除 IDisposable，因为它已由基类型 {1} 实现。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">从类型 {0} 中删除终结器，重写 Dispose(bool disposing)，并在 "disposing" 为 false 的代码路径中加入终结逻辑。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">移除 {0}，重写 Dispose(bool disposing)，并在 "disposing" 为 true 的代码路径中加入释放逻辑。</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
@@ -842,11 +842,6 @@
         <target state="translated">從 {0} 實作的介面清單中移除 IDisposable，因為其已由基底類型 {1} 實作。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.</source>
-        <target state="translated">從類型 {0} 中移除完成項、覆寫 Dispose(bool disposing)，並將完成項邏輯置於 'disposing' 為 false 的程式碼路徑中。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
         <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
         <target state="translated">移除 {0}、覆寫 Dispose(bool disposing)，並將處置邏輯放在 'disposing' 為 true 的程式碼路徑中。</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="translated">請勿將 Async Lambdas 儲存為 Void 傳回委派類型</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
+        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="new">Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
         <source>Propagate CancellationTokens When Possible</source>
         <target state="translated">於可能時散佈 CancellationToken</target>
@@ -838,43 +843,43 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by {0} as it is already implemented by base type {1}.</source>
-        <target state="translated">從 {0} 實作的介面清單中移除 IDisposable，因為其已由基底類型 {1} 實作。</target>
+        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'.</source>
+        <target state="needs-review-translation">從 {0} 實作的介面清單中移除 IDisposable，因為其已由基底類型 {1} 實作。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
-        <target state="translated">移除 {0}、覆寫 Dispose(bool disposing)，並將處置邏輯放在 'disposing' 為 true 的程式碼路徑中。</target>
+        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.</source>
+        <target state="needs-review-translation">移除 {0}、覆寫 Dispose(bool disposing)，並將處置邏輯放在 'disposing' 為 true 的程式碼路徑中。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
-        <source>Ensure that {0} is declared as public and sealed.</source>
-        <target state="translated">請確認 {0} 已宣告為公用且已密封。</target>
+        <source>Ensure that '{0}' is declared as public and sealed.</source>
+        <target state="needs-review-translation">請確認 {0} 已宣告為公用且已密封。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageRenameDispose">
-        <source>Rename {0} to 'Dispose' and ensure that it is declared as public and sealed.</source>
-        <target state="translated">將 {0} 重新命名為 'Dispose'，並確認已將其宣告為公用且密封。</target>
+        <source>Rename '{0}' to 'Dispose' and ensure that it is declared as public and sealed.</source>
+        <target state="needs-review-translation">將 {0} 重新命名為 'Dispose'，並確認已將其宣告為公用且密封。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeBoolSignature">
-        <source>Ensure that {0} is declared as protected, virtual, and unsealed.</source>
-        <target state="translated">請確認 {0} 已宣告為受保護、虛擬以及非密封。</target>
+        <source>Ensure that '{0}' is declared as protected, virtual, and unsealed.</source>
+        <target state="needs-review-translation">請確認 {0} 已宣告為受保護、虛擬以及非密封。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
-        <target state="translated">修改 {0}，使其呼叫 Dispose(true)，然後在目前的物件執行個體上呼叫 GC.SuppressFinalize (在 Visual Basic 中為 'this' 或 'Me')，然後再傳回。</target>
+        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.</source>
+        <target state="needs-review-translation">修改 {0}，使其呼叫 Dispose(true)，然後在目前的物件執行個體上呼叫 GC.SuppressFinalize (在 Visual Basic 中為 'this' 或 'Me')，然後再傳回。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify {0} so that it calls Dispose(false) and then returns.</source>
-        <target state="translated">修改 {0}，使其呼叫 Dispose(false) 然後再傳回。</target>
+        <source>Modify '{0}' so that it calls Dispose(false) and then returns.</source>
+        <target state="needs-review-translation">修改 {0}，使其呼叫 Dispose(false) 然後再傳回。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on {0} or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">提供 {0} 上 Dispose(bool) 的可覆寫實作，或將類型標記為密封。呼叫 Dispose(false) 只會清除原生資源，呼叫 Dispose(true) 則會同時清除受控和原生資源。</target>
+        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">提供 {0} 上 Dispose(bool) 的可覆寫實作，或將類型標記為密封。呼叫 Dispose(false) 只會清除原生資源，呼叫 Dispose(true) 則會同時清除受控和原生資源。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
@@ -781,6 +781,39 @@ public class B : IDisposable
 ");
         }
 
+        [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
+        public void CSharp_CA1063_FinalizeOverride_NoDiagnostic_FinalizeNotOverriden()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class B : IDisposable
+{
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    ~B()
+    {
+        Dispose(false);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+    }
+}
+
+[|public class C : B
+{
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+    }
+}|]
+");
+        }
         #endregion
 
         #region CSharp ProvideDisposeBool Unit Tests


### PR DESCRIPTION
Relax the implementation of this rule to allow for derived types to implement the destructor/finalizer, but still check that the finalizer implementation invokes Dispose(false) and returns if any of its base type has a Dispose(bool) implementation.

Fixes #1950