### PR TITLE
Do not report CA2235 for static and const fields

### DIFF
--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -225,7 +225,7 @@ namespace Microsoft.NetFramework.Analyzers
                     foreach (IFieldSymbol field in nonSerializableFields)
                     {
                         // Only process instance fields
-                        if (field.IsConst || field.IsStatic)
+                        if (field.IsStatic)
                         {
                             continue;
                         }

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -224,6 +224,12 @@ namespace Microsoft.NetFramework.Analyzers
                         namedTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(m => !IsSerializable(m.Type));
                     foreach (IFieldSymbol field in nonSerializableFields)
                     {
+                        // Only process instance fields
+                        if (field.IsConst || field.IsStatic)
+                        {
+                            continue;
+                        }
+
                         // Check for [NonSerialized]
                         if (field.GetAttributes().Any(x => x.AttributeClass.Equals(_nonSerializedAttributeTypeSymbol)))
                         {

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
@@ -531,6 +531,32 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
                 End Class");
         }
 
+        [Fact, WorkItem(1883, "https://github.com/dotnet/roslyn-analyzers/issues/1883")]
+        public void CA2235WithNonInstanceFieldsOfNonSerializableType()
+        {
+            VerifyCSharp(@"
+                using System;
+                public class NonSerializableType { }
+
+                [Serializable]
+                internal class CA2235WithNonInstanceFieldsOfNonSerializableType
+                {
+                    public const NonSerializableType s1 = null;
+                    public static NonSerializableType s2;
+                }");
+
+            VerifyBasic(@"
+                Imports System
+                Public Class NonSerializableType
+                End Class
+
+                <Serializable>
+                Friend Class CA2235WithNonInstanceFieldsOfNonSerializableType 
+                    Public Const s1 As Object = Nothing
+                    Public Shared s2 As NonSerializableType
+                End Class");
+        }
+
         internal static readonly string CA2235Message = MicrosoftNetFrameworkAnalyzersResources.MarkAllNonSerializableFieldsMessage;
 
         private static DiagnosticResult GetCA2235CSharpResultAt(int line, int column, string fieldName, string containerName, string typeName)


### PR DESCRIPTION
Diagnostic is only intended for instance fields.
Fixes #1883