### PR TITLE
Serialization rule tweaks

### DIFF
--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -181,12 +181,11 @@ namespace Microsoft.NetFramework.Analyzers
                     {
                         // Look for a serialization constructor.
                         // A serialization constructor takes two params of type SerializationInfo and StreamingContext.
-                        IMethodSymbol serializationCtor = namedTypeSymbol.Constructors.Where(c => c.Parameters.Count() == 2 &&
-                                                                                        c.Parameters[0].Type ==
-                                                                                        _serializationInfoTypeSymbol &&
-                                                                                        c.Parameters[1].Type ==
-                                                                                        _streamingContextTypeSymbol)
-                            .SingleOrDefault();
+                        IMethodSymbol serializationCtor = namedTypeSymbol.Constructors
+                            .SingleOrDefault(
+                                c => c.Parameters.Length == 2 &&
+                                     c.Parameters[0].Type == _serializationInfoTypeSymbol &&
+                                     c.Parameters[1].Type == _streamingContextTypeSymbol);
 
                         // There is no serialization ctor - issue a diagnostic.
                         if (serializationCtor == null)

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -230,14 +230,14 @@ namespace Microsoft.NetFramework.Analyzers
                             continue;
                         }
 
-                        // Only process non-serializable fields
-                        if (IsSerializable(field.Type))
+                        // Only process instance fields
+                        if (field.IsStatic)
                         {
                             continue;
                         }
 
-                        // Only process instance fields
-                        if (field.IsStatic)
+                        // Only process non-serializable fields
+                        if (IsSerializable(field.Type))
                         {
                             continue;
                         }

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -248,16 +248,16 @@ namespace Microsoft.NetFramework.Analyzers
                             continue;
                         }
 
-                        if (field.IsImplicitlyDeclared && field.AssociatedSymbol != null)
-                        {
-                            context.ReportDiagnostic(field.AssociatedSymbol.CreateDiagnostic(RuleCA2235,
-                                field.AssociatedSymbol.Name, namedTypeSymbol.Name, field.Type));
-                        }
-                        else
-                        {
-                            context.ReportDiagnostic(field.CreateDiagnostic(RuleCA2235, field.Name, namedTypeSymbol.Name,
+                        ISymbol targetSymbol = field.IsImplicitlyDeclared && field.AssociatedSymbol != null 
+                            ? field.AssociatedSymbol 
+                            : field;
+
+                        context.ReportDiagnostic(
+                            targetSymbol.CreateDiagnostic(
+                                RuleCA2235,
+                                targetSymbol.Name,
+                                namedTypeSymbol.Name,
                                 field.Type));
-                        }
                     }
                 }
             }

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -222,10 +222,20 @@ namespace Microsoft.NetFramework.Analyzers
                 // If this is type is marked Serializable and doesn't implement ISerializable, check its fields' types as well
                 if (isSerializable && !implementsISerializable)
                 {
-                    System.Collections.Generic.IEnumerable<IFieldSymbol> nonSerializableFields =
-                        namedTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(m => !IsSerializable(m.Type));
-                    foreach (IFieldSymbol field in nonSerializableFields)
+                    foreach (ISymbol member in namedTypeSymbol.GetMembers())
                     {
+                        // Only process field members
+                        if (!(member is IFieldSymbol field))
+                        {
+                            continue;
+                        }
+
+                        // Only process non-serializable fields
+                        if (IsSerializable(field.Type))
+                        {
+                            continue;
+                        }
+
                         // Only process instance fields
                         if (field.IsStatic)
                         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -162,10 +162,13 @@ namespace Microsoft.NetFramework.Analyzers
                     return;
                 }
 
+                var implementsISerializable = namedTypeSymbol.AllInterfaces.Contains(_iserializableTypeSymbol);
+                var isSerializable = IsSerializable(namedTypeSymbol);
+
                 // If the type is public and implements ISerializable
-                if (namedTypeSymbol.DeclaredAccessibility == Accessibility.Public && namedTypeSymbol.AllInterfaces.Contains(_iserializableTypeSymbol))
+                if (namedTypeSymbol.DeclaredAccessibility == Accessibility.Public && implementsISerializable)
                 {
-                    if (!IsSerializable(namedTypeSymbol))
+                    if (!isSerializable)
                     {
                         // CA2237 : Mark serializable types with the SerializableAttribute
                         if (namedTypeSymbol.BaseType.SpecialType == SpecialType.System_Object ||
@@ -218,7 +221,7 @@ namespace Microsoft.NetFramework.Analyzers
                 }
 
                 // If this is type is marked Serializable and doesn't implement ISerializable, check its fields' types as well
-                if (IsSerializable(namedTypeSymbol) && !namedTypeSymbol.AllInterfaces.Contains(_iserializableTypeSymbol))
+                if (isSerializable && !implementsISerializable)
                 {
                     System.Collections.Generic.IEnumerable<IFieldSymbol> nonSerializableFields =
                         namedTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(m => !IsSerializable(m.Type));

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -248,6 +248,8 @@ namespace Microsoft.NetFramework.Analyzers
                             continue;
                         }
 
+                        // Handle compiler-generated fields (without source declaration) that have an associated symbol in code.
+                        // For example, auto-property backing fields.
                         ISymbol targetSymbol = field.IsImplicitlyDeclared && field.AssociatedSymbol != null 
                             ? field.AssociatedSymbol 
                             : field;

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
                 End Class");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/3898")]
+        [Fact]
         public void CA2235WithSerializableLibraryTypes()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.NetFramework.Analyzers.UnitTests
 {
-    public partial class MarkAllNonSerializableFieldsTests : DiagnosticAnalyzerTestBase
+    public class MarkAllNonSerializableFieldsTests : DiagnosticAnalyzerTestBase
     {
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/MarkAllNonSerializableFieldsTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
                 [Serializable]
                 public class CA2235WithSerializableLibraryTypes
                 {
-                    public Regex R = new Regex(""\w+"");
+                    public Regex R = new Regex(@""\w+"");
                     public Nullable<int> NI = new Nullable<int>(42);
                     public bool? NB = true;
                     public Version V = new Version(1, 1, 12, 2);
@@ -157,12 +157,11 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
 
                 <Serializable>
                 Public Class CA2235WithSerializableLibraryTypes
-
                     Public R As Regex = New Regex(""\w+"")
-                    Public NI As Nullable(Of Integer)  = new Nullable(Of Integer)(42)
+                    Public NI As Nullable(Of Integer) = new Nullable(Of Integer)(42)
                     Public NB As Boolean? = true
                     Public V As Version = New Version(1, 1, 12, 2)
-                }");
+                End Class");
         }
 
         [Fact]


### PR DESCRIPTION
Avoids some duplicate work, allocations and adds some comments.

Also removes `Skip` from a test that passes correctly (once its test code was made to compile).

Possibly easiest to review commit-by-commit.