### PR TITLE
Fix CA1710 (IdentifiersShouldHaveCorrectSuffix) for event symbol type

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
@@ -155,6 +155,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         const string eventHandlerString = "EventHandler";
                         var eventSymbol = (IEventSymbol)saContext.Symbol;
                         if (!eventSymbol.Type.Name.EndsWith(eventHandlerString, StringComparison.Ordinal) &&
+                            eventSymbol.Type.IsInSource() &&
                             eventSymbol.Type.TypeKind == TypeKind.Delegate &&
                             ((INamedTypeSymbol)eventSymbol.Type).DelegateInvokeMethod?.HasEventHandlerSignature(eventArgsType) == true)
                         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
@@ -147,16 +147,22 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 }
                 , SymbolKind.NamedType);
 
-                context.RegisterSymbolAction((saContext) =>
+                var eventArgsType = WellKnownTypes.EventArgs(context.Compilation);
+                if (eventArgsType != null)
                 {
-                    const string eventHandlerString = "EventHandler";
-                    var eventSymbol = saContext.Symbol as IEventSymbol;
-                    if (!eventSymbol.Type.Name.EndsWith(eventHandlerString, StringComparison.Ordinal))
+                    context.RegisterSymbolAction((saContext) =>
                     {
-                        saContext.ReportDiagnostic(eventSymbol.CreateDiagnostic(DefaultRule, eventSymbol.Type.Name, eventHandlerString));
-                    }
-                },
-                SymbolKind.Event);
+                        const string eventHandlerString = "EventHandler";
+                        var eventSymbol = (IEventSymbol)saContext.Symbol;
+                        if (!eventSymbol.Type.Name.EndsWith(eventHandlerString, StringComparison.Ordinal) &&
+                            eventSymbol.Type.TypeKind == TypeKind.Delegate &&
+                            ((INamedTypeSymbol)eventSymbol.Type).DelegateInvokeMethod?.HasEventHandlerSignature(eventArgsType) == true)
+                        {
+                            saContext.ReportDiagnostic(eventSymbol.CreateDiagnostic(DefaultRule, eventSymbol.Type.Name, eventHandlerString));
+                        }
+                    },
+                    SymbolKind.Event);
+                }
             }
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffixTests.cs
@@ -1079,6 +1079,31 @@ Public NotInheritable Class VerifiableAttribute
 End Class");
         }
 
+        [Fact, WorkItem(1822, "https://github.com/dotnet/roslyn-analyzers/issues/1822")]
+        public void CA1710_SystemAction_CSharp()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public event Action MyEvent;
+}");
+        }
+
+        [Fact, WorkItem(1822, "https://github.com/dotnet/roslyn-analyzers/issues/1822")]
+        public void CA1710_CustomDelegate_CSharp()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public delegate void MyDelegate(int param);
+    public event MyDelegate MyEvent;
+}");
+        }
+
         private static DiagnosticResult GetCA1710BasicResultAt(int line, int column, string symbolName, string replacementName, bool isSpecial = false)
         {
             return GetBasicResultAt(

--- a/src/Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -382,5 +382,16 @@ namespace Analyzer.Utilities.Extensions
 
             throw new ArgumentException("Invalid paramater", nameof(parameterSymbol));
         }
+
+        /// <summary>
+        /// Returns true for void returning methods with two parameters, where
+        /// the first parameter is of <see cref="object"/> type and the second
+        /// parameter inherits from or equals <see cref="EventArgs"/> type.
+        /// </summary>
+        public static bool HasEventHandlerSignature(this IMethodSymbol method, INamedTypeSymbol eventArgsType)
+            => eventArgsType != null &&
+               method.Parameters.Length == 2 &&
+               method.Parameters[0].Type.SpecialType == SpecialType.System_Object &&
+               method.Parameters[1].Type.DerivesFrom(eventArgsType, baseTypesOnly: true);
     }
 }

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -552,5 +552,13 @@ namespace Analyzer.Utilities.Extensions
         {
             return symbol.GetAttributes().Any(attr => attr.AttributeClass.Equals(attribute));
         }
+
+        /// <summary>
+        /// Indicates if a symbol has at least one location in source.
+        /// </summary>
+        public static bool IsInSource(this ISymbol symbol)
+        {
+            return symbol.Locations.Any(l => l.IsInSource);
+        }
     }
 }


### PR DESCRIPTION
Fire CA1710 (Event type name should end with "EventHandler") only if event type matches event handler signature
Fixes #1822