### PR TITLE
Make CA1715 (IdentifiersShouldHaveCorrectPrefix) configurable for sin…

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -47,6 +47,8 @@ Option Values:
 | `private` | Analyzes private APIs that are only visible within the containing type. |
 | `all` | Analyzes all APIs, regardless of the symbol visibility. |
 
+Default Value: `public`
+
 Example: `dotnet_code_quality.api_surface = all`
 
 Users can also provide a comma separated list of above option values. For example, `dotnet_code_quality.api_surface = private, internal` configures analysis of the entire non-public API surface.
@@ -58,6 +60,8 @@ Configurable Rules: [CA2007](../src/Microsoft.CodeQuality.Analyzers/Microsoft.Co
 
 Option Values: One or more fields of enum [Microsoft.CodeAnalysis.CompilationOptions.OutputKind](http://source.roslyn.io/#q=Microsoft.CodeAnalysis.OutputKind) as a comma separated list.
 
+Default Value: All output kinds
+
 Example: `dotnet_code_quality.CA2007.output_kind = ConsoleApplication, DynamicallyLinkedLibrary`
 
 ### Async void methods
@@ -67,4 +71,17 @@ Configurable Rules: [CA2007](../src/Microsoft.CodeQuality.Analyzers/Microsoft.Co
 
 Option Values: `true` or `false`
 
+Default Value: `false`
+
 Example: `dotnet_code_quality.CA2007.skip_async_void_methods = true`
+
+### Single letter type parameters
+Option Name: `allow_single_letter_type_parameters`
+
+Configurable Rules: [CA1715](https://docs.microsoft.com/visualstudio/code-quality/ca1715-identifiers-should-have-correct-prefix)
+
+Option Values: `true` or `false`
+
+Default Value: `false`
+
+Example: `dotnet_code_quality.CA1715.allow_single_letter_type_parameters = true`

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefix.cs
@@ -59,14 +59,20 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                 Debug.Assert(context.Symbol.MatchesConfiguredVisibility(context.Options, TypeParameterRule, context.CancellationToken));
 
+                bool allowSingleLetterTypeParameters = context.Options.GetBoolOptionValue(
+                    optionName: EditorConfigOptionNames.AllowSingleLetterTypeParameters,
+                    rule: TypeParameterRule,
+                    defaultValue: false,
+                    cancellationToken: context.CancellationToken);
+
                 switch (context.Symbol.Kind)
                 {
                     case SymbolKind.NamedType:
-                        AnalyzeNamedTypeSymbol((INamedTypeSymbol)context.Symbol, context.ReportDiagnostic);
+                        AnalyzeNamedTypeSymbol((INamedTypeSymbol)context.Symbol, allowSingleLetterTypeParameters, context.ReportDiagnostic);
                         break;
 
                     case SymbolKind.Method:
-                        AnalyzeMethodSymbol((IMethodSymbol)context.Symbol, context.ReportDiagnostic);
+                        AnalyzeMethodSymbol((IMethodSymbol)context.Symbol, allowSingleLetterTypeParameters, context.ReportDiagnostic);
                         break;
                 }
             },
@@ -74,15 +80,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 SymbolKind.NamedType);
         }
 
-        private static void AnalyzeNamedTypeSymbol(INamedTypeSymbol symbol, Action<Diagnostic> addDiagnostic)
+        private static void AnalyzeNamedTypeSymbol(INamedTypeSymbol symbol, bool allowSingleLetterTypeParameters, Action<Diagnostic> addDiagnostic)
         {
-            foreach (ITypeParameterSymbol parameter in symbol.TypeParameters)
-            {
-                if (parameter.Name.Length > 1 && !HasCorrectPrefix(parameter, 'T'))
-                {
-                    addDiagnostic(parameter.CreateDiagnostic(TypeParameterRule, parameter.Name));
-                }
-            }
+            AnalyzeTypeParameters(symbol.TypeParameters, allowSingleLetterTypeParameters, addDiagnostic);
 
             if (symbol.TypeKind == TypeKind.Interface &&
                 symbol.IsPublic() &&
@@ -92,13 +92,22 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
         }
 
-        private static void AnalyzeMethodSymbol(IMethodSymbol symbol, Action<Diagnostic> addDiagnostic)
+        private static void AnalyzeMethodSymbol(IMethodSymbol symbol, bool allowSingleLetterTypeParameters, Action<Diagnostic> addDiagnostic)
+            => AnalyzeTypeParameters(symbol.TypeParameters, allowSingleLetterTypeParameters, addDiagnostic);
+
+        private static void AnalyzeTypeParameters(ImmutableArray<ITypeParameterSymbol> typeParameters, bool allowSingleLetterTypeParameters, Action<Diagnostic> addDiagnostic)
         {
-            foreach (ITypeParameterSymbol parameter in symbol.TypeParameters)
+            foreach (var typeParameter in typeParameters)
             {
-                if (parameter.Name.Length > 1 && !HasCorrectPrefix(parameter, 'T'))
+                if (!HasCorrectPrefix(typeParameter, 'T'))
                 {
-                    addDiagnostic(parameter.CreateDiagnostic(TypeParameterRule, parameter.Name));
+                    // Check if single letter type parameters are allowed through configuration.
+                    if (allowSingleLetterTypeParameters && typeParameter.Name.Length == 1)
+                    {
+                        continue;
+                    }
+
+                    addDiagnostic(typeParameter.CreateDiagnostic(TypeParameterRule, typeParameter.Name));
                 }
             }
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
@@ -217,8 +217,9 @@ public class C2
 ");
         }
 
+        [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
         [Fact]
-        public void TestTypeParameterNamesCSharp_NoDiagnosticCases()
+        public void TestTypeParameterNamesCSharp_SingleLetterCases_Default()
         {
             VerifyCSharp(@"
 using System;
@@ -244,7 +245,89 @@ public class Class4<T>
 public class Class6<TTypeParameter>
 {
 }
-");
+",
+            GetCA1715CSharpResultAt(4, 25, CA1715TypeParameterMessage, "V"),
+            GetCA1715CSharpResultAt(8, 31, CA1715TypeParameterMessage, "V"),
+            GetCA1715CSharpResultAt(10, 24, CA1715TypeParameterMessage, "V"),
+            GetCA1715CSharpResultAt(16, 24, CA1715TypeParameterMessage, "K"),
+            GetCA1715CSharpResultAt(16, 27, CA1715TypeParameterMessage, "V"));
+        }
+
+        [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
+        [Theory]
+        [InlineData(@"")]
+        [InlineData(@"dotnet_code_quality.allow_single_letter_type_parameters = false")]
+        [InlineData(@"dotnet_code_quality.CA1715.allow_single_letter_type_parameters = false")]
+        [InlineData(@"dotnet_code_quality.allow_single_letter_type_parameters = true
+                      dotnet_code_quality.CA1715.allow_single_letter_type_parameters = false")]
+        public void TestTypeParameterNamesCSharp_SingleLetterCases_EditorConfig_Diagnostic(string editorConfigText)
+        {
+            VerifyCSharp(@"
+using System;
+
+public class IInterface<V>
+{
+}
+
+public delegate void Callback<V>();
+
+public class Class2<T, V>
+{
+}
+
+public class Class4<T>
+{
+    public void Method<K, V>(K key, V value)
+    {
+        Console.WriteLine(key.ToString() + value.ToString());
+    }
+}
+
+public class Class6<TTypeParameter>
+{
+}
+",
+            GetEditorConfigAdditionalFile(editorConfigText),
+            GetCA1715CSharpResultAt(4, 25, CA1715TypeParameterMessage, "V"),
+            GetCA1715CSharpResultAt(8, 31, CA1715TypeParameterMessage, "V"),
+            GetCA1715CSharpResultAt(10, 24, CA1715TypeParameterMessage, "V"),
+            GetCA1715CSharpResultAt(16, 24, CA1715TypeParameterMessage, "K"),
+            GetCA1715CSharpResultAt(16, 27, CA1715TypeParameterMessage, "V"));
+        }
+
+        [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
+        [Theory]
+        [InlineData(@"dotnet_code_quality.allow_single_letter_type_parameters = true")]
+        [InlineData(@"dotnet_code_quality.CA1715.allow_single_letter_type_parameters = true")]
+        [InlineData(@"dotnet_code_quality.allow_single_letter_type_parameters = false
+                      dotnet_code_quality.CA1715.allow_single_letter_type_parameters = true")]
+        public void TestTypeParameterNamesCSharp_SingleLetterCases_EditorConfig_NoDiagnostic(string editorConfigText)
+        {
+            VerifyCSharp(@"
+using System;
+
+public class IInterface<V>
+{
+}
+
+public delegate void Callback<V>();
+
+public class Class2<T, V>
+{
+}
+
+public class Class4<T>
+{
+    public void Method<K, V>(K key, V value)
+    {
+        Console.WriteLine(key.ToString() + value.ToString());
+    }
+}
+
+public class Class6<TTypeParameter>
+{
+}
+", GetEditorConfigAdditionalFile(editorConfigText));
         }
 
         [Fact]
@@ -413,8 +496,9 @@ End Class
 ");
         }
 
+        [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
         [Fact]
-        public void TestTypeParameterNamesBasic_NoDiagnosticCases()
+        public void TestTypeParameterNamesBasic_SingleLetterCases_Default()
         {
             VerifyBasic(@"
 Imports System
@@ -435,7 +519,79 @@ End Class
 
 Public Class Class6(Of TTypeParameter)
 End Class
-");
+",
+            GetCA1715BasicResultAt(4, 28, CA1715TypeParameterMessage, "V"),
+            GetCA1715BasicResultAt(7, 33, CA1715TypeParameterMessage, "V"),
+            GetCA1715BasicResultAt(9, 27, CA1715TypeParameterMessage, "V"),
+            GetCA1715BasicResultAt(13, 26, CA1715TypeParameterMessage, "K"),
+            GetCA1715BasicResultAt(13, 29, CA1715TypeParameterMessage, "V"));
+        }
+
+        [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
+        [Theory]
+        [InlineData(@"")]
+        [InlineData(@"dotnet_code_quality.allow_single_letter_type_parameters = false")]
+        [InlineData(@"dotnet_code_quality.CA1715.allow_single_letter_type_parameters = false")]
+        [InlineData(@"dotnet_code_quality.allow_single_letter_type_parameters = true
+                      dotnet_code_quality.CA1715.allow_single_letter_type_parameters = false")]
+        public void TestTypeParameterNamesBasic_SingleLetterCases_EditorConfig_Diagnostic(string editorConfigText)
+        {
+            VerifyBasic(@"
+Imports System
+
+Public Class IInterface(Of V)
+End Class
+
+Public Delegate Sub Callback(Of V)()
+
+Public Class Class2(Of T, V)
+End Class
+
+Public Class Class4(Of T)
+    Public Sub Method(Of K, V)(key As K, value As V)
+        Console.WriteLine(key.ToString() + value.ToString())
+    End Sub
+End Class
+
+Public Class Class6(Of TTypeParameter)
+End Class
+",
+            GetEditorConfigAdditionalFile(editorConfigText),
+            GetCA1715BasicResultAt(4, 28, CA1715TypeParameterMessage, "V"),
+            GetCA1715BasicResultAt(7, 33, CA1715TypeParameterMessage, "V"),
+            GetCA1715BasicResultAt(9, 27, CA1715TypeParameterMessage, "V"),
+            GetCA1715BasicResultAt(13, 26, CA1715TypeParameterMessage, "K"),
+            GetCA1715BasicResultAt(13, 29, CA1715TypeParameterMessage, "V"));
+        }
+
+        [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
+        [Theory]
+        [InlineData(@"dotnet_code_quality.allow_single_letter_type_parameters = true")]
+        [InlineData(@"dotnet_code_quality.CA1715.allow_single_letter_type_parameters = true")]
+        [InlineData(@"dotnet_code_quality.allow_single_letter_type_parameters = false
+                      dotnet_code_quality.CA1715.allow_single_letter_type_parameters = true")]
+        public void TestTypeParameterNamesBasic_SingleLetterCases_EditorConfig_NoDiagnostic(string editorConfigText)
+        {
+            VerifyBasic(@"
+Imports System
+
+Public Class IInterface(Of V)
+End Class
+
+Public Delegate Sub Callback(Of V)()
+
+Public Class Class2(Of T, V)
+End Class
+
+Public Class Class4(Of T)
+    Public Sub Method(Of K, V)(key As K, value As V)
+        Console.WriteLine(key.ToString() + value.ToString())
+    End Sub
+End Class
+
+Public Class Class6(Of TTypeParameter)
+End Class
+", GetEditorConfigAdditionalFile(editorConfigText));
         }
 
         internal static readonly string CA1715InterfaceMessage = MicrosoftApiDesignGuidelinesAnalyzersResources.IdentifiersShouldHaveCorrectPrefixMessageInterface;

--- a/src/Utilities/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Options/EditorConfigOptionNames.cs
@@ -27,5 +27,10 @@ namespace Analyzer.Utilities
         /// Allowed option values: One or more fields of <see cref="Microsoft.CodeAnalysis.CompilationOptions.OutputKind"/> as a comma separated list.
         /// </summary>
         public const string OutputKind = "output_kind";
+
+        /// <summary>
+        /// Boolean option to configure if single letter type parameter names are allowed for CA1715 (https://docs.microsoft.com/visualstudio/code-quality/ca1715-identifiers-should-have-correct-prefix).
+        /// </summary>
+        public const string AllowSingleLetterTypeParameters = "allow_single_letter_type_parameters";
     }
 }


### PR DESCRIPTION
…gle letter type parameters

Fixes #1604

By default, we _do not_ allow single letter type parameter names to match the original FxCop rule. This option enables changing this default behavior, which is an especially useful knob for developers coming from Java background which prefer single letter identifier names and consider CA1715 violations on single letter type parameter names as significant noise to render this rule useless.