### PR TITLE
Regex injection tainted data DFA

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Security/MicrosoftNetCoreSecurityResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/MicrosoftNetCoreSecurityResources.resx
@@ -174,4 +174,10 @@
   <data name="ReviewCodeForProcessCommandInjectionVulnerabilitiesTitle" xml:space="preserve">
     <value>Review code for process command injection vulnerabilities</value>
   </data>
+  <data name="ReviewCodeForRegexInjectionVulnerabilitiesMessage" xml:space="preserve">
+    <value>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</value>
+  </data>
+  <data name="ReviewCodeForRegexInjectionVulnerabilitiesTitle" xml:space="preserve">
+    <value>Review code for regex injection vulnerabalities</value>
+  </data>
 </root>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/ReviewCodeForRegexInjectionVulnerabilities.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/ReviewCodeForRegexInjectionVulnerabilities.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.NetCore.Analyzers.Security.Helpers;
+
+namespace Microsoft.NetCore.Analyzers.Security
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class ReviewCodeForRegexInjectionVulnerabilities : SourceTriggeredTaintedDataAnalyzerBase
+    {
+        internal static readonly DiagnosticDescriptor Rule = SecurityHelpers.CreateDiagnosticDescriptor(
+            "CA3012",
+            nameof(MicrosoftNetCoreSecurityResources.ReviewCodeForRegexInjectionVulnerabilitiesTitle),
+            nameof(MicrosoftNetCoreSecurityResources.ReviewCodeForRegexInjectionVulnerabilitiesMessage),
+            isEnabledByDefault: false,
+            helpLinkUri: null); // TODO paulming: Help link.  https://github.com/dotnet/roslyn-analyzers/issues/1892
+
+        protected override SinkKind SinkKind { get { return SinkKind.Regex; } }
+
+        protected override DiagnosticDescriptor TaintedDataEnteringSinkDescriptor { get { return Rule; } }
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.cs.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.de.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.es.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.fr.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.it.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ja.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ko.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.pl.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.pt-BR.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ru.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.tr.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.zh-Hans.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.zh-Hant.xlf
@@ -67,6 +67,16 @@
         <target state="new">Review code for process command injection vulnerabilities</target>
         <note />
       </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesMessage">
+        <source>Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
+        <target state="new">Potential regex injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReviewCodeForRegexInjectionVulnerabilitiesTitle">
+        <source>Review code for regex injection vulnerabalities</source>
+        <target state="new">Review code for regex injection vulnerabalities</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForSqlInjectionVulnerabilitiesMessage">
         <source>Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential SQL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ReviewCodeForRegexInjectionVulnerabilitiesTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ReviewCodeForRegexInjectionVulnerabilitiesTests.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace Microsoft.NetCore.Analyzers.Security.UnitTests
+{
+    public class ReviewCodeForRegexInjectionVulnerabilitiesTests : TaintedDataAnalyzerTestBase
+    {
+        protected override DiagnosticDescriptor Rule => ReviewCodeForRegexInjectionVulnerabilities.Rule;
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ReviewCodeForRegexInjectionVulnerabilities();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new ReviewCodeForRegexInjectionVulnerabilities();
+        }
+
+        [Fact]
+        public void Constructor_Diagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+using System.Web;
+using System.Text.RegularExpressions;
+
+public partial class WebForm : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string input = Request.Form[""in""];
+        new Regex(input);
+    }
+}",
+                GetCSharpResultAt(11, 9, 10, 24, "Regex.Regex(string pattern)", "void WebForm.Page_Load(object sender, EventArgs e)", "NameValueCollection HttpRequest.Form", "void WebForm.Page_Load(object sender, EventArgs e)"));
+        }
+
+        [Fact]
+        public void Constructor_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+using System.Web;
+using System.Text.RegularExpressions;
+
+public partial class WebForm : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string input = Request.Form[""in""];
+        new Regex(""^\\d{1,10}$"");
+    }
+}");
+        }
+
+        [Fact]
+        public void IsMatch_Diagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+using System.Web;
+using System.Text.RegularExpressions;
+
+public partial class WebForm : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string input = Request.Form[""in""];
+        Regex.IsMatch(""string to check"", input);
+    }
+}",
+                GetCSharpResultAt(11, 9, 10, 24, "bool Regex.IsMatch(string input, string pattern)", "void WebForm.Page_Load(object sender, EventArgs e)", "NameValueCollection HttpRequest.Form", "void WebForm.Page_Load(object sender, EventArgs e)"));
+        }
+
+        [Fact]
+        public void IsMatch_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+using System.Web;
+using System.Text.RegularExpressions;
+
+public partial class WebForm : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string input = Request.Form[""in""];
+        Regex.IsMatch(input, ""^[a-z]{1,128}$"");
+    }
+}");
+        }
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ReviewCodeForRegexInjectionVulnerabilitiesTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ReviewCodeForRegexInjectionVulnerabilitiesTests.cs
@@ -58,7 +58,7 @@ public partial class WebForm : System.Web.UI.Page
         }
 
         [Fact]
-        public void IsMatch_Diagnostic()
+        public void IsMatch_Static_Diagnostic()
         {
             VerifyCSharpWithDependencies(@"
 using System;
@@ -77,7 +77,7 @@ public partial class WebForm : System.Web.UI.Page
         }
 
         [Fact]
-        public void IsMatch_NoDiagnostic()
+        public void IsMatch_Static_NoDiagnostic()
         {
             VerifyCSharpWithDependencies(@"
 using System;
@@ -90,6 +90,25 @@ public partial class WebForm : System.Web.UI.Page
     {
         string input = Request.Form[""in""];
         Regex.IsMatch(input, ""^[a-z]{1,128}$"");
+    }
+}");
+        }
+
+        [Fact]
+        public void IsMatch_Instance_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+using System.Web;
+using System.Text.RegularExpressions;
+
+public partial class WebForm : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string input = Request.Form[""in""];
+        Regex r = new Regex(""^[a-z]{1,128}$"");
+        r.IsMatch(input);
     }
 }");
         }

--- a/src/Utilities/Analyzer.Utilities.projitems
+++ b/src/Utilities/Analyzer.Utilities.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\OperationBlockAnalysisContextExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\WellKnownDiagnosticTagsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\FilePathInjectionSinks.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\RegexSinks.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\ProcessCommandSinks.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractAnalysisData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\DictionaryAnalysisData.cs" />

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/RegexSinks.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/RegexSinks.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+
+namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
+{
+    internal static class RegexSinks
+    {
+        /// <summary>
+        /// <see cref="SinkInfo"/>s for tainted data process command sinks.
+        /// </summary>
+        public static ImmutableHashSet<SinkInfo> SinkInfos { get; }
+
+        static RegexSinks()
+        {
+            var builder = PooledHashSet<SinkInfo>.GetInstance();
+
+            builder.AddSinkInfo(
+                WellKnownTypes.SystemTextRegularExpressionsRegex,
+                SinkKind.Regex,
+                isInterface: false,
+                isAnyStringParameterInConstructorASink: true,
+                sinkProperties: null,
+                sinkMethodParameters: new[] {
+                    ( "IsMatch", new[] { "pattern" }),
+                    ( "Match", new[] { "pattern" }),
+                    ( "Matches", new[] { "pattern" }),
+                    ( "Replace", new[] { "pattern" }),
+                    ( "Split", new[] { "pattern" }),
+                });
+
+            SinkInfos = builder.ToImmutableAndFree();
+        }
+    }
+}

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/SinkKind.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/SinkKind.cs
@@ -10,5 +10,6 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         XSS,
         FilePathInjection,
         ProcessCommand,
+        Regex,
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -211,7 +211,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 IEnumerable<IArgumentOperation> taintedArguments = GetTaintedArguments(visitedArguments);
                 if (taintedArguments.Any())
                 {
-                    ProcessTaintedDataEnteringInvocationOrCreation(method, visitedArguments, originalOperation);
+                    ProcessTaintedDataEnteringInvocationOrCreation(method, taintedArguments, originalOperation);
                 }
 
                 if (this.IsSanitizingMethod(method))
@@ -234,7 +234,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 IEnumerable<IArgumentOperation> taintedArguments = GetTaintedArguments(visitedArguments);
                 if (taintedArguments.Any())
                 {
-                    ProcessTaintedDataEnteringInvocationOrCreation(localFunction, visitedArguments, originalOperation);
+                    ProcessTaintedDataEnteringInvocationOrCreation(localFunction, taintedArguments, originalOperation);
                 }
 
                 return baseValue;

--- a/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataConfig.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataConfig.cs
@@ -177,6 +177,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 case SinkKind.Dll:
                 case SinkKind.FilePathInjection:
                 case SinkKind.ProcessCommand:
+                case SinkKind.Regex:
                     return WebInputSources.SourceInfos;
 
                 case SinkKind.InformationDisclosure:
@@ -203,6 +204,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 case SinkKind.XSS:  // TODO: Implement as part of CA3002
                 case SinkKind.FilePathInjection:
                 case SinkKind.ProcessCommand:
+                case SinkKind.Regex:
                     return ImmutableHashSet<SanitizerInfo>.Empty;
 
                 default:
@@ -230,6 +232,9 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
                 case SinkKind.ProcessCommand:
                     return ProcessCommandSinks.SinkInfos;
+
+                case SinkKind.Regex:
+                    return RegexSinks.SinkInfos;
 
                 default:
                     Debug.Fail($"Unhandled SinkKind {sinkKind}");

--- a/src/Utilities/WellKnownTypes.cs
+++ b/src/Utilities/WellKnownTypes.cs
@@ -148,6 +148,7 @@ namespace Analyzer.Utilities
         public const string SystemSecurityCryptographyCipherMode = "System.Security.Cryptography.CipherMode";
         public const string SystemDiagnosticsProcess = "System.Diagnostics.Process";
         public const string SystemDiagnosticsProcessStartInfo = "System.Diagnostics.ProcessStartInfo";
+        public const string SystemTextRegularExpressionsRegex = "System.Text.RegularExpressions.Regex";
 
         public static INamedTypeSymbol ICollection(Compilation compilation)
         {


### PR DESCRIPTION
- Sinks hardcoded from FxCop.
- Fixed a bug with passing all the arguments as taintedArguments, instead of just the tainted ones.