### PR TITLE
Guard against null containing assembly in DiagnosticAnalyzerApiUsageA…

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAPIUsageAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAPIUsageAnalyzer.cs
@@ -112,12 +112,13 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                         do
                         {
                             var typeToProcess = typesToProcess.Dequeue();
-                            Debug.Assert(typeToProcess.ContainingAssembly == declaredType.ContainingAssembly);
+                            Debug.Assert(typeToProcess.ContainingAssembly.Equals(declaredType.ContainingAssembly));
                             Debug.Assert(namedTypesToAccessedTypesMap.ContainsKey(typeToProcess));
 
                             foreach (INamedTypeSymbol usedType in namedTypesToAccessedTypesMap[typeToProcess])
                             {
-                                if (s_WorkspaceAssemblyNames.Contains(usedType.ContainingAssembly.Name))
+                                if (usedType.ContainingAssembly != null &&
+                                    s_WorkspaceAssemblyNames.Contains(usedType.ContainingAssembly.Name))
                                 {
                                     violatingTypeNamesBuilder.Add(usedType.ToDisplayString());
                                     violatingUsedTypeNamesBuilder.Add(typeToProcess.ToDisplayString());
@@ -241,6 +242,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 builder.Add(usedType);
 
                 if (!hasAccessToTypeFromWorkspaceAssemblies &&
+                    usedType.ContainingAssembly != null &&
                     s_WorkspaceAssemblyNames.Contains(usedType.ContainingAssembly.Name))
                 {
                     hasAccessToTypeFromWorkspaceAssemblies = true;


### PR DESCRIPTION
…nalyzer

We have few reports of intermittent NRE in this analyzer, but do not have a repro. Adding a null guard that I found while reading the code.