### PR TITLE
Fix a race condition in getting editor config option value

### DIFF
--- a/src/Utilities/Options/CategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Options/CategorizedAnalyzerConfigOptions.cs
@@ -113,7 +113,7 @@ namespace Analyzer.Utilities
                 return defaultValue;
             }
 
-            return (T)_computedOptionValuesMap.GetOrAdd(optionName, _ => ComputeOptionValue(optionName, rule, tryParseValue, defaultValue));
+            return (T)_computedOptionValuesMap.GetOrAdd($"{rule.Id}.{optionName}", _ => ComputeOptionValue(optionName, rule, tryParseValue, defaultValue));
         }
 
         private T ComputeOptionValue<T>(string optionName, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, T defaultValue)


### PR DESCRIPTION
Use the rule ID + option name as the key, otherwise option value computed for first rule will be used for all rules. For example:

```
dotnet_code_quality.CA1707.api_surface = all
dotnet_code_quality.CA1720.api_surface = public
```

We will apply only one of the above settings for all rules based on which rule queries the option first.