### PR TITLE
Dogfood .editorconfig based configuration for FxCop analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -76,3 +76,21 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+
+
+### Configuration for FxCop analyzers executed on this repo
+
+# Default analyzed API surface = 'all' (public APIs + non-public APIs)
+dotnet_code_quality.api_surface = all
+
+# Restrict the analyzed API surface for certain analyzers to 'public' (public APIs only).
+# CA1043: Use integral or string argument for indexers
+dotnet_code_quality.CA1043.api_surface = public
+# CA1707: Identifiers should not contain underscores
+dotnet_code_quality.CA1707.api_surface = public
+# CA1720: Identifiers should not contain type names
+dotnet_code_quality.CA1720.api_surface = public
+
+# Allow single letter type parameter names
+# CA1715: Identifiers should have correct prefix
+dotnet_code_quality.CA1715.allow_single_letter_type_parameters = true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,4 +7,12 @@
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <!-- Workaround to enable .editorconfig based analyzer configuration until dotnet compilers support .editorconfig based configuration -->
+  <PropertyGroup>
+    <SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory).editorconfig" />
+  </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,8 +20,8 @@
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>2.6.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftNetCompilersVersion>2.6.0</MicrosoftNetCompilersVersion>
-    <MicrosoftCodeAnalysisFXCopAnalyersVersion>2.6.4-ci</MicrosoftCodeAnalysisFXCopAnalyersVersion>
-    <MicrosoftCodeAnalysisAnalyersVersion>2.6.4-ci</MicrosoftCodeAnalysisAnalyersVersion>
+    <MicrosoftCodeAnalysisFXCopAnalyersVersion>2.6.4-beta1.19067.1+c6049bf9</MicrosoftCodeAnalysisFXCopAnalyersVersion>
+    <MicrosoftCodeAnalysisAnalyersVersion>2.6.4-beta1.19067.1+c6049bf9</MicrosoftCodeAnalysisAnalyersVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
 
     <!-- Roslyn Testing -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,8 +20,8 @@
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>2.6.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftNetCompilersVersion>2.6.0</MicrosoftNetCompilersVersion>
-    <MicrosoftCodeAnalysisFXCopAnalyersVersion>2.6.3</MicrosoftCodeAnalysisFXCopAnalyersVersion>
-    <MicrosoftCodeAnalysisAnalyersVersion>2.6.3</MicrosoftCodeAnalysisAnalyersVersion>
+    <MicrosoftCodeAnalysisFXCopAnalyersVersion>2.6.4-ci</MicrosoftCodeAnalysisFXCopAnalyersVersion>
+    <MicrosoftCodeAnalysisAnalyersVersion>2.6.4-ci</MicrosoftCodeAnalysisAnalyersVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
 
     <!-- Roslyn Testing -->

--- a/src/GenerateAnalyzerRulesets/Program.cs
+++ b/src/GenerateAnalyzerRulesets/Program.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace GenerateAnalyzerRulesets
 {
-    class Program
+    public static class Program
     {
         public static int Main(string[] args)
         {

--- a/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
+++ b/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
@@ -1748,10 +1748,10 @@ namespace MetaCompilation.Analyzers
         }
         #endregion
 
-        private class CodeFixHelper
+        private static class CodeFixHelper
         {
             // removes the provided statement from the method that it is in
-            protected internal static SyntaxNode RemoveStatement(StatementSyntax statement)
+            internal static SyntaxNode RemoveStatement(StatementSyntax statement)
             {
                 MethodDeclarationSyntax initializeDeclaration = statement.Ancestors().OfType<MethodDeclarationSyntax>().First();
                 MethodDeclarationSyntax newInitializeDeclaration = initializeDeclaration.RemoveNode(statement, 0);
@@ -1759,7 +1759,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // checks if the statement is a correct regsiter statement
-            protected internal static bool IsCorrectRegister(ExpressionStatementSyntax statement)
+            internal static bool IsCorrectRegister(ExpressionStatementSyntax statement)
             {
                 var expression = statement.Expression as InvocationExpressionSyntax;
                 if (expression == null)
@@ -1800,42 +1800,42 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of the span variable
-            protected internal static string GetSpanName(MethodDeclarationSyntax methodDecl)
+            internal static string GetSpanName(MethodDeclarationSyntax methodDecl)
             {
                 string spanName = (methodDecl.Body.Statements[6] as LocalDeclarationStatementSyntax).Declaration.Variables[0].Identifier.Text;
                 return spanName;
             }
 
             // gets the name of the start span variable
-            protected internal static string GetStartSpanName(MethodDeclarationSyntax methodDecl)
+            internal static string GetStartSpanName(MethodDeclarationSyntax methodDecl)
             {
                 string startIdentifier = (methodDecl.Body.Statements[4] as LocalDeclarationStatementSyntax).Declaration.Variables[0].Identifier.Text;
                 return startIdentifier;
             }
 
             // gets the name of the end span variable
-            protected internal static string GetEndSpanName(MethodDeclarationSyntax methodDecl)
+            internal static string GetEndSpanName(MethodDeclarationSyntax methodDecl)
             {
                 string endIdentifier = (methodDecl.Body.Statements[5] as LocalDeclarationStatementSyntax).Declaration.Variables[0].Identifier.Text;
                 return endIdentifier;
             }
 
             // gets the name of the open paren variable
-            protected internal static string GetOpenParenName(MethodDeclarationSyntax methodDecl)
+            internal static string GetOpenParenName(MethodDeclarationSyntax methodDecl)
             {
                 string openParenName = (methodDecl.Body.Statements[3] as LocalDeclarationStatementSyntax).Declaration.Variables[0].Identifier.Text;
                 return openParenName;
             }
 
             // gets the name of the location variable
-            protected internal static string GetLocationName(MethodDeclarationSyntax methodDecl)
+            internal static string GetLocationName(MethodDeclarationSyntax methodDecl)
             {
                 string locationName = (methodDecl.Body.Statements[7] as LocalDeclarationStatementSyntax).Declaration.Variables[0].Identifier.Text;
                 return locationName;
             }
 
             // adds a statement to the provided method
-            protected internal static SyntaxNode AddStatementToMethod(SyntaxGenerator generator, MethodDeclarationSyntax methodDecl, SyntaxNode statement)
+            internal static SyntaxNode AddStatementToMethod(SyntaxGenerator generator, MethodDeclarationSyntax methodDecl, SyntaxNode statement)
             {
                 var oldStatements = (SyntaxList<SyntaxNode>)methodDecl.Body.Statements;
                 SyntaxList<SyntaxNode> newStatements = oldStatements.Add(statement);
@@ -1844,21 +1844,21 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of the diagnostic variable
-            protected internal static string GetDiagnosticName(MethodDeclarationSyntax methodDecl)
+            internal static string GetDiagnosticName(MethodDeclarationSyntax methodDecl)
             {
                 string diagnosticName = (methodDecl.Body.Statements[8] as LocalDeclarationStatementSyntax).Declaration.Variables[0].Identifier.Text;
                 return diagnosticName;
             }
 
             // gets the context parameter of the analysis method
-            protected internal static string GetContextParameter(MethodDeclarationSyntax methodDecl)
+            internal static string GetContextParameter(MethodDeclarationSyntax methodDecl)
             {
                 string contextName = methodDecl.ParameterList.Parameters[0].Identifier.Text;
                 return contextName;
             }
 
             // builds a register statement
-            protected internal static SyntaxNode BuildRegister(SyntaxGenerator generator, string context, string register, ArgumentListSyntax argumentList)
+            internal static SyntaxNode BuildRegister(SyntaxGenerator generator, string context, string register, ArgumentListSyntax argumentList)
             {
                 SyntaxNode registerIdentifier = generator.IdentifierName(register);
                 SyntaxNode contextIdentifier = generator.IdentifierName(context);
@@ -1868,7 +1868,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of the method registered, null if none found
-            protected internal static string GetRegisterMethodName(InvocationExpressionSyntax invocationExpression)
+            internal static string GetRegisterMethodName(InvocationExpressionSyntax invocationExpression)
             {
                 string methodName = null;
                 ArgumentListSyntax argList = invocationExpression.ArgumentList;
@@ -1892,7 +1892,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of the analysis method
-            protected internal static string AnalysisMethodName(MethodDeclarationSyntax methodDeclaration)
+            internal static string AnalysisMethodName(MethodDeclarationSyntax methodDeclaration)
             {
                 var statements = methodDeclaration.Body.Statements.First() as ExpressionStatementSyntax;
                 var invocationExpression = statements.Expression as InvocationExpressionSyntax;
@@ -1902,14 +1902,14 @@ namespace MetaCompilation.Analyzers
             }
 
             // set method accessibility to accessibility
-            protected internal static SyntaxNode MethodAccessibility(SyntaxGenerator generator, MethodDeclarationSyntax methodDeclaration, Accessibility accessibility)
+            internal static SyntaxNode MethodAccessibility(SyntaxGenerator generator, MethodDeclarationSyntax methodDeclaration, Accessibility accessibility)
             {
                 SyntaxNode newMethod = generator.WithAccessibility(methodDeclaration, accessibility);
                 return newMethod;
             }
 
             // set method return type to returnType
-            protected internal static SyntaxNode MethodReturnType(MethodDeclarationSyntax methodDeclaration, string returnType)
+            internal static SyntaxNode MethodReturnType(MethodDeclarationSyntax methodDeclaration, string returnType)
             {
                 TypeSyntax voidType = SyntaxFactory.ParseTypeName(returnType).WithTrailingTrivia(SyntaxFactory.Whitespace(" "));
                 methodDeclaration = methodDeclaration.WithReturnType(voidType);
@@ -1917,7 +1917,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of the if-statement variable
-            protected internal static string GetIfStatementName(BlockSyntax methodBlock)
+            internal static string GetIfStatementName(BlockSyntax methodBlock)
             {
                 var firstStatement = methodBlock.Statements[0] as LocalDeclarationStatementSyntax;
                 string variableName = firstStatement.Declaration.Variables[0].Identifier.ValueText;
@@ -1925,7 +1925,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of the if-keyword variable
-            protected internal static string GetIfKeywordName(BlockSyntax methodBlock)
+            internal static string GetIfKeywordName(BlockSyntax methodBlock)
             {
                 var secondStatement = methodBlock.Statements[1] as LocalDeclarationStatementSyntax;
                 string variableName = secondStatement.Declaration.Variables[0].Identifier.ValueText;
@@ -1933,7 +1933,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of the trailing trivia variable
-            protected internal static string GetTrailingTriviaName(BlockSyntax ifBlock)
+            internal static string GetTrailingTriviaName(BlockSyntax ifBlock)
             {
                 var trailingTriviaDeclaration = ifBlock.Statements[0] as LocalDeclarationStatementSyntax;
                 string variableName = trailingTriviaDeclaration.Declaration.Variables[0].Identifier.ValueText;
@@ -1941,7 +1941,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of the first parameter of the method
-            protected internal static string GetFirstParameterName(MethodDeclarationSyntax methodDeclaration)
+            internal static string GetFirstParameterName(MethodDeclarationSyntax methodDeclaration)
             {
                 ParameterSyntax firstParameter = methodDeclaration.ParameterList.Parameters[0];
                 string name = firstParameter.Identifier.Text;
@@ -1949,7 +1949,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates an if-statement checking the count of trailing trivia
-            protected internal static SyntaxNode TriviaCountHelper(SyntaxGenerator generator, string name, SyntaxList<StatementSyntax> ifBlockStatements)
+            internal static SyntaxNode TriviaCountHelper(SyntaxGenerator generator, string name, SyntaxList<StatementSyntax> ifBlockStatements)
             {
                 SyntaxNode variableName = generator.IdentifierName(name);
                 SyntaxNode memberAccess = generator.MemberAccessExpression(variableName, "TrailingTrivia");
@@ -1962,7 +1962,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a statement casting context.Node to if-statement
-            protected internal static SyntaxNode IfHelper(SyntaxGenerator generator, string name)
+            internal static SyntaxNode IfHelper(SyntaxGenerator generator, string name)
             {
                 TypeSyntax type = SyntaxFactory.ParseTypeName("IfStatementSyntax");
                 SyntaxNode expression = generator.IdentifierName(name);
@@ -1974,7 +1974,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates the if-keyword statement
-            protected internal static SyntaxNode KeywordHelper(SyntaxGenerator generator, BlockSyntax methodBlock)
+            internal static SyntaxNode KeywordHelper(SyntaxGenerator generator, BlockSyntax methodBlock)
             {
                 string variableName = GetIfStatementName(methodBlock);
                 SyntaxNode identifierName = generator.IdentifierName(variableName);
@@ -1985,7 +1985,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates the HasTrailingTrivia check
-            protected internal static SyntaxNode TriviaCheckHelper(SyntaxGenerator generator, BlockSyntax methodBlock, SyntaxList<StatementSyntax> ifBlockStatements)
+            internal static SyntaxNode TriviaCheckHelper(SyntaxGenerator generator, BlockSyntax methodBlock, SyntaxList<StatementSyntax> ifBlockStatements)
             {
                 string variableName = GetIfKeywordName(methodBlock);
                 SyntaxNode identifierName = generator.IdentifierName(variableName);
@@ -1996,7 +1996,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates the first trailing trivia variable
-            protected internal static SyntaxNode TriviaVarMissingHelper(SyntaxGenerator generator, IfStatementSyntax declaration)
+            internal static SyntaxNode TriviaVarMissingHelper(SyntaxGenerator generator, IfStatementSyntax declaration)
             {
                 MethodDeclarationSyntax methodDecl = declaration.Parent.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
                 var methodBlock = methodDecl.Body as BlockSyntax;
@@ -2014,7 +2014,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates the trivia kind check
-            protected internal static SyntaxNode TriviaKindCheckHelper(SyntaxGenerator generator, IfStatementSyntax ifStatement, SyntaxList<SyntaxNode> ifBlockStatements)
+            internal static SyntaxNode TriviaKindCheckHelper(SyntaxGenerator generator, IfStatementSyntax ifStatement, SyntaxList<SyntaxNode> ifBlockStatements)
             {
                 var ifBlock = ifStatement.Statement as BlockSyntax;
                 string variableName = GetTrailingTriviaName(ifBlock);
@@ -2033,7 +2033,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates the whitespace check
-            protected internal static SyntaxNode WhitespaceCheckHelper(SyntaxGenerator generator, IfStatementSyntax ifStatement, SyntaxList<SyntaxNode> ifBlockStatements)
+            internal static SyntaxNode WhitespaceCheckHelper(SyntaxGenerator generator, IfStatementSyntax ifStatement, SyntaxList<SyntaxNode> ifBlockStatements)
             {
                 var ifBlock = ifStatement.Parent as BlockSyntax;
                 string variableName = GetTrailingTriviaName(ifBlock);
@@ -2050,7 +2050,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // builds an Initialize method
-            protected internal static SyntaxNode BuildInitialize(SyntaxGenerator generator, INamedTypeSymbol notImplementedException, SyntaxList<StatementSyntax> statements, string name)
+            internal static SyntaxNode BuildInitialize(SyntaxGenerator generator, INamedTypeSymbol notImplementedException, SyntaxList<StatementSyntax> statements, string name)
             {
                 TypeSyntax type = SyntaxFactory.ParseTypeName("AnalysisContext");
                 SyntaxNode[] parameters = new[] { generator.ParameterDeclaration(name, type) };
@@ -2065,7 +2065,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a new id with the provided name as a literal expression
-            protected internal static SyntaxNode NewIdCreator(SyntaxGenerator generator, string fieldName, string idName)
+            internal static SyntaxNode NewIdCreator(SyntaxGenerator generator, string fieldName, string idName)
             {
                 SyntaxNode initializer = generator.LiteralExpression(idName);
                 SyntaxNode newField = generator.FieldDeclaration(fieldName, generator.TypeExpression(SpecialType.System_String), Accessibility.Public, DeclarationModifiers.Const, initializer);
@@ -2074,7 +2074,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a variable creating a location for the diagnostic
-            protected internal static SyntaxNode CreateLocation(SyntaxGenerator generator, string ifStatementIdentifier, string spanIdentifier)
+            internal static SyntaxNode CreateLocation(SyntaxGenerator generator, string ifStatementIdentifier, string spanIdentifier)
             {
                 string name = "diagnosticLocation";
 
@@ -2101,7 +2101,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a variable creating a span for the diagnostic
-            protected internal static SyntaxNode CreateSpan(SyntaxGenerator generator, string startIdentifier, string endIdentifier)
+            internal static SyntaxNode CreateSpan(SyntaxGenerator generator, string startIdentifier, string endIdentifier)
             {
                 string name = "diagnosticSpan";
 
@@ -2124,7 +2124,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a variable of the form var variableName = identifierString.SpanStart;
-            protected internal static SyntaxNode CreateEndOrStartSpan(SyntaxGenerator generator, string identifierString, string variableName)
+            internal static SyntaxNode CreateEndOrStartSpan(SyntaxGenerator generator, string identifierString, string variableName)
             {
                 SyntaxNode identifier = generator.IdentifierName(identifierString);
                 SyntaxNode initializer = generator.MemberAccessExpression(identifier, "SpanStart");
@@ -2134,7 +2134,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a variable of the form var openParen = expressionString.OpenParentToken
-            protected internal static SyntaxNode CreateOpenParen(SyntaxGenerator generator, string expressionString)
+            internal static SyntaxNode CreateOpenParen(SyntaxGenerator generator, string expressionString)
             {
                 string name = "openParen";
                 SyntaxNode expression = generator.IdentifierName(expressionString);
@@ -2145,7 +2145,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a variable that creates a diagnostic
-            protected internal static SyntaxNode CreateDiagnostic(SyntaxGenerator generator, string locationName, string ruleName)
+            internal static SyntaxNode CreateDiagnostic(SyntaxGenerator generator, string locationName, string ruleName)
             {
                 SyntaxNode identifier = generator.IdentifierName("Diagnostic");
                 SyntaxNode expression = generator.MemberAccessExpression(identifier, "Create");
@@ -2169,7 +2169,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of the first rule, or null if none is found
-            protected internal static string GetFirstRuleName(ClassDeclarationSyntax declaration)
+            internal static string GetFirstRuleName(ClassDeclarationSyntax declaration)
             {
                 SyntaxList<MemberDeclarationSyntax> members = declaration.Members;
                 FieldDeclarationSyntax rule = null;
@@ -2195,7 +2195,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the analysis method
-            protected internal static MethodDeclarationSyntax GetAnalysis(ClassDeclarationSyntax declaration)
+            internal static MethodDeclarationSyntax GetAnalysis(ClassDeclarationSyntax declaration)
             {
                 SyntaxList<MemberDeclarationSyntax> members = declaration.Members;
                 MethodDeclarationSyntax analysisMethod = null;
@@ -2213,7 +2213,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // check if the member is the SyntaxNodeAnalysis method, returns the MethodDeclarationSyntax if it is, null if not
-            protected internal static MethodDeclarationSyntax IsSyntaxNodeAnalysisMethod(MemberDeclarationSyntax member)
+            internal static MethodDeclarationSyntax IsSyntaxNodeAnalysisMethod(MemberDeclarationSyntax member)
             {
                 MethodDeclarationSyntax analysisMethod = member as MethodDeclarationSyntax;
                 if (analysisMethod == null)
@@ -2248,7 +2248,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a statement that reports a diagnostic
-            protected internal static SyntaxNode CreateDiagnosticReport(SyntaxGenerator generator, string argumentName, string contextName)
+            internal static SyntaxNode CreateDiagnosticReport(SyntaxGenerator generator, string argumentName, string contextName)
             {
                 SyntaxNode argumentExpression = generator.IdentifierName(argumentName);
                 SyntaxNode argument = generator.Argument(argumentExpression);
@@ -2263,7 +2263,7 @@ namespace MetaCompilation.Analyzers
 
             // creates a variable holding a DiagnosticDescriptor
             // uses SyntaxFactory for formatting
-            protected internal static FieldDeclarationSyntax CreateEmptyRule(SyntaxGenerator generator, string idName = "", string titleDefault = "Enter a title for this diagnostic", string messageDefault = "Enter a message to be displayed with this diagnostic",
+            internal static FieldDeclarationSyntax CreateEmptyRule(SyntaxGenerator generator, string idName = "", string titleDefault = "Enter a title for this diagnostic", string messageDefault = "Enter a message to be displayed with this diagnostic",
                                                                     string categoryDefault = "Enter a category for this diagnostic (e.g. Formatting)", ExpressionSyntax severityDefault = null, ExpressionSyntax enabledDefault = null)
             {
                 if (severityDefault == null)
@@ -2332,7 +2332,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates the SupportedDiagnostics property with a get accessor with a not implemented exception
-            protected internal static PropertyDeclarationSyntax CreateSupportedDiagnostics(SyntaxGenerator generator, INamedTypeSymbol notImplementedException)
+            internal static PropertyDeclarationSyntax CreateSupportedDiagnostics(SyntaxGenerator generator, INamedTypeSymbol notImplementedException)
             {
                 TypeSyntax type = SyntaxFactory.ParseTypeName("ImmutableArray<DiagnosticDescriptor>");
                 DeclarationModifiers modifiers = DeclarationModifiers.Override;
@@ -2349,7 +2349,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a SyntaxKind.IfStatement argument
-            protected internal static ArgumentSyntax CreateSyntaxKindIfStatement(SyntaxGenerator generator)
+            internal static ArgumentSyntax CreateSyntaxKindIfStatement(SyntaxGenerator generator)
             {
                 SyntaxNode syntaxKind = generator.IdentifierName("SyntaxKind");
                 SyntaxNode expression = generator.MemberAccessExpression(syntaxKind, "IfStatement");
@@ -2359,7 +2359,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a correct register statement
-            protected internal static SyntaxNode CreateRegister(SyntaxGenerator generator, MethodDeclarationSyntax declaration, string methodName)
+            internal static SyntaxNode CreateRegister(SyntaxGenerator generator, MethodDeclarationSyntax declaration, string methodName)
             {
                 var argument1 = generator.Argument(generator.IdentifierName(methodName)) as ArgumentSyntax;
                 var argument2 = generator.Argument(generator.MemberAccessExpression(generator.IdentifierName("SyntaxKind"), "IfStatement")) as ArgumentSyntax;
@@ -2374,7 +2374,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates the SyntaxNode analysis method
-            protected internal static SyntaxNode CreateAnalysisMethod(SyntaxGenerator generator, string methodName, SemanticModel semanticModel)
+            internal static SyntaxNode CreateAnalysisMethod(SyntaxGenerator generator, string methodName, SemanticModel semanticModel)
             {
                 TypeSyntax type = SyntaxFactory.ParseTypeName("SyntaxNodeAnalysisContext");
                 SyntaxNode[] parameters = new[] { generator.ParameterDeclaration("context", type) };
@@ -2387,7 +2387,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // gets the name of an existing analysis method, or null if none is found
-            protected internal static string GetExistingAnalysisMethodName(ClassDeclarationSyntax classDeclaration)
+            internal static string GetExistingAnalysisMethodName(ClassDeclarationSyntax classDeclaration)
             {
                 IEnumerable<MethodDeclarationSyntax> methods = classDeclaration.Members.OfType<MethodDeclarationSyntax>();
 
@@ -2411,7 +2411,7 @@ namespace MetaCompilation.Analyzers
             }
 
             // creates a method keeping everything except for the parameters, and inserting a parameter of type SyntaxNodeAnalysisContext
-            protected internal static SyntaxNode CreateMethodWithContextParameter(SyntaxGenerator generator, MethodDeclarationSyntax methodDeclaration)
+            internal static SyntaxNode CreateMethodWithContextParameter(SyntaxGenerator generator, MethodDeclarationSyntax methodDeclaration)
             {
                 TypeSyntax type = SyntaxFactory.ParseTypeName("SyntaxNodeAnalysisContext");
                 SyntaxNode[] parameters = new[] { generator.ParameterDeclaration("context", type) };
@@ -2423,7 +2423,7 @@ namespace MetaCompilation.Analyzers
                 return newDeclaration;
             }
 
-            protected internal static List<string> GetAllRuleNames(ClassDeclarationSyntax declaration)
+            internal static List<string> GetAllRuleNames(ClassDeclarationSyntax declaration)
             {
                 List<string> ruleNames = new List<string>();
                 IEnumerable<FieldDeclarationSyntax> fieldMembers = declaration.Members.OfType<FieldDeclarationSyntax>();
@@ -2438,7 +2438,7 @@ namespace MetaCompilation.Analyzers
                 return ruleNames;
             }
 
-            protected internal static SyntaxList<SyntaxNode> CreateRuleList(Document document, List<string> ruleNames)
+            internal static SyntaxList<SyntaxNode> CreateRuleList(Document document, List<string> ruleNames)
             {
                 string argumentListString = "";
                 foreach (string ruleName in ruleNames)

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
@@ -188,7 +188,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     nameof(SymbolKind.Parameter),
                     nameof(SymbolKind.Property));
 
+#pragma warning disable CA1815 // Override equals and operator equals on value types
             private struct NodeAndSymbol
+#pragma warning restore CA1815 // Override equals and operator equals on value types
             {
                 public TInvocationExpressionSyntax Invocation { get; set; }
                 public IMethodSymbol Method { get; set; }

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
                 cfg, OperationVisitor.ValueDomain.UnknownOrMayBeValue);
         }
 
-        public static TAnalysisData Flow(DataFlowOperationVisitor<TAnalysisData, TAbstractAnalysisValue> operationVisitor, BasicBlock block, TAnalysisData data)
+        protected static TAnalysisData Flow(DataFlowOperationVisitor<TAnalysisData, TAbstractAnalysisValue> operationVisitor, BasicBlock block, TAnalysisData data)
         {
             if (block.Kind == BasicBlockKind.Entry)
             {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
             }
         }
         public PredicateValueKind GetPredicateKind(IOperation operation) => _predicateValueKindMap.TryGetValue(operation, out var valueKind) ? valueKind : PredicateValueKind.Unknown;
-        public TAnalysisResult MergedStateForUnhandledThrowOperationsOpt;
+        public TAnalysisResult MergedStateForUnhandledThrowOperationsOpt { get; }
         public ControlFlowGraph ControlFlowGraph { get; }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionsShouldImplementGenericInterface.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionsShouldImplementGenericInterface.cs
@@ -177,7 +177,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                        missingInterface.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
         }
 
+#pragma warning disable CA1815 // Override equals and operator equals on value types
         private struct CollectionsInterfaceStatus
+#pragma warning restore CA1815 // Override equals and operator equals on value types
         {
             public bool IListPresent { get; set; }
             public bool GenericIListPresent { get; set; }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
@@ -500,7 +500,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         /// <summary>
         /// Validates implementation of Dispose method. The method must call Dispose(true) and then GC.SuppressFinalize(this).
         /// </summary>
-        private struct DisposeImplementationValidator
+        private sealed class DisposeImplementationValidator
         {
             // this type will be created per compilation
             // this is actually a bug - https://github.com/dotnet/roslyn-analyzers/issues/845
@@ -632,7 +632,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         /// <summary>
         /// Validates implementation of the finalizer. This method must call Dispose(false) and then return
         /// </summary>
-        private struct FinalizeImplementationValidator
+        private sealed class FinalizeImplementationValidator
         {
             // Avoid storing per-compilation data into the fields of a diagnostic analyzer.
             // this is actually a bug - https://github.com/dotnet/roslyn-analyzers/issues/845

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStrings.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStrings.cs
@@ -66,16 +66,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         protected abstract SyntaxNode GetInvocationExpression(SyntaxNode invocationNode);
 
-        private struct PerCompilationAnalyzer
+        private sealed class PerCompilationAnalyzer
         {
             // this type will be created per compilation 
-            // this is actually a bug - https://github.com/dotnet/roslyn-analyzers/issues/845
-#pragma warning disable RS1008 
             private readonly Compilation _compilation;
             private readonly INamedTypeSymbol _string;
             private readonly INamedTypeSymbol _uri;
             private readonly Func<SyntaxNode, SyntaxNode> _expressionGetter;
-#pragma warning restore RS1008
 
             public PerCompilationAnalyzer(
                 Compilation compilation,

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AttributeStringLiteralsShouldParseCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AttributeStringLiteralsShouldParseCorrectly.cs
@@ -48,10 +48,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DefaultRule, EmptyRule);
 
-        private static List<ValueValidator> s_tokensToValueValidator =
+        private static readonly List<ValueValidator> s_tokensToValueValidator =
             new List<ValueValidator>(
-                new[] { new ValueValidator(new[] { "guid" }, "Guid", GuidValueValidator),
-                        new ValueValidator(new[] { "url", "uri", "urn" }, "Uri", UrlValueValidator, "UriTemplate")});
+                new[] { new ValueValidator(ImmutableArray.Create("guid"), "Guid", GuidValueValidator),
+                        new ValueValidator(ImmutableArray.Create("url", "uri", "urn"), "Uri", UrlValueValidator, "UriTemplate")});
 
         private static bool GuidValueValidator(string value)
         {
@@ -244,9 +244,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
     internal class ValueValidator
     {
-        private string _ignoredName;
+        private readonly string _ignoredName;
 
-        public string[] AcceptedTokens { get; }
+        public ImmutableArray<string> AcceptedTokens { get; }
         public string TypeName { get; }
         public Func<string, bool> IsValidValue { get; }
 
@@ -255,7 +255,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             return _ignoredName != null && string.Equals(_ignoredName, name, StringComparison.OrdinalIgnoreCase);
         }
 
-        public ValueValidator(string[] acceptedTokens, string typeName, Func<string, bool> isValidValue, string ignoredName = null)
+        public ValueValidator(ImmutableArray<string> acceptedTokens, string typeName, Func<string, bool> isValidValue, string ignoredName = null)
         {
             _ignoredName = ignoredName;
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/ApprovedCipherModeAnalyzer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/ApprovedCipherModeAnalyzer.cs
@@ -28,7 +28,16 @@ namespace Microsoft.NetCore.Analyzers.Security
             typeof(SystemSecurityCryptographyResources));
 
         internal static DiagnosticDescriptor Rule =
-            CreateDiagnosticDescriptor(DiagnosticId, Title, Message, Description);
+            new DiagnosticDescriptor(
+                DiagnosticId,
+                Title,
+                Message,
+                DiagnosticCategory.Security,
+                DiagnosticHelpers.DefaultDiagnosticSeverity,
+                isEnabledByDefault: false,
+                description: Description,
+                helpLinkUri: null,
+                customTags: WellKnownDiagnosticTags.Telemetry);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -40,20 +49,6 @@ namespace Microsoft.NetCore.Analyzers.Security
                 "ECB",
                 "OFB",
                 "CFB");
-
-        private static DiagnosticDescriptor CreateDiagnosticDescriptor(string ruleId, LocalizableString title, LocalizableString message, LocalizableString description, string uri = null)
-        {
-            return new DiagnosticDescriptor(
-                ruleId,
-                title,
-                message,
-                DiagnosticCategory.Security,
-                DiagnosticHelpers.DefaultDiagnosticSeverity,
-                isEnabledByDefault: false,
-                description: description,
-                helpLinkUri: uri,
-                customTags: WellKnownDiagnosticTags.Telemetry);
-        }
 
         public sealed override void Initialize(AnalysisContext context)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithms.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithms.cs
@@ -42,35 +42,33 @@ namespace Microsoft.NetCore.Analyzers.Security
             SystemSecurityCryptographyResources.ResourceManager,
             typeof(SystemSecurityCryptographyResources));
 
-        internal static DiagnosticDescriptor DoNotUseBrokenCryptographyRule = CreateDiagnosticDescriptor(DoNotUseBrokenCryptographyRuleId,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsTitle,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsMessage,
-                                                                                          s_localizableDoNotUseBrokenAlgorithmsDescription,
-                                                                                          CA5351HelpLink);
+        internal static DiagnosticDescriptor DoNotUseBrokenCryptographyRule =
+            new DiagnosticDescriptor(
+                DoNotUseBrokenCryptographyRuleId,
+                s_localizableDoNotUseBrokenAlgorithmsTitle,
+                s_localizableDoNotUseBrokenAlgorithmsMessage,
+                DiagnosticCategory.Security,
+                DiagnosticHelpers.DefaultDiagnosticSeverity,
+                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                description: s_localizableDoNotUseBrokenAlgorithmsDescription,
+                helpLinkUri: CA5351HelpLink,
+                customTags: WellKnownDiagnosticTags.Telemetry);
 
-        internal static DiagnosticDescriptor DoNotUseWeakCryptographyRule = CreateDiagnosticDescriptor(DoNotUseWeakCryptographyRuleId,
-                                                                                          s_localizableDoNotUseWeakAlgorithmsTitle,
-                                                                                          s_localizableDoNotUseWeakAlgorithmsMessage,
-                                                                                          s_localizableDoNotUseWeakAlgorithmsDescription,
-                                                                                          CA5350HelpLink);
+        internal static DiagnosticDescriptor DoNotUseWeakCryptographyRule =
+            new DiagnosticDescriptor(
+                DoNotUseWeakCryptographyRuleId,
+                s_localizableDoNotUseWeakAlgorithmsTitle,
+                s_localizableDoNotUseWeakAlgorithmsMessage,
+                DiagnosticCategory.Security,
+                DiagnosticHelpers.DefaultDiagnosticSeverity,
+                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                description: s_localizableDoNotUseWeakAlgorithmsDescription,
+                helpLinkUri: CA5350HelpLink,
+                customTags: WellKnownDiagnosticTags.Telemetry);
 
         protected abstract SyntaxNodeAnalyzer GetAnalyzer(CompilationStartAnalysisContext context, CompilationSecurityTypes cryptTypes);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DoNotUseBrokenCryptographyRule, DoNotUseWeakCryptographyRule);
-
-        private static DiagnosticDescriptor CreateDiagnosticDescriptor(string ruleId, LocalizableString title, LocalizableString message, LocalizableString description, string uri = null)
-        {
-            return new DiagnosticDescriptor(
-                ruleId,
-                title,
-                message,
-                DiagnosticCategory.Security,
-                DiagnosticHelpers.DefaultDiagnosticSeverity,
-                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
-                description: description,
-                helpLinkUri: uri,
-                customTags: WellKnownDiagnosticTags.Telemetry);
-        }
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
@@ -80,18 +80,18 @@ namespace Microsoft.NetFramework.Analyzers
             #region Environment classes
             private class XmlDocumentEnvironment
             {
-                internal SyntaxNode XmlDocumentDefinition;
-                internal bool IsXmlResolverSet;
-                internal bool IsSecureResolver;
+                internal SyntaxNode XmlDocumentDefinition { get; set; }
+                internal bool IsXmlResolverSet { get; set; }
+                internal bool IsSecureResolver { get; set; }
             }
 
             private class XmlTextReaderEnvironment
             {
-                internal SyntaxNode XmlTextReaderDefinition;
-                internal bool IsDtdProcessingSet;
-                internal bool IsDtdProcessingDisabled;
-                internal bool IsXmlResolverSet;
-                internal bool IsSecureResolver;
+                internal SyntaxNode XmlTextReaderDefinition { get; set; }
+                internal bool IsDtdProcessingSet { get; set; }
+                internal bool IsDtdProcessingDisabled { get; set; }
+                internal bool IsXmlResolverSet { get; set; }
+                internal bool IsSecureResolver { get; set; }
 
                 internal XmlTextReaderEnvironment(bool isTargetFrameworkSecure)
                 {
@@ -105,11 +105,11 @@ namespace Microsoft.NetFramework.Analyzers
 
             private class XmlReaderSettingsEnvironment
             {
-                internal SyntaxNode XmlReaderSettingsDefinition;
-                internal bool IsDtdProcessingDisabled;
-                internal bool IsMaxCharactersFromEntitiesLimited;
-                internal bool IsSecureResolver;
-                internal bool IsConstructedInCodeBlock;
+                internal SyntaxNode XmlReaderSettingsDefinition { get; set; }
+                internal bool IsDtdProcessingDisabled { get; set; }
+                internal bool IsMaxCharactersFromEntitiesLimited { get; set; }
+                internal bool IsSecureResolver { get; set; }
+                internal bool IsConstructedInCodeBlock { get; set; }
 
                 // this constructor is used for keep track of XmlReaderSettings not created in the code block
                 internal XmlReaderSettingsEnvironment() { }

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
@@ -285,12 +285,12 @@ namespace Microsoft.NetFramework.Analyzers
 
             private class XsltSettingsEnvironment
             {
-                internal ISymbol XsltSettingsSymbol;
-                internal ISymbol XsltSettingsDefinitionSymbol;
-                internal SyntaxNode XsltSettingsDefinition;
-                internal ISymbol EnclosingConstructSymbol;
-                internal bool IsScriptDisabled;
-                internal bool IsDocumentFunctionDisabled;
+                internal ISymbol XsltSettingsSymbol { get; set; }
+                internal ISymbol XsltSettingsDefinitionSymbol { get; set; }
+                internal SyntaxNode XsltSettingsDefinition { get; set; }
+                internal ISymbol EnclosingConstructSymbol { get; set; }
+                internal bool IsScriptDisabled { get; set; }
+                internal bool IsDocumentFunctionDisabled { get; set; }
             }
         }
     }

--- a/src/Microsoft.NetFramework.Analyzers/VisualBasic/Helpers/SyntaxNodeHelper.vb
+++ b/src/Microsoft.NetFramework.Analyzers/VisualBasic/Helpers/SyntaxNodeHelper.vb
@@ -1,7 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Collections.Generic
-Imports System.Linq
 Imports Microsoft.NetFramework.Analyzers.Helpers
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -12,13 +10,7 @@ Namespace Microsoft.NetFramework.VisualBasic.Analyzers.Helpers
     Public NotInheritable Class BasicSyntaxNodeHelper
         Inherits SyntaxNodeHelper
 
-        Private Shared s_defaultInstance As BasicSyntaxNodeHelper = New BasicSyntaxNodeHelper()
-
-        Public Shared ReadOnly Property DefaultInstance As BasicSyntaxNodeHelper
-            Get
-                Return s_defaultInstance
-            End Get
-        End Property
+        Public Shared ReadOnly Property DefaultInstance As BasicSyntaxNodeHelper = New BasicSyntaxNodeHelper()
 
         Private Sub New()
         End Sub

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
@@ -33,7 +33,9 @@ namespace Roslyn.Diagnostics.Analyzers
             }
         }
 
+#pragma warning disable CA1815 // Override equals and operator equals on value types
         private struct RemovedApiLine
+#pragma warning restore CA1815 // Override equals and operator equals on value types
         {
             public string Text { get; private set; }
             public ApiLine ApiLine { get; private set; }
@@ -45,7 +47,9 @@ namespace Roslyn.Diagnostics.Analyzers
             }
         }
 
+#pragma warning disable CA1815 // Override equals and operator equals on value types
         private struct ApiData
+#pragma warning restore CA1815 // Override equals and operator equals on value types
         {
             public ImmutableArray<ApiLine> ApiList { get; private set; }
             public ImmutableArray<RemovedApiLine> RemovedApiList { get; private set; }

--- a/src/Test.Utilities/DiffUtil.cs
+++ b/src/Test.Utilities/DiffUtil.cs
@@ -99,7 +99,9 @@ namespace Test.Utilities
         /// </summary>
         private abstract class LongestCommonSubsequence<TSequence>
         {
+#pragma warning disable CA1815 // Override equals and operator equals on value types
             protected struct Edit
+#pragma warning restore CA1815 // Override equals and operator equals on value types
             {
                 public EditKind Kind { get; private set; }
                 public int IndexA { get; private set; }

--- a/src/Utilities/AbstractVersionCheckAnalyzer.cs
+++ b/src/Utilities/AbstractVersionCheckAnalyzer.cs
@@ -28,8 +28,8 @@ namespace Analyzer.Utilities
                                                         isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
                                                         description: s_localizableDescription);
 
-        private static Version s_MicrosoftCodeAnalysisMinVersion = new Version("2.6");
-        private static Version s_MicrosoftCodeAnalysisDogfoodVersion = new Version("42.42");
+        private static readonly Version s_MicrosoftCodeAnalysisMinVersion = new Version("2.6");
+        private static readonly Version s_MicrosoftCodeAnalysisDogfoodVersion = new Version("42.42");
         private static readonly Version s_MicrosoftCodeAnalysisVersion = typeof(AnalysisContext).GetTypeInfo().Assembly.GetName().Version;
 
         // Execute IOperation analyzers if we are either using dogfood bits of Microsoft.CodeAnalysis or its version is >= 2.6

--- a/src/Utilities/WordParser.cs
+++ b/src/Utilities/WordParser.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Text;
 
@@ -196,7 +197,7 @@ namespace Analyzer.Utilities
         /// <exception cref="ArgumentException">
         ///     <paramref name="options"/> is not one or more of the <see cref="WordParserOptions"/> values.
         /// </exception>
-        public static bool ContainsWord(string text, WordParserOptions options, params string[] words)
+        public static bool ContainsWord(string text, WordParserOptions options, ImmutableArray<string> words)
         {
             return ContainsWord(text, options, NullChar, words);
         }
@@ -230,9 +231,9 @@ namespace Analyzer.Utilities
         /// <exception cref="ArgumentException">
         ///     <paramref name="options"/> is not one or more of the <see cref="WordParserOptions"/> values.
         /// </exception>
-        internal static bool ContainsWord(string text, WordParserOptions options, char prefix, params string[] words)
+        internal static bool ContainsWord(string text, WordParserOptions options, char prefix, ImmutableArray<string> words)
         {
-            if (words == null)
+            if (words.IsDefault)
             {
                 throw new ArgumentNullException(nameof(words));
             }


### PR DESCRIPTION
Primarily increases the analyzed API surface for CA rules to include all APIs (public + non-public APIs), and corresponding fixes/suppressions.

**TODO:** Update Versions.props to use latest 2.6.4-beta1 myget drop once #2018 is merged and corresponding signed build is published