### PR TITLE
NetDataContractSerializer insecure deserializer rules

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerMethodsBase.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerMethodsBase.cs
@@ -70,7 +70,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                         {
                             IInvocationOperation invocationOperation = 
                                 (IInvocationOperation) operationAnalysisContext.Operation;
-                            if (invocationOperation.TargetMethod.ContainingType == deserializerTypeSymbol
+                            if (invocationOperation.Instance?.Type == deserializerTypeSymbol
                                 && cachedDeserializationMethodNames.Contains(invocationOperation.TargetMethod.MetadataName))
                             {
                                 operationAnalysisContext.ReportDiagnostic(
@@ -88,7 +88,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                         {
                             IMethodReferenceOperation methodReferenceOperation =
                                 (IMethodReferenceOperation) operationAnalysisContext.Operation;
-                            if (methodReferenceOperation.Method.ContainingType == deserializerTypeSymbol
+                            if (methodReferenceOperation.Instance?.Type == deserializerTypeSymbol
                                 && cachedDeserializationMethodNames.Contains(methodReferenceOperation.Method.MetadataName))
                             {
                                 operationAnalysisContext.ReportDiagnostic(

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethods.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethods.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.NetCore.Analyzers.Security.Helpers;
+
+namespace Microsoft.NetCore.Analyzers.Security
+{
+    /// <summary>
+    /// For detecting deserialization with <see cref="System.Runtime.Serialization.Formatters.Binary.NetDataContractSerializer"/>.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    class DoNotUseInsecureDeserializerNetDataContractSerializerMethods : DoNotUseInsecureDeserializerMethodsBase
+    {
+        // TODO paulming: Help links URLs.
+        internal static readonly DiagnosticDescriptor RealMethodUsedDescriptor =
+            SecurityHelpers.CreateDiagnosticDescriptor(
+                "CA2310",
+                nameof(MicrosoftNetCoreSecurityResources.NetDataContractSerializerMethodUsedTitle),
+                nameof(MicrosoftNetCoreSecurityResources.NetDataContractSerializerMethodUsedMessage),
+                isEnabledByDefault: false,
+                helpLinkUri: null,
+                descriptionResourceStringName: nameof(MicrosoftNetCoreSecurityResources.NetDataContractSerializerMethodUsedDescription));
+
+        protected override string DeserializerTypeMetadataName =>
+            WellKnownTypes.SystemRuntimeSerializationNetDataContractSerializer;
+
+        protected override ImmutableHashSet<string> DeserializationMethodNames =>
+            SecurityHelpers.NetDataContractSerializerDeserializationMethods;
+
+        protected override DiagnosticDescriptor MethodUsedDescriptor => RealMethodUsedDescriptor;
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.NetCore.Analyzers.Security.Helpers;
+
+namespace Microsoft.NetCore.Analyzers.Security
+{
+    /// <summary>
+    /// For detecting deserialization with <see cref="System.Runtime.Serialization.Formatters.Binary.NetDataContractSerializer"/> when its Binder property is not set.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder : DoNotUseInsecureDeserializerWithoutBinderBase
+    {
+        // TODO paulming: Help link URLs.
+        internal static readonly DiagnosticDescriptor RealBinderDefinitelyNotSetDescriptor =
+            SecurityHelpers.CreateDiagnosticDescriptor(
+                "CA2311",
+                nameof(MicrosoftNetCoreSecurityResources.NetDataContractSerializerDeserializeWithoutBinderSetTitle),
+                nameof(MicrosoftNetCoreSecurityResources.NetDataContractSerializerDeserializeWithoutBinderSetMessage),
+                isEnabledByDefault: false,
+                helpLinkUri: null);
+        internal static readonly DiagnosticDescriptor RealBinderMaybeNotSetDescriptor =
+            SecurityHelpers.CreateDiagnosticDescriptor(
+                "CA2312",
+                nameof(MicrosoftNetCoreSecurityResources.NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle),
+                nameof(MicrosoftNetCoreSecurityResources.NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage),
+                isEnabledByDefault: false,
+                helpLinkUri: null);
+
+        protected override string DeserializerTypeMetadataName => 
+            WellKnownTypes.SystemRuntimeSerializationNetDataContractSerializer;
+
+        protected override string SerializationBinderPropertyMetadataName => "Binder";
+
+        protected override ImmutableHashSet<string> DeserializationMethodNames => 
+            SecurityHelpers.NetDataContractSerializerDeserializationMethods;
+
+        protected override DiagnosticDescriptor BinderDefinitelyNotSetDescriptor => RealBinderDefinitelyNotSetDescriptor;
+
+        protected override DiagnosticDescriptor BinderMaybeNotSetDescriptor => RealBinderMaybeNotSetDescriptor;
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
@@ -97,7 +97,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                 {
                                     IInvocationOperation invocationOperation =
                                         (IInvocationOperation)operationAnalysisContext.Operation;
-                                    if (invocationOperation.TargetMethod.ContainingType == deserializerTypeSymbol
+                                    if (invocationOperation.Instance?.Type == deserializerTypeSymbol
                                         && cachedDeserializationMethodNames.Contains(invocationOperation.TargetMethod.Name))
                                     {
                                         rootOperationsNeedingAnalysis.Add(operationAnalysisContext.Operation.GetRoot());
@@ -110,8 +110,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                                 {
                                     IMethodReferenceOperation methodReferenceOperation =
                                         (IMethodReferenceOperation)operationAnalysisContext.Operation;
-                                    if (methodReferenceOperation.Method.ContainingType == deserializerTypeSymbol
-                                        && cachedDeserializationMethodNames.Contains(
+                                    if (methodReferenceOperation.Instance?.Type == deserializerTypeSymbol
+                                       && cachedDeserializationMethodNames.Contains(
                                             methodReferenceOperation.Method.MetadataName))
                                     {
                                         rootOperationsNeedingAnalysis.Add(operationAnalysisContext.Operation.GetRoot());

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/Helpers/SecurityHelpers.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/Helpers/SecurityHelpers.cs
@@ -48,6 +48,15 @@ namespace Microsoft.NetCore.Analyzers.Security.Helpers
                 "UnsafeDeserializeMethodResponse");
 
         /// <summary>
+        /// Deserialization methods for <see cref="System.Runtime.Serialization.NetDataContractSerializer"/>.
+        /// </summary>
+        public static readonly ImmutableHashSet<string> NetDataContractSerializerDeserializationMethods =
+            ImmutableHashSet.Create(
+                StringComparer.Ordinal,
+                "Deserialize",
+                "ReadObject");
+
+        /// <summary>
         /// Gets a <see cref="LocalizableResourceString"/> from <see cref="MicrosoftNetCoreSecurityResources"/>.
         /// </summary>
         /// <param name="name">Name of the resource string to retrieve.</param>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/MicrosoftNetCoreSecurityResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/MicrosoftNetCoreSecurityResources.resx
@@ -180,4 +180,25 @@
   <data name="ReviewCodeForRegexInjectionVulnerabilitiesTitle" xml:space="preserve">
     <value>Review code for regex injection vulnerabalities</value>
   </data>
+  <data name="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage" xml:space="preserve">
+    <value>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</value>
+  </data>
+  <data name="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle" xml:space="preserve">
+    <value>Ensure NetDataContractSerializer.Binder is set before deserializing</value>
+  </data>
+  <data name="NetDataContractSerializerDeserializeWithoutBinderSetMessage" xml:space="preserve">
+    <value>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</value>
+  </data>
+  <data name="NetDataContractSerializerDeserializeWithoutBinderSetTitle" xml:space="preserve">
+    <value>Do not deserialize without first setting NetDataContractSerializer.Binder</value>
+  </data>
+  <data name="NetDataContractSerializerMethodUsedDescription" xml:space="preserve">
+    <value>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</value>
+  </data>
+  <data name="NetDataContractSerializerMethodUsedMessage" xml:space="preserve">
+    <value>The method '{0}' is insecure when deserializing untrusted data.</value>
+  </data>
+  <data name="NetDataContractSerializerMethodUsedTitle" xml:space="preserve">
+    <value>Do not use insecure deserializer NetDataContractSerializer</value>
+  </data>
 </root>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.cs.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.de.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.es.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.fr.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.it.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ja.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ko.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.pl.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.pt-BR.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.ru.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.tr.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.zh-Hans.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/MicrosoftNetCoreSecurityResources.zh-Hant.xlf
@@ -27,6 +27,41 @@
         <target state="new">Do not use insecure deserializer LosFormatter</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeMaybeWithoutBinderSetTitle">
+        <source>Ensure NetDataContractSerializer.Binder is set before deserializing</source>
+        <target state="new">Ensure NetDataContractSerializer.Binder is set before deserializing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerDeserializeWithoutBinderSetTitle">
+        <source>Do not deserialize without first setting NetDataContractSerializer.Binder</source>
+        <target state="new">Do not deserialize without first setting NetDataContractSerializer.Binder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedDescription">
+        <source>The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedMessage">
+        <source>The method '{0}' is insecure when deserializing untrusted data.</source>
+        <target state="new">The method '{0}' is insecure when deserializing untrusted data.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NetDataContractSerializerMethodUsedTitle">
+        <source>Do not use insecure deserializer NetDataContractSerializer</source>
+        <target state="new">Do not use insecure deserializer NetDataContractSerializer</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReviewCodeForDllInjectionVulnerabilitiesMessage">
         <source>Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</source>
         <target state="new">Potential DLL injection vulnerability was found where '{0}' in method '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.</target>

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializationLosFormatterTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializationLosFormatterTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
     public class DoNotUseInsecureDeserializerLosFormatterTests : DiagnosticAnalyzerTestBase
     {
         private static readonly DiagnosticDescriptor Rule = DoNotUseInsecureDeserializerLosFormatter.RealMethodUsedDescriptor;

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterMethodsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterMethodsTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
     public class DoNotUseInsecureDeserializerBinaryFormatterMethodsTests : DiagnosticAnalyzerTestBase
     {
         private static readonly DiagnosticDescriptor Rule = DoNotUseInsecureDeserializerBinaryFormatterMethods.RealMethodUsedDescriptor;

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethodsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethodsTests.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.NetCore.Analyzers.Security.UnitTests
+{
+    public class DoNotUseInsecureDeserializerNetDataContractSerializerMethodsTests : DiagnosticAnalyzerTestBase
+    {
+        private static readonly DiagnosticDescriptor Rule = DoNotUseInsecureDeserializerNetDataContractSerializerMethods.RealMethodUsedDescriptor;
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new DoNotUseInsecureDeserializerNetDataContractSerializerMethods();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DoNotUseInsecureDeserializerNetDataContractSerializerMethods();
+        }
+
+        [Fact]
+        public void Deserialize_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object D(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.Deserialize(new MemoryStream(bytes));
+        }
+    }
+}",
+                GetCSharpResultAt(12, 20, Rule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+        }
+
+        [Fact]
+        public void Deserialize_Reference_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public delegate object Des(Stream s);
+        public Des GetDeserializer()
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.Deserialize;
+        }
+    }
+}",
+                GetCSharpResultAt(13, 20, Rule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+        }
+
+        [Fact]
+        public void ReadObject_Stream_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object D(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.ReadObject(new MemoryStream(bytes));
+        }
+    }
+}",
+                GetCSharpResultAt(12, 20, Rule, "object XmlObjectSerializer.ReadObject(Stream stream)"));
+        }
+
+        [Fact]
+        public void ReadObject_Stream_Reference_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public delegate object Des(Stream s);
+        public Des D()
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.ReadObject;
+        }
+    }
+}",
+                GetCSharpResultAt(13, 20, Rule, "object XmlObjectSerializer.ReadObject(Stream stream)"));
+        }
+
+        [Fact]
+        public void ReadObject_XmlReader_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+using System.Xml;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object D(XmlReader xmlReader)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.ReadObject(xmlReader);
+        }
+    }
+}",
+                GetCSharpResultAt(13, 20, Rule, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
+        }
+
+        [Fact]
+        public void ReadObject_XmlReader_Reference_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+using System.Xml;
+
+namespace Blah
+{
+    public class Program
+    {
+        public delegate object Des(XmlReader r);
+        public Des D()
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.ReadObject;
+        }
+    }
+}",
+                GetCSharpResultAt(14, 20, Rule, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
+        }
+
+        [Fact]
+        public void Serialize_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public byte[] S(object o)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            MemoryStream ms = new MemoryStream();
+            serializer.Serialize(ms, o);
+            return ms.ToArray();
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void Serialize_Reference_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public delegate void Ser(Stream s, object o);
+        public Ser GetSerializer()
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.Serialize;
+        }
+    }
+}");
+        }
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinderTests.cs
@@ -1,0 +1,500 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.NetCore.Analyzers.Security.UnitTests
+{
+    [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
+    public class DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinderTests : DiagnosticAnalyzerTestBase
+    {
+        private static readonly DiagnosticDescriptor BinderNotSetRule = DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder.RealBinderDefinitelyNotSetDescriptor;
+
+        private static readonly DiagnosticDescriptor BinderMaybeNotSetRule = DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder.RealBinderMaybeNotSetDescriptor;
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder();
+        }
+
+        protected void VerifyCSharpWithMyBinderDefined(string source, params DiagnosticResult[] expected)
+        {
+            string myBinderCSharpSourceCode = @"
+using System;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class MyBinder : SerializationBinder
+    {
+        public override Type BindToType(string assemblyName, string typeName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class SomeOtherSerializer
+    {
+        public object Deserialize(byte[] bytes)
+        {
+            return null;
+        }
+    }
+}
+            ";
+
+            this.VerifyCSharp(
+                new[] { source, myBinderCSharpSourceCode }.ToFileAndSource(),
+                expected);
+        }
+
+        [Fact]
+        public void Deserialize_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.Deserialize(new MemoryStream(bytes));
+        }
+    }
+}",
+            GetCSharpResultAt(12, 20, BinderNotSetRule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+        }
+
+        // Ideally, we'd detect that serializer.Binder is always null.
+        [Fact]
+        public void DeserializeWithInstanceField_Diagnostic_NotIdeal()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        NetDataContractSerializer serializer = new NetDataContractSerializer();
+
+        public object TestMethod(byte[] bytes)
+        {
+            return this.serializer.Deserialize(new MemoryStream(bytes));
+        }
+    }
+}",
+            GetCSharpResultAt(13, 20, BinderMaybeNotSetRule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+        }
+
+        [Fact]
+        public void Deserialize_BinderMaybeSet_Diagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            if (Environment.MachineName.StartsWith(""a""))
+            {
+                serializer.Binder = new MyBinder();
+            }
+
+            return serializer.Deserialize(new MemoryStream(bytes));
+        }
+    }
+}",
+            GetCSharpResultAt(18, 20, BinderMaybeNotSetRule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+        }
+
+        [Fact]
+        public void Deserialize_BinderSet_NoDiagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            serializer.Binder = new MyBinder();
+            return serializer.Deserialize(new MemoryStream(bytes));
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void TwoDeserializersOneBinderOnFirst_Diagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes1, byte[] bytes2)
+        {
+            if (Environment.GetEnvironmentVariable(""USEFIRST"") == ""1"")
+            {
+                NetDataContractSerializer bf = new NetDataContractSerializer();
+                bf.Binder = new MyBinder();
+                return bf.Deserialize(new MemoryStream(bytes1));
+            }
+            else
+            {
+                return new NetDataContractSerializer().Deserialize(new MemoryStream(bytes2));
+            }
+        }
+    }
+}",
+                GetCSharpResultAt(20, 24, BinderNotSetRule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+        }
+
+        [Fact]
+        public void TwoDeserializersOneBinderOnSecond_Diagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes1, byte[] bytes2)
+        {
+            if (Environment.GetEnvironmentVariable(""USEFIRST"") == ""1"")
+            {
+                return new NetDataContractSerializer().Deserialize(new MemoryStream(bytes1));
+            }
+            else
+            {
+                return (new NetDataContractSerializer() { Binder = new MyBinder() }).Deserialize(new MemoryStream(bytes2));
+            }
+        }
+    }
+}",
+                GetCSharpResultAt(14, 24, BinderNotSetRule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+
+        }
+
+        [Fact]
+        public void TwoDeserializersNoBinder_Diagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes1, byte[] bytes2)
+        {
+            if (Environment.GetEnvironmentVariable(""USEFIRST"") == ""1"")
+            {
+                return new NetDataContractSerializer().Deserialize(new MemoryStream(bytes1));
+            }
+            else
+            {
+                return new NetDataContractSerializer().Deserialize(new MemoryStream(bytes2));
+            }
+        }
+    }
+}",
+                GetCSharpResultAt(14, 24, BinderNotSetRule, "object NetDataContractSerializer.Deserialize(Stream stream)"),
+                GetCSharpResultAt(18, 24, BinderNotSetRule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+
+        }
+
+        [Fact]
+        public void BinderSetInline_NoDiagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes)
+        {
+            return (new NetDataContractSerializer() { Binder = new MyBinder() }).Deserialize(new MemoryStream(bytes));
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void Serialize_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public byte[] S(object o)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            MemoryStream ms = new MemoryStream();
+            serializer.Serialize(ms, o);
+            return ms.ToArray();
+        }
+    }
+}");
+        }
+
+
+        [Fact]
+        public void Deserialize_InvokedAsDelegate_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        delegate object DeserializeDelegate(Stream s);
+
+        public object DeserializeWithDelegate(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            DeserializeDelegate del = serializer.Deserialize;
+            return del(new MemoryStream(bytes));
+        }
+    }
+}",
+                GetCSharpResultAt(15, 20, BinderNotSetRule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+        }
+
+        [Fact]
+        public void ReadObject_Stream_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.ReadObject(new MemoryStream(bytes));
+        }
+    }
+}",
+            GetCSharpResultAt(12, 20, BinderNotSetRule, "object XmlObjectSerializer.ReadObject(Stream stream)"));
+        }
+
+        [Fact]
+        public void ReadObject_Stream_BinderMaybeSet_Diagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            if (Environment.MachineName.StartsWith(""a""))
+            {
+                serializer.Binder = new MyBinder();
+            }
+
+            return serializer.ReadObject(new MemoryStream(bytes));
+        }
+    }
+}",
+            GetCSharpResultAt(18, 20, BinderMaybeNotSetRule, "object XmlObjectSerializer.ReadObject(Stream stream)"));
+        }
+
+        [Fact]
+        public void ReadObject_Stream_BinderSet_NoDiagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            serializer.Binder = new MyBinder();
+            return serializer.ReadObject(new MemoryStream(bytes));
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void ReadObject_Stream_InvokedAsDelegate_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Blah
+{
+    public class Program
+    {
+        delegate object DeserializeDelegate(Stream s);
+
+        public object DeserializeWithDelegate(byte[] bytes)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            DeserializeDelegate del = serializer.ReadObject;
+            return del(new MemoryStream(bytes));
+        }
+    }
+}",
+                GetCSharpResultAt(15, 20, BinderNotSetRule, "object XmlObjectSerializer.ReadObject(Stream stream)"));
+        }
+
+        [Fact]
+        public void ReadObject_XmlReader_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+using System.Xml;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(XmlReader xmlReader)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            return serializer.ReadObject(xmlReader);
+        }
+    }
+}",
+            GetCSharpResultAt(13, 20, BinderNotSetRule, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
+        }
+
+        [Fact]
+        public void ReadObject_XmlReader_BinderMaybeSet_Diagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Xml;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(XmlReader xmlReader)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            if (Environment.MachineName.StartsWith(""a""))
+            {
+                serializer.Binder = new MyBinder();
+            }
+
+            return serializer.ReadObject(xmlReader);
+        }
+    }
+}",
+            GetCSharpResultAt(19, 20, BinderMaybeNotSetRule, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
+        }
+
+        [Fact]
+        public void ReadObject_XmlReader_BinderSet_NoDiagnostic()
+        {
+            VerifyCSharpWithMyBinderDefined(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Xml;
+
+namespace Blah
+{
+    public class Program
+    {
+        public object TestMethod(XmlReader xmlReader)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            serializer.Binder = new MyBinder();
+            return serializer.ReadObject(xmlReader);
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void ReadObject_XmlReader_InvokedAsDelegate_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+using System.Runtime.Serialization;
+using System.Xml;
+
+namespace Blah
+{
+    public class Program
+    {
+        delegate object DeserializeDelegate(XmlReader r);
+
+        public object DeserializeWithDelegate(XmlReader xmlReader)
+        {
+            NetDataContractSerializer serializer = new NetDataContractSerializer();
+            DeserializeDelegate del = serializer.ReadObject;
+            return del(xmlReader);
+        }
+    }
+}",
+                GetCSharpResultAt(16, 20, BinderNotSetRule, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
+        }
+    }
+}

--- a/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
@@ -44,6 +44,7 @@ namespace Test.Utilities
         private static readonly MetadataReference s_systemDiagnosticsDebugReference = MetadataReference.CreateFromFile(typeof(Debug).Assembly.Location);
         private static readonly MetadataReference s_systemDataReference = MetadataReference.CreateFromFile(typeof(System.Data.DataSet).Assembly.Location);
         private static readonly MetadataReference s_systemWebReference = MetadataReference.CreateFromFile(typeof(System.Web.HttpRequest).Assembly.Location);
+        private static readonly MetadataReference s_systemRuntimeSerialization = MetadataReference.CreateFromFile(typeof(System.Runtime.Serialization.NetDataContractSerializer).Assembly.Location);
         private static readonly MetadataReference s_testReferenceAssembly = MetadataReference.CreateFromFile(typeof(OtherDll.OtherDllStaticMethods).Assembly.Location);
         private static readonly MetadataReference s_systemXmlLinq = MetadataReference.CreateFromFile(typeof(System.Xml.Linq.XAttribute).Assembly.Location);
         protected static readonly CompilationOptions s_CSharpDefaultOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
@@ -442,6 +443,7 @@ namespace Test.Utilities
                 .AddMetadataReference(projectId, s_systemDiagnosticsDebugReference)
                 .AddMetadataReference(projectId, s_systemWebReference)
                 .AddMetadataReference(projectId, s_systemXmlLinq)
+                .AddMetadataReference(projectId, s_systemRuntimeSerialization)
                 .WithProjectCompilationOptions(projectId, options)
                 .WithProjectParseOptions(projectId, parseOptions)
                 .GetProject(projectId);

--- a/src/Utilities/WellKnownTypes.cs
+++ b/src/Utilities/WellKnownTypes.cs
@@ -149,6 +149,7 @@ namespace Analyzer.Utilities
         public const string SystemDiagnosticsProcess = "System.Diagnostics.Process";
         public const string SystemDiagnosticsProcessStartInfo = "System.Diagnostics.ProcessStartInfo";
         public const string SystemTextRegularExpressionsRegex = "System.Text.RegularExpressions.Regex";
+        public const string SystemRuntimeSerializationNetDataContractSerializer = "System.Runtime.Serialization.NetDataContractSerializer";
 
         public static INamedTypeSymbol ICollection(Compilation compilation)
         {


### PR DESCRIPTION
- More deserialization rules.
- Checking types by looking at the instance of invoked / referenced methods, rather than the target method itself, since NetDataContractSerializer derives from XmlObjectSerializer.