### PR TITLE
Add a NuGet package for command line Code Metrics

### DIFF
--- a/RoslynAnalyzers.sln
+++ b/RoslynAnalyzers.sln
@@ -136,6 +136,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Metrics", "src\Tools\Metric
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerateAnalyzerRulesets", "src\GenerateAnalyzerRulesets\GenerateAnalyzerRulesets.csproj", "{CC0DB31C-87B7-4ABF-A95A-B12526F3056D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeMetrics.Package", "nuget\Microsoft.CodeMetrics\Microsoft.CodeMetrics.Package.csproj", "{2B6F5206-54AE-4990-92F6-4F068D298519}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Metrics.Legacy", "src\Tools\Metrics.Legacy.csproj", "{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Utilities\Analyzer.Utilities.projitems*{ec946164-1e17-410b-b7d9-7de7e6268d63}*SharedItemsImports = 13
@@ -555,6 +559,22 @@ Global
 		{CC0DB31C-87B7-4ABF-A95A-B12526F3056D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CC0DB31C-87B7-4ABF-A95A-B12526F3056D}.Release|x86.ActiveCfg = Release|Any CPU
 		{CC0DB31C-87B7-4ABF-A95A-B12526F3056D}.Release|x86.Build.0 = Release|Any CPU
+		{2B6F5206-54AE-4990-92F6-4F068D298519}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B6F5206-54AE-4990-92F6-4F068D298519}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B6F5206-54AE-4990-92F6-4F068D298519}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2B6F5206-54AE-4990-92F6-4F068D298519}.Debug|x86.Build.0 = Debug|Any CPU
+		{2B6F5206-54AE-4990-92F6-4F068D298519}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B6F5206-54AE-4990-92F6-4F068D298519}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B6F5206-54AE-4990-92F6-4F068D298519}.Release|x86.ActiveCfg = Release|Any CPU
+		{2B6F5206-54AE-4990-92F6-4F068D298519}.Release|x86.Build.0 = Release|Any CPU
+		{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A}.Debug|x86.Build.0 = Debug|Any CPU
+		{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A}.Release|x86.ActiveCfg = Release|Any CPU
+		{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -612,6 +632,8 @@ Global
 		{EFC1EAEF-88A9-41DA-8EC9-0EB6C8A05027} = {BBE0A1C9-3995-4BD1-995E-38DE862BE208}
 		{EEF553EA-1D3D-44A1-A334-1F9220698FB8} = {C0B86774-8307-444F-9EE4-98D62C3424F9}
 		{CC0DB31C-87B7-4ABF-A95A-B12526F3056D} = {C0B86774-8307-444F-9EE4-98D62C3424F9}
+		{2B6F5206-54AE-4990-92F6-4F068D298519} = {C0B86774-8307-444F-9EE4-98D62C3424F9}
+		{CC9AB5FC-F63C-40D7-B809-9FCA5ACC5C8A} = {C0B86774-8307-444F-9EE4-98D62C3424F9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FC44ACA9-AEA3-4EE6-881C-2E08ED281B5F}

--- a/assets/install.ps1
+++ b/assets/install.ps1
@@ -1,6 +1,12 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersDir = Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers"
+if (-Not (Test-Path $analyzersDir))
+{
+    return
+}
+
+$analyzersPaths = Join-Path ( $analyzersDir ) * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/assets/uninstall.ps1
+++ b/assets/uninstall.ps1
@@ -1,6 +1,12 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersDir = Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers"
+if (-Not (Test-Path $analyzersDir))
+{
+    return
+}
+
+$analyzersPaths = Join-Path ( $analyzersDir ) * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/eng/GenerateAnalyzerNuspec.csx
+++ b/eng/GenerateAnalyzerNuspec.csx
@@ -5,10 +5,12 @@ string configuration = Args[3];
 string tfm = Args[4];
 var metadataList = Args[5].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 var fileList = Args[6].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-var assemblyList = Args[7].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-var dependencyList = Args[8].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-var rulesetsDir = Args[9];
-var legacyRulesets = Args[10].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+var folderList = Args[7].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+var assemblyList = Args[8].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+var dependencyList = Args[9].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+var rulesetsDir = Args[10];
+var legacyRulesets = Args[11].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+var artifactsBinDir = Args[12];
 
 var result = new StringBuilder();
 
@@ -95,7 +97,7 @@ if (fileList.Length > 0 || assemblyList.Length > 0)
     {
         IEnumerable<string> targets;
 
-        if (assembly.Contains(csName))
+		if (assembly.Contains(csName))
         {
             targets = new[] { csTarget };
         }
@@ -118,8 +120,18 @@ if (fileList.Length > 0 || assemblyList.Length > 0)
 
     foreach (string file in fileList)
     {
-        var fileWithPath = System.IO.Path.IsPathRooted(file) ? file : Path.Combine(projectDir, file);
+        var fileWithPath = Path.IsPathRooted(file) ? file : Path.Combine(projectDir, file);
         result.AppendLine(FileElement(fileWithPath, "build"));
+    }
+
+    foreach (string folder in folderList)
+    {
+        string folderPath = Path.Combine(artifactsBinDir, folder, configuration, tfm);
+        foreach (var file in Directory.EnumerateFiles(folderPath))
+        {
+            var fileWithPath = Path.Combine(folderPath, file);
+            result.AppendLine(FileElement(fileWithPath, folder));
+        }
     }
 
     result.AppendLine(FileElement(Path.Combine(assetsDir, "Install.ps1"), "tools"));

--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -36,7 +36,7 @@
       <AnalyzerNupkgFile Include="$(PackagePropsFileDir)\$(PackagePropsFileName)"/>
     </ItemGroup>
     
-      <MSBuild Projects="$(RepoRoot)src\GenerateAnalyzerRulesets\GenerateAnalyzerRulesets.csproj" Targets="Build">
+    <MSBuild Projects="$(RepoRoot)src\GenerateAnalyzerRulesets\GenerateAnalyzerRulesets.csproj" Targets="Build">
       <Output TaskParameter="TargetOutputs" PropertyName="_GenerateAnalyzerRulesetsPath"/>
     </MSBuild>
 
@@ -50,7 +50,7 @@
   <Target Name="GenerateAnalyzerNuspecFile"
           BeforeTargets="GenerateNuspec"
           DependsOnTargets="InitializeSourceControlInformation;GenerateAnalyzerRulesets" 
-          Condition="'@(AnalyzerNupkgFile)' != '' or '@(AnalyzerNupkgAssembly)' != '' or '@(AnalyzerNupkgDependency)' != ''">
+          Condition="'@(AnalyzerNupkgFile)' != '' or '@(AnalyzerNupkgFolder)' != '' or '@(AnalyzerNupkgAssembly)' != '' or '@(AnalyzerNupkgDependency)' != ''">
     <ItemGroup>
       <_NuspecMetadata Include="version=$(PackageVersion)" />
       <_NuspecMetadata Include="id=$(NuspecPackageId)" />
@@ -77,6 +77,6 @@
       <_CscToolPath Condition="!HasTrailingSlash('$(_CscToolPath)')">$(_CscToolPath)\</_CscToolPath>
     </PropertyGroup>
 
-    <Exec Command='"$(_CscToolPath)csi.exe" "$(RepoRoot)eng\GenerateAnalyzerNuspec.csx" "$(NuspecFile)" "$(AssetsDir)\" "$(MSBuildProjectDirectory)" "$(Configuration)" "$(TargetFramework)" "@(_NuspecMetadata)" "@(AnalyzerNupkgFile)" "@(AnalyzerNupkgAssembly)" "@(AnalyzerNupkgDependency)" "$(_GeneratedRulesetsDir)" "@(AnalyzerLegacyRuleset)"' />
+    <Exec Command='"$(_CscToolPath)csi.exe" "$(RepoRoot)eng\GenerateAnalyzerNuspec.csx" "$(NuspecFile)" "$(AssetsDir)\" "$(MSBuildProjectDirectory)" "$(Configuration)" "$(TargetFramework)" "@(_NuspecMetadata)" "@(AnalyzerNupkgFile)" "@(AnalyzerNupkgFolder)" "@(AnalyzerNupkgAssembly)" "@(AnalyzerNupkgDependency)" "$(_GeneratedRulesetsDir)" "@(AnalyzerLegacyRuleset)" "$(ArtifactsBinDir)\"' />
   </Target>
 </Project>

--- a/nuget/Microsoft.CodeMetrics/Microsoft.CodeMetrics.Package.csproj
+++ b/nuget/Microsoft.CodeMetrics/Microsoft.CodeMetrics.Package.csproj
@@ -1,0 +1,28 @@
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NuspecPackageId>Microsoft.CodeMetrics</NuspecPackageId>
+    <Description>Report source based Code Metrics</Description>
+    <Summary>Microsoft.CodeMetrics</Summary>
+    <ReleaseNotes>Tool to report source based code metrics</ReleaseNotes>
+    <PackageTags>Roslyn CodeAnalysis CodeMetrics Metrics Compiler CSharp VB VisualBasic Syntax Semantics</PackageTags>
+    <ContainsPortedFxCopRules>false</ContainsPortedFxCopRules>
+	  <GeneratePackagePropsFile>false</GeneratePackagePropsFile>
+	  <NoWarn>$(NoWarn);NU5100</NoWarn>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <AnalyzerNupkgFolder Include="Metrics" />
+    <AnalyzerNupkgFolder Include="Metrics.Legacy" />
+    <AnalyzerNupkgFile Include="Microsoft.CodeMetrics.targets" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Tools\Metrics.csproj" />
+    <ProjectReference Include="..\..\src\Tools\Metrics.Legacy.csproj" />
+  </ItemGroup>
+</Project>

--- a/nuget/Microsoft.CodeMetrics/Microsoft.CodeMetrics.targets
+++ b/nuget/Microsoft.CodeMetrics/Microsoft.CodeMetrics.targets
@@ -1,0 +1,19 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  <PropertyGroup>
+    <MetricsExeFolder>$(MSBuildThisFileDirectory)\..\Metrics</MetricsExeFolder>
+    <MetricsExeName>Metrics</MetricsExeName>
+    <MetricsOutputFile Condition="'$(MetricsOutputFile)' == ''">$(MSBuildProjectName).Metrics.xml</MetricsOutputFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(LEGACY_CODE_METRICS_MODE)' == 'true'">
+    <MetricsExeFolder>$(MetricsExeFolder).Legacy</MetricsExeFolder>
+    <MetricsExeName>$(MetricsExeName).Legacy</MetricsExeName>
+  </PropertyGroup>
+
+  <Target Name="Metrics">
+    <Exec Command='$(MetricsExeFolder)\$(MetricsExeName).exe /project:$(MSBuildProjectFullPath) /out:$(MetricsOutputFile)'
+          WorkingDirectory="$(MSBuildProjectDirectory)">
+    </Exec>
+  </Target>
+</Project>

--- a/src/Tools/Metrics.Legacy.csproj
+++ b/src/Tools/Metrics.Legacy.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net46</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsShipping>true</IsShipping>
+    <DefineConstants>$(DefineConstants),LEGACY_CODE_METRICS_MODE</DefineConstants>
   </PropertyGroup>
   <Import Project="..\Utilities\Analyzer.Utilities.projitems" Label="Shared" />
   <ItemGroup>


### PR DESCRIPTION
Fixes #1756
See https://docs.microsoft.com/en-us/visualstudio/code-quality/how-to-generate-code-metrics-data?view=vs-2017#command-line-code-metrics for background

1. Users can now execute Metrics.exe by installing the `Microsoft.CodeMetrics` NuGet package and then executing `msbuild /t:Metrics` on their project file.
2. Metrics can be executed in legacy mode by specifying `/p:LEGACY_CODE_METRICS_MODE=true` on the MSBuild command line.
3. Additionally, users can override the output file by specifying `/p:MetricsOutputFile=<filename>` on the MSBuild command line.

Verified that the locally generated Microsoft.CodeMetrics NuGet package can be installed on a managed project and above functionality works.

------

**Example 1:**
```
C:\Users\mavasani\source\repos\ClassLibrary3\ClassLibrary3>msbuild /t:Metrics
Microsoft (R) Build Engine version 16.0.360-preview+g9781d96883 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

Build started 1/22/2019 4:29:57 PM.
Project "C:\Users\mavasani\source\repos\ClassLibrary3\ClassLibrary3\ClassLibrary3.csproj" on node 1 (Metrics target(s))
.
Metrics:
  C:\Users\mavasani\source\repos\ClassLibrary3\packages\Microsoft.CodeMetrics.2.6.4-ci\build\\..\Metrics\Metrics.exe /p
  roject:C:\Users\mavasani\source\repos\ClassLibrary3\ClassLibrary3\ClassLibrary3.csproj /out:ClassLibrary3.Metrics.xml
  Loading ClassLibrary3.csproj...
  Computing code metrics for ClassLibrary3.csproj...
  Writing output to 'ClassLibrary3.Metrics.xml'...
  Completed Successfully.
Done Building Project "C:\Users\mavasani\source\repos\ClassLibrary3\ClassLibrary3\ClassLibrary3.csproj" (Metrics target
(s)).


Build succeeded.
    0 Warning(s)
    0 Error(s)
```

------

**Example 2 (Legacy mode with overridden output file):**
```
C:\Users\mavasani\source\repos\ClassLibrary3\ClassLibrary3>msbuild /t:Metrics /p:LEGACY_CODE_METRICS_MODE=true /p:MetricsOutputFile="Legacy.xml"
Microsoft (R) Build Engine version 16.0.360-preview+g9781d96883 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

Build started 1/22/2019 4:31:00 PM.
The "MetricsOutputFile" property is a global property, and cannot be modified.
Project "C:\Users\mavasani\source\repos\ClassLibrary3\ClassLibrary3\ClassLibrary3.csproj" on node 1 (Metrics target(s))
.
Metrics:
  C:\Users\mavasani\source\repos\ClassLibrary3\packages\Microsoft.CodeMetrics.2.6.4-ci\build\\..\Metrics.Legacy\Metrics
  .Legacy.exe /project:C:\Users\mavasani\source\repos\ClassLibrary3\ClassLibrary3\ClassLibrary3.csproj /out:Legacy.xml
  Loading ClassLibrary3.csproj...
  Computing code metrics for ClassLibrary3.csproj...
  Writing output to 'Legacy.xml'...
  Completed Successfully.
Done Building Project "C:\Users\mavasani\source\repos\ClassLibrary3\ClassLibrary3\ClassLibrary3.csproj" (Metrics target
(s)).


Build succeeded.
    0 Warning(s)
    0 Error(s)
```