### PR TITLE
Implement CA1712: Do not prefix enum values with type name

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeName.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeName.cs
@@ -55,11 +55,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            int numPrefixed = enumValues.Count(m => m.Name.StartsWith(symbol.Name, StringComparison.OrdinalIgnoreCase));
-            int percentPrefixed = 100 * numPrefixed / enumValues.Count();
+            var prefixedValues = enumValues.Where(m => m.Name.StartsWith(symbol.Name, StringComparison.OrdinalIgnoreCase));
+            int percentPrefixed = 100 * prefixedValues.Count() / enumValues.Count();
             if (percentPrefixed >= PercentValuesPrefixedThreshold)
             {
-                context.ReportDiagnostic(symbol.CreateDiagnostic(Rule, symbol.Name));
+                foreach (var value in prefixedValues)
+                {
+                    context.ReportDiagnostic(value.CreateDiagnostic(Rule, symbol.Name));
+                }
             }
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeName.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeName.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using static Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MicrosoftApiDesignGuidelinesAnalyzersResources;
+
+namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
+{
+    /// <summary>
+    /// CA1712: Do not prefix enum values with type name
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class DoNotPrefixEnumValuesWithTypeNameAnalyzer : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA1712";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(DoNotPrefixEnumValuesWithTypeNameTitle), ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(DoNotPrefixEnumValuesWithTypeNameMessage), ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(DoNotPrefixEnumValuesWithTypeNameDescription), ResourceManager, typeof(MicrosoftApiDesignGuidelinesAnalyzersResources));
+
+        internal static DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(
+                RuleId,
+                s_localizableTitle,
+                s_localizableMessage,
+                DiagnosticCategory.Naming,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                description: s_localizableDescription,
+                helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182237.aspx",
+                customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext analysisContext)
+        {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            analysisContext.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeNamedType(SymbolAnalysisContext context)
+        {
+            var symbol = (INamedTypeSymbol)context.Symbol;
+            if (symbol.TypeKind == TypeKind.Enum && 
+                symbol.GetMembers().Any(m => m.Kind == SymbolKind.Field && m.Name.StartsWith(symbol.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                context.ReportDiagnostic(symbol.CreateDiagnostic(Rule, symbol.Name));
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -1017,7 +1017,7 @@
     <value>Do not catch general exception types</value>
   </data>
   <data name="DoNotPrefixEnumValuesWithTypeNameDescription" xml:space="preserve">
-    <value>An enumeration should not contain a member whose name starts with the type name of the enumeration.</value>
+    <value>An enumeration's values should not start with the type name of the enumeration.</value>
   </data>
   <data name="DoNotPrefixEnumValuesWithTypeNameMessage" xml:space="preserve">
     <value>Do not prefix enum values with the name of the enum type '{0}'. </value>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MicrosoftApiDesignGuidelinesAnalyzersResources.resx
@@ -1016,4 +1016,13 @@
   <data name="DoNotCatchGeneralExceptionTypesTitle" xml:space="preserve">
     <value>Do not catch general exception types</value>
   </data>
+  <data name="DoNotPrefixEnumValuesWithTypeNameDescription" xml:space="preserve">
+    <value>An enumeration should not contain a member whose name starts with the type name of the enumeration.</value>
+  </data>
+  <data name="DoNotPrefixEnumValuesWithTypeNameMessage" xml:space="preserve">
+    <value>Do not prefix enum values with the name of the enum type '{0}'. </value>
+  </data>
+  <data name="DoNotPrefixEnumValuesWithTypeNameTitle" xml:space="preserve">
+    <value>Do not prefix enum values with type name</value>
+  </data>
 </root>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
@@ -67,6 +67,21 @@
         <target state="translated">Nepředávejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">Neukládejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
@@ -67,6 +67,21 @@
         <target state="translated">Async-Lambdas nicht als "Void" zurückgebende Delegattypen übergeben</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">Async-Lambdas nicht als "Void" zurückgebende Delegattypen speichern</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.de.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
@@ -67,6 +67,21 @@
         <target state="translated">No pasar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">No almacenar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.es.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.fr.xlf
@@ -67,6 +67,21 @@
         <target state="translated">Ne pas passer de lambdas asynchrones en tant que types délégués retournant void</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">Ne pas stocker de lambdas asynchrones en tant que types délégués retournant void</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
@@ -67,6 +67,21 @@
         <target state="translated">Non passare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">Non archiviare espressioni lambda asincrone come tipi delegati che restituiscono void</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.it.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
@@ -67,6 +67,21 @@
         <target state="translated">デリゲート型を返す Void として非同期ラムダを渡さないでください</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">デリゲート型を返す Void として非同期ラムダを格納しないでください</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ja.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
@@ -67,6 +67,21 @@
         <target state="translated">비동기 람다를 Void 반환 대리자 형식으로 전달하지 마세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">비동기 람다를 Void 반환 대리자 형식으로 저장하지 마세요.</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ko.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pl.xlf
@@ -67,6 +67,21 @@
         <target state="translated">Nie przekazuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">Nie przechowuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
@@ -67,6 +67,21 @@
         <target state="translated">Não passar lambdas assíncronas como tipos delegados que retornam void</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">Não armazenar lambdas assíncronas como tipos delegados que retornam void</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.pt-BR.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
@@ -67,6 +67,21 @@
         <target state="translated">Не передавайте асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">Не храните асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.ru.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
@@ -67,6 +67,21 @@
         <target state="translated">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Geçirme</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Depolamayın</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.tr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
@@ -67,6 +67,21 @@
         <target state="translated">不要将异步 Lambda 作为 Void 返回委托类型传递</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">不要将异步 Lambda 作为 Void 返回委托类型存储</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hans.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
@@ -67,6 +67,21 @@
         <target state="translated">請勿將 Async Lambdas 傳遞為 Void 傳回委派類型</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
+        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
+        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">
+        <source>Do not prefix enum values with the name of the enum type '{0}'. </source>
+        <target state="new">Do not prefix enum values with the name of the enum type '{0}'. </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotPrefixEnumValuesWithTypeNameTitle">
+        <source>Do not prefix enum values with type name</source>
+        <target state="new">Do not prefix enum values with type name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
         <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
         <target state="translated">請勿將 Async Lambdas 儲存為 Void 傳回委派類型</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.zh-Hant.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameDescription">
-        <source>An enumeration should not contain a member whose name starts with the type name of the enumeration.</source>
-        <target state="new">An enumeration should not contain a member whose name starts with the type name of the enumeration.</target>
+        <source>An enumeration's values should not start with the type name of the enumeration.</source>
+        <target state="new">An enumeration's values should not start with the type name of the enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPrefixEnumValuesWithTypeNameMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
+{
+    public class DoNotPrefixEnumValuesWithTypeNameTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new DoNotPrefixEnumValuesWithTypeNameAnalyzer();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DoNotPrefixEnumValuesWithTypeNameAnalyzer();
+        }
+
+        [Fact]
+        public void CSharp_NoDiagnostic_NoPrefix()
+        {
+            VerifyCSharp(@" 
+                class A
+                { 
+                    enum State
+                    {
+                        Ok = 0,
+                        Error = 1,
+                        Unknown = 2
+                    };
+                }");
+        }
+
+        [Fact]
+        public void Basic_NoDiagnostic_NoPrefix()
+        {
+            VerifyBasic(@"
+                Class A
+                    Private Enum State
+                        Ok = 0
+                        Err = 1
+                        Unknown = 2
+                    End Enum
+                End Class");
+        }
+
+        [Fact]
+        public void CSharp_Diagnostic_OneValuePrefixed()
+        {
+            VerifyCSharp(@"
+                class A
+                {
+                    enum State
+                    {
+                        Ok = 0,
+                        StateError = 1,
+                        Unknown = 2
+                    };
+                }",
+                GetCSharpResultAt(4, 26, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+        }
+
+        [Fact]
+        public void Basic_Diagnostic_OneValuePrefixed()
+        {
+            VerifyBasic(@"
+                Class A
+                    Private Enum State
+                        Ok = 0
+                        StateErr = 1
+                        Unknown = 2
+                    End Enum
+                End Class
+                ",
+                GetBasicResultAt(3, 34, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+        }
+
+        [Fact]
+        public void CSharp_Diagnostic_EachValuePrefixed()
+        {
+            VerifyCSharp(@"
+                class A
+                {
+                    enum State
+                    {
+                        StateOk = 0,
+                        StateError = 1,
+                        StateUnknown = 2
+                    };
+                }",
+                GetCSharpResultAt(4, 26, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+        }
+
+        [Fact]
+        public void CSharp_Diagnostic_PrefixCaseDiffers()
+        {
+            VerifyCSharp(@"
+                class A
+                {
+                    enum State
+                    {
+                        stateOk = 0,
+                        Error = 1,
+                        Unknown = 2
+                    };
+                }",
+                GetCSharpResultAt(4, 26, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
@@ -60,7 +60,9 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                         StateUnknown = 2
                     };
                 }",
-                GetCSharpResultAt(4, 26, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+                GetCSharpResultAt(6, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
+                GetCSharpResultAt(7, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
+                GetCSharpResultAt(8, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
         }
 
         [Fact]
@@ -75,7 +77,9 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                     End Enum
                 End Class
                 ",
-                GetBasicResultAt(3, 34, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+                GetBasicResultAt(4, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
+                GetBasicResultAt(5, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
+                GetBasicResultAt(6, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
         }
 
         [Fact]
@@ -108,7 +112,9 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                         Invalid = 3
                     };
                 }",
-                GetCSharpResultAt(4, 26, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+                GetCSharpResultAt(6, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
+                GetCSharpResultAt(7, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
+                GetCSharpResultAt(8, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
         }
 
         [Fact]
@@ -122,7 +128,7 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                         stateOk = 0
                     };
                 }",
-                GetCSharpResultAt(4, 26, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+                GetCSharpResultAt(6, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
@@ -48,37 +48,6 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
         }
 
         [Fact]
-        public void CSharp_Diagnostic_OneValuePrefixed()
-        {
-            VerifyCSharp(@"
-                class A
-                {
-                    enum State
-                    {
-                        Ok = 0,
-                        StateError = 1,
-                        Unknown = 2
-                    };
-                }",
-                GetCSharpResultAt(4, 26, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
-        }
-
-        [Fact]
-        public void Basic_Diagnostic_OneValuePrefixed()
-        {
-            VerifyBasic(@"
-                Class A
-                    Private Enum State
-                        Ok = 0
-                        StateErr = 1
-                        Unknown = 2
-                    End Enum
-                End Class
-                ",
-                GetBasicResultAt(3, 34, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
-        }
-
-        [Fact]
         public void CSharp_Diagnostic_EachValuePrefixed()
         {
             VerifyCSharp(@"
@@ -95,6 +64,54 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
         }
 
         [Fact]
+        public void Basic_Diagnostic_EachValuePrefixed()
+        {
+            VerifyBasic(@"
+                Class A
+                    Private Enum State
+                        StateOk = 0
+                        StateErr = 1
+                        StateUnknown = 2
+                    End Enum
+                End Class
+                ",
+                GetBasicResultAt(3, 34, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+        }
+
+        [Fact]
+        public void CSharp_NoDiagnostic_HalfOfValuesPrefixed()
+        {
+            VerifyCSharp(@"
+                class A
+                {
+                    enum State
+                    {
+                        Ok = 0,
+                        StateError = 1,
+                        StateUnknown = 2,
+                        Invalid = 3
+                    };
+                }");
+        }
+
+        [Fact]
+        public void CSharp_Diagnostic_ThreeOfFourValuesPrefixed()
+        {
+            VerifyCSharp(@"
+                class A
+                {
+                    enum State
+                    {
+                        StateOk = 0,
+                        StateError = 1,
+                        StateUnknown = 2,
+                        Invalid = 3
+                    };
+                }",
+                GetCSharpResultAt(4, 26, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+        }
+
+        [Fact]
         public void CSharp_Diagnostic_PrefixCaseDiffers()
         {
             VerifyCSharp(@"
@@ -102,12 +119,22 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                 {
                     enum State
                     {
-                        stateOk = 0,
-                        Error = 1,
-                        Unknown = 2
+                        stateOk = 0
                     };
                 }",
                 GetCSharpResultAt(4, 26, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+        }
+
+        [Fact]
+        public void CSharp_NoDiagnostic_EmptyEnum()
+        {
+            VerifyCSharp(@"
+                class A
+                {
+                    enum State
+                    {
+                    };
+                }");
         }
     }
 }


### PR DESCRIPTION
Fixes #448 

Reporting a single diagnostic on the enum type if any field member's name starts with the enum type's name (case-insensitive comparison). 