### PR TITLE
Dogfood and cleanup violations from IDE analyzers and fixers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,10 +48,10 @@ dotnet_style_null_propagation = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
 
 # Field preferences
-dotnet_style_readonly_field = true:error
+dotnet_style_readonly_field = true:warning
  
 # Parameter preferences
-dotnet_code_quality_unused_parameters = all:error
+dotnet_code_quality_unused_parameters = all:warning
 
 ### CSharp code style settings ###
 [*.cs]
@@ -87,13 +87,13 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 
 # Expression-level preferences
-csharp_style_unused_value_assignment_preference = discard_variable:error
+csharp_style_unused_value_assignment_preference = discard_variable:warning
 
 ### Visual Basic code style settings ###
 [*.vb]
 
 # Expression-level preferences
-visual_basic_style_unused_value_assignment_preference = unused_local_variable:error
+visual_basic_style_unused_value_assignment_preference = unused_local_variable:warning
 
 
 ### Configuration for FxCop analyzers executed on this repo ###

--- a/.editorconfig
+++ b/.editorconfig
@@ -24,15 +24,17 @@ indent_size = 2
 [*.json]
 indent_size = 2
 
-# Dotnet code style settings:
+### Dotnet code style settings ###
+
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
+
 # Avoid "this." and "Me." if not necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
 
 # Use language keywords instead of framework type names for type references
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
@@ -45,12 +47,19 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
 
-# CSharp code style settings:
+# Field preferences
+dotnet_style_readonly_field = true:error
+ 
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:error
+
+### CSharp code style settings ###
 [*.cs]
+
 # Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none
@@ -77,8 +86,18 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 
+# Expression-level preferences
+csharp_style_unused_value_assignment_preference = discard_variable:error
 
-### Configuration for FxCop analyzers executed on this repo
+### Visual Basic code style settings ###
+[*.vb]
+
+# Expression-level preferences
+visual_basic_style_unused_value_assignment_preference = unused_local_variable:error
+
+
+### Configuration for FxCop analyzers executed on this repo ###
+[*.{cs,vb}]
 
 # Default analyzed API surface = 'all' (public APIs + non-public APIs)
 dotnet_code_quality.api_surface = all

--- a/eng/Analyzers_ShippingRules.ruleset
+++ b/eng/Analyzers_ShippingRules.ruleset
@@ -19,5 +19,11 @@
     <!-- Skipped due to https://github.com/dotnet/roslyn-analyzers/issues/1711 -->
     <Rule Id="RS1022" Action="None" />
   </Rules>
+  
+  <!-- TODO: Move the below configurations to .editorconfig once compilers supports .editorconfig -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
+    <Rule Id="IDE0051" Action="Error" /> <!-- Remove unused private members -->
+	<Rule Id="IDE0052" Action="Error" /> <!-- Remove unread private members -->
+  </Rules>
 
 </RuleSet>

--- a/eng/Analyzers_ShippingRules.ruleset
+++ b/eng/Analyzers_ShippingRules.ruleset
@@ -22,8 +22,8 @@
   
   <!-- TODO: Move the below configurations to .editorconfig once compilers supports .editorconfig -->
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
-    <Rule Id="IDE0051" Action="Error" /> <!-- Remove unused private members -->
-	<Rule Id="IDE0052" Action="Error" /> <!-- Remove unread private members -->
+    <Rule Id="IDE0051" Action="Warning" /> <!-- Remove unused private members -->
+    <Rule Id="IDE0052" Action="Warning" /> <!-- Remove unread private members -->
   </Rules>
 
 </RuleSet>

--- a/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
+++ b/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
@@ -1669,7 +1669,7 @@ namespace MetaCompilation.Analyzers
                     continue;
                 }
 
-                SyntaxList<SyntaxNode> nodeArgs = CodeFixHelper.CreateRuleList(document, ruleNames);
+                SyntaxList<SyntaxNode> nodeArgs = CodeFixHelper.CreateRuleList(ruleNames);
                 SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
                 SyntaxNode newInvocationExpression = (generator.InvocationExpression(generator.MemberAccessExpression(generator.IdentifierName("ImmutableArray"), "Create"), nodeArgs));
                 SyntaxTriviaList leadingTrivia = SyntaxFactory.TriviaList(SyntaxFactory.ParseLeadingTrivia("// This array contains all the diagnostics that can be shown to the user").ElementAt(0), SyntaxFactory.EndOfLine("\r\n"));
@@ -2438,7 +2438,7 @@ namespace MetaCompilation.Analyzers
                 return ruleNames;
             }
 
-            internal static SyntaxList<SyntaxNode> CreateRuleList(Document document, List<string> ruleNames)
+            internal static SyntaxList<SyntaxNode> CreateRuleList(List<string> ruleNames)
             {
                 string argumentListString = "";
                 foreach (string ruleName in ruleNames)
@@ -2454,8 +2454,6 @@ namespace MetaCompilation.Analyzers
                 }
 
                 ArgumentListSyntax argumentListSyntax = SyntaxFactory.ParseArgumentList("(" + argumentListString + ")");
-                SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
-
                 SeparatedSyntaxList<ArgumentSyntax> args = argumentListSyntax.Arguments;
                 var nodeArgs = new SyntaxList<SyntaxNode>();
                 foreach (ArgumentSyntax arg in args)

--- a/src/MetaCompilation.Analyzers/Core/DiagnosticAnalyzer.cs
+++ b/src/MetaCompilation.Analyzers/Core/DiagnosticAnalyzer.cs
@@ -332,14 +332,14 @@ namespace MetaCompilation.Analyzers
         // Performs stateful analysis
         private class CompilationAnalyzer
         {
-            private List<IMethodSymbol> _analyzerMethodSymbols = new List<IMethodSymbol>();
-            private List<IPropertySymbol> _analyzerPropertySymbols = new List<IPropertySymbol>();
-            private List<IFieldSymbol> _analyzerFieldSymbols = new List<IFieldSymbol>();
-            private List<INamedTypeSymbol> _otherAnalyzerClassSymbols = new List<INamedTypeSymbol>();
+            private readonly List<IMethodSymbol> _analyzerMethodSymbols = new List<IMethodSymbol>();
+            private readonly List<IPropertySymbol> _analyzerPropertySymbols = new List<IPropertySymbol>();
+            private readonly List<IFieldSymbol> _analyzerFieldSymbols = new List<IFieldSymbol>();
+            private readonly List<INamedTypeSymbol> _otherAnalyzerClassSymbols = new List<INamedTypeSymbol>();
             private IMethodSymbol _initializeSymbol;
             private IPropertySymbol _propertySymbol;
             private INamedTypeSymbol _analyzerClassSymbol;
-            private Dictionary<string, string> _branchesDict = new Dictionary<string, string>();
+            private readonly Dictionary<string, string> _branchesDict = new Dictionary<string, string>();
             private readonly List<IMethodSymbol> _codeFixMethodSymbols = new List<IMethodSymbol>();
 
             //"main" method, performs the analysis once state has been collected
@@ -2037,9 +2037,7 @@ namespace MetaCompilation.Analyzers
                 }
 
                 Location getAccessorKeywordLocation = propertyDeclaration.AccessorList.Accessors.First().Keyword.GetLocation();
-
-
-                if (statements.First() is ThrowStatementSyntax throwStatement)
+                if (statements.First() is ThrowStatementSyntax)
                 {
                     ReportDiagnostic(context, IncorrectAccessorReturnRule, getAccessorKeywordLocation);
                     return false;
@@ -2539,7 +2537,6 @@ namespace MetaCompilation.Analyzers
                 }
                 else
                 {
-                    var analyzerClass = _analyzerClassSymbol.DeclaringSyntaxReferences[0].GetSyntax() as ClassDeclarationSyntax;
                     Location idLocation = null;
                     foreach (IFieldSymbol field in _analyzerFieldSymbols)
                     {

--- a/src/MetaCompilation.Analyzers/Core/MetaCompilation.Analyzers.csproj
+++ b/src/MetaCompilation.Analyzers/Core/MetaCompilation.Analyzers.csproj
@@ -7,6 +7,7 @@
       Restore would conclude that there is a cyclic dependency between us and the MetaCompilation.Analyzers nuget package.
     -->
     <PackageId>*$(MSBuildProjectFullPath)*</PackageId>
+    <NoWarn>$(NoWarn);IDE0019</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />

--- a/src/MetaCompilation.Analyzers/UnitTests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/src/MetaCompilation.Analyzers/UnitTests/Helpers/DiagnosticVerifier.Helper.cs
@@ -118,11 +118,6 @@ namespace MetaCompilation.Analyzers.UnitTests
                 throw new ArgumentException("Unsupported Language");
             }
 
-            for (int i = 0; i < sources.Length; i++)
-            {
-                string fileName = language == LanguageNames.CSharp ? "Test" + i + ".cs" : "Test" + i + ".vb";
-            }
-
             Project project = CreateProject(sources, language);
             Document[] documents = project.Documents.ToArray();
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpImmutableObjectMethodAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/CSharpImmutableObjectMethodAnalyzer.cs
@@ -79,8 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers
             }
 
             //If we can't find the method symbol, quit
-            var methodSymbol = model.GetSymbolInfo(candidateInvocation).Symbol as IMethodSymbol;
-            if (methodSymbol == null)
+            if (!(model.GetSymbolInfo(candidateInvocation).Symbol is IMethodSymbol methodSymbol))
             {
                 return;
             }
@@ -93,8 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers
             }
 
             //If we're not in one of the known immutable types, quit
-            var parentType = methodSymbol.ReceiverType as INamedTypeSymbol;
-            if (parentType == null)
+            if (!(methodSymbol.ReceiverType is INamedTypeSymbol parentType))
             {
                 return;
             }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -184,8 +184,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
 
             internal void OperationBlockStart(OperationBlockStartAnalysisContext context)
             {
-                var method = context.OwningSymbol as IMethodSymbol;
-                if (method == null)
+                if (!(context.OwningSymbol is IMethodSymbol method))
                 {
                     return;
                 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -156,8 +156,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 var idToAnalyzerMap = new ConcurrentDictionary<string, ConcurrentDictionary<string, ConcurrentBag<Location>>>();
                 compilationContext.RegisterOperationAction(operationAnalysisContext =>
                 {
-                    var objectCreation = ((IFieldInitializerOperation)operationAnalysisContext.Operation).Value as IObjectCreationOperation;
-                    if (objectCreation == null)
+                    if (!(((IFieldInitializerOperation)operationAnalysisContext.Operation).Value is IObjectCreationOperation objectCreation))
                     {
                         return;
                     }
@@ -174,10 +173,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     AnalyzeHelpLinkUri(operationAnalysisContext, objectCreation);
 
                     string categoryOpt = null;
-                    ImmutableArray<(string prefix, int start, int end)> allowedIdsInfoList;
                     if (!checkCategoryAndAllowedIds ||
                         !TryAnalyzeCategory(operationAnalysisContext, objectCreation,
-                            additionalTextOpt, categoryAndAllowedIdsMap, out categoryOpt, out allowedIdsInfoList))
+                            additionalTextOpt, categoryAndAllowedIdsMap, out categoryOpt, out var allowedIdsInfoList))
                     {
                         allowedIdsInfoList = default(ImmutableArray<(string prefix, int start, int end)>);
                     }
@@ -329,11 +327,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
                         // Factory methods to track declaration locations for every analyzer rule ID.
                         ConcurrentBag<Location> AddLocationFactory(string analyzerName)
-                        {
-                            var newBag = new ConcurrentBag<Location>();
-                            newBag.Add(location);
-                            return newBag;
-                        };
+                            => new ConcurrentBag<Location> { location };
 
                         ConcurrentBag<Location> UpdateLocationsFactory(string analyzerName, ConcurrentBag<Location> bag)
                         {

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
@@ -475,8 +475,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 }
 
                 // Get the context parameter on which we are registering an action.
-                var contextParameter = model.GetSymbolInfo(receiver, cancellationToken).Symbol as IParameterSymbol;
-                if (contextParameter == null)
+                if (!(model.GetSymbolInfo(receiver, cancellationToken).Symbol is IParameterSymbol contextParameter))
                 {
                     return;
                 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
@@ -81,7 +81,7 @@ public class MyDerivedCodeActionWithEquivalenceKey : MyAbstractCodeActionWithEqu
 
             if (withCustomCodeActions)
             {
-                sourceSuffix = sourceSuffix + CSharpCustomCodeActions;
+                sourceSuffix += CSharpCustomCodeActions;
             }
 
             // Verify expected diagnostics for fixer that supports FixAllProvider.
@@ -433,7 +433,7 @@ End Class
 
             if (withCustomCodeActions)
             {
-                sourceSuffix = sourceSuffix + VisualBasicCustomCodeActions;
+                sourceSuffix += VisualBasicCustomCodeActions;
             }
 
             // Verify expected diagnostics for fixer that supports FixAllProvider.

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
@@ -26,11 +26,6 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow.DisposeAnalysis
             Debug.Assert(kind != DisposeAbstractValueKind.Disposed);
         }
 
-        private DisposeAbstractValue(IOperation disposingOrEscapingOperation, DisposeAbstractValueKind kind)
-            : this(ImmutableHashSet.Create(disposingOrEscapingOperation), kind)
-        {
-        }
-
         public DisposeAbstractValue(ImmutableHashSet<IOperation> disposingOrEscapingOperations, DisposeAbstractValueKind kind)
         {
             VerifyArguments(disposingOrEscapingOperations, kind);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/BasicBlock.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/BasicBlock.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
     [DebuggerDisplay("{Kind} ({Statements.Length} statements)")]
     internal class BasicBlock
     {
-        private ImmutableArray<IOperation>.Builder _statements;
-        private ImmutableHashSet<BasicBlock>.Builder _successors;
-        private ImmutableHashSet<BasicBlock>.Builder _predecessors;
+        private readonly ImmutableArray<IOperation>.Builder _statements;
+        private readonly ImmutableHashSet<BasicBlock>.Builder _successors;
+        private readonly ImmutableHashSet<BasicBlock>.Builder _predecessors;
 
         public BasicBlock(BasicBlockKind kind)
         {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraph.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraph.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
     [DebuggerDisplay("CFG ({_blocks.Count} blocks)")]
     internal class ControlFlowGraph
     {
-        private ImmutableHashSet<BasicBlock>.Builder _blocks;
+        private readonly ImmutableHashSet<BasicBlock>.Builder _blocks;
 
         public static ControlFlowGraph Create(IOperation body)
         {

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraphGenerator.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/ControlFlow/ControlFlowGraphGenerator.cs
@@ -90,8 +90,8 @@ namespace Microsoft.CodeAnalysis.Operations.ControlFlow
 
         #endregion
 
-        private IList<BasicBlock> _blocks;
-        private IDictionary<ILabelSymbol, BasicBlock> _labeledBlocks;
+        private readonly IList<BasicBlock> _blocks;
+        private readonly IDictionary<ILabelSymbol, BasicBlock> _labeledBlocks;
         private BasicBlock _currentBlock;
         private ControlFlowGraph _graph;
 

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractEquatable.cs
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/FlowAnalysis/Framework/DataFlow/AbstractEquatable.cs
@@ -29,9 +29,9 @@ namespace Microsoft.CodeAnalysis.Operations.DataFlow
 
         public static bool operator ==(CacheBasedEquatable<T> value1, CacheBasedEquatable<T> value2)
         {
-            if ((object)value1 == null)
+            if (value1 is null)
             {
-                return (object)value2 == null;
+                return value2 is null;
             }
 
             return value1.Equals(value2);

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Microsoft.CodeQuality.Analyzers.Exp.csproj
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Microsoft.CodeQuality.Analyzers.Exp.csproj
@@ -7,6 +7,7 @@
       Restore would conclude that there is a cyclic dependency between us and the Microsoft.CodeQuality.Analyzers nuget package.
     -->
     <PackageId>*$(MSBuildProjectFullPath)*</PackageId>
+    <NoWarn>$(NoWarn);IDE0018;IDE0019;IDE0059;IDE0060</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeQuality.CSharp.Analyzers.Exp" />

--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpRethrowToPreserveStackDetails.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpRethrowToPreserveStackDetails.cs
@@ -34,8 +34,7 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines
                 {
                     case SyntaxKind.CatchClause:
                         {
-                            var local = context.SemanticModel.GetSymbolInfo(expr).Symbol as ILocalSymbol;
-                            if (local == null || local.Locations.Length == 0)
+                            if (!(context.SemanticModel.GetSymbolInfo(expr).Symbol is ILocalSymbol local) || local.Locations.Length == 0)
                             {
                                 return;
                             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DefineAccessorsForAttributeArguments.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DefineAccessorsForAttributeArguments.Fixer.cs
@@ -74,8 +74,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SymbolEditor symbolEditor = SymbolEditor.Create(document);
             SemanticModel model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-            var parameterSymbol = model.GetDeclaredSymbol(parameter, cancellationToken) as IParameterSymbol;
-            if (parameterSymbol == null)
+            if (!(model.GetDeclaredSymbol(parameter, cancellationToken) is IParameterSymbol parameterSymbol))
             {
                 return document;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
@@ -78,8 +78,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                 compilationStartContext.RegisterOperationBlockStartAction(operationBlockContext =>
                 {
-                    var methodSymbol = operationBlockContext.OwningSymbol as IMethodSymbol;
-                    if (methodSymbol == null)
+                    if (!(operationBlockContext.OwningSymbol is IMethodSymbol methodSymbol))
                     {
                         return;
                     }
@@ -97,8 +96,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     operationBlockContext.RegisterOperationAction(operationContext =>
                     {
                         // Get ThrowOperation's ExceptionType
-                        var thrownExceptionType = ((IThrowOperation)operationContext.Operation).Exception?.Type as INamedTypeSymbol;
-                        if (thrownExceptionType != null && thrownExceptionType.DerivesFrom(exceptionType))
+                        if (((IThrowOperation)operationContext.Operation).Exception?.Type is INamedTypeSymbol thrownExceptionType && thrownExceptionType.DerivesFrom(exceptionType))
                         {
                             // If no exceptions are allowed or if the thrown exceptions is not an allowed one..
                             if (methodCategory.AllowedExceptions.IsEmpty || !methodCategory.AllowedExceptions.Any(n => IsAssignableTo(thrownExceptionType, n, compilation)))

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
@@ -219,7 +219,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     }
 
                     shifted++;
-                    current = current >> 1;
+                    current >>= 1;
                 }
             }
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
@@ -42,8 +42,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             SemanticModel model =
                 await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-            INamedTypeSymbol type = model.GetDeclaredSymbol(declaration) as INamedTypeSymbol;
-            if (type == null || type.TypeKind != TypeKind.Class && type.TypeKind != TypeKind.Struct)
+            if (!(model.GetDeclaredSymbol(declaration) is INamedTypeSymbol type) || type.TypeKind != TypeKind.Class && type.TypeKind != TypeKind.Struct)
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.cs
@@ -65,8 +65,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol equatableType)
         {
-            var namedType = context.Symbol as INamedTypeSymbol;
-            if (namedType == null || !(namedType.TypeKind == TypeKind.Struct || namedType.TypeKind == TypeKind.Class))
+            if (!(context.Symbol is INamedTypeSymbol namedType) || !(namedType.TypeKind == TypeKind.Struct || namedType.TypeKind == TypeKind.Class))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
@@ -135,8 +135,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         return;
                     }
 
-                    var disposeInterfaceMethod = disposableType.GetMembers(DisposeMethodName).Single() as IMethodSymbol;
-                    if (disposeInterfaceMethod == null)
+                    if (!(disposableType.GetMembers(DisposeMethodName).Single() is IMethodSymbol disposeInterfaceMethod))
                     {
                         return;
                     }
@@ -147,8 +146,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         return;
                     }
 
-                    var suppressFinalizeMethod = garbageCollectorType.GetMembers(SuppressFinalizeMethodName).Single() as IMethodSymbol;
-                    if (suppressFinalizeMethod == null)
+                    if (!(garbageCollectorType.GetMembers(SuppressFinalizeMethodName).Single() is IMethodSymbol suppressFinalizeMethod))
                     {
                         return;
                     }
@@ -234,8 +232,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             private void AnalyzeOperationBlock(OperationBlockAnalysisContext context)
             {
-                var method = context.OwningSymbol as IMethodSymbol;
-                if (method == null)
+                if (!(context.OwningSymbol is IMethodSymbol method))
                 {
                     return;
                 }
@@ -637,7 +634,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             // Avoid storing per-compilation data into the fields of a diagnostic analyzer.
             // this is actually a bug - https://github.com/dotnet/roslyn-analyzers/issues/845
 #pragma warning disable RS1008
-            private INamedTypeSymbol _type;
+            private readonly INamedTypeSymbol _type;
 #pragma warning restore RS1008
             private bool _callDispose;
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.Fixer.cs
@@ -38,8 +38,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            var methodSymbol = semanticModel.GetDeclaredSymbol(nodeToFix, context.CancellationToken) as IMethodSymbol;
-            if (methodSymbol == null)
+            if (!(semanticModel.GetDeclaredSymbol(nodeToFix, context.CancellationToken) is IMethodSymbol methodSymbol))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.cs
@@ -64,10 +64,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             if (operationBlocks != null && operationBlocks.Length == 1)
             {
-                IBlockOperation block = operationBlocks[0] as IBlockOperation;
 
                 // Analyze IBlockOperation blocks.
-                if (block == null)
+                if (!(operationBlocks[0] is IBlockOperation block))
                 {
                     return true;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             // list of operator alternate names: https://docs.microsoft.com/visualstudio/code-quality/ca2225-operator-overloads-have-named-alternates
 
             // the most common case; create a static method with the already specified types
-            Func<string, ExpectedAlternateMethodGroup> createSingle = methodName => new ExpectedAlternateMethodGroup(methodName);
+            ExpectedAlternateMethodGroup createSingle(string methodName) => new ExpectedAlternateMethodGroup(methodName);
             switch (operatorName)
             {
                 case "op_Addition":

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
@@ -35,8 +35,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
 
             SemanticModel model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-            var typeSymbol = model.GetDeclaredSymbol(declaration) as INamedTypeSymbol;
-            if (typeSymbol == null)
+            if (!(model.GetDeclaredSymbol(declaration) is INamedTypeSymbol typeSymbol))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
@@ -39,8 +39,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
 
             SemanticModel model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-            var typeSymbol = model.GetDeclaredSymbol(declaration) as INamedTypeSymbol;
-            if (typeSymbol == null)
+            if (!(model.GetDeclaredSymbol(declaration) is INamedTypeSymbol typeSymbol))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
@@ -57,8 +57,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         /// </summary>
         private static void AnalyzeSymbol(SymbolAnalysisContext context)
         {
-            var property = context.Symbol as IPropertySymbol;
-            if (property == null)
+            if (!(context.Symbol is IPropertySymbol property))
             {
                 return;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
@@ -44,9 +44,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             analysisContext.RegisterOperationBlockStartAction(context =>
             {
-                var methodSymbol = context.OwningSymbol as IMethodSymbol;
 
-                if (methodSymbol == null ||
+                if (!(context.OwningSymbol is IMethodSymbol methodSymbol) ||
                     methodSymbol.ReturnsVoid ||
                     methodSymbol.ReturnType.Kind == SymbolKind.ArrayType ||
                     methodSymbol.Parameters.Length > 0 ||

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -353,8 +353,6 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 return false;
             }
 
-            ITypeSymbol parameterType = method.Parameters.Single().Type;
-
             return true;
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/DoNotIgnoreMethodResults.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/DoNotIgnoreMethodResults.cs
@@ -137,8 +137,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
                 compilationContext.RegisterOperationBlockStartAction(osContext =>
                 {
-                    var method = osContext.OwningSymbol as IMethodSymbol;
-                    if (method == null)
+                    if (!(osContext.OwningSymbol is IMethodSymbol method))
                     {
                         return;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotCallOverridableMethodsInConstructors.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/DoNotCallOverridableMethodsInConstructors.cs
@@ -76,8 +76,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         {
             // This diagnostic is only relevant in constructors.
             // TODO: should this apply to instance field initializers for VB?
-            var m = symbol as IMethodSymbol;
-            if (m == null || m.MethodKind != MethodKind.Constructor)
+            if (!(symbol is IMethodSymbol m) || m.MethodKind != MethodKind.Constructor)
             {
                 return true;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
@@ -65,8 +65,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
                 compilationContext.RegisterOperationBlockStartAction(blockStartContext =>
                 {
-                    var methodSymbol = blockStartContext.OwningSymbol as IMethodSymbol;
-                    if (methodSymbol == null || !ShouldAnalyze(methodSymbol, blockStartContext.Compilation, skippedAttributes))
+                    if (!(blockStartContext.OwningSymbol is IMethodSymbol methodSymbol) || !ShouldAnalyze(methodSymbol, blockStartContext.Compilation, skippedAttributes))
                     {
                         return;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHaveZeroValueTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHaveZeroValueTests.cs
@@ -149,10 +149,6 @@ public enum E2
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
         public void CSharp_EnumsShouldZeroValueFlagsMultipleZero_Internal()
         {
-            // Remove all members that have the value zero from {0} except for one member that is named 'None'.
-            string expectedMessage1 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsMultipleZeros, "E");
-            string expectedMessage2 = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsMultipleZeros, "E2");
-
             var code = @"// Some comment
 public class Outer
 {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
@@ -162,10 +162,5 @@ End Namespace
 ",
                 GetBasicResultAt(2, 11, IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "Namespace", "Namespace"));
         }
-
-        private DiagnosticResult GetResultNoLocation(DiagnosticDescriptor rule, params object[] messageArguments)
-        {
-            return new DiagnosticResult(rule).WithArguments(messageArguments);
-        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
@@ -1299,18 +1299,6 @@ public class DerivedClass<T> : BaseClass<T>
             GetCA1036CSharpOperatorsResultAt(4, 14, "BaseClass", @"==, !=, <, <=, >, >="));
         }
 
-        private static DiagnosticResult GetCA1036CSharpEqualsResultAt(int line, int column, string typeName)
-        {
-            var message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideMethodsOnComparableTypesMessageEquals, typeName);
-            return GetCSharpResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, message);
-        }
-
-        private static DiagnosticResult GetCA1036BasicEqualsResultAt(int line, int column, string typeName)
-        {
-            var message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideMethodsOnComparableTypesMessageEquals, typeName);
-            return GetBasicResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, message);
-        }
-
         private static DiagnosticResult GetCA1036CSharpOperatorsResultAt(int line, int column, string typeName, string operators)
         {
             var message = string.Format(MicrosoftApiDesignGuidelinesAnalyzersResources.OverrideMethodsOnComparableTypesMessageOperator, typeName, operators);

--- a/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpInitializeStaticFieldsInline.cs
+++ b/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpInitializeStaticFieldsInline.cs
@@ -17,8 +17,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
         protected override bool InitialiesStaticField(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             var assignmentNode = (AssignmentExpressionSyntax)node;
-            var leftSymbol = semanticModel.GetSymbolInfo(assignmentNode.Left, cancellationToken).Symbol as IFieldSymbol;
-            return leftSymbol != null && leftSymbol.IsStatic;
+            return semanticModel.GetSymbolInfo(assignmentNode.Left, cancellationToken).Symbol is IFieldSymbol leftSymbol && leftSymbol.IsStatic;
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpTestForNaNCorrectly.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpTestForNaNCorrectly.Fixer.cs
@@ -17,8 +17,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
     {
         protected override SyntaxNode GetBinaryExpression(SyntaxNode node)
         {
-            var argumentSyntax = node as ArgumentSyntax;
-            return argumentSyntax != null ? argumentSyntax.Expression : node;
+            return node is ArgumentSyntax argumentSyntax ? argumentSyntax.Expression : node;
         }
 
         protected override bool IsEqualsOperator(SyntaxNode node)

--- a/src/Microsoft.NetCore.Analyzers/Core/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
@@ -108,8 +108,7 @@ namespace Microsoft.NetCore.Analyzers.Resources
                 return false;
             }
 
-            var stringValue = constValue.Value as string;
-            if (stringValue == null)
+            if (!(constValue.Value is string stringValue))
             {
                 return false;
             }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/CallGCSuppressFinalizeCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/CallGCSuppressFinalizeCorrectly.cs
@@ -160,8 +160,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         return;
                     }
 
-                    var parameterSymbol = _semanticModel.GetSymbolInfo(invocationExpression.Arguments.Single().Value.Syntax).Symbol as IParameterSymbol;
-                    if (parameterSymbol == null || !parameterSymbol.IsThis)
+                    if (!(_semanticModel.GetSymbolInfo(invocationExpression.Arguments.Single().Value.Syntax).Symbol is IParameterSymbol parameterSymbol) || !parameterSymbol.IsThis)
                     {
                         analysisContext.ReportDiagnostic(invocationExpression.Syntax.CreateDiagnostic(
                             NotPassedThisRule,

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableTypesShouldDeclareFinalizer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableTypesShouldDeclareFinalizer.cs
@@ -71,8 +71,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                             }
 
                             var fieldReference = (IFieldReferenceOperation)target;
-                            var field = fieldReference.Member as IFieldSymbol;
-                            if (field == null || field.Kind != SymbolKind.Field || field.IsStatic)
+                            if (!(fieldReference.Member is IFieldSymbol field) || field.Kind != SymbolKind.Field || field.IsStatic)
                             {
                                 return;
                             }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
@@ -66,8 +66,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             switch (type.TypeKind)
             {
                 case TypeKind.Array:
-                    var arrayType = type as IArrayTypeSymbol;
-                    return arrayType != null && IsPrimitiveType(arrayType.ElementType);
+                    return type is IArrayTypeSymbol arrayType && IsPrimitiveType(arrayType.ElementType);
                 case TypeKind.Class:
                 case TypeKind.TypeParameter:
                     INamedTypeSymbol marshalByRefObjectTypeSymbol = compilation.GetTypeByMetadataName("System.MarshalByRefObject");

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotRaiseReservedExceptionTypes.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotRaiseReservedExceptionTypes.cs
@@ -133,9 +133,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             var objectCreationNode = (TObjectCreationExpressionSyntax)context.Node;
             SyntaxNode targetType = GetTypeSyntaxNode(objectCreationNode);
 
-            var typeSymbol = context.SemanticModel.GetSymbolInfo(targetType).Symbol as INamedTypeSymbol;
             // GetSymbolInfo().Symbol might return an error type symbol 
-            if (typeSymbol == null)
+            if (!(context.SemanticModel.GetSymbolInfo(targetType).Symbol is INamedTypeSymbol typeSymbol))
             {
                 return;
             }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/InitializeStaticFieldsInline.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/InitializeStaticFieldsInline.cs
@@ -57,8 +57,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             analysisContext.RegisterCodeBlockStartAction<TLanguageKindEnum>(codeBlockStartContext =>
             {
-                var methodSym = codeBlockStartContext.OwningSymbol as IMethodSymbol;
-                if (methodSym == null ||
+                if (!(codeBlockStartContext.OwningSymbol is IMethodSymbol methodSym) ||
                     !methodSym.IsStatic ||
                     methodSym.MethodKind != MethodKind.SharedConstructor)
                 {

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithms.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithms.cs
@@ -117,9 +117,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                 SyntaxNode node = context.Node;
                 SemanticModel model = context.SemanticModel;
                 ISymbol symbol = node.GetDeclaredOrReferencedSymbol(model);
-                IMethodSymbol method = symbol as IMethodSymbol;
 
-                if (method == null)
+                if (!(symbol is IMethodSymbol method))
                 {
                     return;
                 }

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
@@ -206,9 +206,8 @@ namespace Microsoft.NetFramework.Analyzers
 
             private void AnalyzeInvocation(OperationAnalysisContext context)
             {
-                IInvocationOperation invocationExpression = context.Operation as IInvocationOperation;
 
-                if (invocationExpression == null)
+                if (!(context.Operation is IInvocationOperation invocationExpression))
                 {
                     return;
                 }
@@ -261,7 +260,6 @@ namespace Microsoft.NetFramework.Analyzers
                             && method.Parameters[0].Type.SpecialType == SpecialType.System_String)
                         {
                             // inputUri can load be a URL.  Should further investigate if this is worth flagging.
-                            DiagnosticDescriptor rule = RuleDoNotUseInsecureDtdProcessing;
                             Diagnostic diag = Diagnostic.Create(
                                     RuleDoNotUseInsecureDtdProcessing,
                                     expressionSyntax.GetLocation(),
@@ -329,14 +327,12 @@ namespace Microsoft.NetFramework.Analyzers
 
             private void AnalyzeFieldDeclaration(OperationAnalysisContext context)
             {
-                var assign = context.Operation as IAssignmentOperation;
-                if (assign == null)
+                if (!(context.Operation is IAssignmentOperation assign))
                 {
                     return;
                 }
 
-                IFieldSymbol field = context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree)?.GetSymbolInfo(assign.Target.Syntax).Symbol as IFieldSymbol;
-                if (field == null)
+                if (!(context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree)?.GetSymbolInfo(assign.Target.Syntax).Symbol is IFieldSymbol field))
                 {
                     return;
                 }
@@ -346,9 +342,8 @@ namespace Microsoft.NetFramework.Analyzers
 
             private void AnalyzeObjectCreationInternal(OperationAnalysisContext context, ISymbol variable, IOperation valueOpt)
             {
-                IObjectCreationOperation objCreation = valueOpt as IObjectCreationOperation;
 
-                if (objCreation == null)
+                if (!(valueOpt is IObjectCreationOperation objCreation))
                 {
                     return;
                 }
@@ -382,9 +377,7 @@ namespace Microsoft.NetFramework.Analyzers
 
             private void AnalyzeObjectCreationForXmlDocument(OperationAnalysisContext context, ISymbol variable, IObjectCreationOperation objCreation)
             {
-                XmlDocumentEnvironment xmlDocumentEnvironment;
-
-                if (variable == null || !_xmlDocumentEnvironments.TryGetValue(variable, out xmlDocumentEnvironment))
+                if (variable == null || !_xmlDocumentEnvironments.TryGetValue(variable, out var xmlDocumentEnvironment))
                 {
                     xmlDocumentEnvironment = new XmlDocumentEnvironment
                     {
@@ -411,17 +404,15 @@ namespace Microsoft.NetFramework.Analyzers
                         if (init is IAssignmentOperation assign)
                         {
                             var propValue = assign.Value;
-                            IPropertySymbol prop = context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree)?.GetSymbolInfo(assign.Target.Syntax).Symbol as IPropertySymbol;
-                            if (prop == null)
+                            if (!(context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree)?.GetSymbolInfo(assign.Target.Syntax).Symbol is IPropertySymbol prop))
                             {
                                 continue;
                             }
 
                             if (prop.MatchPropertyDerivedByName(_xmlTypes.XmlDocument, "XmlResolver"))
                             {
-                                IConversionOperation operation = propValue as IConversionOperation;
 
-                                if (operation == null)
+                                if (!(propValue is IConversionOperation operation))
                                 {
                                     return;
                                 }
@@ -486,8 +477,7 @@ namespace Microsoft.NetFramework.Analyzers
                         if (init is IAssignmentOperation assign)
                         {
                             var propValue = assign.Value;
-                            IPropertySymbol prop = context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree)?.GetSymbolInfo(assign.Target.Syntax).Symbol as IPropertySymbol;
-                            if (prop == null)
+                            if (!(context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree)?.GetSymbolInfo(assign.Target.Syntax).Symbol is IPropertySymbol prop))
                             {
                                 continue;
                             }
@@ -569,8 +559,7 @@ namespace Microsoft.NetFramework.Analyzers
                         if (init is IAssignmentOperation assign)
                         {
                             var propValue = assign.Value;
-                            IPropertySymbol prop = context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree)?.GetSymbolInfo(assign.Target.Syntax).Symbol as IPropertySymbol;
-                            if (prop == null)
+                            if (!(context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree)?.GetSymbolInfo(assign.Target.Syntax).Symbol is IPropertySymbol prop))
                             {
                                 continue;
                             }
@@ -580,9 +569,8 @@ namespace Microsoft.NetFramework.Analyzers
                                     _xmlTypes)
                                 )
                             {
-                                IConversionOperation operation = propValue as IConversionOperation;
 
-                                if (operation == null)
+                                if (!(propValue is IConversionOperation operation))
                                 {
                                     return;
                                 }
@@ -704,9 +692,8 @@ namespace Microsoft.NetFramework.Analyzers
                 }
 
                 SemanticModel model = context.Compilation.GetSemanticModel(expression.Syntax.SyntaxTree);
-                var propRef = expression.Target as IPropertyReferenceOperation;
 
-                if (propRef == null) // A variable/field assignment
+                if (!(expression.Target is IPropertyReferenceOperation propRef)) // A variable/field assignment
                 {
                     ISymbol symbolAssignedTo = expression.Target.Syntax.GetDeclaredOrReferencedSymbol(model);
 

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessingInApiDesign.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessingInApiDesign.cs
@@ -119,9 +119,8 @@ namespace Microsoft.NetFramework.Analyzers
                 SyntaxNode node = context.Node;
                 SemanticModel model = context.SemanticModel;
 
-                IMethodSymbol methodSymbol = SyntaxNodeHelper.GetDeclaredSymbol(node, model) as IMethodSymbol;
 
-                if (methodSymbol == null ||
+                if (!(SyntaxNodeHelper.GetDeclaredSymbol(node, model) is IMethodSymbol methodSymbol) ||
                     methodSymbol.MethodKind != MethodKind.Constructor ||
                     !((methodSymbol.ContainingType != _xmlTypes.XmlDocument) && methodSymbol.ContainingType.DerivesFrom(_xmlTypes.XmlDocument, baseTypesOnly: true)))
                 {
@@ -173,9 +172,8 @@ namespace Microsoft.NetFramework.Analyzers
                 SyntaxNode node = context.Node;
                 SemanticModel model = context.SemanticModel;
 
-                IMethodSymbol methodSymbol = SyntaxNodeHelper.GetDeclaredSymbol(node, model) as IMethodSymbol;
 
-                if (methodSymbol == null ||
+                if (!(SyntaxNodeHelper.GetDeclaredSymbol(node, model) is IMethodSymbol methodSymbol) ||
                     // skip constructors since we report on the absence of secure assignment in AnalyzeNodeForXmlDocumentDerivedTypeConstructorDecl
                     methodSymbol.MethodKind == MethodKind.Constructor ||
                     !((methodSymbol.ContainingType != _xmlTypes.XmlDocument) && methodSymbol.ContainingType.DerivesFrom(_xmlTypes.XmlDocument, baseTypesOnly: true)))
@@ -221,9 +219,8 @@ namespace Microsoft.NetFramework.Analyzers
                 SyntaxNode node = context.Node;
                 SemanticModel model = context.SemanticModel;
 
-                IMethodSymbol methodSymbol = SyntaxNodeHelper.GetDeclaredSymbol(node, model) as IMethodSymbol;
 
-                if (methodSymbol == null ||
+                if (!(SyntaxNodeHelper.GetDeclaredSymbol(node, model) is IMethodSymbol methodSymbol) ||
                     methodSymbol.MethodKind != MethodKind.Constructor ||
                     !((methodSymbol.ContainingType != _xmlTypes.XmlTextReader) && methodSymbol.ContainingType.DerivesFrom(_xmlTypes.XmlTextReader, baseTypesOnly: true)))
                 {
@@ -292,9 +289,8 @@ namespace Microsoft.NetFramework.Analyzers
                 SyntaxNode node = context.Node;
                 SemanticModel model = context.SemanticModel;
 
-                IMethodSymbol methodSymbol = SyntaxNodeHelper.GetDeclaredSymbol(node, model) as IMethodSymbol;
 
-                if (methodSymbol == null ||
+                if (!(SyntaxNodeHelper.GetDeclaredSymbol(node, model) is IMethodSymbol methodSymbol) ||
                    !((methodSymbol.ContainingType != _xmlTypes.XmlTextReader) && methodSymbol.ContainingType.DerivesFrom(_xmlTypes.XmlTextReader, baseTypesOnly: true)))
                 {
                     return;

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
@@ -269,8 +269,6 @@ namespace Microsoft.NetFramework.Analyzers
                             _xsltSettingsEnvironments[lhsExpressionSymbol] = env;
                         }
 
-                        ITypeSymbol rhsType = model.GetTypeInfo(rhs).Type;
-
                         if (isXlstSettingsEnableDocumentFunctionProperty)
                         {
                             env.IsDocumentFunctionDisabled = SyntaxNodeHelper.NodeHasConstantValueBoolFalse(rhs, model);

--- a/src/Microsoft.NetFramework.Analyzers/Core/Helpers/SecurityDiagnosticHelpers.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/Helpers/SecurityDiagnosticHelpers.cs
@@ -149,21 +149,18 @@ namespace Microsoft.NetFramework.Analyzers.Helpers
 
         public static bool IsExpressionEqualsNull(IOperation operation)
         {
-            ILiteralOperation literal = operation as ILiteralOperation;
-            return literal != null && literal.HasNullConstantValue();
+            return operation is ILiteralOperation literal && literal.HasNullConstantValue();
         }
 
         public static bool IsExpressionEqualsDtdProcessingParse(IOperation operation)
         {
-            IFieldReferenceOperation enumRef = operation as IFieldReferenceOperation;
-            return enumRef != null && enumRef.HasConstantValue(2); // DtdProcessing.Parse
+            return operation is IFieldReferenceOperation enumRef && enumRef.HasConstantValue(2); // DtdProcessing.Parse
         }
 
         public static bool IsExpressionEqualsIntZero(IOperation operation)
         {
-            ILiteralOperation literal = operation as ILiteralOperation;
 
-            if (literal == null || !literal.ConstantValue.HasValue)
+            if (!(operation is ILiteralOperation literal) || !literal.ConstantValue.HasValue)
             {
                 return false;
             }

--- a/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.MvcAttributeSymbols.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.MvcAttributeSymbols.cs
@@ -98,9 +98,7 @@ namespace Microsoft.NetFramework.Analyzers
 
                                     foreach (TypedConstant tc in a.ConstructorArguments[0].Values)
                                     {
-                                        string s = tc.Value as string;
-                                        MvcHttpVerbs v;
-                                        if (s != null && Enum.TryParse(s, true /* ignoreCase */, out v))
+                                        if (tc.Value is string s && Enum.TryParse(s, true /* ignoreCase */, out MvcHttpVerbs v))
                                         {
                                             verbs |= v;
                                         }

--- a/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.cs
@@ -115,9 +115,8 @@ namespace Microsoft.NetFramework.Analyzers
                         (SymbolAnalysisContext symbolContext) =>
                         {
                             // TODO enhancements: Consider looking at non-ActionResult-derived return types as well.
-                            IMethodSymbol methodSymbol = symbolContext.Symbol as IMethodSymbol;
-                            if (methodSymbol == null
-                                || methodSymbol.MethodKind != MethodKind.Ordinary 
+                            if (!(symbolContext.Symbol is IMethodSymbol methodSymbol)
+                                || methodSymbol.MethodKind != MethodKind.Ordinary
                                 || methodSymbol.IsStatic
                                 || !methodSymbol.IsPublic()
                                 || !methodSymbol.ReturnType.Inherits(actionResultSymbol)  // FxCop implementation only looks at ActionResult-derived return types.
@@ -128,10 +127,7 @@ namespace Microsoft.NetFramework.Analyzers
                             }
 
                             ImmutableArray<AttributeData> methodAttributes = methodSymbol.GetAttributes();
-                            MvcHttpVerbs verbs;
-                            bool isAntiforgeryTokenDefined;
-                            bool isAction;
-                            mvcAttributeSymbols.ComputeAttributeInfo(methodAttributes, out verbs, out isAntiforgeryTokenDefined, out isAction);
+                            mvcAttributeSymbols.ComputeAttributeInfo(methodAttributes, out var verbs, out var isAntiforgeryTokenDefined, out var isAction);
 
                             if (!isAction)
                             {

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseGenericCodeActionCreateToCreateCodeAction.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseGenericCodeActionCreateToCreateCodeAction.cs
@@ -41,8 +41,7 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
 
             public void AnalyzeNode(SyntaxNodeAnalysisContext context)
             {
-                var invocation = context.Node as InvocationExpressionSyntax;
-                if (invocation == null)
+                if (!(context.Node is InvocationExpressionSyntax invocation))
                 {
                     return;
                 }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIAnalyzer.Impl.cs
@@ -446,9 +446,7 @@ namespace Roslyn.Diagnostics.Analyzers
                             if (attribute.AttributeConstructor.Parameters.Length == 1 &&
                                 attribute.ConstructorArguments.Length == 1)
                             {
-                                var forwardedType = attribute.ConstructorArguments[0].Value as INamedTypeSymbol;
-
-                                if (forwardedType != null)
+                                if (attribute.ConstructorArguments[0].Value is INamedTypeSymbol forwardedType)
                                 {
                                     VisitForwardedTypeRecursively(forwardedType, reportDiagnostic, attribute.ApplicationSyntaxReference.GetSyntax(cancellationToken).GetLocation(), cancellationToken);
                                 }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
@@ -77,8 +77,7 @@ namespace Roslyn.Diagnostics.Analyzers
                         return;
                     }
 
-                    var genericEmptyEnumerableSymbol = linqEnumerableSymbol.GetMembers(EmptyMethodName).FirstOrDefault() as IMethodSymbol;
-                    if (genericEmptyEnumerableSymbol == null ||
+                    if (!(linqEnumerableSymbol.GetMembers(EmptyMethodName).FirstOrDefault() is IMethodSymbol genericEmptyEnumerableSymbol) ||
                         genericEmptyEnumerableSymbol.Arity != 1 ||
                         genericEmptyEnumerableSymbol.Parameters.Length != 0)
                     {
@@ -130,11 +129,10 @@ namespace Roslyn.Diagnostics.Analyzers
             protected bool ShouldAnalyzeArrayCreationExpression(SyntaxNode expression, SemanticModel semanticModel)
             {
                 TypeInfo typeInfo = semanticModel.GetTypeInfo(expression);
-                var arrayType = typeInfo.Type as IArrayTypeSymbol;
 
                 return typeInfo.ConvertedType != null &&
                     typeInfo.ConvertedType.OriginalDefinition == GenericEnumerableSymbol &&
-                    arrayType != null &&
+                    typeInfo.Type is IArrayTypeSymbol arrayType &&
                     arrayType.Rank == 1;
             }
 

--- a/src/Test.Utilities/CodeFixTestBase.cs
+++ b/src/Test.Utilities/CodeFixTestBase.cs
@@ -67,7 +67,7 @@ namespace Test.Utilities
             Solution newSolution;
             if (onlyFixFirstFixableDiagnostic || codeFixIndex.HasValue)
             {
-                newSolution = runner.ApplySingleFix(project, ImmutableArray<TestAdditionalDocument>.Empty, codeFixIndex.HasValue ? codeFixIndex.Value : 0, fixableDiagnosticIndex: 0);
+                newSolution = runner.ApplySingleFix(project, ImmutableArray<TestAdditionalDocument>.Empty, codeFixIndex ?? 0, fixableDiagnosticIndex: 0);
             }
             else
             {
@@ -119,14 +119,13 @@ namespace Test.Utilities
                 document = project.GetDocument(document.Id);
             }
 
-            var additionalFileName = newAdditionalFileToVerify.Name;
             var additionalFileText = newAdditionalFileToVerify.GetText().ToString();
 
             Solution newSolution;
             var runner = new CodeFixRunner(analyzerOpt, codeFixProvider, validationMode);
             if (onlyFixFirstFixableDiagnostic || codeFixIndex.HasValue)
             {
-                newSolution = runner.ApplySingleFix(document.Project, additionalFiles, codeFixIndex.HasValue ? codeFixIndex.Value : 0, fixableDiagnosticIndex: 0);
+                newSolution = runner.ApplySingleFix(document.Project, additionalFiles, codeFixIndex ?? 0, fixableDiagnosticIndex: 0);
             }
             else
             {

--- a/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
@@ -351,7 +351,7 @@ namespace Test.Utilities
 
             for (int i = 0; i < sources.Length; i++)
             {
-                MarkupTestFile.GetPositionAndSpan(sources[i].Source, out string source, out int? pos, out TextSpan? span);
+                MarkupTestFile.GetPositionAndSpan(sources[i].Source, out string source, out _, out TextSpan? span);
 
                 sources[i].Source = source;
                 spans[i] = span;

--- a/src/Test.Utilities/MarkupTestFile.cs
+++ b/src/Test.Utilities/MarkupTestFile.cs
@@ -215,7 +215,7 @@ namespace Test.Utilities
 
         public static void GetSpans(string input, out string output, out IDictionary<string, IList<TextSpan>> spans)
         {
-            GetPositionAndSpans(input, out output, out int? cursorPositionOpt, out spans);
+            GetPositionAndSpans(input, out output, out _, out spans);
         }
 
         public static void GetPositionAndSpans(string input, out string output, out int cursorPosition, out IList<TextSpan> spans)
@@ -227,7 +227,7 @@ namespace Test.Utilities
 
         public static void GetPosition(string input, out string output, out int cursorPosition)
         {
-            GetPositionAndSpans(input, out output, out cursorPosition, out IList<TextSpan> spans);
+            GetPositionAndSpans(input, out output, out cursorPosition, out _);
         }
 
         public static void GetPositionAndSpan(string input, out string output, out int? cursorPosition, out TextSpan? textSpan)
@@ -246,7 +246,7 @@ namespace Test.Utilities
 
         public static void GetSpans(string input, out string output, out IList<TextSpan> spans)
         {
-            GetPositionAndSpans(input, out output, out int? pos, out spans);
+            GetPositionAndSpans(input, out output, out int? _, out spans);
         }
 
         public static void GetSpan(string input, out string output, out TextSpan textSpan)

--- a/src/Test.Utilities/WorkItemAttribute.cs
+++ b/src/Test.Utilities/WorkItemAttribute.cs
@@ -7,13 +7,10 @@ namespace Test.Utilities
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
     public class WorkItemAttribute : Attribute
     {
-        private readonly int _id;
-        private readonly string _source;
-
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable CA1801 // Remove unused parameter
         public WorkItemAttribute(int id, string source)
         {
-            _id = id;
-            _source = source;
         }
     }
 }

--- a/src/Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -143,9 +143,8 @@ namespace Analyzer.Utilities.Extensions
         public static bool IsImplementationOfInterfaceMethod(this IMethodSymbol method, ITypeSymbol typeArgument, INamedTypeSymbol interfaceType, string interfaceMethodName)
         {
             INamedTypeSymbol constructedInterface = typeArgument != null ? interfaceType?.Construct(typeArgument) : interfaceType;
-            var interfaceMethod = constructedInterface?.GetMembers(interfaceMethodName).Single() as IMethodSymbol;
 
-            return interfaceMethod != null && method.Equals(method.ContainingType.FindImplementationForInterfaceMember(interfaceMethod));
+            return constructedInterface?.GetMembers(interfaceMethodName).Single() is IMethodSymbol interfaceMethod && method.Equals(method.ContainingType.FindImplementationForInterfaceMember(interfaceMethod));
         }
 
         /// <summary>

--- a/src/Utilities/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Extensions/IOperationExtensions.cs
@@ -248,8 +248,7 @@ namespace Analyzer.Utilities.Extensions
 
         public static IConditionalAccessOperation GetConditionalAccess(this IConditionalAccessInstanceOperation operation)
         {
-            Func<IConditionalAccessOperation, bool> predicate = c => c.Operation.Syntax == operation.Syntax;
-            return operation.GetAncestor(OperationKind.ConditionalAccess, predicate);
+            return operation.GetAncestor(OperationKind.ConditionalAccess, (IConditionalAccessOperation c) => c.Operation.Syntax == operation.Syntax);
         }
 
         /// <summary>
@@ -337,8 +336,7 @@ namespace Analyzer.Utilities.Extensions
                 operation.Property.ContainingType.IsAnonymousType)
             {
                 var declarationSyntax = operation.Property.ContainingType.DeclaringSyntaxReferences[0].GetSyntax();
-                Func<IAnonymousObjectCreationOperation, bool> predicate = a => a.Syntax == declarationSyntax;
-                return operation.GetAncestor(OperationKind.AnonymousObjectCreation, predicate);
+                return operation.GetAncestor(OperationKind.AnonymousObjectCreation, (IAnonymousObjectCreationOperation a) => a.Syntax == declarationSyntax);
             }
 
             return null;

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -15,8 +15,7 @@ namespace Analyzer.Utilities.Extensions
     {
         public static bool IsType(this ISymbol symbol)
         {
-            var typeSymbol = symbol as ITypeSymbol;
-            return typeSymbol != null && typeSymbol.IsType;
+            return symbol is ITypeSymbol typeSymbol && typeSymbol.IsType;
         }
 
         public static bool IsAccessorMethod(this ISymbol symbol)

--- a/src/Utilities/Options/CategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Options/CategorizedAnalyzerConfigOptions.cs
@@ -128,7 +128,9 @@ namespace Analyzer.Utilities
             return defaultValue;
 
             // Local functions.
+#pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/32973
             bool TryGetSpecificOptionValue(string specificOptionKey, out T specificOptionValue)
+#pragma warning restore IDE0060 // Remove unused parameter
             {
                 if (SpecificOptions.TryGetValue(specificOptionKey, out var specificRuleOptions) &&
                     specificRuleOptions.TryGetValue(optionName, out var valueString))
@@ -140,7 +142,9 @@ namespace Analyzer.Utilities
                 return false;
             }
 
+#pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/32973
             bool TryGetGeneralOptionValue(out T generalOptionValue)
+#pragma warning restore IDE0060 // Remove unused parameter
             {
                 if (GeneralOptions.TryGetValue(optionName, out var valueString))
                 {


### PR DESCRIPTION
Also added stronger configuration for some IDE code quality rules (though they still won't break CI but will show up  as errors in errorlist and produce squiggles), suppress certain rules for some projects and also make certain rules silent.

After this change, there should be no messages from IDE diagnostics in the error list for RoslynAnalyzers.sln.