### PR TITLE
Enable IDE0055 (formatting analyzer) with CodeStyle NuGet package in VS IDE and CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,11 @@
     <LangVersion Condition="'$(Language)' == 'VB'">15.5</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- We generate per-project assembly attributes files, so we can safely delete them when cleaning the project -->
+    <TargetFrameworkMonikerAssemblyAttributesFileClean>true</TargetFrameworkMonikerAssemblyAttributesFileClean>
+  </PropertyGroup>
+
   <!-- Workaround to enable .editorconfig based analyzer configuration until dotnet compilers support .editorconfig based configuration -->
   <PropertyGroup>
     <SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>

--- a/eng/Analyzers_NonShippingRules_Build.ruleset
+++ b/eng/Analyzers_NonShippingRules_Build.ruleset
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Common diagnostic rules for all Roslyn Analyzer projects"
+         Description="This file contains diagnostic settings used by all Roslyn Analyzer projects. Projects that need specific settings should have their own rule set files that Include this one, and then make the necessary adjustments." 
+         ToolsVersion="14.0">
+  <Include Path=".\Analyzers_NonShippingRules.ruleset" Action="Default" />
+  
+  <!-- Bump up formatting diagnostic to a Warning during build -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
+    <Rule Id="IDE0055" Action="Warning" /> <!-- Formatting -->
+  </Rules>
+</RuleSet>

--- a/eng/Analyzers_ShippingRules.ruleset
+++ b/eng/Analyzers_ShippingRules.ruleset
@@ -24,6 +24,10 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
     <Rule Id="IDE0051" Action="Warning" /> <!-- Remove unused private members -->
     <Rule Id="IDE0052" Action="Warning" /> <!-- Remove unread private members -->
+    
+    <!-- Fix Formatting - default to Info severity for typing.
+         Overridden to Warning severity in build-only ruleset. -->
+    <Rule Id="IDE0055" Action="Info" />
   </Rules>
 
 </RuleSet>

--- a/eng/Analyzers_ShippingRules_Build.ruleset
+++ b/eng/Analyzers_ShippingRules_Build.ruleset
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Common diagnostic rules for all Roslyn Analyzer projects"
+         Description="This file contains diagnostic settings used by all Roslyn Analyzer projects. Projects that need specific settings should have their own rule set files that Include this one, and then make the necessary adjustments." 
+         ToolsVersion="14.0">
+  <Include Path=".\Analyzers_ShippingRules.ruleset" Action="Default" />
+  
+  <!-- Bump up formatting diagnostic to a Warning during build -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
+    <Rule Id="IDE0055" Action="Warning" /> <!-- Formatting -->
+  </Rules>
+</RuleSet>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,9 +19,10 @@
 
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>2.6.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftNetCompilersVersion>2.6.0</MicrosoftNetCompilersVersion>
+    <MicrosoftNetCompilersVersion>2.11.0-beta1-final</MicrosoftNetCompilersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyersVersion>2.6.4-beta1.19067.1+c6049bf9</MicrosoftCodeAnalysisFXCopAnalyersVersion>
     <MicrosoftCodeAnalysisAnalyersVersion>2.6.4-beta1.19067.1+c6049bf9</MicrosoftCodeAnalysisAnalyersVersion>
+    <CodeStyleAnalyersVersion>2.11.0-beta2-63603-03</CodeStyleAnalyersVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
 
     <!-- Roslyn Testing -->

--- a/eng/common/CIBuild.cmd
+++ b/eng/common/CIBuild.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -rebuild -test -sign -pack -publish -ci %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -build -test -sign -pack -publish -ci %*"
 exit /b %ErrorLevel%

--- a/eng/common/CIBuild.cmd
+++ b/eng/common/CIBuild.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -build -test -sign -pack -publish -ci %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -rebuild -test -sign -pack -publish -ci %*"
 exit /b %ErrorLevel%

--- a/eng/common/cibuild.sh
+++ b/eng/common/cibuild.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-. "$scriptroot/build.sh" --restore --rebuild --test --pack --publish --ci $@
+. "$scriptroot/build.sh" --restore --build --test --pack --publish --ci $@

--- a/eng/common/cibuild.sh
+++ b/eng/common/cibuild.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-. "$scriptroot/build.sh" --restore --build --test --pack --publish --ci $@
+. "$scriptroot/build.sh" --restore --rebuild --test --pack --publish --ci $@

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,7 +22,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(CodeStyleAnalyersVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Language)' == 'VB'">
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(CodeStyleAnalyersVersion)" />
+    <!-- https://github.com/dotnet/roslyn-analyzers/issues/2095 tracks uncommenting the below -->
+    <!-- <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(CodeStyleAnalyersVersion)" /> -->
   </ItemGroup>
 
   <!-- Setup the correct code analysis rulesets -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,9 +17,43 @@
     <None Include="$(MSBuildThisFileDirectory)Common\Test\App.config" CopyToOutputDirectory="PreserveNewest" Condition="'$(IsUnitTestProject)' == 'true'" />
   </ItemGroup>
 
+  <!-- Code Style analyzers -->
+  <ItemGroup Condition="'$(Language)' == 'C#'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(CodeStyleAnalyersVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Language)' == 'VB'">
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(CodeStyleAnalyersVersion)" />
+  </ItemGroup>
+
   <!-- Setup the correct code analysis rulesets -->
-  <PropertyGroup>
-    <CodeAnalysisRuleSet Condition="'$(IsTestProject)' == 'true' or '$(NonShipping)' == 'true'">$(MSBuildThisFileDirectory)..\eng\Analyzers_NonShippingRules.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)' == ''">$(MSBuildThisFileDirectory)..\eng\Analyzers_ShippingRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(IsTestProject)' == 'true' or '$(NonShipping)' == 'true'">
+      <Choose>
+        <When Condition="'$(DesignTimeBuild)' == 'true'">
+          <PropertyGroup>
+            <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\eng\Analyzers_NonShippingRules.ruleset</CodeAnalysisRuleSet>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\eng\Analyzers_NonShippingRules_Build.ruleset</CodeAnalysisRuleSet>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
+    </When>
+    <Otherwise>
+      <Choose>
+        <When Condition="'$(DesignTimeBuild)' == 'true'">
+          <PropertyGroup>
+            <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\eng\Analyzers_ShippingRules.ruleset</CodeAnalysisRuleSet>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\eng\Analyzers_ShippingRules_Build.ruleset</CodeAnalysisRuleSet>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
+++ b/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
@@ -2281,7 +2281,7 @@ namespace MetaCompilation.Analyzers
                 var arguments = new ArgumentSyntax[6];
                 string whitespace = "            ";
                 SyntaxNode id = idName != ""
-                    ? generator.LiteralExpression(idName) 
+                    ? generator.LiteralExpression(idName)
                     : generator.IdentifierName("").WithTrailingTrivia(SyntaxFactory.ParseTrailingTrivia("/* The ID here should be the public constant declared above */"));
 
                 var idArg = generator.Argument("id", RefKind.None, id).WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.Whitespace(whitespace)) as ArgumentSyntax;

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
         {
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             var generator = editor.Generator;
-            
+
             var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var typeIsSealed = ((INamedTypeSymbol)model.GetDeclaredSymbol(classDecl)).IsSealed;
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
@@ -88,7 +88,7 @@ public class MyDerivedCodeActionWithEquivalenceKey : MyAbstractCodeActionWithEqu
             VerifyCSharp(source + fixAllProviderString + sourceSuffix, validationMode, expected);
 
             // Verify RS1016 (OverrideGetFixAllProviderRule) diagnostic for fixer that does not support FixAllProvider.
-            expected = new DiagnosticResult[]{ missingGetFixAllProviderOverrideDiagnostic };
+            expected = new DiagnosticResult[] { missingGetFixAllProviderOverrideDiagnostic };
             VerifyCSharp(source + sourceSuffix, validationMode, expected);
         }
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzerTests.cs
@@ -41,7 +41,7 @@ class MyAnalyzer : DiagnosticAnalyzer
     {
     }
 }";
-            DiagnosticResult[] expected = new[] { GetCSharpRS1007ExpectedDiagnostic(11, 9), GetCSharpRS1015ExpectedDiagnostic(11, 9)};
+            DiagnosticResult[] expected = new[] { GetCSharpRS1007ExpectedDiagnostic(11, 9), GetCSharpRS1015ExpectedDiagnostic(11, 9) };
             VerifyCSharp(source, expected);
         }
 
@@ -104,7 +104,7 @@ class MyAnalyzer : DiagnosticAnalyzer
     }
 }";
             DiagnosticResult[] expected = new[] {
-                GetCSharpRS1007ExpectedDiagnostic(11, 9), 
+                GetCSharpRS1007ExpectedDiagnostic(11, 9),
                 GetCSharpRS1015ExpectedDiagnostic(11, 118),
                 GetCSharpRS1007ExpectedDiagnostic(14, 9),
                 GetCSharpRS1015ExpectedDiagnostic(14, 9)

--- a/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Microsoft.CodeQuality.Analyzers.Exp.csproj
+++ b/src/Microsoft.CodeQuality.Analyzers.Exp/Core/Microsoft.CodeQuality.Analyzers.Exp.csproj
@@ -7,7 +7,7 @@
       Restore would conclude that there is a cyclic dependency between us and the Microsoft.CodeQuality.Analyzers nuget package.
     -->
     <PackageId>*$(MSBuildProjectFullPath)*</PackageId>
-    <NoWarn>$(NoWarn);IDE0018;IDE0019;IDE0059;IDE0060</NoWarn>
+    <NoWarn>$(NoWarn);IDE0018;IDE0019;IDE0055;IDE0059;IDE0060</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeQuality.CSharp.Analyzers.Exp" />

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 return;
             }
-            
+
             // exclude Immutable collections
             // see https://github.com/dotnet/roslyn-analyzers/issues/1900 for details
             if (!immutableInterfaces.IsEmpty &&

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFields.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 // Additionally, by default only report externally visible fields for FxCop compat.
                 if (!field.IsStatic &&
                     !field.IsConst &&
-                    field.DeclaredAccessibility != Accessibility.Private && 
+                    field.DeclaredAccessibility != Accessibility.Private &&
                     field.MatchesConfiguredVisibility(symbolAnalysisContext.Options, Rule, symbolAnalysisContext.CancellationToken))
                 {
                     symbolAnalysisContext.ReportDiagnostic(field.CreateDiagnostic(Rule));

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         public override void Initialize(AnalysisContext analysisContext)
         {
             if (!CultureInfo.CurrentCulture.Name.Equals("en", StringComparison.Ordinal) &&
-				!CultureInfo.CurrentCulture.Parent.Name.Equals("en", StringComparison.Ordinal))
+                !CultureInfo.CurrentCulture.Parent.Name.Equals("en", StringComparison.Ordinal))
             {
                 // FxCop compat: Skip for non-English cultures.
                 return;

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHaveZeroValue.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHaveZeroValue.Fixer.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             ISymbol declaredSymbol = model.GetDeclaredSymbol(node, context.CancellationToken);
             Debug.Assert(declaredSymbol != null);
             string title;
-            
+
             foreach (string customTag in diagnostic.Descriptor.CustomTags)
             {
                 switch (customTag)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static void AnalyzeSymbol(SymbolAnalysisContext context)
         {
             var namedTypeSymbol = context.Symbol as INamedTypeSymbol;
-            
+
             // Do not descent into non-publicly visible types by default
             // Note: This is the behavior of FxCop, it might be more correct to descend into internal but not private
             // types because "InternalsVisibleTo" could be set. But it might be bad for users to start seeing warnings

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             // Note all the descriptors/rules for this analyzer have the same ID and category and hence
             // will always have identical configured visibility.
             var matchesConfiguration = symbol.MatchesConfiguredVisibility(context.Options, AssemblyRule, context.CancellationToken);
-            
+
             return (!(matchesConfiguration && !symbol.IsOverride)) ||
                 symbol.IsAccessorMethod() || symbol.IsImplementationOfAnyInterfaceMember();
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffix.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffix.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         (SymbolAnalysisContext symbolAnalysisContext) =>
                         {
                             var namedTypeSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
-                            
+
                             // Note all the descriptors/rules for this analyzer have the same ID and category and hence
                             // will always have identical configured visibility.
                             if (!namedTypeSymbol.MatchesConfiguredVisibility(symbolAnalysisContext.Options, TypeNoAlternateRule, symbolAnalysisContext.CancellationToken))

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywords.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywords.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         // Properties common to all DiagnosticDescriptors for this rule:
         private const string HelpLinkUri = "https://docs.microsoft.com/visualstudio/code-quality/ca1716-identifiers-should-not-match-keywords";
-        
+
         internal static DiagnosticDescriptor MemberParameterRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageMemberParameter,

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NestedTypesShouldNotBeVisible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/NestedTypesShouldNotBeVisible.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         // Properties common to the descriptors defined by this analyzer.
         private const string HelpLinkUrl = "https://docs.microsoft.com/visualstudio/code-quality/ca1034-nested-types-should-not-be-visible";
-        
+
         internal static DiagnosticDescriptor DefaultRule = new DiagnosticDescriptor(RuleId,
                                                                              s_localizableTitle,
                                                                              s_localizableMessageDefault,

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloads.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.RegisterSymbolAction(symbolAnalysisContext =>
             {
                 var namedType = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
-                
+
                 // FxCop compat: only analyze externally visible symbols by default.
                 if (!namedType.MatchesConfiguredVisibility(symbolAnalysisContext.Options, Rule, symbolAnalysisContext.CancellationToken))
                 {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
                 if (namedTypeSymbol.IsValueType &&
                     namedTypeSymbol.MatchesConfiguredVisibility(context.Options, Rule, context.CancellationToken) &&
-                    namedTypeSymbol.OverridesEquals() && 
+                    namedTypeSymbol.OverridesEquals() &&
                     !namedTypeSymbol.ImplementsEqualityOperators())
                 {
                     context.ReportDiagnostic(namedTypeSymbol.CreateDiagnostic(Rule));

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropagateCancellationTokensWhenPossible.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePreferredTerms.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePreferredTerms.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(AssemblyRule, NamespaceRule, MemberParameterRule, DelegateParameterRule, TypeTypeParameterRule, MethodTypeParameterRule, TypeRule, MemberRule, AssemblyNoAlternateRule, NamespaceNoAlternateRule, MemberParameterNoAlternateRule, DelegateParameterNoAlternateRule, TypeTypeParameterNoAlternateRule, MethodTypeParameterNoAlternateRule, TypeNoAlternateRule, MemberNoAlternateRule);
+        //ImmutableArray.Create(AssemblyRule, NamespaceRule, MemberParameterRule, DelegateParameterRule, TypeTypeParameterRule, MethodTypeParameterRule, TypeRule, MemberRule, AssemblyNoAlternateRule, NamespaceNoAlternateRule, MemberParameterNoAlternateRule, DelegateParameterNoAlternateRule, TypeTypeParameterNoAlternateRule, MethodTypeParameterNoAlternateRule, TypeNoAlternateRule, MemberNoAlternateRule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiReview/AvoidCallingProblematicMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiReview/AvoidCallingProblematicMethods.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiReview
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            // ImmutableArray.Create(SystemGCCollectRule, SystemThreadingThreadResumeRule, SystemThreadingThreadSuspendRule, SystemTypeInvokeMemberRule, CoInitializeSecurityRule, CoSetProxyBlanketRule, SystemRuntimeInteropServicesSafeHandleDangerousGetHandleRule, SystemReflectionAssemblyLoadFromRule, SystemReflectionAssemblyLoadFileRule, SystemReflectionAssemblyLoadWithPartialNameRule);
+        // ImmutableArray.Create(SystemGCCollectRule, SystemThreadingThreadResumeRule, SystemThreadingThreadSuspendRule, SystemTypeInvokeMemberRule, CoInitializeSecurityRule, CoSetProxyBlanketRule, SystemRuntimeInteropServicesSafeHandleDangerousGetHandleRule, SystemReflectionAssemblyLoadFromRule, SystemReflectionAssemblyLoadFileRule, SystemReflectionAssemblyLoadWithPartialNameRule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/CodeMetricsAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/CodeMetricsAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.CodeMetrics
         /// See CA1509 unit tests for more examples.
         /// </summary>
         private const string CodeMetricsConfigurationFile = "CodeMetricsConfig.txt";
-        
+
         // New rule for invalid entries in CodeMetricsConfigurationFile.
         internal const string CA1509RuleId = "CA1509";
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.Fixer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             context.RegisterCodeFix(
                 new MyCodeAction(
                     MicrosoftMaintainabilityAnalyzersResources.RemoveUnusedParameterMessage,
-                    async ct => await RemoveNodes(context.Document, diagnostic, ct).ConfigureAwait(false), 
+                    async ct => await RemoveNodes(context.Document, diagnostic, ct).ConfigureAwait(false),
                     equivalenceKey: MicrosoftMaintainabilityAnalyzersResources.RemoveUnusedParameterMessage),
                 diagnostic);
 
@@ -76,7 +76,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
             return solution;
         }
-        
+
         private ImmutableArray<IArgumentOperation>? GetOperationArguments(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             // For a given reference symbol node, find an object creration parent or an invocation parent. Then, return arguments of the parent found.

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                     onSerializedAttribute,
                     onSerializingAttribute,
                     obsoleteAttribute);
-                
+
                 UnusedParameterDictionary unusedMethodParameters = new ConcurrentDictionary<IMethodSymbol, ISet<IParameterSymbol>>();
                 ISet<IMethodSymbol> methodsUsedAsDelegates = new HashSet<IMethodSymbol>();
 
@@ -162,7 +162,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         private class UnusedParametersAnalyzer
         {
             #region Per-CodeBlock mutable state
-                       
+
             private readonly HashSet<IParameterSymbol> _unusedParameters;
             private readonly UnusedParameterDictionary _finalUnusedParameters;
             private readonly IMethodSymbol _method;
@@ -174,7 +174,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             public UnusedParametersAnalyzer(IMethodSymbol method, UnusedParameterDictionary finalUnusedParameters)
             {
                 // Initialization: Assume all parameters are unused.
-                _unusedParameters = new HashSet<IParameterSymbol>(method.Parameters);                
+                _unusedParameters = new HashSet<IParameterSymbol>(method.Parameters);
                 _finalUnusedParameters = finalUnusedParameters;
                 _method = method;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/UseNameofInPlaceOfString.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/UseNameofInPlaceOfString.Fixer.cs
@@ -40,13 +40,13 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             Debug.Assert(nodeToReplace != null);
             var stringText = nodeToReplace.FindToken(diagnosticSpan.Start).ValueText;
             context.RegisterCodeFix(CodeAction.Create(
-                    MicrosoftMaintainabilityAnalyzersResources.UseNameOfInPlaceOfStringTitle, 
-                    c => ReplaceWithNameOf(context.Document, nodeToReplace, stringText, c), 
+                    MicrosoftMaintainabilityAnalyzersResources.UseNameOfInPlaceOfStringTitle,
+                    c => ReplaceWithNameOf(context.Document, nodeToReplace, stringText, c),
                     equivalenceKey: nameof(UseNameOfInPlaceOfStringFixer)),
                 context.Diagnostics);
         }
 
-        private async Task<Document> ReplaceWithNameOf(Document document, SyntaxNode nodeToReplace, 
+        private async Task<Document> ReplaceWithNameOf(Document document, SyntaxNode nodeToReplace,
             string stringText, CancellationToken cancellationToken)
         {
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/UseNameofInPlaceOfString.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/UseNameofInPlaceOfString.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             }
 
             var argument = (IArgumentOperation)context.Operation;
-            if ((argument.Value.Kind != OperationKind.Literal 
+            if ((argument.Value.Kind != OperationKind.Literal
                 || argument.ArgumentKind != ArgumentKind.Explicit
                 || argument.Value.Type.SpecialType != SpecialType.System_String))
             {
@@ -77,7 +77,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                     if (HasAMatchInScope(stringText, parametersInScope))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(
-                            RuleWithSuggestion, argument.Value.Syntax.GetLocation(), stringText ));
+                            RuleWithSuggestion, argument.Value.Syntax.GetLocation(), stringText));
                     }
                     return;
                 case PropertyName:

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/VariableNamesShouldNotMatchFieldNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/VariableNamesShouldNotMatchFieldNames.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(LocalRule, ParameterRule);
+        //ImmutableArray.Create(LocalRule, ParameterRule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidDuplicateElementInitialization.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidDuplicateElementInitialization.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         private static ImmutableArray<object> GetConstantArgumentValues(ImmutableArray<IArgumentOperation> arguments)
         {
             var result = new object[arguments.Length];
-            foreach(var argument in arguments)
+            foreach (var argument in arguments)
             {
                 var parameter = argument.Parameter;
                 if (parameter == null ||

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.Fixer.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             cancellationToken.ThrowIfCancellationRequested();
 
             var references = await SymbolFinder.FindReferencesAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
-            
+
             // Filter out cascaded symbol references. For example, accessor references for property symbol.
             references = references.Where(r => symbol.Equals(r.Definition));
 
@@ -102,7 +102,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             }
 
             var allReferencesFixed = true;
-            
+
             // Group references by document and fix references in each document.
             foreach (var referenceLocationGroup in references.Single().Locations.GroupBy(r => r.Document))
             {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
@@ -258,6 +258,6 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             Add(WellKnownTypes.NunitTearDown(compilation));
 
             return builder?.ToImmutable() ?? ImmutableArray<INamedTypeSymbol>.Empty;
-        }       
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ReviewVisibleEventHandlers.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ReviewVisibleEventHandlers.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(SecurityRule, DefaultRule);
+        //ImmutableArray.Create(SecurityRule, DefaultRule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
@@ -99,7 +99,7 @@ public class Sdk
                 .Verify(analyzer, GetDefaultPath(LanguageNames.CSharp), CSharpDefaultResultAt(2, 14, "Sdk", "Xunit.Sdk"));
         }
 
-        [Fact, WorkItem(1673,"https://github.com/dotnet/roslyn-analyzers/issues/1673")]
+        [Fact, WorkItem(1673, "https://github.com/dotnet/roslyn-analyzers/issues/1673")]
         public void CA1724CSharp_NoDiagnostic_NamespaceWithNoTypes()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -273,7 +273,7 @@ internal static class C
                 parseOptions: CodeAnalysis.CSharp.CSharpParseOptions.Default.WithLanguageVersion(CodeAnalysis.CSharp.LanguageVersion.CSharp7_1),
                 compilationOptions: s_CSharpDefaultOptions.WithOutputKind(CodeAnalysis.OutputKind.ConsoleApplication));
         }
- 
+
         [Fact]
         public void CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningTaskInt()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/CodeMetricsAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/CodeMetricsAnalyzerTests.cs
@@ -274,7 +274,7 @@ CA1502(Method): 2
         #endregion
 
         #region CA1505: Avoid unmaintainable code
-        
+
         [Fact]
         public void CA1505_Configuration_CSharp_VerifyDiagnostic()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -679,8 +679,8 @@ class C
     }
 }
 ");
-   
-        VerifyBasic(@"
+
+            VerifyBasic(@"
 Class C
     Public Property Item(i As Integer) As Integer
         Get
@@ -692,12 +692,12 @@ Class C
     End Property
 End Class
 ");
-    }
+        }
 
-    [Fact]
-    public void NoDiagnosticsForPropertySetter()
-    {
-        VerifyCSharp(@"
+        [Fact]
+        public void NoDiagnosticsForPropertySetter()
+        {
+            VerifyCSharp(@"
 class C
 {
     public int Property
@@ -708,7 +708,7 @@ class C
 }
 ");
 
-        VerifyBasic(@"
+            VerifyBasic(@"
 Class C
     Public Property Property1 As Integer
         Get
@@ -720,7 +720,7 @@ Class C
     End Property
 End Class
 ");
-    }
+        }
         [Fact]
         public void NoDiagnosticsForFirstParameterOfExtensionMethod()
         {
@@ -731,7 +731,7 @@ static class C
     static int ExtensionMethod(this int i, int anotherParam) { return anotherParam; }
 }
 ");
-    }
+        }
 
         [Fact]
         public void NoDiagnosticsForSingleStatementMethodsWithDefaultParameters()
@@ -757,15 +757,15 @@ Public Class C
 End Class");
         }
 
-    #endregion
+        #endregion
 
-    #region Unit tests for analyzer diagnostic(s)
+        #region Unit tests for analyzer diagnostic(s)
 
-    [Fact]
-    [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
-    public void CSharp_DiagnosticForSimpleCasesTest()
-    {
-        VerifyCSharp(@"
+        [Fact]
+        [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
+        public void CSharp_DiagnosticForSimpleCasesTest()
+        {
+            VerifyCSharp(@"
 using System;
 
 class C
@@ -803,24 +803,24 @@ class C
     }
 }
 ", TestValidationMode.AllowCompileErrors,
-      // Test0.cs(6,18): warning CA1801: Parameter param of method .ctor is never used. Remove the parameter or use it in the method body.
-      GetCSharpUnusedParameterResultAt(6, 18, "param", ".ctor"),
-      // Test0.cs(10,39): warning CA1801: Parameter param of method UnusedParamMethod is never used. Remove the parameter or use it in the method body.
-      GetCSharpUnusedParameterResultAt(10, 39, "param", "UnusedParamMethod"),
-      // Test0.cs(14,52): warning CA1801: Parameter param1 of method UnusedParamStaticMethod is never used. Remove the parameter or use it in the method body.
-      GetCSharpUnusedParameterResultAt(14, 52, "param1", "UnusedParamStaticMethod"),
-      // Test0.cs(18,46): warning CA1801: Parameter defaultParam of method UnusedDefaultParamMethod is never used. Remove the parameter or use it in the method body.
-      GetCSharpUnusedParameterResultAt(18, 46, "defaultParam", "UnusedDefaultParamMethod"),
-      // Test0.cs(22,59): warning CA1801: Parameter paramsArr of method UnusedParamsArrayParamMethod is never used. Remove the parameter or use it in the method body.
-      GetCSharpUnusedParameterResultAt(22, 59, "paramsArr", "UnusedParamsArrayParamMethod"),
-      // Test0.cs(26,48): warning CA1801: Parameter param1 of method MultipleUnusedParamsMethod is never used. Remove the parameter or use it in the method body.
-      GetCSharpUnusedParameterResultAt(26, 48, "param1", "MultipleUnusedParamsMethod"),
-      // Test0.cs(26,60): warning CA1801: Parameter param2 of method MultipleUnusedParamsMethod is never used. Remove the parameter or use it in the method body.
-      GetCSharpUnusedParameterResultAt(26, 60, "param2", "MultipleUnusedParamsMethod"),
-      // Test0.cs(30,47): warning CA1801: Parameter param1 of method UnusedRefParamMethod is never used. Remove the parameter or use it in the method body.
-      GetCSharpUnusedParameterResultAt(30, 47, "param1", "UnusedRefParamMethod"),
-      // Test0.cs(34,58): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
-      GetCSharpUnusedParameterResultAt(34, 58, "param1", "UnusedErrorTypeParamMethod"));
+          // Test0.cs(6,18): warning CA1801: Parameter param of method .ctor is never used. Remove the parameter or use it in the method body.
+          GetCSharpUnusedParameterResultAt(6, 18, "param", ".ctor"),
+          // Test0.cs(10,39): warning CA1801: Parameter param of method UnusedParamMethod is never used. Remove the parameter or use it in the method body.
+          GetCSharpUnusedParameterResultAt(10, 39, "param", "UnusedParamMethod"),
+          // Test0.cs(14,52): warning CA1801: Parameter param1 of method UnusedParamStaticMethod is never used. Remove the parameter or use it in the method body.
+          GetCSharpUnusedParameterResultAt(14, 52, "param1", "UnusedParamStaticMethod"),
+          // Test0.cs(18,46): warning CA1801: Parameter defaultParam of method UnusedDefaultParamMethod is never used. Remove the parameter or use it in the method body.
+          GetCSharpUnusedParameterResultAt(18, 46, "defaultParam", "UnusedDefaultParamMethod"),
+          // Test0.cs(22,59): warning CA1801: Parameter paramsArr of method UnusedParamsArrayParamMethod is never used. Remove the parameter or use it in the method body.
+          GetCSharpUnusedParameterResultAt(22, 59, "paramsArr", "UnusedParamsArrayParamMethod"),
+          // Test0.cs(26,48): warning CA1801: Parameter param1 of method MultipleUnusedParamsMethod is never used. Remove the parameter or use it in the method body.
+          GetCSharpUnusedParameterResultAt(26, 48, "param1", "MultipleUnusedParamsMethod"),
+          // Test0.cs(26,60): warning CA1801: Parameter param2 of method MultipleUnusedParamsMethod is never used. Remove the parameter or use it in the method body.
+          GetCSharpUnusedParameterResultAt(26, 60, "param2", "MultipleUnusedParamsMethod"),
+          // Test0.cs(30,47): warning CA1801: Parameter param1 of method UnusedRefParamMethod is never used. Remove the parameter or use it in the method body.
+          GetCSharpUnusedParameterResultAt(30, 47, "param1", "UnusedRefParamMethod"),
+          // Test0.cs(34,58): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
+          GetCSharpUnusedParameterResultAt(34, 58, "param1", "UnusedErrorTypeParamMethod"));
         }
 
         [Fact]
@@ -872,7 +872,7 @@ End Class
       GetBasicUnusedParameterResultAt(21, 44, "param1", "UnusedRefParamMethod"),
       // Test0.vb(24,43): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
       GetBasicUnusedParameterResultAt(24, 43, "param1", "UnusedErrorTypeParamMethod"));
-    }
+        }
 
         [Fact]
         public void DiagnosticsForNonFirstParameterOfExtensionMethod()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.Fixer.cs
@@ -24,12 +24,12 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 
         protected override CodeFixProvider GetBasicCodeFixProvider()
         {
-                return new BasicUseNameofInPlaceOfStringFixer();
+            return new BasicUseNameofInPlaceOfStringFixer();
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
-                return new CSharpUseNameofInPlaceOfStringFixer();
+            return new CSharpUseNameofInPlaceOfStringFixer();
         }
 
         [Fact]

--- a/src/Microsoft.NetCore.Analyzers/Core/InteropServices/MarkBooleanPInvokeArgumentsWithMarshalAs.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/InteropServices/MarkBooleanPInvokeArgumentsWithMarshalAs.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(DefaultRule, ReturnRule);
+        //ImmutableArray.Create(DefaultRule, ReturnRule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/InteropServices/UseManagedEquivalentsOfWin32Api.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/InteropServices/UseManagedEquivalentsOfWin32Api.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeMethodsShouldCallBaseClassDispose.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeMethodsShouldCallBaseClassDispose.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotUseTimersThatPreventPowerStateChanges.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotUseTimersThatPreventPowerStateChanges.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
@@ -190,7 +190,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     foreach (var index in IformatProviderParameterIndices)
                     {
                         var argument = invocationExpression.Arguments[index];
-                        
+
                         if (argument != null && currentUICultureProperty != null &&
                             installedUICultureProperty != null && currentThreadCurrentUICultureProperty != null)
                         {

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableCertificateValidation.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableCertificateValidation.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                 description: s_Description,
                 helpLinkUri: null,
                 customTags: WellKnownDiagnosticTags.Telemetry);
-        
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         public sealed override void Initialize(AnalysisContext context)
@@ -49,7 +49,7 @@ namespace Microsoft.NetCore.Analyzers.Security
 
             // Security analyzer - analyze and report diagnostics on generated code.
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
-            
+
             context.RegisterCompilationStartAction(
                 (CompilationStartAnalysisContext compilationStartAnalysisContext) =>
                 {
@@ -69,7 +69,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                     {
                         return;
                     }
-                    
+
                     compilationStartAnalysisContext.RegisterOperationAction(
                         (OperationAnalysisContext operationAnalysisContext) =>
                         {
@@ -99,7 +99,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                     case OperationKind.MethodReference:
                                         var methodReferenceOperation = (IMethodReferenceOperation)delegateCreationOperation.Target;
                                         var methodSymbol = methodReferenceOperation.Method;
-                                        
+
                                         if (!IsCertificateValidationFunction(
                                             methodSymbol,
                                             obj,
@@ -148,7 +148,7 @@ namespace Microsoft.NetCore.Analyzers.Security
             {
                 return false;
             }
-            
+
             if (!parameters[0].Type.Equals(obj)
                 || !parameters[1].Type.Equals(x509Certificate)
                 || !parameters[2].Type.Equals(x509Chain)
@@ -167,7 +167,7 @@ namespace Microsoft.NetCore.Analyzers.Security
         private static bool AlwaysReturnTrue(IEnumerable<IOperation> operations)
         {
             var hasReturnStatement = false;
-            
+
             foreach (var descendant in operations)
             {
                 if (descendant.Kind == OperationKind.Return)

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithms.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithms.cs
@@ -19,10 +19,10 @@ namespace Microsoft.NetCore.Analyzers.Security
 
         private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsTitle = new LocalizableResourceString(
             nameof(SystemSecurityCryptographyResources.DoNotUseWeakCryptographicAlgorithms),
-            SystemSecurityCryptographyResources.ResourceManager, 
+            SystemSecurityCryptographyResources.ResourceManager,
             typeof(SystemSecurityCryptographyResources));
         private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsMessage = new LocalizableResourceString(
-            nameof(SystemSecurityCryptographyResources.DoNotUseWeakCryptographicAlgorithmsMessage), 
+            nameof(SystemSecurityCryptographyResources.DoNotUseWeakCryptographicAlgorithmsMessage),
             SystemSecurityCryptographyResources.ResourceManager,
             typeof(SystemSecurityCryptographyResources));
         private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsDescription = new LocalizableResourceString(
@@ -172,7 +172,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                     messageArgs[1] = _cryptTypes.DES.Name;
                 }
                 else if ((method.ContainingType.DerivesFrom(_cryptTypes.DSA)
-                          && method.MetadataName == SecurityMemberNames.CreateSignature) 
+                          && method.MetadataName == SecurityMemberNames.CreateSignature)
                     || (type == _cryptTypes.DSASignatureFormatter
                         && method.ContainingType.DerivesFrom(_cryptTypes.DSASignatureFormatter)
                         && method.MetadataName == WellKnownMemberNames.InstanceConstructorName))

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -305,7 +305,7 @@ namespace N
             // Should the analyzer even be invoked for compiler generated code?
             VerifyCSharp(source + arrayEmptySource, referenceFlags: ReferenceFlags.None);
         }
-        
+
         [WorkItem(1209, "https://github.com/dotnet/roslyn-analyzers/issues/1209")]
         [Fact]
         public void EmptyArrayCSharp_CompilerGeneratedArrayCreationInIndexerAccess()

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ApprovedCipherModeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ApprovedCipherModeTests.cs
@@ -22,7 +22,7 @@ class TestClass {
         rijn.Mode  = CipherMode.ECB;
     }
 }",
-            GetCSharpResultAt(9, 22, ApprovedCipherModeAnalyzer.Rule,  "ECB"));
+            GetCSharpResultAt(9, 22, ApprovedCipherModeAnalyzer.Rule, "ECB"));
 
             VerifyBasic(@"
 Imports System.Security.Cryptography
@@ -33,7 +33,7 @@ Public Module SecurityCenter
         encripter.Mode = CipherMode.ECB
     End Sub
 End Module",
-            GetBasicResultAt(7, 26, ApprovedCipherModeAnalyzer.Rule,  "ECB"));
+            GetBasicResultAt(7, 26, ApprovedCipherModeAnalyzer.Rule, "ECB"));
         }
 
         [Fact]
@@ -61,7 +61,7 @@ Public Module SecurityCenter
         encripter.Mode = CipherMode.OFB
     End Sub
 End Module",
-            GetBasicResultAt(7, 26, ApprovedCipherModeAnalyzer.Rule,  "OFB"));
+            GetBasicResultAt(7, 26, ApprovedCipherModeAnalyzer.Rule, "OFB"));
         }
 
         [Fact]

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableCertificateValidationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableCertificateValidationTests.cs
@@ -191,7 +191,7 @@ class TestClass
         ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(AcceptAllCertificationsClass.AcceptAllCertifications);
     }
 }";
-            
+
             VerifyCSharpAcrossTwoAssemblies(source1, source2);
         }
 

--- a/src/Microsoft.NetFramework.Analyzers/Core/AvoidDuplicateAccelerators.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/AvoidDuplicateAccelerators.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/CallBaseClassMethodsOnISerializableTypes.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotMarkServicedComponentsWithWebMethod.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
@@ -255,7 +255,7 @@ namespace Microsoft.NetFramework.Analyzers
 
                     if (xmlReaderSettingsIndex < 0)
                     {
-                        if (method.Parameters.Length == 1 
+                        if (method.Parameters.Length == 1
                             && method.Parameters[0].RefKind == RefKind.None
                             && method.Parameters[0].Type.SpecialType == SpecialType.System_String)
                         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/ImplementISerializableCorrectly.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/ImplementISerializableCorrectly.cs
@@ -50,7 +50,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(DefaultRule, MakeVisibleRule, MakeOverridableRule) : ImmutableArray<DiagnosticDescriptor>.Empty;
+        //DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(DefaultRule, MakeVisibleRule, MakeOverridableRule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/ImplementSerializationMethodsCorrectly.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/ImplementSerializationMethodsCorrectly.cs
@@ -70,7 +70,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(VisibilityRule, ReturnTypeRule, ParametersRule, GenericRule, StaticRule) : ImmutableArray<DiagnosticDescriptor>.Empty;
+        //DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(VisibilityRule, ReturnTypeRule, ParametersRule, GenericRule, StaticRule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/MarkAllNonSerializableFields.Fixer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/MarkAllNonSerializableFields.Fixer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NetFramework.Analyzers
             }
 
             Diagnostic diagnostic = context.Diagnostics.Single();
-            
+
             // Fix 1: Add a NonSerialized attribute to the field
             context.RegisterCodeFix(new MyCodeAction(MicrosoftNetFrameworkAnalyzersResources.AddNonSerializedAttributeCodeActionTitle,
                                         async ct => await AddNonSerializedAttribute(context.Document, fieldNode, ct).ConfigureAwait(false),

--- a/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.MvcAttributeSymbols.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.MvcAttributeSymbols.cs
@@ -47,7 +47,7 @@ namespace Microsoft.NetFramework.Analyzers
             /// <param name="antiforgeryTokenDefined">Indicates that the ValidateAntiforgeryToken attribute was specified.</param>
             /// <param name="isAction">Indicates that the MVC controller method doesn't have an attribute saying it's not really an action.</param>
             public void ComputeAttributeInfo(
-                ImmutableArray<AttributeData> attributeDatas, 
+                ImmutableArray<AttributeData> attributeDatas,
                 out MvcHttpVerbs verbs,
                 out bool antiforgeryTokenDefined,
                 out bool isAction)
@@ -90,7 +90,7 @@ namespace Microsoft.NetFramework.Analyzers
                             if (a.AttributeConstructor.Parameters[0].IsParams
                                 && parameterType.TypeKind == TypeKind.Array)
                             {
-                                IArrayTypeSymbol parameterArrayType = (IArrayTypeSymbol) parameterType;
+                                IArrayTypeSymbol parameterArrayType = (IArrayTypeSymbol)parameterType;
                                 if (parameterArrayType.Rank == 1
                                     && parameterArrayType.ElementType.SpecialType == SpecialType.System_String)
                                 {
@@ -112,13 +112,13 @@ namespace Microsoft.NetFramework.Analyzers
                             {
                                 // The [AcceptVerbs(HttpVerbs.Delete)] case.
 
-                                int i = (int) a.ConstructorArguments[0].Value;
-                                verbs |= (MvcHttpVerbs) i;
+                                int i = (int)a.ConstructorArguments[0].Value;
+                                verbs |= (MvcHttpVerbs)i;
 
                                 continue;
                             }
                         }
-                        
+
                         // If we reach here, then we didn't handle the [AcceptVerbs] constructor overload.
                     }
                     else if (IsAttributeClass(a, this.NonActionAttributeSymbol)

--- a/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.cs
@@ -46,10 +46,10 @@ namespace Microsoft.NetFramework.Analyzers
 
         private static readonly DiagnosticDescriptor NoVerbsRule = new DiagnosticDescriptor(
             RuleId,
-            Title, 
-            NoVerbsMessage, 
+            Title,
+            NoVerbsMessage,
             DiagnosticCategory.Security,
-            DiagnosticHelpers.DefaultDiagnosticSeverity, 
+            DiagnosticHelpers.DefaultDiagnosticSeverity,
             isEnabledByDefault: true,
             helpLinkUri: HelpLinkUri);
 

--- a/src/Microsoft.NetFramework.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/MarkWindowsFormsEntryPointsWithStaThread.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/ProvideDeserializationMethodsForOptionalFields.cs
@@ -39,8 +39,8 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2239-provide-deserialization-methods-for-optional-fields",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>  ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(OnDeserializedRule, OnDeserializingRule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+        //ImmutableArray.Create(OnDeserializedRule, OnDeserializingRule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SerializationRulesDiagnosticAnalyzer.cs
@@ -250,8 +250,8 @@ namespace Microsoft.NetFramework.Analyzers
 
                         // Handle compiler-generated fields (without source declaration) that have an associated symbol in code.
                         // For example, auto-property backing fields.
-                        ISymbol targetSymbol = field.IsImplicitlyDeclared && field.AssociatedSymbol != null 
-                            ? field.AssociatedSymbol 
+                        ISymbol targetSymbol = field.IsImplicitlyDeclared && field.AssociatedSymbol != null
+                            ? field.AssociatedSymbol
                             : field;
 
                         context.ReportDiagnostic(

--- a/src/Microsoft.NetFramework.Analyzers/Core/SetLocaleForDataTypes.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SetLocaleForDataTypes.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Microsoft.NetFramework.Analyzers/Core/SpecifyMessageBoxOptions.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/SpecifyMessageBoxOptions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(Rule);
+        //ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIFix.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DeclarePublicAPIFix.cs
@@ -116,7 +116,7 @@ namespace Roslyn.Diagnostics.Analyzers
         {
             for (int i = 0; i < list.Count; i++)
             {
-                if (string.Compare(name, list[i], StringComparison.Ordinal) < 0 )
+                if (string.Compare(name, list[i], StringComparison.Ordinal) < 0)
                 {
                     list.Insert(i, name);
                     return;

--- a/src/Test.Utilities/CodeFixTestBase.cs
+++ b/src/Test.Utilities/CodeFixTestBase.cs
@@ -78,12 +78,12 @@ namespace Test.Utilities
         }
 
         private void VerifyFixAll(
-            string language, 
-            DiagnosticAnalyzer analyzerOpt, 
-            CodeFixProvider codeFixProvider, 
-            string[] oldSources, 
-            string[] newSources, 
-            bool allowNewCompilerDiagnostics, 
+            string language,
+            DiagnosticAnalyzer analyzerOpt,
+            CodeFixProvider codeFixProvider,
+            string[] oldSources,
+            string[] newSources,
+            bool allowNewCompilerDiagnostics,
             bool allowUnsafeCode,
             TestValidationMode validationMode)
         {
@@ -96,15 +96,15 @@ namespace Test.Utilities
         }
 
         protected static void VerifyAdditionalFileFix(
-            string language, 
-            DiagnosticAnalyzer analyzerOpt, 
-            CodeFixProvider codeFixProvider, 
-            string source, 
-            IEnumerable<TestAdditionalDocument> additionalFiles, 
-            TestAdditionalDocument newAdditionalFileToVerify, 
-            int? codeFixIndex = null, 
-            bool allowNewCompilerDiagnostics = false, 
-            bool onlyFixFirstFixableDiagnostic = false, 
+            string language,
+            DiagnosticAnalyzer analyzerOpt,
+            CodeFixProvider codeFixProvider,
+            string source,
+            IEnumerable<TestAdditionalDocument> additionalFiles,
+            TestAdditionalDocument newAdditionalFileToVerify,
+            int? codeFixIndex = null,
+            bool allowNewCompilerDiagnostics = false,
+            bool onlyFixFirstFixableDiagnostic = false,
             TestValidationMode validationMode = DefaultTestValidationMode)
         {
             Document document = CreateDocument(source, language);

--- a/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
@@ -200,7 +200,7 @@ namespace Test.Utilities
 
         protected void VerifyCSharpUnsafeCode(string source, params DiagnosticResult[] expected)
         {
-            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, true, ReferenceFlags.None, compilationOptions: null, parseOptions:null, expected: expected);
+            Verify(new[] { source }.ToFileAndSource(), LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), DefaultTestValidationMode, true, ReferenceFlags.None, compilationOptions: null, parseOptions: null, expected: expected);
         }
 
         protected void VerifyCSharp(string source, params DiagnosticResult[] expected)

--- a/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
+++ b/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
@@ -180,7 +180,7 @@ namespace Text.Analyzers
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-            //ImmutableArray.Create(AssemblyRule, NamespaceRule, TypeRule, MemberRule, MemberParameterRule, DelegateParameterRule, TypeTypeParameterRule, MethodTypeParameterRule, AssemblyMoreMeaningfulNameRule, NamespaceMoreMeaningfulNameRule, TypeMoreMeaningfulNameRule, MemberMoreMeaningfulNameRule, MemberParameterMoreMeaningfulNameRule, DelegateParameterMoreMeaningfulNameRule, TypeTypeParameterMoreMeaningfulNameRule, MethodTypeParameterMoreMeaningfulNameRule);
+        //ImmutableArray.Create(AssemblyRule, NamespaceRule, TypeRule, MemberRule, MemberParameterRule, DelegateParameterRule, TypeTypeParameterRule, MethodTypeParameterRule, AssemblyMoreMeaningfulNameRule, NamespaceMoreMeaningfulNameRule, TypeMoreMeaningfulNameRule, MemberMoreMeaningfulNameRule, MemberParameterMoreMeaningfulNameRule, DelegateParameterMoreMeaningfulNameRule, TypeTypeParameterMoreMeaningfulNameRule, MethodTypeParameterMoreMeaningfulNameRule);
 
         public override void Initialize(AnalysisContext analysisContext)
         {

--- a/src/Tools/Program.cs
+++ b/src/Tools/Program.cs
@@ -29,7 +29,7 @@ namespace Metrics
             {
                 return (int)RunAsync(args, tokenSource.Token).GetAwaiter().GetResult();
             }
-            catch(OperationCanceledException)
+            catch (OperationCanceledException)
             {
                 Console.WriteLine("Operation Cancelled.");
                 return -1;

--- a/src/Utilities/CodeMetrics/CodeAnalysisMetricData.AssemblyMetricData.cs
+++ b/src/Utilities/CodeMetrics/CodeAnalysisMetricData.AssemblyMetricData.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CodeMetrics
                         {
                             processNamespace((INamespaceSymbol)child);
                         }
-                        else if(@namespace.IsGlobalNamespace)
+                        else if (@namespace.IsGlobalNamespace)
                         {
                             includeGlobalNamespace = true;
                         }

--- a/src/Utilities/CodeMetrics/CodeAnalysisMetricData.cs
+++ b/src/Utilities/CodeMetrics/CodeAnalysisMetricData.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CodeMetrics
             }
         }
 
-#region Core Compute Methods
+        #region Core Compute Methods
         public async static Task<CodeAnalysisMetricData> ComputeAsync(Project project, CancellationToken cancellationToken)
         {
             if (project == null)
@@ -216,6 +216,6 @@ namespace Microsoft.CodeAnalysis.CodeMetrics
 #endif
                 select Task.Run(() => ComputeAsync(child, semanticModelProvider, cancellationToken))).ConfigureAwait(false)).ToImmutableArray();
 
-#endregion
+        #endregion
     }
 }

--- a/src/Utilities/CodeMetrics/ComputationalComplexityMetrics.cs
+++ b/src/Utilities/CodeMetrics/ComputationalComplexityMetrics.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CodeMetrics
                         distinctCaseKindsBuilder.Add(caseClauseOperation.CaseKind);
                         if (caseClauseOperation.CaseKind == CaseKind.Relational)
                         {
-                            countBinaryOperator(operation, ((IRelationalCaseClauseOperation)operation).Relation);    
+                            countBinaryOperator(operation, ((IRelationalCaseClauseOperation)operation).Relation);
                         }
                         else
                         {

--- a/src/Utilities/CodeMetrics/MetricsHelper.cs
+++ b/src/Utilities/CodeMetrics/MetricsHelper.cs
@@ -167,9 +167,9 @@ namespace Microsoft.CodeAnalysis.CodeMetrics
                         switch (operationBlock.Kind)
                         {
                             case OperationKind.Block:
-                            // https://github.com/dotnet/roslyn-analyzers/issues/1742
-                            //case OperationKind.MethodBodyOperation:
-                            //case OperationKind.ConstructorBodyOperation:
+                                // https://github.com/dotnet/roslyn-analyzers/issues/1742
+                                //case OperationKind.MethodBodyOperation:
+                                //case OperationKind.ConstructorBodyOperation:
                                 cyclomaticComplexity += 1;
                                 break;
                         }

--- a/src/Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -404,7 +404,7 @@ namespace Analyzer.Utilities.Extensions
                     return false;
             }
         }
-      
+
         public static int GetParameterIndex(this IMethodSymbol methodSymbol, IParameterSymbol parameterSymbol)
         {
             for (var i = 0; i < methodSymbol.Parameters.Length; i++)

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -332,7 +332,7 @@ namespace Analyzer.Utilities.Extensions
 
                 var type1 = method1.Parameters[index].Type.OriginalDefinition;
                 var type2 = method2.Parameters[index].Type.OriginalDefinition;
-                
+
                 if (type1.TypeKind == TypeKind.TypeParameter &&
                     type2.TypeKind == TypeKind.TypeParameter &&
                     ((ITypeParameterSymbol)type1).Ordinal == ((ITypeParameterSymbol)type2).Ordinal)
@@ -463,7 +463,7 @@ namespace Analyzer.Utilities.Extensions
             Debug.Assert(symbol != null);
             Debug.Assert(symbol.IsOverride);
 
-            switch(symbol)
+            switch (symbol)
             {
                 case IMethodSymbol methodSymbol:
                     return methodSymbol.OverriddenMethod;


### PR DESCRIPTION
Formatting violations will now be reported as Suggestions (with ...) while typing in the editor. These violations will be escalated to warnings during local build and correspondingly **break build in CI** (executed with /warnaserror), similar to other analyzer diagnostics enabled on the repo.