### PR TITLE
Some more flow analysis performance improvements

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
@@ -1573,5 +1573,38 @@ class Test
 
             // VB does not support patterns.
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_GotoLoop()
+        {
+            // Ensure we bound the number of value content literals
+            // and avoid infinite analysis iterations.
+            VerifyCSharp(@"
+class C
+{
+    internal static uint ComputeStringHash(string text)
+    {
+        uint hashCode = 0;
+        if (text != null)
+        {
+            hashCode = unchecked((uint)2166136261);
+ 
+            int i = 0;
+            goto start;
+
+again:
+            hashCode = unchecked((text[i] ^ hashCode) * 16777619);
+            i = i + 1;
+
+start:
+            if (i < text.Length)
+                goto again;
+        }
+        return hashCode;
+    }
+}");
+        }
     }
 }

--- a/src/Utilities/BranchWithInfo.cs
+++ b/src/Utilities/BranchWithInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Analyzer.Utilities.Extensions;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
@@ -13,25 +15,22 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public BranchWithInfo(ControlFlowBranch branch)
             : this(branch.Destination, branch.EnteringRegions, branch.LeavingRegions, branch.FinallyRegions,
                   branch.Semantics, branch.Source.BranchValue,
-                  GetControlFlowConditionKind(branch))
+                  GetControlFlowConditionKind(branch),
+                  leavingRegionLocals: ComputeLeavingRegionLocals(branch.LeavingRegions),
+                  leavingRegionFlowCaptures: ComputeLeavingRegionFlowCaptures(branch.LeavingRegions))
         {
-        }
-
-        private static ControlFlowConditionKind GetControlFlowConditionKind(ControlFlowBranch branch)
-        {
-            if (branch.IsConditionalSuccessor ||
-                branch.Source.ConditionKind == ControlFlowConditionKind.None)
-            {
-                return branch.Source.ConditionKind;
-            }
-
-            return branch.Source.ConditionKind.Negate();
         }
 
         public BranchWithInfo(BasicBlock destination)
-            : this(destination, enteringRegions: ImmutableArray<ControlFlowRegion>.Empty, leavingRegions: ImmutableArray<ControlFlowRegion>.Empty,
-                  finallyRegions: ImmutableArray<ControlFlowRegion>.Empty, kind: ControlFlowBranchSemantics.Regular,
-                  branchValueOpt: null, controlFlowConditionKind: ControlFlowConditionKind.None)
+            : this(destination,
+                  enteringRegions: ImmutableArray<ControlFlowRegion>.Empty,
+                  leavingRegions: ImmutableArray<ControlFlowRegion>.Empty,
+                  finallyRegions: ImmutableArray<ControlFlowRegion>.Empty,
+                  kind: ControlFlowBranchSemantics.Regular,
+                  branchValueOpt: null,
+                  controlFlowConditionKind: ControlFlowConditionKind.None,
+                  leavingRegionLocals: ImmutableHashSet<ILocalSymbol>.Empty,
+                  leavingRegionFlowCaptures: ImmutableHashSet<CaptureId>.Empty)
         {
         }
 
@@ -42,7 +41,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             ImmutableArray<ControlFlowRegion> finallyRegions,
             ControlFlowBranchSemantics kind,
             IOperation branchValueOpt,
-            ControlFlowConditionKind controlFlowConditionKind)
+            ControlFlowConditionKind controlFlowConditionKind,
+            IEnumerable<ILocalSymbol> leavingRegionLocals,
+            IEnumerable<CaptureId> leavingRegionFlowCaptures)
         {
             Destination = destination;
             Kind = kind;
@@ -51,6 +52,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             FinallyRegions = finallyRegions;
             BranchValueOpt = branchValueOpt;
             ControlFlowConditionKind = controlFlowConditionKind;
+            LeavingRegionLocals = leavingRegionLocals;
+            LeavingRegionFlowCaptures = leavingRegionFlowCaptures;
         }
 
         public BasicBlock Destination { get; }
@@ -64,14 +67,21 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public ControlFlowConditionKind ControlFlowConditionKind { get; }
 #pragma warning restore CA1721 // Property names should not match get methods
 
-        public BranchWithInfo With(
-            BasicBlock destination,
-            ImmutableArray<ControlFlowRegion> enteringRegions,
-            ImmutableArray<ControlFlowRegion> leavingRegions,
-            ImmutableArray<ControlFlowRegion> finallyRegions)
+        public IEnumerable<ILocalSymbol> LeavingRegionLocals { get; }
+        public IEnumerable<CaptureId> LeavingRegionFlowCaptures { get; }
+
+        public BranchWithInfo WithEmptyRegions(BasicBlock destination)
         {
-            return new BranchWithInfo(destination, enteringRegions, leavingRegions,
-                finallyRegions, Kind, BranchValueOpt, ControlFlowConditionKind);
+            return new BranchWithInfo(
+                destination,
+                enteringRegions: ImmutableArray<ControlFlowRegion>.Empty,
+                leavingRegions: ImmutableArray<ControlFlowRegion>.Empty,
+                finallyRegions: ImmutableArray<ControlFlowRegion>.Empty,
+                kind: Kind,
+                branchValueOpt: BranchValueOpt,
+                controlFlowConditionKind: ControlFlowConditionKind,
+                leavingRegionLocals: ImmutableHashSet<ILocalSymbol>.Empty,
+                leavingRegionFlowCaptures: ImmutableHashSet<CaptureId>.Empty);
         }
 
         public BranchWithInfo With(
@@ -79,7 +89,29 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             ControlFlowConditionKind controlFlowConditionKind)
         {
             return new BranchWithInfo(Destination, EnteringRegions, LeavingRegions,
-                FinallyRegions, Kind, branchValueOpt, controlFlowConditionKind);
+                FinallyRegions, Kind, branchValueOpt, controlFlowConditionKind,
+                LeavingRegionLocals, LeavingRegionFlowCaptures);
+        }
+
+        private static IEnumerable<ILocalSymbol> ComputeLeavingRegionLocals(ImmutableArray<ControlFlowRegion> leavingRegions)
+        {
+            return leavingRegions.SelectMany(r => r.NestedRegions.Concat(r)).Distinct().SelectMany(r => r.Locals);
+        }
+
+        private static IEnumerable<CaptureId> ComputeLeavingRegionFlowCaptures(ImmutableArray<ControlFlowRegion> leavingRegions)
+        {
+            return leavingRegions.SelectMany(r => r.NestedRegions.Concat(r)).Distinct().SelectMany(r => r.CaptureIds);
+        }
+
+        private static ControlFlowConditionKind GetControlFlowConditionKind(ControlFlowBranch branch)
+        {
+            if (branch.IsConditionalSuccessor ||
+                branch.Source.ConditionKind == ControlFlowConditionKind.None)
+            {
+                return branch.Source.ConditionKind;
+            }
+
+            return branch.Source.ConditionKind.Negate();
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
@@ -19,6 +19,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
     /// </summary>
     internal partial class ValueContentAbstractValue : CacheBasedEquatable<ValueContentAbstractValue>
     {
+        // Ensure we bound the number of value content literals and avoid infinite analysis iterations.
+        private const int LiteralsBound = 10;
+
         public static readonly ValueContentAbstractValue UndefinedState = new ValueContentAbstractValue(ImmutableHashSet<object>.Empty, ValueContainsNonLiteralState.Undefined);
         public static readonly ValueContentAbstractValue InvalidState = new ValueContentAbstractValue(ImmutableHashSet<object>.Empty, ValueContainsNonLiteralState.Invalid);
         public static readonly ValueContentAbstractValue MayBeContainsNonLiteralState = new ValueContentAbstractValue(ImmutableHashSet<object>.Empty, ValueContainsNonLiteralState.Maybe);
@@ -150,6 +153,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
             }
 
             ImmutableHashSet<object> mergedLiteralValues = LiteralValues.AddRange(otherState.LiteralValues);
+            if (mergedLiteralValues.Count > LiteralsBound)
+            {
+                return MayBeContainsNonLiteralState;
+            }
+
             ValueContainsNonLiteralState mergedNonLiteralState = Merge(NonLiteralState, otherState.NonLiteralState);
             return Create(mergedLiteralValues, mergedNonLiteralState);
         }

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Debug.Assert(locals.Any() || flowCaptures.Any());
 
             base.ProcessOutOfScopeLocalsAndFlowCaptures(locals, flowCaptures);
-            
+
             var allEntities = PooledHashSet<AnalysisEntity>.GetInstance();
             try
             {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/MapAbstractDomain.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/MapAbstractDomain.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
@@ -41,6 +40,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             if (ReferenceEquals(oldValue, newValue))
             {
                 return 0;
+            }
+
+            if (newValue.Count < oldValue.Count)
+            {
+                FireNonMonotonicAssertIfNeeded(assertMonotonicity);
+                return 1;
             }
 
             // Ensure that every key in oldValue exists in newValue and the value corresponding to that key


### PR DESCRIPTION
Avoid merging analysis data if the input data is coming from a unique predecessor branch, instead just overwrite the new input data.

Also added a threshold on number of tracked literal values for value content analysis - otherwise, we can run into infinite analysis iterations for loops that modify constant value stores for each iteration.