### PR TITLE
Fix a bunch of asserts in flow analysis

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypes.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              s_localizableTitle,
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
-                                                                             DiagnosticSeverity.Error,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: true,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://msdn.microsoft.com/en-us/library/ms182137.aspx",

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidDeadConditionalCode.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidDeadConditionalCode.cs
@@ -8,8 +8,6 @@ using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
-using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
-using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -6364,5 +6364,26 @@ using System.Linq;
     }
 }");
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void NullCompare_Unboxing_InstanceEntityAssert()
+        {
+            VerifyCSharp(@"
+struct S
+{
+    public C C { get; }
+}
+
+class C
+{
+    private object _field;
+    public void M(C c)
+    {
+        var x = (_field as C) ?? ((S)_field).C;
+    }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -6385,5 +6385,74 @@ class C
     }
 }");
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NullCompare_PointsToFlowCaptureAssert()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private C _field;
+    public void M(int[] array, int x)
+    {
+        C c = null;
+        C c2 = null;
+        C c3 = null;
+
+        LocalFunction2();
+        LocalFunction3();
+
+        void LocalFunction()
+        {
+            c = c ?? GetC();
+            c.M2();
+        }
+
+        void LocalFunction2()
+        {
+            LocalFunction();
+            c2 = c2 ?? GetC();
+            c2.M2();
+        }
+
+        void LocalFunction3()
+        {
+            LocalFunction();
+            c3 = c3 ?? GetC();
+            c3.M2();
+        }
+    }
+
+    C GetC() => _field;
+    void M2() { }
+}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact]
+        public void NestedLambdaAndLocalFunctionsWithCaptures()
+        {
+            VerifyCSharp(@"
+using System;
+
+class C
+{
+    public void M(C p, C p1, C p2)
+    {
+        C l1 = p1;
+        LocalFunction();
+        return;
+
+        void LocalFunction()
+        {
+            C l2 = p2;
+            M2(s => s != null && p != null && l1 != null && l2 != null);
+        }
+    }
+
+    void M2(Func<C, bool> f) { }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -5411,7 +5411,6 @@ public class Test
             return;
         }
 
-        // No diagnostic: Copy analysis only tracks value equality, hence we are conservative about flagging redundant reference equal checks.
         if (!ReferenceEquals(c, c2))
         {
         }
@@ -5420,7 +5419,9 @@ public class Test
             // Test0.cs(16,13): warning CA1508: 'c != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(16, 13, "c != null", "true"),
             // Test0.cs(28,13): warning CA1508: 'c != c2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(28, 13, "c != c2", "false"));
+            GetCSharpResultAt(28, 13, "c != c2", "false"),
+            // Test0.cs(40,14): warning CA1508: 'ReferenceEquals(c, c2)' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(40, 14, "ReferenceEquals(c, c2)", "true"));
 
             VerifyBasic(@"
 Public Class C
@@ -5451,7 +5452,6 @@ Public Class Test
             Return
         End If
 
-        ' No diagnostic: Copy analysis only tracks value equality, hence we are conservative about flagging redundant reference equal checks.
         If Not ReferenceEquals(c, c2) Then
         End If
     End Sub
@@ -5459,7 +5459,9 @@ End Class",
             // Test0.vb(12,12): warning CA1508: 'c IsNot Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
             GetBasicResultAt(12, 12, "c IsNot Nothing", "True"),
             // Test0.vb(21,12): warning CA1508: 'c IsNot c2' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
-            GetBasicResultAt(21, 12, "c IsNot c2", "False"));
+            GetBasicResultAt(21, 12, "c IsNot c2", "False"),
+            // Test0.vb(30,16): warning CA1508: 'ReferenceEquals(c, c2)' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(30, 16, "ReferenceEquals(c, c2)", "True"));
         }
 
         [Fact]
@@ -5504,7 +5506,6 @@ public class Test
             return;
         }
 
-        // No diagnostic: Copy analysis only tracks value equality, hence we are conservative about flagging redundant reference equal checks.
         if (!object.Equals(c, c2))
         {
         }
@@ -5513,7 +5514,9 @@ public class Test
             // Test0.cs(16,13): warning CA1508: 'c != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(16, 13, "c != null", "true"),
             // Test0.cs(28,13): warning CA1508: 'c != c2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(28, 13, "c != c2", "false"));
+            GetCSharpResultAt(28, 13, "c != c2", "false"),
+            // Test0.cs(40,14): warning CA1508: 'object.Equals(c, c2)' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(40, 14, "object.Equals(c, c2)", "true"));
 
             VerifyBasic(@"
 Public Class C
@@ -5544,7 +5547,6 @@ Public Class Test
             Return
         End If
 
-        ' No diagnostic: Copy analysis only tracks value equality, hence we are conservative about flagging redundant reference equal checks.
         If Not object.Equals(c, c2) Then
         End If
     End Sub
@@ -5552,7 +5554,9 @@ End Class",
             // Test0.vb(12,12): warning CA1508: 'c IsNot Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
             GetBasicResultAt(12, 12, "c IsNot Nothing", "True"),
             // Test0.vb(21,12): warning CA1508: 'c IsNot c2' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
-            GetBasicResultAt(21, 12, "c IsNot c2", "False"));
+            GetBasicResultAt(21, 12, "c IsNot c2", "False"),
+            // Test0.vb(30,16): warning CA1508: 'object.Equals(c, c2)' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(30, 16, "object.Equals(c, c2)", "True"));
         }
 
         [Fact]
@@ -5587,7 +5591,7 @@ public class Test
             return;
         }
 
-        if (c != c2)
+        if (c != c2)    // No diagnostic reported here as 'object.Equals(c, c2)' does not guarantee reference equality due to Equals override in C.
         {
         }
     }
@@ -5606,8 +5610,6 @@ public class Test
 }",
             // Test0.cs(18,13): warning CA1508: 'c != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(18, 13, "c != null", "true"),
-            // Test0.cs(30,13): warning CA1508: 'c != c2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(30, 13, "c != c2", "false"),
             // Test0.cs(42,14): warning CA1508: 'object.Equals(c, c2)' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(42, 14, "object.Equals(c, c2)", "true"));
 
@@ -5635,7 +5637,7 @@ Public Class Test
             Return
         End If
 
-        If c IsNot c2 Then
+        If c IsNot c2 Then      ' No diagnostic reported here as 'object.Equals(c, c2)' does not guarantee reference equality due to Equals override in C.
         End If
     End Sub
 
@@ -5650,8 +5652,6 @@ Public Class Test
 End Class",
             // Test0.vb(16,12): warning CA1508: 'c IsNot Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
             GetBasicResultAt(16, 12, "c IsNot Nothing", "True"),
-            // Test0.vb(25,12): warning CA1508: 'c IsNot c2' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
-            GetBasicResultAt(25, 12, "c IsNot c2", "False"),
             // Test0.vb(34,16): warning CA1508: 'object.Equals(c, c2)' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
             GetBasicResultAt(34, 16, "object.Equals(c, c2)", "True"));
         }
@@ -5698,7 +5698,6 @@ public class Test
             return;
         }
 
-        // No diagnostic: Copy analysis only tracks value equality, hence we are conservative about flagging redundant reference equal checks.
         if (!c.Equals(c2))
         {
         }
@@ -5707,7 +5706,9 @@ public class Test
             // Test0.cs(16,13): warning CA1508: 'c2 != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(16, 13, "c2 != null", "true"),
             // Test0.cs(28,13): warning CA1508: 'c != c2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(28, 13, "c != c2", "false"));
+            GetCSharpResultAt(28, 13, "c != c2", "false"),
+            // Test0.cs(40,14): warning CA1508: 'c.Equals(c2)' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(40, 14, "c.Equals(c2)", "true"));
 
             VerifyBasic(@"
 Public Class C
@@ -5738,7 +5739,6 @@ Public Class Test
             Return
         End If
 
-        ' No diagnostic: Copy analysis only tracks value equality, hence we are conservative about flagging redundant reference equal checks.
         If Not c.Equals(c2) Then
         End If
     End Sub
@@ -5746,7 +5746,9 @@ End Class",
             // Test0.vb(12,12): warning CA1508: 'c2 IsNot Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
             GetBasicResultAt(12, 12, "c2 IsNot Nothing", "True"),
             // Test0.vb(21,12): warning CA1508: 'c IsNot c2' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
-            GetBasicResultAt(21, 12, "c IsNot c2", "False"));
+            GetBasicResultAt(21, 12, "c IsNot c2", "False"),
+            // Test0.vb(30,16): warning CA1508: 'c.Equals(c2)' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
+            GetBasicResultAt(30, 16, "c.Equals(c2)", "True"));
         }
 
         [Fact]
@@ -5781,7 +5783,7 @@ public class Test
             return;
         }
 
-        if (c != c2)
+        if (c != c2)    // No diagnostic reported here as 'c.Equals(c2)' only guarantees value equality.
         {
         }
     }
@@ -5800,8 +5802,6 @@ public class Test
 }",
             // Test0.cs(18,13): warning CA1508: 'c2 != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(18, 13, "c2 != null", "true"),
-            // Test0.cs(30,13): warning CA1508: 'c != c2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(30, 13, "c != c2", "false"),
             // Test0.cs(42,14): warning CA1508: 'c.Equals(c2)' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(42, 14, "c.Equals(c2)", "true"));
 
@@ -5829,7 +5829,7 @@ Public Class Test
             Return
         End If
 
-        If c IsNot c2 Then
+        If c IsNot c2 Then      ' No diagnostic reported here as 'c.Equals(c2)' only guarantees value equality.
         End If
     End Sub
 
@@ -5844,8 +5844,6 @@ Public Class Test
 End Class",
             // Test0.vb(16,12): warning CA1508: 'c2 IsNot Nothing' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
             GetBasicResultAt(16, 12, "c2 IsNot Nothing", "True"),
-            // Test0.vb(25,12): warning CA1508: 'c IsNot c2' is always 'False'. Remove or refactor the condition(s) to avoid dead code.
-            GetBasicResultAt(25, 12, "c IsNot c2", "False"),
             // Test0.vb(34,16): warning CA1508: 'c.Equals(c2)' is always 'True'. Remove or refactor the condition(s) to avoid dead code.
             GetBasicResultAt(34, 16, "c.Equals(c2)", "True"));
         }
@@ -5853,6 +5851,9 @@ End Class",
         [Fact]
         public void IEquatableEquals_ExplicitImplementation_Diagnostic()
         {
+            // Explicit implementation of Equals means c1.Equals(c2) performs
+            // reference equality using object.Equals(object) overload.
+
             VerifyCSharp(@"
 using System;
 
@@ -5905,7 +5906,9 @@ public class Test
             // Test0.cs(20,13): warning CA1508: 'c2 != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(20, 13, "c2 != null", "true"),
             // Test0.cs(32,13): warning CA1508: 'c != c2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(32, 13, "c != c2", "false"));
+            GetCSharpResultAt(32, 13, "c != c2", "false"),
+            // Test0.cs(44,14): warning CA1508: 'c.Equals(c2)' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(44, 14, "c.Equals(c2)", "true"));
 
             VerifyBasic(@"
 Imports System
@@ -5914,7 +5917,7 @@ Public Class C
     Implements IEquatable(Of C)
 
     Public X As Integer
-    Public Function Equals(other As C) As Boolean Implements IEquatable(Of C).Equals
+    Private Function Equals(other As C) As Boolean Implements IEquatable(Of C).Equals
         Return True
     End Function
 End Class
@@ -5989,7 +5992,7 @@ public class Test
             return;
         }
 
-        if (c != c2)
+        if (c != c2)    // No diagnostic reported here as 'c.Equals(c2)' only guarantees value equality.
         {
         }
     }
@@ -6009,8 +6012,6 @@ public class Test
 ",
             // Test0.cs(20,13): warning CA1508: 'c2 != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(20, 13, "c2 != null", "true"),
-            // Test0.cs(32,13): warning CA1508: 'c != c2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(32, 13, "c != c2", "false"),
             // Test0.cs(44,14): warning CA1508: 'c.Equals(c2)' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(44, 14, "c.Equals(c2)", "true"));
         }
@@ -6053,7 +6054,7 @@ public class Test
             return;
         }
 
-        if (c != c2)
+        if (c != c2)    // No diagnostic reported here as 'c.Equals(c2)' only guarantees value equality.
         {
         }
     }
@@ -6073,8 +6074,6 @@ public class Test
 ",
             // Test0.cs(24,13): warning CA1508: 'c2 != null' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(24, 13, "c2 != null", "true"),
-            // Test0.cs(36,13): warning CA1508: 'c != c2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(36, 13, "c != c2", "false"),
             // Test0.cs(48,14): warning CA1508: 'c.Equals(c2)' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(48, 14, "c.Equals(c2)", "true"));
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -6454,5 +6454,32 @@ class C
     void M2(Func<C, bool> f) { }
 }");
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void CopyAnalysisAssert_IndexerArrayAccessWithCast()
+        {
+            VerifyCSharp(@"
+public struct S
+{
+    public object Value { get; }
+}
+
+public class C
+{
+    public void M(S[] arguments)
+    {
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            if (arguments[i].Value != null)
+            {
+                var value = (string)arguments[i].Value;
+                var value2 = (S)arguments[i + 1].Value;
+            }
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
@@ -1606,5 +1606,272 @@ start:
     }
 }");
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_MayBeLiteralAssignedInLoop()
+        {
+            VerifyCSharp(@"
+using System.Diagnostics;
+
+class C
+{
+    public int Int { get; }
+    public C[] ArrayOfC { get; }
+    void M(int x)
+    {
+        int lastOffset = -1;
+        foreach (var c in ArrayOfC)
+        {
+            int offset = c.Int;
+            if (offset >= 0)
+            {
+                if (lastOffset != offset)
+                {
+                    Debug.Assert(lastOffset < offset);
+                    Debug.Assert((lastOffset >= 0) || (offset == 0));
+                    lastOffset = offset;
+                }
+                else
+                {
+                    System.Console.Write(offset);
+                }
+            }
+        }
+    }
+}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_YieldBreakInTryFinally()
+        {
+            VerifyCSharp(@"
+using System.Collections.Generic;
+
+class C
+{
+    private static IEnumerable<IList<T>> M<T>(List<IEnumerator<T>> enumerators)
+    {
+        try
+        {
+            while (true)
+            {
+                for (int i = 0; i < enumerators.Count; i++)
+                {
+                    var e = enumerators[i];
+                    if (!e.MoveNext())
+                    {
+                        yield break;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            foreach (var enumerator in enumerators)
+            {
+                enumerator.Dispose();
+            }
+        }
+    }
+}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_NullableBool()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private object Field;
+    public void M(C c)
+    {
+        bool? status = c.Field?.Equals(c);
+    }
+}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_DefaultExpression()
+        {
+            VerifyCSharp(@"
+struct S
+{
+}
+
+class C
+{
+    public void M(S s)
+    {
+        if (object.Equals(s, default(S)))
+        {
+        }
+    }
+}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_Boxing_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public void M(int i)
+    {
+        object o = i;       // Implicit boxing.
+        if ((int)o == i)    // Always true.
+        {
+        }
+        
+        object o2 = (object)i;    // Explicit boxing with direct cast.
+        if ((int)o2 == i)         // Always true.
+        {
+        }
+
+        object o3 = i as object;    // Explicit boxing with try cast.
+        if ((int)o3 == i)           // Always true.
+        {
+        }
+
+        if (o == (object)i)    // Always false, but our current implementation is conservative and does not flag it.
+        {
+        }
+    }
+}",
+    // Test0.cs(7,13): warning CA1508: '(int)o == i' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+    GetCSharpResultAt(7, 13, "(int)o == i", "true"),
+    // Test0.cs(12,13): warning CA1508: '(int)o2 == i' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+    GetCSharpResultAt(12, 13, "(int)o2 == i", "true"),
+    // Test0.cs(17,13): warning CA1508: '(int)o3 == i' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+    GetCSharpResultAt(17, 13, "(int)o3 == i", "true"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_Boxing_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public void M(int i, int i2, int i3, int i4)
+    {
+        object o = i;       // Implicit boxing.
+        i = 1;
+        if ((int)o == i)    // May or may not be true.
+        {
+        }
+        if (o is 1)         // May or may not be true.
+        {
+        }
+        
+        object o2 = (object)i2;    // Explicit boxing with direct cast.
+        i2 = 2;
+        if ((int)o2 == i2)         // May or may not be true.
+        {
+        }
+        if (o2 is 2)               // May or may not be true.
+        {
+        }
+
+        object o3 = i3;       // Implicit boxing.
+        o3 = 3;
+        if ((int)o3 == i3)    // May or may not be true.
+        {
+        }
+        if (i3 == 3)           // May or may not be true.
+        {
+        }
+
+        object o4 = (object)i4;    // Explicit boxing with direct cast.
+        o4 = 4;
+        if ((int)o4 == i4)         // May or may not be true.
+        {
+        }
+        if (i4 == 4)               // May or may not be true.
+        {
+        }
+    }
+}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_Unboxing_Diagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public void M(object o, object o2, object o3)
+    {
+        var i = (int)o;         // Explicit unboxing with direct cast.
+        if ((int)o == i)        // Always true.
+        {
+        }
+
+        if (o == (object)i)     // Always false, but our current implementation is conservative and does not flag it.
+        {
+        }
+
+        var i2 = o2 as int?;    // Explicit unboxing with try cast involving nullable types.
+        if ((int)o2 == i2)      // Always true, but our current implementation is conservative and does not flag it.
+        {
+        }
+
+        if (o2 == (object)i2)   // Always false, but our current implementation is conservative and does not flag it.
+        {
+        }
+    }
+}",
+            // Test0.cs(7,13): warning CA1508: '(int)o == i' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+            GetCSharpResultAt(7, 13, "(int)o == i", "true"));
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void ValueCompare_Unboxing_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+class C
+{
+    public void M(object o, object o2, object o3, object o4)
+    {
+        var i = (int)o;         // Explicit unboxing with direct cast.
+        i = 1;
+        if ((int)o == i)        // May or may not be true.
+        {
+        }
+
+        var i2 = (int)o2;         // Explicit unboxing with direct cast.
+        o2 = 2;
+        if ((int)o2 == i2)        // May or may not be true.
+        {
+        }
+
+        var i3 = o3 as int?;    // Explicit unboxing with try cast involving nullable types.
+        i3 = 3;
+        if ((int)o3 == i3)      // May or may not be true.
+        {
+        }
+
+        var i4 = o4 as int?;    // Explicit unboxing with try cast involving nullable types.
+        o4 = 4;
+        if ((int)o4 == i4)      // May or may not be true.
+        {
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -5101,5 +5101,29 @@ namespace MyComments
 }
 ");
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
+        [Fact]
+        public void CopyAnalysisAssert_AddressSharedOutParam()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public void M(C c)
+    {
+        M(out c);
+
+        if (c == default(C))
+        {
+        }
+    }
+
+    private void M<T>(out T t)
+    {
+        t = default(T);
+    }
+}");
+        }
     }
 }

--- a/src/Utilities/Analyzer.Utilities.projitems
+++ b/src/Utilities/Analyzer.Utilities.projitems
@@ -32,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\PooledHashSetExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\OperationBlockAnalysisContextExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\WellKnownDiagnosticTagsExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\CopyAnalysis\SetCopyAbstractValuePredicateKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PointsToAnalysis\TrackedEntitiesBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\FilePathInjectionSinks.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\XssSanitizers.cs" />
@@ -125,6 +126,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractAnalysisDomain.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\AbstractBlockAnalysisResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\InterproceduralAnalysisConfigurationParameters.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\ConversionInference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\InterproceduralCaptureId.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\ArgumentInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Framework\DataFlow\InterproceduralAnalysisKind.cs" />

--- a/src/Utilities/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Extensions/IMethodSymbolExtensions.cs
@@ -422,6 +422,19 @@ namespace Analyzer.Utilities.Extensions
             }
         }
 
+        public static bool IsLambdaOrLocalFunction(this IMethodSymbol method)
+        {
+            switch (method.MethodKind)
+            {
+                case MethodKind.LambdaMethod:
+                case MethodKind.LocalFunction:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
         public static int GetParameterIndex(this IMethodSymbol methodSymbol, IParameterSymbol parameterSymbol)
         {
             for (var i = 0; i < methodSymbol.Parameters.Length; i++)

--- a/src/Utilities/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Extensions/ISymbolExtensions.cs
@@ -592,5 +592,8 @@ namespace Analyzer.Utilities.Extensions
         {
             return symbol.Locations.Any(l => l.IsInSource);
         }
+
+        public static bool IsLambdaOrLocalFunction(this ISymbol symbol)
+            => (symbol as IMethodSymbol)?.IsLambdaOrLocalFunction() == true;
     }
 }

--- a/src/Utilities/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Extensions/ITypeSymbolExtensions.cs
@@ -179,6 +179,9 @@ namespace Analyzer.Utilities.Extensions
         public static bool IsReferenceTypeOrNullableValueType(this ITypeSymbol typeSymbol)
             => typeSymbol != null && (typeSymbol.IsReferenceType || typeSymbol.IsNullableValueType());
 
+        public static bool IsNullableOfBoolean(this ITypeSymbol typeSymbol)
+            => typeSymbol.IsNullableValueType() && ((INamedTypeSymbol)typeSymbol).TypeArguments[0].SpecialType == SpecialType.System_Boolean;
+
         public static Accessibility DetermineMinimalAccessibility(this ITypeSymbol typeSymbol)
         {
             return typeSymbol.Accept(MinimalAccessibilityVisitor.Instance);

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValueKind.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValueKind.cs
@@ -13,9 +13,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
         NotApplicable,
 
         /// <summary>
-        /// Copy shared by one or more <see cref="AnalysisEntity"/> instances.
+        /// Copy of a reference shared by one or more <see cref="AnalysisEntity"/> instances.
         /// </summary>
-        Known,
+        KnownReferenceCopy,
+
+        /// <summary>
+        /// Copy of a value shared by one or more <see cref="AnalysisEntity"/> instances.
+        /// </summary>
+        KnownValueCopy,
 
         /// <summary>
         /// Copy may or may not be shared by other <see cref="AnalysisEntity"/> instances.
@@ -26,5 +31,35 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
         /// Invalid state for an unreachable path from predicate analysis.
         /// </summary>
         Invalid,
+    }
+
+    internal static class CopyAbstractValueKindExtensions
+    {
+        public static bool IsKnown(this CopyAbstractValueKind kind)
+        {
+            switch (kind)
+            {
+                case CopyAbstractValueKind.KnownValueCopy:
+                case CopyAbstractValueKind.KnownReferenceCopy:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        public static CopyAbstractValueKind MergeIfBothKnown(this CopyAbstractValueKind kind, CopyAbstractValueKind kindToMerge)
+        {
+            if (!kind.IsKnown() ||
+                !kindToMerge.IsKnown())
+            {
+                return kind;
+            }
+
+            // Can only ensure value copy if one of the kinds is a value copy.
+            return kind == CopyAbstractValueKind.KnownValueCopy || kindToMerge == CopyAbstractValueKind.KnownValueCopy ?
+                CopyAbstractValueKind.KnownValueCopy :
+                CopyAbstractValueKind.KnownReferenceCopy;
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
@@ -133,6 +133,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                 if (coreAnalysisData.TryGetValue(kvp.Key, out var currentValue))
                 {
                     var newCopyEntities = currentValue.AnalysisEntities;
+                    var newKind = currentValue.Kind;
                     foreach (var predicatedCopyEntity in predicatedValue.AnalysisEntities)
                     {
                         // Predicate copy value has an entity which is not part of the current copy value.
@@ -142,6 +143,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                             if (coreAnalysisData.TryGetValue(predicatedCopyEntity, out var predicatedCopyEntityValue))
                             {
                                 newCopyEntities = newCopyEntities.Union(predicatedCopyEntityValue.AnalysisEntities);
+                                newKind = newKind.MergeIfBothKnown(predicatedCopyEntityValue.Kind);
                             }
                             else
                             {
@@ -153,7 +155,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                     // Check if we need to change the current copy value.
                     if (newCopyEntities.Count != currentValue.AnalysisEntities.Count)
                     {
-                        var newCopyValue = new CopyAbstractValue(newCopyEntities);
+                        var newCopyValue = new CopyAbstractValue(newCopyEntities, newKind);
                         foreach (var copyEntity in newCopyEntities)
                         {
                             coreAnalysisData[copyEntity] = newCopyValue;

--- a/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/SetCopyAbstractValuePredicateKind.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/CopyAnalysis/SetCopyAbstractValuePredicateKind.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
+{
+    using CopyAnalysisResult = DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue>;
+
+    internal partial class CopyAnalysis : ForwardDataFlowAnalysis<CopyAnalysisData, CopyAnalysisContext, CopyAnalysisResult, CopyBlockAnalysisResult, CopyAbstractValue>
+    {
+        /// <summary>
+        /// Predicate kind for <see cref="CopyDataFlowOperationVisitor.SetAbstractValue(CopyAnalysisData, AnalysisEntity, CopyAbstractValue, System.Func{AnalysisEntity, CopyAbstractValue}, SetCopyAbstractValuePredicateKind?, bool)"/>
+        /// to indicte if the copy equality check for the SetAbstractValue call is a reference compare or a value compare operation.
+        /// </summary>
+        internal enum SetCopyAbstractValuePredicateKind
+        {
+            ValueCompare,
+            ReferenceCompare
+        }
+    }
+}

--- a/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
                         CopyAbstractValue copyValue = GetCopyAbstractValue(target);
                         if (copyValue.Kind.IsKnown())
                         {
-                            // TODO: File a tracking bug to enable the below assert.
+                            // https://github.com/dotnet/roslyn-analyzers/issues/2106 tracks enabling the below assert.
                             //Debug.Assert(copyValue.AnalysisEntities.Contains(targetEntity));
                             foreach (var analysisEntity in copyValue.AnalysisEntities)
                             {

--- a/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
@@ -107,9 +107,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
                     if (equals)
                     {
                         CopyAbstractValue copyValue = GetCopyAbstractValue(target);
-                        if (copyValue.Kind == CopyAbstractValueKind.Known)
+                        if (copyValue.Kind.IsKnown())
                         {
-                            Debug.Assert(copyValue.AnalysisEntities.Contains(targetEntity));
+                            // TODO: File a tracking bug to enable the below assert.
+                            //Debug.Assert(copyValue.AnalysisEntities.Contains(targetEntity));
                             foreach (var analysisEntity in copyValue.AnalysisEntities)
                             {
                                 SetAbstractValue(targetAnalysisData, analysisEntity, currentAssignedValue);

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AddressSharedEntitiesProvider.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AddressSharedEntitiesProvider.cs
@@ -40,7 +40,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
             if (parameter.RefKind != RefKind.None &&
                 assignedValueOpt?.AnalysisEntityOpt != null)
             {
-                var copyValue = new CopyAbstractValue(ComputeAddressSharedEntities());
+                var addressSharedEntities = ComputeAddressSharedEntities();
+                var isReferenceCopy = !addressSharedEntities.Any(a => a.Type.IsValueType);
+                var copyValue = new CopyAbstractValue(addressSharedEntities, isReferenceCopy);
                 foreach (var entity in copyValue.AnalysisEntities)
                 {
                     _addressSharedEntitiesBuilder[entity] = copyValue;

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -296,6 +296,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             IEnumerable<AnalysisEntity> dependentAnalysisEntities;
             if (AnalysisEntityFactory.TryCreate(assignedValueOperation, out AnalysisEntity valueAnalysisEntity))
             {
+                if (!valueAnalysisEntity.Type.HasValueCopySemantics())
+                {
+                    // Unboxing conversion from assigned value (reference type) to target (value copy semantics).
+                    // We do not need to transfer any data for such a case as there is no entity for unboxed value.
+                    return;
+                }
+
                 dependentAnalysisEntities = GetChildAnalysisEntities(valueAnalysisEntity);
             }
             else

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -360,6 +360,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                             instanceLocationOpt = instancePointsToValue;
                         }
                     }
+
+                    if (instanceLocationOpt == null)
+                    {
+                        return false;
+                    }
                 }
                 else
                 {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -347,8 +347,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             {
                 if (instanceOpt.Type.IsValueType)
                 {
-                    if (TryCreate(instanceOpt, out parentOpt))
+                    if (TryCreate(instanceOpt, out var instanceEntityOpt) &&
+                        instanceEntityOpt.Type.IsValueType)
                     {
+                        parentOpt = instanceEntityOpt;
                         instanceLocationOpt = parentOpt.InstanceLocation;
                     }
                     else

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/ConversionInference.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/ConversionInference.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
+{
+    /// <summary>
+    /// Conversion inference result.
+    /// </summary>
+    internal struct ConversionInference : IEquatable<ConversionInference>
+    {
+        public static ConversionInference Create(IConversionOperation operation)
+            => Create(
+                targetTypeOpt: operation.Type,
+                sourceTypeOpt: operation.Operand.Type,
+                isTryCast: operation.IsTryCast);
+
+        public static ConversionInference Create(IIsPatternOperation operation)
+            => Create(
+                targetTypeOpt: operation.Pattern.GetPatternType(),
+                sourceTypeOpt: operation.Value.Type,
+                isTryCast: true);
+
+        public static ConversionInference Create(
+            ITypeSymbol targetTypeOpt,
+            ITypeSymbol sourceTypeOpt,
+            bool isTryCast)
+        {
+            return new ConversionInference
+            {
+                IsTryCast = isTryCast,
+                AlwaysSucceed = !isTryCast, // For direct cast, we assume the cast will always succeed as the initial default value.
+                AlwaysFail = false,
+                IsBoxing = targetTypeOpt != null &&
+                       !targetTypeOpt.IsValueType &&
+                       sourceTypeOpt?.IsValueType == true,
+                IsUnboxing = targetTypeOpt != null &&
+                       targetTypeOpt.IsValueType &&
+                       sourceTypeOpt != null &&
+                       !sourceTypeOpt.IsValueType
+            };
+        }
+
+        public bool IsTryCast { get; set; }
+        public bool AlwaysSucceed { get; set; }
+        public bool AlwaysFail { get; set; }
+        public bool IsBoxing { get; set; }
+        public bool IsUnboxing { get; set; }
+
+        public override bool Equals(object obj)
+            => obj is ConversionInference other && Equals(other);
+
+        public bool Equals(ConversionInference other)
+        {
+            return IsTryCast == other.IsTryCast &&
+                AlwaysSucceed == other.AlwaysSucceed &&
+                AlwaysFail == other.AlwaysFail &&
+                IsBoxing == other.IsBoxing &&
+                IsUnboxing == other.IsUnboxing;
+        }
+
+        public override int GetHashCode()
+            => HashUtilities.Combine(IsTryCast, AlwaysSucceed, AlwaysFail, IsBoxing, IsUnboxing);
+
+        public static bool operator ==(ConversionInference left, ConversionInference right)
+            => left.Equals(right);
+
+        public static bool operator !=(ConversionInference left, ConversionInference right)
+            => !(left == right);
+    }
+}

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -296,6 +296,22 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                             // reprocess the successor by adding it to the worklist.
                             UpdateInput(resultBuilder, successorBlockOpt, mergedSuccessorInput);
 
+                            if (isBackEdge)
+                            {
+                                // For back edges, analysis data in subsequent iterations needs
+                                // to be merged with analysis data from previous iterations.
+                                var enclosingRegion = successorBlockOpt.EnclosingRegion;
+                                while (enclosingRegion.EnclosingRegion?.FirstBlockOrdinal == successorBlockOpt.Ordinal)
+                                {
+                                    enclosingRegion = enclosingRegion.EnclosingRegion;
+                                }
+
+                                for (int i = successorBlockOpt.Ordinal; i <= enclosingRegion.LastBlockOrdinal; i++)
+                                {
+                                    blockToUniqueInputFlowMap[i] = null;
+                                }
+                            }
+
                             if (uniqueSuccessors.Add(successorBlockOpt))
                             {
                                 worklist.Add(successorBlockOpt.Ordinal);

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -2441,7 +2441,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             return cfg;
         }
 
-        private ImmutableStack<IOperation> GetInterproceduralCallStackForOwningSymbol(IMethodSymbol forOwningSymbol)
+        private ImmutableStack<IOperation> GetInterproceduralCallStackForOwningSymbol(ISymbol forOwningSymbol)
         {
             if (OwningSymbol.Equals(forOwningSymbol))
             {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisConfigurationParameters.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisConfigurationParameters.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         /// This is done for performance reasons for analyzing methods with extremely large call trees.
         /// https://github.com/dotnet/roslyn-analyzers/issues/1809 tracks improving this heuristic.
         /// </summary>
-        private const uint DefaultMaxInterproceduralLambdaOrLocalFunctionCallChain = 10;
+        private const uint DefaultMaxInterproceduralLambdaOrLocalFunctionCallChain = 3;
 
         private InterproceduralAnalysisConfiguration(
             InterproceduralAnalysisKind interproceduralAnalysisKind,

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
@@ -37,7 +37,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             ImmutableHashSet<TAnalysisContext> methodsBeingAnalyzed,
             Func<IOperation, TAbstractAnalysisValue> getCachedAbstractValueFromCaller,
             Func<IMethodSymbol, ControlFlowGraph> getInterproceduralControlFlowGraph,
-            Func<IOperation, AnalysisEntity> getAnalysisEntityForFlowCapture)
+            Func<IOperation, AnalysisEntity> getAnalysisEntityForFlowCapture,
+            Func<IMethodSymbol, ImmutableStack<IOperation>> getInterproceduralCallStackForOwningSymbol)
         {
             Debug.Assert(initialAnalysisData != null);
             Debug.Assert(!arguments.IsDefault);
@@ -47,6 +48,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Debug.Assert(getCachedAbstractValueFromCaller != null);
             Debug.Assert(getInterproceduralControlFlowGraph != null);
             Debug.Assert(getAnalysisEntityForFlowCapture != null);
+            Debug.Assert(getInterproceduralCallStackForOwningSymbol != null);
 
             InitialAnalysisData = initialAnalysisData;
             InvocationInstanceOpt = invocationInstanceOpt;
@@ -59,6 +61,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             GetCachedAbstractValueFromCaller = getCachedAbstractValueFromCaller;
             GetInterproceduralControlFlowGraph = getInterproceduralControlFlowGraph;
             GetAnalysisEntityForFlowCapture = getAnalysisEntityForFlowCapture;
+            GetInterproceduralCallStackForOwningSymbol = getInterproceduralCallStackForOwningSymbol;
         }
 
         public TAnalysisData InitialAnalysisData { get; }
@@ -72,6 +75,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public Func<IOperation, TAbstractAnalysisValue> GetCachedAbstractValueFromCaller { get; }
         public Func<IMethodSymbol, ControlFlowGraph> GetInterproceduralControlFlowGraph { get; }
         public Func<IOperation, AnalysisEntity> GetAnalysisEntityForFlowCapture { get; }
+        public Func<IMethodSymbol, ImmutableStack<IOperation>> GetInterproceduralCallStackForOwningSymbol { get; }
 
         protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Func<IOperation, TAbstractAnalysisValue> getCachedAbstractValueFromCaller,
             Func<IMethodSymbol, ControlFlowGraph> getInterproceduralControlFlowGraph,
             Func<IOperation, AnalysisEntity> getAnalysisEntityForFlowCapture,
-            Func<IMethodSymbol, ImmutableStack<IOperation>> getInterproceduralCallStackForOwningSymbol)
+            Func<ISymbol, ImmutableStack<IOperation>> getInterproceduralCallStackForOwningSymbol)
         {
             Debug.Assert(initialAnalysisData != null);
             Debug.Assert(!arguments.IsDefault);
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public Func<IOperation, TAbstractAnalysisValue> GetCachedAbstractValueFromCaller { get; }
         public Func<IMethodSymbol, ControlFlowGraph> GetInterproceduralControlFlowGraph { get; }
         public Func<IOperation, AnalysisEntity> GetAnalysisEntityForFlowCapture { get; }
-        public Func<IMethodSymbol, ImmutableStack<IOperation>> GetInterproceduralCallStackForOwningSymbol { get; }
+        public Func<ISymbol, ImmutableStack<IOperation>> GetInterproceduralCallStackForOwningSymbol { get; }
 
         protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
         {

--- a/src/Utilities/FlowAnalysis/Framework/DataFlow/PredicatedAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/Framework/DataFlow/PredicatedAnalysisData.cs
@@ -83,6 +83,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         protected void StartTrackingPredicatedData(AnalysisEntity predicatedEntity, DictionaryAnalysisData<TKey, TValue> truePredicatedData, DictionaryAnalysisData<TKey, TValue> falsePredicatedData)
         {
             Debug.Assert(predicatedEntity.Type.SpecialType == SpecialType.System_Boolean ||
+                predicatedEntity.Type.IsNullableOfBoolean() ||
                 predicatedEntity.Type.Language == LanguageNames.VisualBasic && predicatedEntity.Type.SpecialType == SpecialType.System_Object);
             Debug.Assert(predicatedEntity.CaptureIdOpt != null, "Currently we only support predicated data tracking for flow captures");
 

--- a/src/Utilities/HashUtilities.cs
+++ b/src/Utilities/HashUtilities.cs
@@ -19,6 +19,9 @@ namespace Analyzer.Utilities
         internal static int Combine<T>(ImmutableArray<T> array) => Combine(array, 0);
         internal static int Combine<T>(ImmutableArray<T> array, int currentKey) => Combine(array, array.Length, currentKey);
 
+        public static int Combine<T>(params T[] sequence)
+            => Combine(sequence, sequence.Length, currentKey: 0);
+
         public static int Combine<T>(IEnumerable<T> sequence, int length, int currentKey)
         {
             var hashCode = Combine(length, currentKey);


### PR DESCRIPTION
Also handle the boxing/unboxing conversions and copy values properly, which required support to handle reference copies in CopyAnalysis.

I have few more asserts while building Roslyn C# compilers, which I plan to address in subsequent commits/PR.

~~TODO: File an issue for one assert I disabled in this PR as this needs a bigger refactoring/feature level work.~~ Filed https://github.com/dotnet/roslyn-analyzers/issues/2106