### PR TITLE
Fix incorrect location of csi.exe in VS 2019

### DIFF
--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -72,7 +72,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_CscToolPath>$(CscToolPath)</_CscToolPath>
+      <_CscToolPath>$(RoslynTargetsPath)</_CscToolPath>
+      <_CscToolPath Condition="'$(_CscToolPath)' == ''">$(CscToolPath)</_CscToolPath>
       <_CscToolPath Condition="'$(_CscToolPath)' == ''">$(MSBuildBinPath)\Roslyn</_CscToolPath>
       <_CscToolPath Condition="!HasTrailingSlash('$(_CscToolPath)')">$(_CscToolPath)\</_CscToolPath>
     </PropertyGroup>


### PR DESCRIPTION
Fixes a mistake introduced in #2081 related to the path to csi.exe. This tool remains in the 15.0\Bin\Roslyn folder in Visual Studio 2019, but the script was attempting to call it in Current\Bin\Roslyn.