### PR TITLE
Minimizing PropertySetAbstractValue allocations and minor cleanup

### DIFF
--- a/src/Utilities/FlowAnalysis/FlowAnalysis.Utilities.projitems
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis.Utilities.projitems
@@ -4,8 +4,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <HasSharedItems>true</HasSharedItems>
     <SharedGUID>ec946164-1e17-410b-b7d9-7de7e6268d63</SharedGUID>
-	
-	<!-- CA1724: Type name conflicts in whole or in part with namepsace name -->
+    <!-- CA1724: Type name conflicts in whole or in part with namepsace name -->
     <NoWarn>$(NoWarn);CA1724</NoWarn>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
@@ -107,7 +106,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SingleThreadedConcurrentDictionary.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(ExcludeInternalFlowAnalyses)' != 'true'">
-	  <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\FilePathInjectionSinks.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\FilePathInjectionSinks.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\PooledHashSetExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\XssSanitizers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\TaintedDataAnalysis\RegexSinks.cs" />
@@ -147,6 +146,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PropertySetAnalysis\PropertyMapperCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PropertySetAnalysis\PropertySetAbstractValueKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PropertySetAnalysis\PropertySetAbstractValue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PropertySetAnalysis\PropertySetAbstractValue.ValuePool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PropertySetAnalysis\PropertySetAnalysis.PropertySetAbstractValueDomain.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PropertySetAnalysis\PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PropertySetAnalysis\PropertySetAnalysis.cs" />

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.ValuePool.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.ValuePool.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
+{
+    internal partial class PropertySetAbstractValue
+    {
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+                               // The arrays will be completely filled.
+        private class ValuePool
+        {
+            /// <summary>
+            /// Index is the <see cref="PropertySetAbstractValueKind" />.
+            /// </summary>
+            private readonly PropertySetAbstractValue[] OneDimensionalPool;
+
+            /// <summary>
+            /// Indices are the two <see cref="PropertySetAbstractValueKind"/>s.
+            /// </summary>
+            private readonly PropertySetAbstractValue[,] TwoDimensionalPool;
+
+            public ValuePool()
+            {
+                int[] values = Enum.GetValues(typeof(PropertySetAbstractValueKind)).Cast<int>().ToArray();
+                Array.Sort(values);
+                for (int i = 0; i < values.Length; i++)
+                {
+                    Debug.Assert(values[i] == i, $"{nameof(PropertySetAbstractValueKind)} isn't a contiguous enum starting at 0");
+                }
+
+                this.OneDimensionalPool = new PropertySetAbstractValue[values.Length];
+                foreach (int i in values)
+                {
+                    if (i == (int)PropertySetAbstractValueKind.Unknown)
+                    {
+                        this.OneDimensionalPool[i] = PropertySetAbstractValue.Unknown;
+                    }
+                    else
+                    {
+                        this.OneDimensionalPool[i] = new PropertySetAbstractValue(
+                            ImmutableArray.Create<PropertySetAbstractValueKind>((PropertySetAbstractValueKind)i));
+                    }
+                }
+
+                this.TwoDimensionalPool = new PropertySetAbstractValue[values.Length, values.Length];
+                foreach (int i in values)
+                {
+                    foreach (int j in values)
+                    {
+                        if (j == (int)PropertySetAbstractValueKind.Unknown)
+                        {
+                            // Because extra PropertySetAbstractValueKinds are implicitly Unknown, and the second kind (j) is 
+                            // Unknown, we can just reuse the one-dimensional pool's instances.
+                            this.TwoDimensionalPool[i, j] = OneDimensionalPool[i];
+                        }
+                        else
+                        {
+                            this.TwoDimensionalPool[i, j] = new PropertySetAbstractValue(
+                                ImmutableArray.Create<PropertySetAbstractValueKind>(
+                                    (PropertySetAbstractValueKind)i,
+                                    (PropertySetAbstractValueKind)j));
+                        }
+                    }
+                }
+            }
+
+            public PropertySetAbstractValue GetInstance(PropertySetAbstractValueKind v1)
+            {
+                return this.OneDimensionalPool[(int)v1];
+            }
+
+            public PropertySetAbstractValue GetInstance(PropertySetAbstractValueKind v1, PropertySetAbstractValueKind v2)
+            {
+                return this.TwoDimensionalPool[(int)v1, (int)v2];
+            }
+        }
+#pragma warning restore CA1814 // Prefer jagged arrays over multidimensional
+    }
+}

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.ValuePool.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.ValuePool.cs
@@ -9,8 +9,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
 {
     internal partial class PropertySetAbstractValue
     {
-#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
-                               // The arrays will be completely filled.
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional - the arrays will be completely filled.
         private class ValuePool
         {
             /// <summary>
@@ -53,8 +52,9 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                     {
                         if (j == (int)PropertySetAbstractValueKind.Unknown)
                         {
-                            // Because extra PropertySetAbstractValueKinds are implicitly Unknown, and the second kind (j) is 
-                            // Unknown, we can just reuse the one-dimensional pool's instances.
+                            // Because PropertySetAbstractValueKinds beyond the KnownPropertyAbstractValues array are
+                            // implicitly Unknown, and the second kind (j) is Unknown, we can just reuse the one-dimensional
+                            // pool's instances.
                             this.TwoDimensionalPool[i, j] = OneDimensionalPool[i];
                         }
                         else

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
@@ -74,7 +74,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
             }
 
             protected override PropertySetAnalysisData MergeAnalysisData(PropertySetAnalysisData value1, PropertySetAnalysisData value2)
-                => BinaryFormatterAnalysisDomainInstance.Merge(value1, value2);
+                => PropertySetAnalysisDomainInstance.Merge(value1, value2);
             protected override PropertySetAnalysisData GetClonedAnalysisData(PropertySetAnalysisData analysisData)
                 => GetClonedAnalysisDataHelper(analysisData);
             public override PropertySetAnalysisData GetEmptyAnalysisData()

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.cs
@@ -20,7 +20,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
     /// </summary>
     internal partial class PropertySetAnalysis : ForwardDataFlowAnalysis<PropertySetAnalysisData, PropertySetAnalysisContext, PropertySetAnalysisResult, PropertySetBlockAnalysisResult, PropertySetAbstractValue>
     {
-        public static readonly PropertySetAnalysisDomain BinaryFormatterAnalysisDomainInstance = new PropertySetAnalysisDomain(PropertySetAbstractValueDomain.Default);
+        public static readonly PropertySetAnalysisDomain PropertySetAnalysisDomainInstance = new PropertySetAnalysisDomain(PropertySetAbstractValueDomain.Default);
 
         private PropertySetAnalysis(PropertySetAnalysisDomain analysisDomain, PropertySetDataFlowOperationVisitor operationVisitor)
             : base(analysisDomain, operationVisitor)
@@ -114,7 +114,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         private static PropertySetAnalysisResult GetOrComputeResultForAnalysisContext(PropertySetAnalysisContext analysisContext)
         {
             var operationVisitor = new PropertySetDataFlowOperationVisitor(analysisContext);
-            var analysis = new PropertySetAnalysis(BinaryFormatterAnalysisDomainInstance, operationVisitor);
+            var analysis = new PropertySetAnalysis(PropertySetAnalysisDomainInstance, operationVisitor);
             return analysis.GetOrComputeResultCore(analysisContext, cacheResult: true);
         }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisContext.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
 {
     using CopyAnalysisResult = DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue>;
-    using InterproceduralBinaryFormatterAnalysisData = InterproceduralAnalysisData<DictionaryAnalysisData<AbstractLocation, PropertySetAbstractValue>, PropertySetAnalysisContext, PropertySetAbstractValue>;
+    using InterproceduralPropertySetAnalysisData = InterproceduralAnalysisData<DictionaryAnalysisData<AbstractLocation, PropertySetAbstractValue>, PropertySetAnalysisContext, PropertySetAbstractValue>;
     using PointsToAnalysisResult = DataFlowAnalysisResult<PointsToBlockAnalysisResult, PointsToAbstractValue>;
     using PropertySetAnalysisData = DictionaryAnalysisData<AbstractLocation, PropertySetAbstractValue>;
     using ValueContentAnalysisResult = DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>;
@@ -36,7 +36,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
             ValueContentAnalysisResult valueContentAnalysisResultOpt,
             Func<PropertySetAnalysisContext, PropertySetAnalysisResult> getOrComputeAnalysisResult,
             ControlFlowGraph parentControlFlowGraphOpt,
-            InterproceduralBinaryFormatterAnalysisData interproceduralAnalysisDataOpt,
+            InterproceduralPropertySetAnalysisData interproceduralAnalysisDataOpt,
             string typeToTrackMetadataName,
             ConstructorMapper constructorMapper,
             PropertyMapperCollection propertyMappers,
@@ -96,7 +96,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
             IOperation operation,
             PointsToAnalysisResult pointsToAnalysisResultOpt,
             CopyAnalysisResult copyAnalysisResultOpt,
-            InterproceduralBinaryFormatterAnalysisData interproceduralAnalysisData)
+            InterproceduralPropertySetAnalysisData interproceduralAnalysisData)
         {
             Debug.Assert(pointsToAnalysisResultOpt != null);
             Debug.Assert(copyAnalysisResultOpt == null);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetBlockAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetBlockAnalysisResult.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 
@@ -12,7 +10,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
 
     /// <summary>
     /// Result from execution of <see cref="PropertySetAnalysis"/> on a basic block.
-    /// It stores BinaryFormatter values for each <see cref="AbstractLocation"/> at the start and end of the basic block.
+    /// It stores <see cref="PropertySetAbstractValue"/>s for each <see cref="AbstractLocation"/> at the start and end of the basic block.
     /// </summary>
     internal class PropertySetBlockAnalysisResult : AbstractBlockAnalysisResult
     {


### PR DESCRIPTION
- I only have scenarios involving two properties so far, so just pooling PropertySetAbstractValues for up to two PropertySetAbstractValueKinds.