### PR TITLE
Make DisposeAnalysis and CA2000 (DisposeObjectsBeforeLosingScope) more aggressive

### DIFF
--- a/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
@@ -217,10 +217,14 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValu
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue.DisposingOrEscapingOperations.get -> System.Collections.Immutable.ImmutableHashSet<Microsoft.CodeAnalysis.IOperation>
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue.Kind.get -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
-Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.Disposed = 2 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
-Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.MaybeDisposed = 3 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.Disposed = 5 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.Escaped = 3 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.Invalid = 1 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.MaybeDisposed = 6 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.NotDisposable = 0 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
-Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.NotDisposed = 1 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.NotDisposed = 2 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.NotDisposedOrEscaped = 4 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind.Unknown = 7 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValueKind
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysis
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysisContext
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysisResult
@@ -611,6 +615,7 @@ static Microsoft.CodeAnalysis.PooledHashSet<T>.CreatePool() -> Microsoft.CodeAna
 static Microsoft.CodeAnalysis.PooledHashSet<T>.GetInstance() -> Microsoft.CodeAnalysis.PooledHashSet<T>
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation.NoLocation -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation.Null -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation
+static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue.Invalid -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue.NotDisposable -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue.NotDisposed -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue.Unknown -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
@@ -156,11 +156,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                             {
                                                 // For MaybeDisposed, conservatively mark the field as disposed as we don't support path sensitive analysis.
                                                 case DisposeAbstractValueKind.MaybeDisposed:
+                                                case DisposeAbstractValueKind.Unknown:
+                                                case DisposeAbstractValueKind.Escaped:
                                                 case DisposeAbstractValueKind.Disposed:
                                                     disposed = true;
                                                     addOrUpdateFieldDisposedValue(field, disposed);
                                                     break;
-
                                             }
                                         }
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SystemRuntimeAnalyzersResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SystemRuntimeAnalyzersResources.resx
@@ -384,8 +384,11 @@
   <data name="DisposeObjectsBeforeLosingScopeDescription" xml:space="preserve">
     <value>If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</value>
   </data>
-  <data name="DisposeObjectsBeforeLosingScopeMessage" xml:space="preserve">
+  <data name="DisposeObjectsBeforeLosingScopeNotDisposedMessage" xml:space="preserve">
     <value>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</value>
+  </data>
+  <data name="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage" xml:space="preserve">
+    <value>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</value>
   </data>
   <data name="DisposeObjectsBeforeLosingScopeTitle" xml:space="preserve">
     <value>Dispose objects before losing scope</value>

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.cs.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.de.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.es.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.fr.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.it.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ja.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ko.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.pl.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.pt-BR.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ru.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.tr.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.zh-Hans.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.zh-Hant.xlf
@@ -17,7 +17,12 @@
         <target state="new">If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DisposeObjectsBeforeLosingScopeMessage">
+      <trans-unit id="DisposeObjectsBeforeLosingScopeMayBeDisposedMessage">
+        <source>In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</source>
+        <target state="new">In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DisposeObjectsBeforeLosingScopeNotDisposedMessage">
         <source>In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</source>
         <target state="new">In method '{0}', call System.IDisposable.Dispose on object created by '{1}' before all references to it are out of scope.</target>
         <note />

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValueKind.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValueKind.cs
@@ -13,9 +13,34 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
         NotDisposable,
 
         /// <summary>
+        /// Indicates a value for disposable locations that are not feasible on the given program path.
+        /// For example,
+        /// <code>
+        ///     var x = flag ? new Disposable() : null;
+        ///     if (x == null)
+        ///     {
+        ///         // Disposable allocation above cannot exist on this code path.
+        ///     }
+        /// </code>
+        /// </summary>
+        Invalid,
+
+        /// <summary>
         /// Indicates disposable locations that are not disposed.
         /// </summary>
         NotDisposed,
+
+        /// <summary>
+        /// Indicates disposable locations that have escaped the declaring method's scope.
+        /// For example, a disposable allocation assigned to a field/property or
+        /// escped as a return value for a function, or assigned to a ref or out parameter, etc.
+        /// </summary>
+        Escaped,
+
+        /// <summary>
+        /// Indicates disposable locations that are either not disposed or escaped.
+        /// </summary>
+        NotDisposedOrEscaped,
 
         /// <summary>
         /// Indicates disposable locations that are disposed.
@@ -23,8 +48,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
         Disposed,
 
         /// <summary>
-        /// Indicates disposable locations that may be disposed.
+        /// Indicates disposable locations that may be disposed on some program path(s).
         /// </summary>
-        MaybeDisposed
+        MaybeDisposed,
+
+        /// <summary>
+        /// Indicates disposable locations whose dispose state is unknown.
+        /// </summary>
+        Unknown,
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
                 // }
                 var isNullEqualsOnWhenTrue = FlowBranchConditionKind == ControlFlowConditionKind.WhenTrue &&
                     (operation.OperatorKind == BinaryOperatorKind.Equals || operation.OperatorKind == BinaryOperatorKind.ObjectValueEquals);
-                
+
                 // if (x != null) { ... }
                 // else
                 // {
@@ -384,7 +384,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
 
                 return value;
             }
-            
+
             #endregion
         }
     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -113,11 +113,25 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
                 }
             }
 
+            private void HandlePossibleInvalidatingOperation(IOperation invalidatedInstance)
+            {
+                PointsToAbstractValue instanceLocation = GetPointsToAbstractValue(invalidatedInstance);
+                foreach (AbstractLocation location in instanceLocation.Locations)
+                {
+                    if (CurrentAnalysisData.TryGetValue(location, out DisposeAbstractValue currentDisposeValue) &&
+                        currentDisposeValue.Kind != DisposeAbstractValueKind.NotDisposable)
+                    {
+                        SetAbstractValue(location, DisposeAbstractValue.Invalid);
+                    }
+                }
+            }
+
             private void HandlePossibleEscapingOperation(IOperation escapingOperation, ImmutableHashSet<AbstractLocation> escapedLocations)
             {
                 foreach (AbstractLocation escapedLocation in escapedLocations)
                 {
-                    if (CurrentAnalysisData.TryGetValue(escapedLocation, out DisposeAbstractValue currentDisposeValue))
+                    if (CurrentAnalysisData.TryGetValue(escapedLocation, out DisposeAbstractValue currentDisposeValue) &&
+                        currentDisposeValue.Kind != DisposeAbstractValueKind.Unknown)
                     {
                         DisposeAbstractValue newDisposeValue = currentDisposeValue.WithNewEscapingOperation(escapingOperation);
                         SetAbstractValue(escapedLocation, newDisposeValue);
@@ -313,6 +327,64 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
                 return value;
             }
 
+            public override DisposeAbstractValue VisitBinaryOperatorCore(IBinaryOperation operation, object argument)
+            {
+                var value = base.VisitBinaryOperatorCore(operation, argument);
+
+                // Handle null-check for a disposable symbol on a control flow branch.
+                //     var x = flag ? new Disposable() : null;
+                //     if (x == null)
+                //     {
+                //         // Disposable allocation above cannot exist on this code path.
+                //     }
+                //
+
+                // if (x == null)
+                // {
+                //      // This code path
+                // }
+                var isNullEqualsOnWhenTrue = FlowBranchConditionKind == ControlFlowConditionKind.WhenTrue &&
+                    (operation.OperatorKind == BinaryOperatorKind.Equals || operation.OperatorKind == BinaryOperatorKind.ObjectValueEquals);
+                
+                // if (x != null) { ... }
+                // else
+                // {
+                //      // This code path
+                // }
+                var isNullNotEqualsOnWhenFalse = FlowBranchConditionKind == ControlFlowConditionKind.WhenFalse &&
+                    (operation.OperatorKind == BinaryOperatorKind.NotEquals || operation.OperatorKind == BinaryOperatorKind.ObjectValueNotEquals);
+
+                if (isNullEqualsOnWhenTrue || isNullNotEqualsOnWhenFalse)
+                {
+                    if (GetNullAbstractValue(operation.RightOperand) == NullAbstractValue.Null)
+                    {
+                        // if (x == null)
+                        HandlePossibleInvalidatingOperation(operation.LeftOperand);
+                    }
+                    else if (GetNullAbstractValue(operation.LeftOperand) == NullAbstractValue.Null)
+                    {
+                        // if (null == x)
+                        HandlePossibleInvalidatingOperation(operation.RightOperand);
+                    }
+                }
+
+                return value;
+            }
+
+            public override DisposeAbstractValue VisitIsNull(IIsNullOperation operation, object argument)
+            {
+                var value = base.VisitIsNull(operation, argument);
+
+                // Handle null-check for a disposable symbol on a control flow branch.
+                // See comments in VisitBinaryOperatorCore override above for further details.
+                if (FlowBranchConditionKind == ControlFlowConditionKind.WhenTrue)
+                {
+                    HandlePossibleInvalidatingOperation(operation.Operand);
+                }
+
+                return value;
+            }
+            
             #endregion
         }
     }


### PR DESCRIPTION
Current implementation of CA2000 dispose analysis only flags disposable creations for which we are certain that _no Dispose invocations_ are made on **all control flow paths**.

New implementation makes the analysis more aggressive by also flagging the cases where disposable creations **may not be disposed on some program paths**. For such cases, we recommend usage of standard dispose patterns such as using statement, using declaration or a try-finally with a dedicated local variable to hold the disposable creation and a dispose invocation in finally. The diagnostic message for the may be disposed violations is weaker in the sense that it does not state that a dispose leak will certainly happen on some program path, as claiming that requires complete path sensitive analysis, which is tracked with #1581. Instead the diagnostic message states that using standard dispose patterns is recommended to avoid possible leaks.

```
In method '{0}', refactor the code to ensure that disposable object created by '{1}' is disposed on all paths where references to it go out of scope. If possible, wrap the creation within a 'using' statement or declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.
```

I have used the same diagnostic ID `CA2000` for the may be disposed violations for compatibility with legacy FxCop, especially so that we respect any existing suppressions.

**Further work:** I plan to address #1580 after this change to even flag possible leaks in exceptional paths. I am also planning to add an editorconfig options to enable end user to turn off the may be disposed violations either completely or just for exceptional paths.