### PR TITLE
CA3075 don't pessimistically assume insecure XmlReaderSettings if unknown

### DIFF
--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
@@ -284,19 +284,10 @@ namespace Microsoft.NetFramework.Analyzers
                             return;
                         }
 
-                        if (!_xmlReaderSettingsEnvironments.TryGetValue(settingsSymbol, out XmlReaderSettingsEnvironment env))
-                        {
-                            // symbol for settings is not found => passed in without any change => assume insecure
-                            Diagnostic diag = Diagnostic.Create(
-                                RuleDoNotUseInsecureDtdProcessing,
-                                expressionSyntax.GetLocation(),
-                                SecurityDiagnosticHelpers.GetLocalizableResourceString(
-                                    nameof(MicrosoftNetFrameworkAnalyzersResources.XmlReaderCreateInsecureInputMessage)
-                                )
-                            );
-                            context.ReportDiagnostic(diag);
-                        }
-                        else if (!env.IsDtdProcessingDisabled && !(env.IsSecureResolver && env.IsMaxCharactersFromEntitiesLimited))
+                        // If we have no XmlReaderSettingsEnvironment, then we don't know.
+                        if (_xmlReaderSettingsEnvironments.TryGetValue(settingsSymbol, out XmlReaderSettingsEnvironment env)
+                            && !env.IsDtdProcessingDisabled
+                            && !(env.IsSecureResolver && env.IsMaxCharactersFromEntitiesLimited))
                         {
                             Diagnostic diag;
                             if (env.IsConstructedInCodeBlock)
@@ -319,6 +310,7 @@ namespace Microsoft.NetFramework.Analyzers
                                     )
                                 );
                             }
+
                             context.ReportDiagnostic(diag);
                         }
                     }

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
         }
 
         [Fact]
-        public async Task XmlReaderSettingsDefaultAsFieldShouldGenerateDiagnostic()
+        public async Task XmlReaderSettingsDefaultAsFieldShouldNotGenerateDiagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Xml;
@@ -38,13 +38,11 @@ namespace TestNamespace
 
         public void TestMethod(string path)
         {
-            var reader = XmlReader.Create(path, settings);  // we treat the field the same as parameter
+            var reader = XmlReader.Create(path, settings);  // analyzer only looks at a code block, so the field's state is unknown
         }
     }
 }
-",
-                GetCA3075XmlReaderCreateInsecureInputCSharpResultAt(12, 26)
-            );
+");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Xml
@@ -55,12 +53,10 @@ Namespace TestNamespace
 
         Public Sub TestMethod(path As String)
             Dim reader = XmlReader.Create(path, settings)
-            ' we treat the field the same as parameter
+            ' analyzer only looks at a code block, so the field's state is unknown
         End Sub
     End Class
-End Namespace",
-                GetCA3075XmlReaderCreateInsecureInputBasicResultAt(9, 26)
-            );
+End Namespace");
         }
 
         [Fact]
@@ -134,7 +130,7 @@ End Namespace");
         }
 
         [Fact]
-        public async Task XmlReaderSettingsAsInputSetDtdProcessingToParseShouldGenerateDiagnostic()
+        public async Task XmlReaderSettingsAsInputSetDtdProcessingToParseShouldNotGenerateDiagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Xml;
@@ -149,9 +145,7 @@ namespace TestNamespace
         }
     }
 }
-",
-                GetCA3075XmlReaderCreateInsecureInputCSharpResultAt(10, 26)
-            );
+");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Xml
@@ -162,13 +156,11 @@ Namespace TestNamespace
             Dim reader = XmlReader.Create(path, settings)
         End Sub
     End Class
-End Namespace",
-                GetCA3075XmlReaderCreateInsecureInputBasicResultAt(7, 26)
-             );
+End Namespace");
         }
 
         [Fact]
-        public async Task XmlReaderSettingsAsInputInGetShouldGenerateDiagnostic()
+        public async Task XmlReaderSettingsAsInputInGetShouldNotGenerateDiagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Xml;
@@ -186,9 +178,7 @@ public class TestClass
         }
     }
 }
-",
-                GetCA3075XmlReaderCreateInsecureInputCSharpResultAt(12, 32)
-            );
+");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Xml
@@ -202,13 +192,11 @@ Public Class TestClass
             Return reader
         End Get
     End Property
-End Class",
-                GetCA3075XmlReaderCreateInsecureInputBasicResultAt(9, 39)
-            );
+End Class");
         }
 
         [Fact]
-        public async Task XmlReaderSettingsAsInputInTryShouldGenerateDiagnostic()
+        public async Task XmlReaderSettingsAsInputInTryShouldNotGenerateDiagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
@@ -228,9 +216,7 @@ class TestClass6a
         finally { }
     }
 }
-",
-                GetCA3075XmlReaderCreateInsecureInputCSharpResultAt(13, 26)
-            );
+");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -247,13 +233,11 @@ Class TestClass6a
         Finally
         End Try
     End Sub
-End Class",
-                GetCA3075XmlReaderCreateInsecureInputBasicResultAt(10, 26)
-            );
+End Class");
         }
 
         [Fact]
-        public async Task XmlReaderSettingsAsInputInCatchShouldGenerateDiagnostic()
+        public async Task XmlReaderSettingsAsInputInCatchShouldNotGenerateDiagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
@@ -272,9 +256,7 @@ class TestClass6a
         finally { }
     }
 }
-",
-                GetCA3075XmlReaderCreateInsecureInputCSharpResultAt(13, 26)
-            );
+");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -290,13 +272,11 @@ Class TestClass6a
         Finally
         End Try
     End Sub
-End Class",
-                GetCA3075XmlReaderCreateInsecureInputBasicResultAt(11, 26)
-            );
+End Class");
         }
 
         [Fact]
-        public async Task XmlReaderSettingsAsInputInFinallyShouldGenerateDiagnostic()
+        public async Task XmlReaderSettingsAsInputInFinallyShouldNotGenerateDiagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
@@ -315,9 +295,7 @@ class TestClass6a
         }
     }
 }
-",
-                GetCA3075XmlReaderCreateInsecureInputCSharpResultAt(14, 26)
-            );
+");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -334,13 +312,11 @@ Class TestClass6a
             Dim reader = XmlReader.Create(xml, settings)
         End Try
     End Sub
-End Class",
-                GetCA3075XmlReaderCreateInsecureInputBasicResultAt(13, 26)
-            );
+End Class");
         }
 
         [Fact]
-        public async Task XmlReaderSettingsAsInputInAsyncAwaitShouldGenerateDiagnostic()
+        public async Task XmlReaderSettingsAsInputInAsyncAwaitShouldNotGenerateDiagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Threading.Tasks;
@@ -362,9 +338,7 @@ class TestClass
         await TestMethod();
     }
 }
-",
-                GetCA3075XmlReaderCreateInsecureInputCSharpResultAt(12, 26)
-            );
+");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Threading.Tasks
@@ -383,13 +357,11 @@ End Function)
     Private Async Sub TestMethod2()
         Await TestMethod()
     End Sub
-End Class",
-                GetCA3075XmlReaderCreateInsecureInputBasicResultAt(10, 22)
-            );
+End Class");
         }
 
         [Fact]
-        public async Task XmlReaderSettingsAsInputInDelegateShouldGenerateDiagnostic()
+        public async Task XmlReaderSettingsAsInputInDelegateShouldNotGenerateDiagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Xml;
@@ -405,9 +377,7 @@ class TestClass
         var reader = XmlReader.Create(xml, settings);
     };
 }
-",
-                GetCA3075XmlReaderCreateInsecureInputCSharpResultAt(12, 22)
-            );
+");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Xml
@@ -422,9 +392,7 @@ Class TestClass
     Dim reader = XmlReader.Create(xml, settings)
 
 End Sub
-End Class",
-                GetCA3075XmlReaderCreateInsecureInputBasicResultAt(11, 18)
-            );
+End Class");
         }
 
         [Fact]

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingXmlReaderCreateUsingInsecureConstructedXmlReaderSettingsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingXmlReaderCreateUsingInsecureConstructedXmlReaderSettingsTests.cs
@@ -14,6 +14,41 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
     public partial class DoNotUseInsecureDtdProcessingAnalyzerTests
     {
         [Fact]
+        public async Task DefaultXmlReaderSettingsInStaticFieldShouldNotGenerateDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Xml;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        private static readonly XmlReaderSettings Settings = new XmlReaderSettings();
+
+        public void TestMethod(string path)
+        {
+            XmlReader reader = XmlReader.Create(path, Settings);
+        }
+    }
+}
+"
+            );
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Imports System.Xml
+
+Namespace TestNamespace
+    Public Class TestClass
+        Private Shared ReadOnly Settings As New XmlReaderSettings()
+
+        Public Sub TestMethod(path As String)
+            Dim reader As XmlReader = XmlReader.Create(path, Settings)
+        End Sub
+    End Class
+End Namespace");
+        }
+
+        [Fact]
         public async Task DefaultXmlReaderSettingsShouldNotGenerateDiagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"


### PR DESCRIPTION
Fixes #2105.  With the analyzer only looking at one code block at a time, XmlReaderSetting instances from member fields and input parameters are in an unknown state.  Instead of assuming insecure, we should not generate diagnostics on unknowns.