### PR TITLE
Minor cleanups

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithms.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureCryptographicAlgorithms.cs
@@ -17,8 +17,8 @@ namespace Microsoft.NetCore.Analyzers.Security
         internal const string DoNotUseWeakCryptographyRuleId = "CA5350";
         internal const string DoNotUseBrokenCryptographyRuleId = "CA5351";
 
-        internal const string CA5350HelpLink = "https://aka.ms/CA5350";
-        internal const string CA5351HelpLink = "https://aka.ms/CA5351";
+        internal const string CA5350HelpLink = "https://docs.microsoft.com/visualstudio/code-quality/ca5350-do-not-use-weak-cryptographic-algorithms";
+        internal const string CA5351HelpLink = "https://docs.microsoft.com/visualstudio/code-quality/ca5351-do-not-use-broken-cryptographic-algorithms";
 
         private static readonly LocalizableString s_localizableDoNotUseWeakAlgorithmsTitle = new LocalizableResourceString(
             nameof(SystemSecurityCryptographyResources.DoNotUseWeakCryptographicAlgorithms),

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
@@ -136,7 +136,7 @@
     <value>When deserializing an instance of class {0}, method {1} can call dangerous method {2}.</value>
   </data>
   <data name="DoNotDisableCertificateValidation" xml:space="preserve">
-    <value>Do Not Disable Certification Validation</value>
+    <value>Do Not Disable Certificate Validation</value>
   </data>
   <data name="DoNotDisableCertificateValidationDescription" xml:space="preserve">
     <value>A certificate can help authenticate the identity of the server. Clients should validate the server certificate to ensure requests are sent to the intended server. If the ServerCertificateValidationCallback always returns 'true', any certificate will pass validation.</value>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">Nezakazujte ověření certifikace</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">Nezakazujte ověření certifikace</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">Zertifikatüberprüfung nicht deaktivieren</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">Zertifikatüberprüfung nicht deaktivieren</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">No deshabilite la validación de la certificación.</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">No deshabilite la validación de la certificación.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">Ne pas désactiver la validation de certification</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">Ne pas désactiver la validation de certification</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">Non disabilitare la convalida del certificato</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">Non disabilitare la convalida del certificato</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">証明書の検証を無効にしない</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">証明書の検証を無効にしない</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">인증 유효성 검사를 비활성화하면 안 됨</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">인증 유효성 검사를 비활성화하면 안 됨</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">Nie wyłączaj walidacji certyfikacji</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">Nie wyłączaj walidacji certyfikacji</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">Não desabilitar a validação de certificação</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">Não desabilitar a validação de certificação</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">Не отключать проверку сертификации</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">Не отключать проверку сертификации</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">Sertifika Doğrulamasını Devre Dışı Bırakmayın</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">Sertifika Doğrulamasını Devre Dışı Bırakmayın</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">不要禁用证书验证</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">不要禁用证书验证</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidation">
-        <source>Do Not Disable Certification Validation</source>
-        <target state="translated">不要停用憑證驗證</target>
+        <source>Do Not Disable Certificate Validation</source>
+        <target state="needs-review-translation">不要停用憑證驗證</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableCertificateValidationDescription">

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NetFramework.Analyzers
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
                                                                              isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
-                                                                             helpLinkUri: "http://aka.ms/CA2153",
+                                                                             helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2153-avoid-handling-corrupted-state-exceptions",
                                                                              customTags: WellKnownDiagnosticTags.Telemetry);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessing.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NetFramework.Analyzers
     public sealed class DoNotUseInsecureDtdProcessingAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA3075";
-        private const string HelpLink = "http://aka.ms/CA3075";
+        private const string HelpLink = "https://docs.microsoft.com/visualstudio/code-quality/ca3075-insecure-dtd-processing";
 
         internal static DiagnosticDescriptor RuleDoNotUseInsecureDtdProcessing = CreateDiagnosticDescriptor(
                                                                                     SecurityDiagnosticHelpers.GetLocalizableResourceString(nameof(MicrosoftNetFrameworkAnalyzersResources.DoNotUseInsecureDtdProcessingGenericMessage)),

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessingInApiDesign.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureDtdProcessingInApiDesign.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NetFramework.Analyzers
     public abstract class DoNotUseInsecureDtdProcessingInApiDesignAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA3077";
-        private const string HelpLink = "http://aka.ms/CA3077";
+        private const string HelpLink = "https://docs.microsoft.com/visualstudio/code-quality/ca3077-insecure-processing-in-api-design-xml-document-and-xml-text-reader";
 
         internal static DiagnosticDescriptor RuleDoNotUseInsecureDtdProcessingInApiDesign = CreateDiagnosticDescriptor(SecurityDiagnosticHelpers.GetLocalizableResourceString(nameof(MicrosoftNetFrameworkAnalyzersResources.DoNotUseInsecureDtdProcessingGenericMessage)),
                                                                                                                         SecurityDiagnosticHelpers.GetLocalizableResourceString(nameof(MicrosoftNetFrameworkAnalyzersResources.DoNotUseInsecureDtdProcessingInApiDesignDescription)),

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotUseInsecureXSLTScriptExecution.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NetFramework.Analyzers
     public abstract class DoNotUseInsecureXSLTScriptExecutionAnalyzer<TLanguageKindEnum> : DiagnosticAnalyzer where TLanguageKindEnum : struct
     {
         internal const string RuleId = "CA3076";
-        private const string HelpLink = "http://aka.ms/CA3076";
+        private const string HelpLink = "https://docs.microsoft.com/visualstudio/code-quality/ca3076-insecure-xslt-script-execution";
         internal static DiagnosticDescriptor RuleDoNotUseInsecureXSLTScriptExecution = CreateDiagnosticDescriptor(SecurityDiagnosticHelpers.GetLocalizableResourceString(nameof(MicrosoftNetFrameworkAnalyzersResources.DoNotUseInsecureDtdProcessingGenericMessage)),
                                                                                                                 SecurityDiagnosticHelpers.GetLocalizableResourceString(nameof(MicrosoftNetFrameworkAnalyzersResources.DoNotUseInsecureXSLTScriptExecutionDescription)),
                                                                                                                  HelpLink);

--- a/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NetFramework.Analyzers
     public partial class MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA3147";
-        private const string HelpLinkUri = "https://aka.ms/ca3147";
+        private const string HelpLinkUri = "https://docs.microsoft.com/visualstudio/code-quality/ca3147-mark-verb-handlers-with-validateantiforgerytoken";
 
         private static readonly LocalizableString Title = new LocalizableResourceString(
             nameof(MicrosoftSecurityAnalyzersResources.MarkVerbHandlersWithValidateAntiforgeryTokenTitle),

--- a/src/Microsoft.NetFramework.Analyzers/Core/MicrosoftSecurityAnalyzersResources.resx
+++ b/src/Microsoft.NetFramework.Analyzers/Core/MicrosoftSecurityAnalyzersResources.resx
@@ -130,7 +130,7 @@
     <value>Missing ValidateAntiForgeryTokenAttribute on MVC controller action {0} which by default accepts POST requests.</value>
   </data>
   <data name="MarkVerbHandlersWithValidateAntiforgeryTokenTitle" xml:space="preserve">
-    <value>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</value>
+    <value>Mark Verb Handlers With Validate Antiforgery Token</value>
   </data>
   <data name="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage" xml:space="preserve">
     <value>Missing ValidateAntiForgeryTokenAttribute on controller action {0}.</value>

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.cs.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.de.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.es.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.fr.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.it.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.ja.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.ko.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.pl.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.ru.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.tr.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">

--- a/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.NetFramework.Analyzers/Core/xlf/MicrosoftSecurityAnalyzersResources.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenTitle">
-        <source>MarkVerbHandlersWithValidateAntiforgeryTokenTitle</source>
-        <target state="translated">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
+        <source>Mark Verb Handlers With Validate Antiforgery Token</source>
+        <target state="needs-review-translation">MarkVerbHandlersWithValidateAntiforgeryTokenTitle</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkVerbHandlersWithValidateAntiforgeryTokenVerbsAndNoTokenMessage">


### PR DESCRIPTION
- CA3147's had a weird title.
- CA5359's title should've said "certificate", not "certification".
- Replacing aka.ms URLs with docs.microsoft.com.