### PR TITLE
Namespace isolation analyzer

### DIFF
--- a/RoslynAnalyzers.sln
+++ b/RoslynAnalyzers.sln
@@ -186,6 +186,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PerformanceSensit
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Workspaces.Utilities", "src\Utilities\Workspaces\Workspaces.Utilities.shproj", "{99F594B1-3916-471D-A761-A6731FC50E9A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "IsolateNamespaceAnalyzer", "IsolateNamespaceAnalyzer", "{53DF5D65-1BB7-41D6-AADA-C2C528BFDAD3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetAnalyzers.IsolateNamespaceAnalyzer", "src\DotNetAnalyzers\Core\IsolateNamespaceAnalyzer\DotNetAnalyzers.IsolateNamespaceAnalyzer.csproj", "{DF802689-F6F7-49B9-AB95-3CC287F9D424}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetAnalyzers.IsolateNamespaceAnalyzer.Package", "nuget\DotNetAnalyzers\DotNetAnalyzers.IsolateNamespaceAnalyzer.Package.csproj", "{B845E770-F1A8-4557-892A-05F3634AFDEF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetAnalyzers.IsolateNamespaceAnalyzer.Setup", "src\DotNetAnalyzers\Setup\IsolateNamespaceAnalyzer\DotNetAnalyzers.IsolateNamespaceAnalyzer.Setup.csproj", "{88C985E0-791D-4CF0-9EC7-39840B61DA70}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{99f594b1-3916-471d-a761-a6731fc50e9a}*SharedItemsImports = 13
@@ -758,6 +766,30 @@ Global
 		{1718D626-A991-4874-A6A5-2136E68152B2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1718D626-A991-4874-A6A5-2136E68152B2}.Release|x86.ActiveCfg = Release|Any CPU
 		{1718D626-A991-4874-A6A5-2136E68152B2}.Release|x86.Build.0 = Release|Any CPU
+		{DF802689-F6F7-49B9-AB95-3CC287F9D424}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF802689-F6F7-49B9-AB95-3CC287F9D424}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF802689-F6F7-49B9-AB95-3CC287F9D424}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DF802689-F6F7-49B9-AB95-3CC287F9D424}.Debug|x86.Build.0 = Debug|Any CPU
+		{DF802689-F6F7-49B9-AB95-3CC287F9D424}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF802689-F6F7-49B9-AB95-3CC287F9D424}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF802689-F6F7-49B9-AB95-3CC287F9D424}.Release|x86.ActiveCfg = Release|Any CPU
+		{DF802689-F6F7-49B9-AB95-3CC287F9D424}.Release|x86.Build.0 = Release|Any CPU
+		{B845E770-F1A8-4557-892A-05F3634AFDEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B845E770-F1A8-4557-892A-05F3634AFDEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B845E770-F1A8-4557-892A-05F3634AFDEF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B845E770-F1A8-4557-892A-05F3634AFDEF}.Debug|x86.Build.0 = Debug|Any CPU
+		{B845E770-F1A8-4557-892A-05F3634AFDEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B845E770-F1A8-4557-892A-05F3634AFDEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B845E770-F1A8-4557-892A-05F3634AFDEF}.Release|x86.ActiveCfg = Release|Any CPU
+		{B845E770-F1A8-4557-892A-05F3634AFDEF}.Release|x86.Build.0 = Release|Any CPU
+		{88C985E0-791D-4CF0-9EC7-39840B61DA70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88C985E0-791D-4CF0-9EC7-39840B61DA70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88C985E0-791D-4CF0-9EC7-39840B61DA70}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{88C985E0-791D-4CF0-9EC7-39840B61DA70}.Debug|x86.Build.0 = Debug|Any CPU
+		{88C985E0-791D-4CF0-9EC7-39840B61DA70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88C985E0-791D-4CF0-9EC7-39840B61DA70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88C985E0-791D-4CF0-9EC7-39840B61DA70}.Release|x86.ActiveCfg = Release|Any CPU
+		{88C985E0-791D-4CF0-9EC7-39840B61DA70}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -837,6 +869,10 @@ Global
 		{1D3D05A7-461E-4CEC-BF38-860793014066} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
 		{1718D626-A991-4874-A6A5-2136E68152B2} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
 		{99F594B1-3916-471D-A761-A6731FC50E9A} = {1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}
+		{53DF5D65-1BB7-41D6-AADA-C2C528BFDAD3} = {E2E56F9F-AD96-4235-9ACE-CBF26CC5C421}
+		{DF802689-F6F7-49B9-AB95-3CC287F9D424} = {53DF5D65-1BB7-41D6-AADA-C2C528BFDAD3}
+		{B845E770-F1A8-4557-892A-05F3634AFDEF} = {53DF5D65-1BB7-41D6-AADA-C2C528BFDAD3}
+		{88C985E0-791D-4CF0-9EC7-39840B61DA70} = {53DF5D65-1BB7-41D6-AADA-C2C528BFDAD3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FC44ACA9-AEA3-4EE6-881C-2E08ED281B5F}

--- a/nuget/DotNetAnalyzers/DotNetAnalyzers.IsolateNamespaceAnalyzer.Package.csproj
+++ b/nuget/DotNetAnalyzers/DotNetAnalyzers.IsolateNamespaceAnalyzer.Package.csproj
@@ -1,0 +1,30 @@
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.3</TargetFramework>
+
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NuspecPackageId>DotNetAnalyzers.IsolateNamespaceAnalyzer</NuspecPackageId>
+    <Description>Isolate Namespace Analyzer</Description>
+    <Summary>Isolate Namespace Analyzer</Summary>
+    <ReleaseNotes>Isolate Namespace Analyzer</ReleaseNotes>
+    <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics NamespaceIsolation Architecture</PackageTags>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard1.3'">
+      <PropertyGroup>
+        <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+  <ItemGroup>
+    <AnalyzerNupkgAssembly Include="DotNetAnalyzers.IsolateNamespaceAnalyzer.dll" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotNetAnalyzers\Core\IsolateNamespaceAnalyzer\DotNetAnalyzers.IsolateNamespaceAnalyzer.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/DotNetAnalyzers.IsolateNamespaceAnalyzer.csproj
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/DotNetAnalyzers.IsolateNamespaceAnalyzer.csproj
@@ -1,0 +1,21 @@
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <!--
+      PackageId is used by Restore. If we set it to DotNetAnalyzers.IsolateNamespaceAnalyzer,
+      Restore would conclude that there is a cyclic dependency between us and the DotNetAnalyzers.IsolateNamespaceAnalyzer package.
+    -->
+    <PackageId>*$(MSBuildProjectFullPath)*</PackageId>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\Roslyn.Diagnostics.Analyzers\Core\RoslynDiagnosticIds.cs" Link="RoslynDiagnosticIds.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="DotNetAnalyzers.UnitTests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.0" />
+  </ItemGroup>
+  <Import Project="..\..\..\Utilities\Compiler\Analyzer.Utilities.projitems" Label="Shared" />
+</Project>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/DotNetAnalyzersResources.resx
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/DotNetAnalyzersResources.resx
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TypeIsInIsolatedNamespaceDescription" xml:space="preserve">
+    <value>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</value>
+  </data>
+  <data name="TypeIsInIsolatedNamespaceMessage" xml:space="preserve">
+    <value>Type '{0}' is isolated and may not be used from namespace '{1}'.</value>
+  </data>
+  <data name="TypeIsInIsolatedNamespaceTitle" xml:space="preserve">
+    <value>Types within isolated namespaces may not be used externally</value>
+  </data>
+</root>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/NamespaceIsIsolatedAnalyzer.cs
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/NamespaceIsIsolatedAnalyzer.cs
@@ -1,0 +1,420 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using DiagnosticIds = Roslyn.Diagnostics.Analyzers.RoslynDiagnosticIds;
+
+namespace DotNetAnalyzers.IsolateNamespaceAnalyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class NamespaceIsIsolatedAnalyzer : DiagnosticAnalyzer
+    {
+        public static readonly DiagnosticDescriptor TypeIsInIsolatedNamespaceRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.TypeIsInIsolatedNamespaceRuleId,
+            title: DotNetAnalyzersResources.TypeIsInIsolatedNamespaceTitle,
+            messageFormat: DotNetAnalyzersResources.TypeIsInIsolatedNamespaceMessage,
+            category: "ApiDesign",
+            defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+            description: DotNetAnalyzersResources.TypeIsInIsolatedNamespaceDescription,
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(TypeIsInIsolatedNamespaceRule);
+
+        public override void Initialize(AnalysisContext analysisContext)
+        {
+            analysisContext.EnableConcurrentExecution();
+
+            // Analyzer needs to get callbacks for generated code, and might report diagnostics in generated code.
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+            analysisContext.RegisterCompilationStartAction(
+                compilationStartAnalysisContext =>
+                {
+                    var predicate = BuildIsolationPredicate(compilationStartAnalysisContext.Compilation);
+
+                    // If no isolation attribute exist on the assembly, there's nothing to do
+                    if (predicate == null)
+                        return;
+
+                    analysisContext.RegisterSyntaxNodeAction(
+                        context =>
+                        {
+                            switch (context.Node)
+                            {
+                                case LocalDeclarationStatementSyntax localDeclarationStatementSyntax:
+                                    foreach (var syntax in localDeclarationStatementSyntax.Declaration.Variables)
+                                    {
+                                        var localDeclarationTypeSymbol = (ILocalSymbol)context.SemanticModel.GetDeclaredSymbol(syntax);
+                                        Verify(localDeclarationTypeSymbol.Type, localDeclarationStatementSyntax.Declaration.Type);
+                                    }
+                                    break;
+
+                                case FieldDeclarationSyntax fieldDeclarationSyntax:
+                                    foreach (var syntax in fieldDeclarationSyntax.Declaration.Variables)
+                                    {
+                                        var fieldSymbol = (IFieldSymbol)context.SemanticModel.GetDeclaredSymbol(syntax);
+                                        Verify(fieldSymbol.Type, fieldDeclarationSyntax.Declaration.Type);
+                                    }
+                                    break;
+
+                                case EventFieldDeclarationSyntax eventFieldDeclarationSyntax:
+                                    foreach (var syntax in eventFieldDeclarationSyntax.Declaration.Variables)
+                                    {
+                                        var eventFieldSymbol = (IEventSymbol)context.SemanticModel.GetDeclaredSymbol(syntax);
+                                        Verify(eventFieldSymbol.Type, eventFieldDeclarationSyntax.Declaration.Type);
+                                    }
+                                    break;
+
+                                case PropertyDeclarationSyntax propertyDeclarationSyntax:
+                                    var propertySymbol = context.SemanticModel.GetDeclaredSymbol(propertyDeclarationSyntax);
+                                    Verify(propertySymbol.Type, propertyDeclarationSyntax.Type);
+                                    break;
+
+                                case EventDeclarationSyntax eventDeclarationSyntax:
+                                    var eventSymbol = context.SemanticModel.GetDeclaredSymbol(eventDeclarationSyntax);
+                                    Verify(eventSymbol.Type, eventDeclarationSyntax.Type);
+                                    break;
+
+                                case ParameterSyntax parameterSyntax:
+                                    var parameterSymbol = context.SemanticModel.GetDeclaredSymbol(parameterSyntax);
+                                    Verify(parameterSymbol.Type, parameterSyntax.Type);
+                                    break;
+
+                                case StructDeclarationSyntax structDeclarationSyntax:
+                                    VerifyConstraintClauses(structDeclarationSyntax.ConstraintClauses);
+                                    break;
+
+                                case ClassDeclarationSyntax classDeclarationSyntax:
+                                    if (classDeclarationSyntax.BaseList != null)
+                                    {
+                                        foreach (var syntax in classDeclarationSyntax.BaseList.Types)
+                                        {
+                                            var baseTypeSymbol = (ITypeSymbol)context.SemanticModel.GetSymbolInfo(syntax.Type).Symbol;
+                                            if (baseTypeSymbol != null)
+                                                Verify(baseTypeSymbol, syntax.Type);
+                                        }
+                                    }
+
+                                    VerifyConstraintClauses(classDeclarationSyntax.ConstraintClauses);
+                                    break;
+
+                                case TypeOfExpressionSyntax typeOfExpressionSyntax:
+                                    var typeSymbol = (ITypeSymbol)context.SemanticModel.GetSymbolInfo(typeOfExpressionSyntax.Type).Symbol;
+                                    Verify(typeSymbol, typeOfExpressionSyntax.Type);
+                                    break;
+                            }
+
+                            void Verify(ITypeSymbol targetSymbol, SyntaxNode syntax) => VerifyIsolation(context.ReportDiagnostic, targetSymbol, context.ContainingSymbol, syntax);
+
+                            void VerifyConstraintClauses(SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses)
+                            {
+                                if (constraintClauses.Count != 0)
+                                {
+                                    foreach (var constraintClauseSyntax in constraintClauses)
+                                    {
+                                        foreach (var typeParameterConstraintSyntax in constraintClauseSyntax.Constraints)
+                                        {
+                                            if (typeParameterConstraintSyntax is TypeConstraintSyntax typeConstraintSyntax)
+                                            {
+                                                var typeSymbol = (ITypeSymbol)context.SemanticModel.GetSymbolInfo(typeConstraintSyntax.Type).Symbol;
+                                                if (typeSymbol != null)
+                                                {
+                                                    Verify(typeSymbol, typeConstraintSyntax.Type);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        SyntaxKind.LocalDeclarationStatement,
+                        SyntaxKind.PropertyDeclaration,
+                        SyntaxKind.FieldDeclaration,
+                        SyntaxKind.EventFieldDeclaration,
+                        SyntaxKind.EventDeclaration,
+                        SyntaxKind.Parameter,
+                        SyntaxKind.TypeOfExpression,
+                        SyntaxKind.StructDeclaration,
+                        SyntaxKind.ClassDeclaration);
+
+                    compilationStartAnalysisContext.RegisterOperationAction(
+                        context =>
+                        {
+                            switch (context.Operation)
+                            {
+                                case IArrayCreationOperation arrayCreation:
+                                    if (arrayCreation.Syntax is ArrayCreationExpressionSyntax arrayCreationExpression)
+                                        VerifyOperation(arrayCreation.Type, arrayCreationExpression.Type);
+                                    break;
+
+                                case IObjectCreationOperation objectCreation:
+                                    if (objectCreation.Syntax is ObjectCreationExpressionSyntax objectCreationExpression)
+                                        VerifyOperation(objectCreation.Type, objectCreationExpression.Type);
+                                    break;
+
+                                case IMethodReferenceOperation methodReference:
+                                    if (methodReference.Method.IsStatic)
+                                        VerifyMethod(methodReference.Syntax, methodReference.Method, UnwrapMethodReference(methodReference.Syntax));
+                                    break;
+
+                                case IMemberReferenceOperation memberReference:
+                                    if (memberReference.Member.IsStatic)
+                                        VerifyOperation(memberReference.Member.ContainingType, GetOwningMemberSyntax(memberReference.Syntax));
+                                    break;
+
+                                case IInvocationOperation invocation:
+                                    if (invocation.TargetMethod.IsStatic)
+                                    {
+                                        var syntax = invocation.Syntax is InvocationExpressionSyntax ies ? ies.Expression : invocation.Syntax;
+                                        VerifyMethod(invocation.Syntax, invocation.TargetMethod, GetOwningMemberSyntax(syntax));
+                                    }
+                                    break;
+                            }
+
+                            void VerifyOperation(ITypeSymbol targetSymbol, SyntaxNode syntax) => VerifyIsolation(context.ReportDiagnostic, targetSymbol, context.ContainingSymbol, syntax);
+
+                            void VerifyMethod(SyntaxNode syntax, IMethodSymbol method, SyntaxNode diagnosticSyntax)
+                            {
+                                UnwrapMethodNameSyntax();
+
+                                if (syntax is GenericNameSyntax genericNameSyntax &&
+                                    genericNameSyntax.TypeArgumentList.Arguments.Count == method.TypeArguments.Length)
+                                {
+                                    for (var i = 0; i < method.TypeArguments.Length; i++)
+                                    {
+                                        var typeArgument = method.TypeArguments[i];
+                                        var typeArgumentSyntax = genericNameSyntax.TypeArgumentList.Arguments[i];
+                                        VerifyOperation(typeArgument, typeArgumentSyntax);
+                                    }
+                                }
+
+                                VerifyOperation(method.ContainingType, diagnosticSyntax);
+
+                                void UnwrapMethodNameSyntax()
+                                {
+                                    // Loop to avoid recursion
+                                    while (true)
+                                    {
+                                        switch (syntax)
+                                        {
+                                            case InvocationExpressionSyntax invocationExpressionSyntax:
+                                                syntax = invocationExpressionSyntax.Expression;
+                                                continue;
+                                            case MemberAccessExpressionSyntax memberAccessExpressionSyntax:
+                                                syntax = memberAccessExpressionSyntax.Name;
+                                                continue;
+                                            case MemberBindingExpressionSyntax memberAccessExpressionSyntax:
+                                                syntax = memberAccessExpressionSyntax.Name;
+                                                continue;
+                                            default:
+                                                return;
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        OperationKind.ArrayCreation,
+                        OperationKind.ObjectCreation,
+                        OperationKind.FieldReference,
+                        OperationKind.PropertyReference,
+                        OperationKind.EventReference,
+                        OperationKind.MethodReference,
+                        OperationKind.Invocation);
+
+                    SyntaxNode UnwrapMethodReference(SyntaxNode syntax)
+                    {
+                        // Loop to avoid recursion
+                        while (true)
+                        {
+                            switch (syntax)
+                            {
+                                case MemberAccessExpressionSyntax memberAccessExpressionSyntax when memberAccessExpressionSyntax.Expression is MemberAccessExpressionSyntax:
+                                    syntax = memberAccessExpressionSyntax.Expression;
+                                    continue;
+                                case MemberAccessExpressionSyntax memberAccessExpressionSyntax:
+                                    return memberAccessExpressionSyntax.Name;
+                                default:
+                                    return syntax;
+                            }
+                        }
+                    }
+
+                    SyntaxNode GetOwningMemberSyntax(SyntaxNode syntax)
+                    {
+                        if (syntax is MemberAccessExpressionSyntax memberAccessExpressionSyntax)
+                        {
+                            switch (memberAccessExpressionSyntax.Expression)
+                            {
+                                case IdentifierNameSyntax identifierNameSyntax:
+                                    return identifierNameSyntax;
+                                case MemberAccessExpressionSyntax expressionMemberAccessExpressionSyntax:
+                                    return expressionMemberAccessExpressionSyntax.Name;
+                            }
+                        }
+
+                        return syntax;
+                    }
+
+                    void VerifyIsolation(Action<Diagnostic> reportDiagnostic, ITypeSymbol targetSymbol, ISymbol containingSymbol, SyntaxNode syntax)
+                    {
+                        syntax = UnwrapQualifiedName(syntax);
+
+                        if (targetSymbol is IArrayTypeSymbol arrayTypeSymbol)
+                        {
+                            syntax = syntax is ArrayTypeSyntax arrayTypeSyntax ? arrayTypeSyntax.ElementType : syntax;
+                            VerifyIsolation(reportDiagnostic, arrayTypeSymbol.ElementType, containingSymbol, syntax);
+                        }
+                        else
+                        {
+                            VerifyTypeIsolation(targetSymbol);
+
+                            if (targetSymbol is INamedTypeSymbol namedTypeSymbol &&
+                                syntax is GenericNameSyntax genericNameSyntax &&
+                                namedTypeSymbol.TypeArguments.Length != 0 &&
+                                namedTypeSymbol.TypeArguments.Length == genericNameSyntax.Arity)
+                            {
+                                for (var i = 0; i < namedTypeSymbol.TypeArguments.Length; i++)
+                                {
+                                    var typeArgument = namedTypeSymbol.TypeArguments[i];
+                                    var typeArgumentSyntax = genericNameSyntax.TypeArgumentList.Arguments[i];
+                                    VerifyIsolation(reportDiagnostic, typeArgument, containingSymbol, UnwrapQualifiedName(typeArgumentSyntax));
+                                }
+                            }
+                        }
+
+                        void VerifyTypeIsolation(ITypeSymbol typeSymbol)
+                        {
+                            var isIsolationViolation = !predicate(typeSymbol.ContainingNamespace, containingSymbol.ContainingNamespace);
+
+                            if (isIsolationViolation)
+                            {
+                                // Type '{0}' is isolated and may not be used from namespace '{1}'.
+                                reportDiagnostic(
+                                    Diagnostic.Create(
+                                        TypeIsInIsolatedNamespaceRule,
+                                        syntax.GetLocation(),
+                                        typeSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                                        containingSymbol.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)));
+                            }
+                        }
+
+                        SyntaxNode UnwrapQualifiedName(SyntaxNode syntaxNode)
+                        {
+                            return syntaxNode is QualifiedNameSyntax qualifiedName ? qualifiedName.Right : syntaxNode;
+                        }
+                    }
+
+                    IsolationPredicate BuildIsolationPredicate(Compilation compilation)
+                    {
+                        var assemblyAttributes = compilation.Assembly.GetAttributes();
+
+                        var isolateNamespaceAttributes = assemblyAttributes
+                            .Where(attr => attr.AttributeClass.Name == nameof(IsolateNamespaceAttribute) &&
+                                           attr.AttributeConstructor.Parameters.Length == 1 &&
+                                           attr.AttributeConstructor.Parameters[0].Type.SpecialType == SpecialType.System_String);
+
+                        var isolateNamespaceGroupAttributes = assemblyAttributes
+                            .Where(attr => attr.AttributeClass.Name == nameof(IsolateNamespaceGroupAttribute) &&
+                                           attr.AttributeConstructor.Parameters.Length == 1 &&
+                                           attr.AttributeConstructor.Parameters[0].Type is IArrayTypeSymbol arrayTypeSymbol &&
+                                           arrayTypeSymbol.ElementType.SpecialType == SpecialType.System_String)
+                            .Select(attr => attr.ConstructorArguments[0].Values.Select(v => (string)v.Value).ToArray());
+
+                        // The set of namespaces participating in isolation.
+                        var isolatedNamespaces = new HashSet<string>(StringComparer.Ordinal);
+
+                        // Isolated namespaces that are visible to other namespaces are modeled here,
+                        // whether due to group membership or IsolateNamespaceAttribute.AllowFrom.
+                        var friendPairs = new HashSet<(string target, string from)>();
+
+                        foreach (var attribute in isolateNamespaceAttributes)
+                        {
+                            var ns = (string)attribute.ConstructorArguments[0].Value;
+                            isolatedNamespaces.Add(ns);
+                            var allowFrom = attribute.NamedArguments.FirstOrDefault(kvp => kvp.Key == nameof(IsolateNamespaceAttribute.AllowFrom)).Value;
+                            if (allowFrom.Kind == TypedConstantKind.Array &&
+                                allowFrom.Type is IArrayTypeSymbol arrayTypeSymbol &&
+                                arrayTypeSymbol.ElementType.SpecialType == SpecialType.System_String)
+                            {
+                                foreach (var value in allowFrom.Values)
+                                {
+                                    var ns2 = (string)value.Value;
+                                    friendPairs.Add((ns, ns2));
+                                }
+                            }
+                        }
+
+                        foreach (var groupValues in isolateNamespaceGroupAttributes)
+                        {
+                            for (int i = 0; i < groupValues.Length; i++)
+                            {
+                                var ns1 = groupValues[i];
+                                isolatedNamespaces.Add(ns1);
+
+                                for (int j = 0; j < groupValues.Length; j++)
+                                {
+                                    if (i == j)
+                                        continue;
+
+                                    var ns2 = groupValues[j];
+                                    friendPairs.Add((ns1, ns2));
+                                }
+                            }
+                        }
+
+                        // If no matching attributes were declared on the assembly, return null which will
+                        // short circuit further analysis.
+                        if (isolatedNamespaces.Count == 0 && friendPairs.Count == 0)
+                            return null;
+
+                        // A cache of namespace strings by symbol.
+                        var dic = ImmutableDictionary<INamespaceSymbol, string>.Empty;
+
+                        // Return a predicate to use when evaluating references between types.
+                        return (targetNamespace, fromNamespace) =>
+                        {
+                            // Null namespaces can happen. Just bail.
+                            if (targetNamespace == null || fromNamespace == null)
+                                return true;
+
+                            // If the namespaces match, it's fine.
+                            if (targetNamespace.Equals(fromNamespace))
+                                return true;
+
+                            var target = ImmutableInterlocked.GetOrAdd(ref dic, targetNamespace, ns => ns.ToString());
+
+                            // If the target is subject to isolation...
+                            if (isolatedNamespaces.Contains(target))
+                            {
+                                // ...ensure the relationship is allowed
+                                var from = ImmutableInterlocked.GetOrAdd(ref dic, fromNamespace, ns => ns.ToString());
+
+                                return friendPairs.Contains((target, from));
+                            }
+
+                            // The target is not explicitly modeled, so it's fine.
+                            return true;
+                        };
+                    }
+                });
+        }
+
+        /// <summary>
+        /// Predicate for testing isolation violations between namespaces.
+        /// </summary>
+        /// <param name="targetNamespace">The namespace being referenced.</param>
+        /// <param name="fromNamespace">The namespace the reference is within.</param>
+        /// <returns><c>true</c> if the reference is allowed, otherwise <c>false</c> for an isolation violation.</returns>
+        private delegate bool IsolationPredicate(INamespaceSymbol targetNamespace, INamespaceSymbol fromNamespace);
+    }
+}

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/NamespaceIsolationAttributes.cs
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/NamespaceIsolationAttributes.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace DotNetAnalyzers.IsolateNamespaceAnalyzer
+{
+    // NOTE these attributes are provided for `nameof` operations, and as a reference for
+    // consumers of this analyzer to copy into their own code base.
+    //
+    // These attributes may exist in any namespace and must be applied to the assembly.
+    //
+    // e.g.:
+    //
+    // [assembly: IsolateNamespace("Project.PrivateNamespace")]
+
+    /// <summary>
+    /// Signals to the <c>DotNetAnalyzers.IsolateNamespaceAnalyzer</c> that types within a
+    /// namespace may not be referenced from other namespaces within the assembly, other than
+    /// those specified in <see cref="AllowFrom"/>.
+    /// </summary>
+    [Conditional("EMIT_ISOLATION_ATTRIBUTES")]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    internal sealed class IsolateNamespaceAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the string that identifies the global namespace.
+        /// </summary>
+        public const string GlobalNamespace = "<global namespace>";
+
+        /// <summary>
+        /// Gets the namespace to isolate within this assembly.
+        /// </summary>
+        public string Namespace { get; }
+
+        /// <summary>
+        /// An optional set of namespaces whose member types are allowed to reference
+        /// those within <see cref="Namespace"/> in the same assembly.
+        /// </summary>
+        public string[] AllowFrom { get; set; }
+
+        /// <summary>
+        /// Initialises a new instance of <see cref="IsolateNamespaceAttribute"/>.
+        /// </summary>
+        /// <param name="namespace">The namespace to isolate.</param>
+        public IsolateNamespaceAttribute(string @namespace)
+        {
+            Namespace = @namespace ?? throw new ArgumentNullException(nameof(@namespace));
+        }
+    }
+
+    /// <summary>
+    /// Signals to the <c>DotNetAnalyzers.IsolateNamespaceAnalyzer</c> that, within an assembly,
+    /// types belonging to the specified group of namespaces may mutually reference one another,
+    /// yet are isolated from types in other namespaces of that same assembly.
+    /// </summary>
+    [Conditional("EMIT_ISOLATION_ATTRIBUTES")]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    internal sealed class IsolateNamespaceGroupAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the string that identifies the global namespace.
+        /// </summary>
+        public const string GlobalNamespace = "<global namespace>";
+
+        /// <summary>
+        /// Gets the set of namespaces that belong to this isolation group.
+        /// </summary>
+        public string[] Namespaces { get; }
+
+        /// <summary>
+        /// Initialises a new instance of <see cref="IsolateNamespaceGroupAttribute"/>.
+        /// </summary>
+        /// <param name="namespaces">The set of namespaces that belong to this isolation group.</param>
+        public IsolateNamespaceGroupAttribute(params string[] namespaces)
+        {
+            Namespaces = namespaces;
+        }
+    }
+}

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.cs.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.cs.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.de.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.de.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.es.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.es.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.fr.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.fr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.it.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.it.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.ja.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.ja.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.ko.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.ko.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.pl.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.pl.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.pt-BR.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.pt-BR.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.ru.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.ru.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.tr.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.tr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.zh-Hans.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.zh-Hans.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.zh-Hant.xlf
+++ b/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/xlf/DotNetAnalyzersResources.zh-Hant.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../DotNetAnalyzersResources.resx">
+    <body>
+      <trans-unit id="TypeIsInIsolatedNamespaceDescription">
+        <source>Types in isolated namespaces may not be used from outside that namespace within the same assembly.</source>
+        <target state="new">Types in isolated namespaces may not be used from outside that namespace within the same assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceMessage">
+        <source>Type '{0}' is isolated and may not be used from namespace '{1}'.</source>
+        <target state="new">Type '{0}' is isolated and may not be used from namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TypeIsInIsolatedNamespaceTitle">
+        <source>Types within isolated namespaces may not be used externally</source>
+        <target state="new">Types within isolated namespaces may not be used externally</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/DotNetAnalyzers/Setup/IsolateNamespaceAnalyzer/DotNetAnalyzers.IsolateNamespaceAnalyzer.Setup.csproj
+++ b/src/DotNetAnalyzers/Setup/IsolateNamespaceAnalyzer/DotNetAnalyzers.IsolateNamespaceAnalyzer.Setup.csproj
@@ -1,0 +1,21 @@
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <PublishWindowsPdb>false</PublishWindowsPdb>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\IsolateNamespaceAnalyzer\DotNetAnalyzers.IsolateNamespaceAnalyzer.csproj">
+      <Name>DotNetAnalyzers.IsolateNamespaceAnalyzer</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/DotNetAnalyzers/Setup/IsolateNamespaceAnalyzer/source.extension.vsixmanifest
+++ b/src/DotNetAnalyzers/Setup/IsolateNamespaceAnalyzer/source.extension.vsixmanifest
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="CBFFCF2E-85A3-48F4-ABF4-EF2C045E950B" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>Isolate Namespace Analyzer</DisplayName>
+    <Description xml:space="preserve">Isolate Namespace analyzer</Description>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27130.0,]" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.Analyzer" Path="DotNetAnalyzers.IsolateNamespaceAnalyzer.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="DotNetAnalyzers.IsolateNamespaceAnalyzer.dll" />
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+</PackageManifest>

--- a/src/DotNetAnalyzers/UnitTests/DotNetAnalyzers.UnitTests.csproj
+++ b/src/DotNetAnalyzers/UnitTests/DotNetAnalyzers.UnitTests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Test.Utilities\Test.Utilities.csproj" />
+    <ProjectReference Include="..\Core\IsolateNamespaceAnalyzer\DotNetAnalyzers.IsolateNamespaceAnalyzer.csproj" />
     <ProjectReference Include="..\Core\PublicApiAnalyzer\DotNetAnalyzers.PublicApiAnalyzer.csproj" />
     <ProjectReference Include="..\Core\PublicApiAnalyzer.CodeFixes\DotNetAnalyzers.PublicApiAnalyzer.CodeFixes.csproj" />
     <ProjectReference Include="..\Core\BannedApiAnalyzer\DotNetAnalyzers.BannedApiAnalyzer.csproj" />

--- a/src/DotNetAnalyzers/UnitTests/NamespaceIsIsolatedAnalyzerTests.cs
+++ b/src/DotNetAnalyzers/UnitTests/NamespaceIsIsolatedAnalyzerTests.cs
@@ -1,0 +1,1169 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Xunit;
+
+namespace DotNetAnalyzers.IsolateNamespaceAnalyzer.UnitTests
+{
+    public sealed class NamespaceIsIsolatedAnalyzerTests
+    {
+        [Fact]
+        public async Task CSharp_Instantiate_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M() => new IsolatedClass();
+    }
+}
+
+class Outside
+{
+    void M() => new Isolated.IsolatedClass();
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 30, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_LocalVarDeclaration_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M() { IsolatedClass i; }
+    }
+}
+
+class Outside
+{
+    void M() { Isolated.IsolatedClass i; }
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 25, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareField_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        IsolatedClass F;
+    }
+}
+
+class Outside
+{
+    public Isolated.IsolatedClass F;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 21, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareField_IsolatedType_TypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        System.Collections.Generic.List<IsolatedClass> F;
+    }
+}
+
+class Outside
+{
+    public System.Collections.Generic.List<Isolated.IsolatedClass> F;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 53, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareField_IsolatedType_NestedTypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        System.Collections.Generic.List<System.Action<IsolatedClass>> F;
+    }
+}
+
+class Outside
+{
+    public System.Collections.Generic.List<System.Action<Isolated.IsolatedClass>> F;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 67, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareProperty_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        IsolatedClass P { get; }
+    }
+}
+
+class Outside
+{
+    public Isolated.IsolatedClass P { get; }
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 21, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareProperty_IsolatedType_TypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        System.Collections.Generic.List<IsolatedClass> P { get; }
+    }
+}
+
+class Outside
+{
+    public System.Collections.Generic.List<Isolated.IsolatedClass> P { get; }
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 53, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareEvent_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    delegate void IsolatedDelegate();
+
+    class Inside
+    {
+        event IsolatedDelegate E { add { } remove { } }
+    }
+}
+
+class Outside
+{
+    public event Isolated.IsolatedDelegate E { add { } remove { } }
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 27, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedDelegate", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareEvent_IsolatedType_TypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        event System.Action<IsolatedClass> E { add { } remove { } }
+    }
+}
+
+class Outside
+{
+    public event System.Action<Isolated.IsolatedClass> E { add { } remove { } }
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 41, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareEventField_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    delegate void IsolatedDelegate();
+
+    class Inside
+    {
+        event IsolatedDelegate E;
+    }
+}
+
+class Outside
+{
+    public event Isolated.IsolatedDelegate E;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 27, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedDelegate", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareEventField_IsolatedType_TypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        event System.Action<IsolatedClass> E;
+    }
+}
+
+class Outside
+{
+    public event System.Action<Isolated.IsolatedClass> E;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 41, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareParameter_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M(IsolatedClass i) {}
+    }
+}
+
+class Outside
+{
+    public void M(Isolated.IsolatedClass i) {}
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 28, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareParameter_IsolatedType_TypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M(System.Action<IsolatedClass> i) {}
+    }
+}
+
+class Outside
+{
+    public void M(System.Action<Isolated.IsolatedClass> i) {}
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 42, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DerivedClass_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside : IsolatedClass {}
+}
+
+class Outside : Isolated.IsolatedClass {}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(11, 26, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DerivedClass_IsolatedType_TypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside : System.Collections.Generic.List<IsolatedClass> {}
+}
+
+class Outside : System.Collections.Generic.List<Isolated.IsolatedClass> {}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(11, 58, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareType_Class_TypeConstraint_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside<T> where T : IsolatedClass {}
+}
+
+class Outside<T> where T : Isolated.IsolatedClass {}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(11, 37, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_DeclareType_Struct_TypeConstraint_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    struct Inside<T> where T : IsolatedClass {}
+}
+
+struct Outside<T> where T : Isolated.IsolatedClass {}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(11, 38, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticMethodInvocation_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static void M() {}
+    }
+
+    class Inside
+    {
+        void M() => IsolatedClass.M();
+    }
+}
+
+class Outside
+{
+    void M() => Isolated.IsolatedClass.M();
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(19, 26, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticMethodInvocation_IsolatedType_TypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        object M() => System.Array.Empty<IsolatedClass>();
+    }
+}
+
+class Outside
+{
+    object M() => System.Array.Empty<Isolated.IsolatedClass>();
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 47, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticMethodInvocation_IsolatedType_StaticUsing()
+        {
+            var staticUsing = "using static Isolated.IsolatedClass;\n";
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static void M() {}
+    }
+
+    class Inside
+    {
+        void N() => M();
+    }
+}
+
+class Outside
+{
+    void N() => M();
+}
+";
+
+            await VerifyCSharpAsync(
+                staticUsing + AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(20, 17, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_ExtensionMethodInvocation_IsolatedType()
+        {
+            var source = $@"
+using Isolated;
+
+{_isolateNamespaceAttributeDeclaration}
+
+namespace Isolated
+{{
+    static class IsolatedClass
+    {{
+        public static void M(this string s) {{}}
+    }}
+
+    class Inside
+    {{
+        void M1() => """".M();
+        void M2() => """"?.M();
+    }}
+
+    namespace Outside
+    {{
+        class C
+        {{
+            void M1() => """".M();
+            void M2() => """"?.M();
+        }}
+    }}
+}}
+
+class Outside
+{{
+    void M1() => """".M();
+    void M2() => """"?.M();
+}}
+
+{_isolateNamespaceAttributeSource}";
+
+            await VerifyCSharpAsync(
+                source,
+                GetCSharpResultAt(23, 26, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "Isolated.Outside"),
+                GetCSharpResultAt(24, 29, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "Isolated.Outside"),
+                GetCSharpResultAt(31, 18, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"),
+                GetCSharpResultAt(32, 21, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticFieldAccess_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static int F;
+    }
+
+    class Inside
+    {
+        void M() => IsolatedClass.F++;
+    }
+}
+
+class Outside
+{
+    void M() => Isolated.IsolatedClass.F++;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(19, 26, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticFieldAccess_IsolatedType_StaticUsing()
+        {
+            var staticUsing = "using static Isolated.IsolatedClass;\n";
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static int F;
+    }
+
+    class Inside
+    {
+        void M() => F++;
+    }
+}
+
+class Outside
+{
+    void M() => F++;
+}
+";
+
+            await VerifyCSharpAsync(
+                staticUsing + AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(20, 17, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticPropertyAccess_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static int P { get; }
+    }
+
+    class Inside
+    {
+        int M => IsolatedClass.P;
+    }
+}
+
+class Outside
+{
+    int M => Isolated.IsolatedClass.P;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(19, 23, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticPropertyAccess_IsolatedType_StaticUsing()
+        {
+            var staticUsing = "using static Isolated.IsolatedClass;\n";
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static int P { get; }
+    }
+
+    class Inside
+    {
+        int M => P;
+    }
+}
+
+class Outside
+{
+    int M => P;
+}
+";
+
+            await VerifyCSharpAsync(
+                staticUsing + AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(20, 14, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticEventAccess_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static event System.Action E;
+    }
+
+    class Inside
+    {
+        void M() => IsolatedClass.E += () => { };
+    }
+}
+
+class Outside
+{
+    void M() => Isolated.IsolatedClass.E += () => { };
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(19, 26, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticEventAccess_IsolatedType_StaticUsing()
+        {
+            var staticUsing = "using static Isolated.IsolatedClass;\n";
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static event System.Action E;
+    }
+
+    class Inside
+    {
+        void M() => E += () => { };
+    }
+}
+
+class Outside
+{
+    void M() => E += () => { };
+}
+";
+
+            await VerifyCSharpAsync(
+                staticUsing + AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(20, 17, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_ConstAccess_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public const int C = 1234;
+    }
+
+    class Inside
+    {
+        int M => IsolatedClass.C;
+    }
+}
+
+class Outside
+{
+    int M => Isolated.IsolatedClass.C;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(19, 23, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_ConstAccess_IsolatedType_StaticUsing()
+        {
+            var staticUsing = "using static Isolated.IsolatedClass;\n";
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public const int C = 1234;
+    }
+
+    class Inside
+    {
+        int N => C;
+    }
+}
+
+class Outside
+{
+    int N => C;
+}
+";
+
+            await VerifyCSharpAsync(
+                staticUsing + AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(20, 14, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticMethodGroupAccess_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static void M() {}
+    }
+
+    class Inside
+    {
+        System.Action M => IsolatedClass.M;
+    }
+}
+
+class Outside
+{
+    System.Action M => Isolated.IsolatedClass.M;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(19, 33, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticMethodGroupAccess_IsolatedType_TypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static void M() {}
+    }
+
+    class Inside
+    {
+        System.Func<object> M => System.Array.Empty<IsolatedClass>;
+    }
+}
+
+class Outside
+{
+    System.Func<object> M => System.Array.Empty<Isolated.IsolatedClass>;
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(19, 58, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_StaticMethodGroupAccess_IsolatedType_StaticUsing()
+        {
+            var staticUsing = "using static Isolated.IsolatedClass;\n";
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static void M() {}
+    }
+
+    class Inside
+    {
+        System.Action MG => M;
+    }
+}
+
+class Outside
+{
+    System.Action MG => M;
+}
+";
+
+            await VerifyCSharpAsync(
+                staticUsing + AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(20, 25, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_Typeof_IsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static void M() {}
+    }
+
+    class Inside
+    {
+        System.Type M => typeof(IsolatedClass);
+    }
+}
+
+class Outside
+{
+    System.Type M => typeof(Isolated.IsolatedClass);
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(19, 38, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_Typeof_IsolatedType_TypeParameter()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass
+    {
+        public static void M() {}
+    }
+
+    class Inside
+    {
+        System.Type M => typeof(System.Action<IsolatedClass>);
+    }
+}
+
+class Outside
+{
+    System.Type M => typeof(System.Action<Isolated.IsolatedClass>);
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(19, 52, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_Instantiate_IsolatedType_NonGlobalNamespace()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M() => new IsolatedClass();
+    }
+}
+
+namespace Outside
+{
+    class Outside
+    {
+        void M() => new Isolated.IsolatedClass();
+    }
+}
+";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(18, 34, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "Outside"));
+        }
+
+        [Fact]
+        public async Task CSharp_Instantiate_ArrayOfIsolatedType()
+        {
+            var source = @"
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        object M() => new IsolatedClass[0];
+    }
+}
+
+class Outside
+{
+    object M() => new Isolated.IsolatedClass[0];
+}";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceAttribute(source),
+                GetCSharpResultAt(16, 32, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_MultiLevelIsolatedNamespace()
+        {
+            var source = @"
+[assembly: IsolateNamespace(""Nested.Isolated"")]
+
+namespace Nested.Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M() => new IsolatedClass();
+    }
+}
+
+class Outside
+{
+    void M() => new Nested.Isolated.IsolatedClass();
+}
+";
+
+            await VerifyCSharpAsync(
+                source + _isolateNamespaceAttributeSource,
+                GetCSharpResultAt(16, 37, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Nested.Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_IsolationAttributeCanBeInAnyNamespace()
+        {
+            var source = @"
+[assembly: Foo.IsolateNamespace(""Isolated"")]
+
+namespace Isolated
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M() => new IsolatedClass();
+    }
+}
+
+class Outside
+{
+    void M() => new Isolated.IsolatedClass();
+}
+
+namespace Foo
+{
+    class IsolateNamespaceAttribute : System.Attribute { public IsolateNamespaceAttribute(string ns) { } }
+}
+";
+
+            await VerifyCSharpAsync(
+                source,
+                GetCSharpResultAt(16, 30, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_IsolationWithAllow()
+        {
+            var source = @"
+[assembly: IsolateNamespace(""Isolated1"", AllowFrom = new[] { ""Isolated2"" })]
+
+namespace Isolated1
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M1() => new Isolated1.IsolatedClass();
+        void M2() => new Isolated2.IsolatedClass();
+    }
+}
+
+namespace Isolated2
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M1() => new Isolated1.IsolatedClass();
+        void M2() => new Isolated2.IsolatedClass();
+    }
+}
+
+class Outside
+{
+    void M1() => new Isolated1.IsolatedClass(); // FAIL
+    void M2() => new Isolated2.IsolatedClass();
+}";
+
+            await VerifyCSharpAsync(
+                source + _isolateNamespaceAttributeSource,
+                GetCSharpResultAt(28, 32, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated1.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_IsolationGroups()
+        {
+            var source = @"
+namespace Isolated1
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M1() => new Isolated1.IsolatedClass();
+        void M2() => new Isolated2.IsolatedClass();
+    }
+}
+
+namespace Isolated2
+{
+    class IsolatedClass {}
+
+    class Inside
+    {
+        void M1() => new Isolated1.IsolatedClass();
+        void M2() => new Isolated2.IsolatedClass();
+    }
+}
+
+class Outside
+{
+    void M1() => new Isolated1.IsolatedClass();
+    void M2() => new Isolated2.IsolatedClass();
+}";
+
+            await VerifyCSharpAsync(
+                AddIsolateNamespaceGroupAttribute(source),
+                GetCSharpResultAt(28, 32, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated1.IsolatedClass", "<global namespace>"),
+                GetCSharpResultAt(29, 32, NamespaceIsIsolatedAnalyzer.TypeIsInIsolatedNamespaceRule, "Isolated2.IsolatedClass", "<global namespace>"));
+        }
+
+        [Fact]
+        public async Task CSharp_HandlesConditionalAccessExpressions()
+        {
+            var source = @"
+class C
+{
+    string M(string s) => s?.ToUpper();
+}";
+
+            await VerifyCSharpAsync(AddIsolateNamespaceGroupAttribute(source));
+        }
+
+        #region Test support
+
+        private const string _isolateNamespaceAttributeDeclaration = @"[assembly: IsolateNamespace(""Isolated"")]";
+        private const string _isolateNamespaceAttributeSource = @"class IsolateNamespaceAttribute : System.Attribute
+{
+    public IsolateNamespaceAttribute(string ns)
+    {
+        Namespace = ns;
+    }
+
+    public string Namespace { get; }
+    public string[] AllowFrom { get; set; }
+}";
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor descriptor, string v3, string v4)
+        {
+            return new DiagnosticResult(descriptor)
+                .WithLocation(line, column)
+                .WithArguments(v3, v4);
+        }
+
+        private static string AddIsolateNamespaceAttribute(string source)
+        {
+            return $@"{_isolateNamespaceAttributeDeclaration}
+
+{source}
+
+{_isolateNamespaceAttributeSource}";
+        }
+
+        private static string AddIsolateNamespaceGroupAttribute(string source)
+        {
+            return $@"[assembly: IsolateNamespaceGroup(""Isolated1"", ""Isolated2"")]
+
+{source}
+
+class IsolateNamespaceGroupAttribute : System.Attribute {{ public IsolateNamespaceGroupAttribute(params string[] ns) {{ }} }}";
+        }
+
+        private static async Task VerifyCSharpAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new CSharpCodeFixTest<NamespaceIsIsolatedAnalyzer, EmptyCodeFixProvider, XUnitVerifier>
+            {
+                TestState =
+                {
+                    Sources = { source }
+                }
+            };
+
+            test.Exclusions &= ~AnalysisExclusions.GeneratedCode;
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync();
+        }
+
+        #endregion
+    }
+}

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
@@ -35,5 +35,6 @@ namespace Roslyn.Diagnostics.Analyzers
         public const string RoslynAnalyzerMustUseCategoriesFromSpecifiedRangeRuleId = "RS0029";
         public const string SymbolIsBannedRuleId = "RS0030";
         public const string DuplicateBannedSymbolRuleId = "RS0031";
+        public const string TypeIsInIsolatedNamespaceRuleId = "RS0032";
     }
 }


### PR DESCRIPTION
This analyzer allows constraining references between types within an assembly based on their namespaces. It does this by isolating one or more namespaces relative to others. This can enforce architectural layering patterns without dividing code into multiple projects/assemblies.

Decisions about the content and number of assemblies used in a system influence architectural boundaries and deployment granularity. This analyzer allows some freedom in case you wish to treat these two concerns separately.

In the project system we recently merged several assemblies. That exercise motivated thinking about this analyzer.

## Usage

Imagine a project has three namespaces:

1. `App.Common`
3. `App.Server`
2. `App.Client`

To enfore isolation with this analyzer you would add:

```c#
[assembly: IsolateNamespace("App.Server")]
[assembly: IsolateNamespace("App.Client")]
```

With this, types in `App.Common` and `App.Client` may not reference types in `App.Server`.

Similarly, types in `App.Common` and `App.Server` may not reference types in `App.Client`.

You can add exceptions to these rules via the `AllowFrom` property. In the following example `App.Server.Implementation` is the only namespace allowed to reference types in `App.Server`:

```c#
[assembly: IsolateNamespace("App.Server", AllowFrom = new[] { "App.Server.Implementation" })]
```

Alternatively you may specify a group of namespaces that may each mutally reference one another, yet those outside may not reference into the group. The following example differs from the previous in that `App.Server.Implementation` is isolated from outside referrers as well:

```c#
[assembly: IsolateNamespaceGroup("App.Server", "App.Server.Implementation")]
//                         ^^^^^
```

## Attributes

The `IsolateNamespaceAttribute` and `IsolateNamespaceGroupAttribute` are both available for reference in `/src/DotNetAnalyzers/Core/IsolateNamespaceAnalyzer/NamespaceIsolationAttributes.cs`. Users may copy the implementations into their own source, and locate the types in any namespace. They will be matched by non-qualified type name and constructor parameters.

I considered using a text file as is done with some other analyzers (banned APIs, public APIs) but decided that attributes were more discoverable and enforced correctness at design time.

## Notes

- I don't know that this is the right repo for this analyzer, but I do know it will get a good quality review here 😄 

- The implementation requires considerably use of syntax nodes and is currently only implemented for C#.

- None of `DotNetAnalyzers.*` are currently mentioned in `README.md`.

- I feel the default severity of this analyzer should be 'error' rather than 'warning'.

- In future I'd like to extend this analyzer (or create another) that ensures all types within a namespace are internal. This would have been useful on several codebases I've worked on in the past.