### PR TITLE
implementing fixer for CA1820

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpTestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpTestForEmptyStringsUsingStringLength.Fixer.cs
@@ -4,6 +4,8 @@ using System.Composition;
 using Microsoft.NetCore.Analyzers.Runtime;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
 {
@@ -13,5 +15,27 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public class CSharpTestForEmptyStringsUsingStringLengthFixer : TestForEmptyStringsUsingStringLengthFixer
     {
+        protected override SyntaxNode GetBinaryExpression(SyntaxNode node)
+        {
+            return node is ArgumentSyntax argumentSyntax ? argumentSyntax.Expression : node;
+        }
+        protected override bool IsEqualsOperator(SyntaxNode node)
+        {
+            return node.IsKind(SyntaxKind.EqualsExpression);
+        }
+        protected override bool IsNotEqualsOperator(SyntaxNode node)
+        {
+            return node.IsKind(SyntaxKind.NotEqualsExpression);
+        }
+
+        protected override SyntaxNode GetLeftOperand(SyntaxNode binaryExpressionSyntax)
+        {
+            return ((BinaryExpressionSyntax)binaryExpressionSyntax).Left;
+        }
+
+        protected override SyntaxNode GetRightOperand(SyntaxNode binaryExpressionSyntax)
+        {
+            return ((BinaryExpressionSyntax)binaryExpressionSyntax).Right;
+        }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
@@ -2,7 +2,14 @@
 
 using Microsoft.CodeAnalysis.CodeFixes;
 using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Formatting;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
@@ -18,12 +25,139 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
             return WellKnownFixAllProviders.BatchFixer;
         }
-
-        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // Fixer not yet implemented.
-            return Task.CompletedTask;
+            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            SyntaxNode node = root.FindNode(context.Span);
 
+            SyntaxNode binaryExpressionSyntax = GetBinaryExpression(node);
+
+            if (!IsEqualsOperator(binaryExpressionSyntax) && !IsNotEqualsOperator(binaryExpressionSyntax))
+            {
+                return;
+            }
+
+            SemanticModel model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+            FixResolution resolution = TryGetFixResolution(binaryExpressionSyntax, model);
+
+            if (resolution != null)
+            {
+                // We cannot have multiple overlapping diagnostics of this id.
+                Diagnostic diagnostic = context.Diagnostics.Single();
+
+                var methodInvocationAction = CodeAction.Create(SystemRuntimeAnalyzersResources.TestForEmptyStringsUsingStringLengthMessage,
+                    async ct => await ConvertToMethodInvocation(context, resolution).ConfigureAwait(false),
+                    equivalenceKey: "TestForEmptyStringCorrectlyUsingIsNullOrEmpty");
+
+                context.RegisterCodeFix(methodInvocationAction, diagnostic);
+
+                var stringLengthAction = CodeAction.Create(SystemRuntimeAnalyzersResources.TestForEmptyStringsUsingStringLengthMessage,
+                    async ct => await ConvertToStringLengthComparison(context, resolution).ConfigureAwait(false),
+                    equivalenceKey: "TestForEmptyStringCorrectlyUsingStringLength");
+
+                context.RegisterCodeFix(stringLengthAction, diagnostic);
+            }
+        }
+
+        private FixResolution TryGetFixResolution(SyntaxNode binaryExpressionSyntax, SemanticModel model)
+        {
+            bool isEqualsOperator = IsEqualsOperator(binaryExpressionSyntax);
+            SyntaxNode leftOperand = GetLeftOperand(binaryExpressionSyntax);
+            SyntaxNode rightOperand = GetRightOperand(binaryExpressionSyntax);
+
+            if (ContainsSystemStringEmpty(leftOperand, model))
+            {
+                return new FixResolution(binaryExpressionSyntax, rightOperand, isEqualsOperator);
+            }
+
+            if (ContainsSystemStringEmpty(rightOperand, model))
+            {
+                return new FixResolution(binaryExpressionSyntax, leftOperand, isEqualsOperator);
+            }
+
+            return null;
+        }
+
+        private static bool ContainsSystemStringEmpty(SyntaxNode expressionSyntax, SemanticModel model)
+        {
+            if (model.GetSymbolInfo(expressionSyntax).Symbol is IFieldSymbol fieldSymbol)
+            {
+                if (fieldSymbol.Type.Equals(model.Compilation.GetTypeByMetadataName("System.String")))
+                {
+                    return fieldSymbol.IsReadOnly && fieldSymbol.Name == "Empty";
+                }
+            }
+
+            return false;
+        }
+
+        private static async Task<Document> ConvertToMethodInvocation(CodeFixContext context, FixResolution fixResolution)
+        {
+            DocumentEditor editor = await DocumentEditor.CreateAsync(context.Document, context.CancellationToken).ConfigureAwait(false);
+
+            SyntaxNode typeNameSyntax = editor.Generator.TypeExpression(SpecialType.System_String);
+            SyntaxNode nullOrEmptyMemberSyntax = editor.Generator.MemberAccessExpression(typeNameSyntax, "IsNullOrEmpty");
+            SyntaxNode nullOrEmptyInvocationSyntax = editor.Generator.InvocationExpression(nullOrEmptyMemberSyntax, fixResolution.ComparisonOperand.WithoutTrailingTrivia());
+
+            SyntaxNode replacementSyntax = fixResolution.UsesEqualsOperator ? nullOrEmptyInvocationSyntax : editor.Generator.LogicalNotExpression(nullOrEmptyInvocationSyntax);
+            SyntaxNode replacementAnnotatedSyntax = replacementSyntax.WithAdditionalAnnotations(Formatter.Annotation).WithTriviaFrom(fixResolution.BinaryExpressionSyntax);
+
+            editor.ReplaceNode(fixResolution.BinaryExpressionSyntax, replacementAnnotatedSyntax);
+
+            return editor.GetChangedDocument();
+        }
+
+        private async Task<Document> ConvertToStringLengthComparison(CodeFixContext context, FixResolution fixResolution)
+        {
+            DocumentEditor editor = await DocumentEditor.CreateAsync(context.Document, context.CancellationToken).ConfigureAwait(false);
+            SyntaxNode leftOperand = GetLeftOperand(fixResolution.BinaryExpressionSyntax);
+            SyntaxNode rightOperand = GetRightOperand(fixResolution.BinaryExpressionSyntax);
+
+            // Take the below example:
+            //   if (f == String.Empty) ...
+            // The comparison operand, f, will now become 'f.Length' and a the other operand will become '0'
+            SyntaxNode zeroLengthSyntax = editor.Generator.LiteralExpression(0);
+            if (leftOperand == fixResolution.ComparisonOperand)
+            {
+                leftOperand = editor.Generator.MemberAccessExpression(leftOperand, "Length");
+                rightOperand = zeroLengthSyntax.WithTriviaFrom(rightOperand);
+            }
+            else
+            {
+                leftOperand = zeroLengthSyntax;
+                rightOperand = editor.Generator.MemberAccessExpression(rightOperand.WithoutTrivia(), "Length");
+            }
+
+            SyntaxNode replacementSyntax = fixResolution.UsesEqualsOperator ?
+                editor.Generator.ValueEqualsExpression(leftOperand, rightOperand) :
+                editor.Generator.ValueNotEqualsExpression(leftOperand, rightOperand);
+
+            SyntaxNode replacementAnnotatedSyntax = replacementSyntax.WithAdditionalAnnotations(Formatter.Annotation);
+
+            editor.ReplaceNode(fixResolution.BinaryExpressionSyntax, replacementAnnotatedSyntax);
+
+            return editor.GetChangedDocument();
+        }
+
+        protected abstract SyntaxNode GetBinaryExpression(SyntaxNode node);
+        protected abstract bool IsEqualsOperator(SyntaxNode node);
+        protected abstract bool IsNotEqualsOperator(SyntaxNode node);
+        protected abstract SyntaxNode GetLeftOperand(SyntaxNode binaryExpressionSyntax);
+        protected abstract SyntaxNode GetRightOperand(SyntaxNode binaryExpressionSyntax);
+
+        private sealed class FixResolution
+        {
+            public SyntaxNode BinaryExpressionSyntax { get; }
+            public SyntaxNode ComparisonOperand { get; }
+            public bool UsesEqualsOperator { get; }
+
+            public FixResolution(SyntaxNode binaryExpressionSyntax, SyntaxNode comparisonOperand, bool usesEqualsOperator)
+            {
+                BinaryExpressionSyntax = binaryExpressionSyntax;
+                ComparisonOperand = comparisonOperand;
+                UsesEqualsOperator = usesEqualsOperator;
+            }
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
@@ -43,20 +43,17 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             if (resolution != null)
             {
-                // We cannot have multiple overlapping diagnostics of this id.
-                Diagnostic diagnostic = context.Diagnostics.Single();
-
                 var methodInvocationAction = CodeAction.Create(SystemRuntimeAnalyzersResources.TestForEmptyStringsUsingStringLengthMessage,
                     async ct => await ConvertToMethodInvocation(context, resolution).ConfigureAwait(false),
                     equivalenceKey: "TestForEmptyStringCorrectlyUsingIsNullOrEmpty");
 
-                context.RegisterCodeFix(methodInvocationAction, diagnostic);
+                context.RegisterCodeFix(methodInvocationAction, context.Diagnostics);
 
                 var stringLengthAction = CodeAction.Create(SystemRuntimeAnalyzersResources.TestForEmptyStringsUsingStringLengthMessage,
                     async ct => await ConvertToStringLengthComparison(context, resolution).ConfigureAwait(false),
                     equivalenceKey: "TestForEmptyStringCorrectlyUsingStringLength");
 
-                context.RegisterCodeFix(stringLengthAction, diagnostic);
+                context.RegisterCodeFix(stringLengthAction, context.Diagnostics);
             }
         }
 
@@ -83,7 +80,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             if (model.GetSymbolInfo(expressionSyntax).Symbol is IFieldSymbol fieldSymbol)
             {
-                if (fieldSymbol.Type.Equals(model.Compilation.GetTypeByMetadataName("System.String")))
+                if (fieldSymbol.Type.SpecialType == SpecialType.System_String)
                 {
                     return fieldSymbol.IsReadOnly && fieldSymbol.Name == "Empty";
                 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForEmptyStringsUsingStringLengthTests.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForEmptyStringsUsingStringLengthTests.Fixer.cs
@@ -5,11 +5,693 @@ using Microsoft.NetCore.VisualBasic.Analyzers.Runtime;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
+using Xunit;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class TestForEmptyStringsUsingStringLengthFixerTests : CodeFixTestBase
     {
+        [Fact]
+        public void CA1820_FixTestEmptyStringsUsingIsNullOrEmpty()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return s == string.Empty;
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return string.IsNullOrEmpty(s);
+    }
+}
+");
+            VerifyBasicFix(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return s = String.Empty
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return String.IsNullOrEmpty(s)
+    End Function
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1820_FixTestEmptyStringsUsingStringLength()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return s == string.Empty;
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return s.Length == 0;
+    }
+}
+", 1);
+
+            VerifyBasicFix(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return s = String.Empty
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return s.Length = 0
+    End Function
+End Class
+", 1);
+        }
+
+        [Fact]
+        public void CA1820_FixTestEmptyStringsUsingIsNullOrEmptyComparisonOnRight()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return string.Empty == s;
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return string.IsNullOrEmpty(s);
+    }
+}
+");
+
+            VerifyBasicFix(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return String.Empty = s
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return String.IsNullOrEmpty(s)
+    End Function
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1820_FixTestEmptyStringsUsingStringLengthComparisonOnRight()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return string.Empty == s;
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return 0 == s.Length;
+    }
+}
+", 1);
+
+            VerifyBasicFix(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return String.Empty = s
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return 0 = s.Length
+    End Function
+End Class
+", 1);
+        }
+
+        [Fact]
+        public void CA1820_FixInequalityTestEmptyStringsUsingIsNullOrEmpty()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return s != string.Empty;
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return !string.IsNullOrEmpty(s);
+    }
+}
+");
+            VerifyBasicFix(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return s <> String.Empty
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return Not String.IsNullOrEmpty(s)
+    End Function
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1820_FixInequalityTestEmptyStringsUsingStringLength()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return s != string.Empty;
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return s.Length != 0;
+    }
+}
+", 1);
+
+            VerifyBasicFix(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return s <> String.Empty
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return s.Length <> 0
+    End Function
+End Class
+", 1);
+        }
+
+        [Fact]
+        public void CA1820_FixInequalityTestEmptyStringsUsingIsNullOrEmptyComparisonOnRight()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return string.Empty != s;
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return !string.IsNullOrEmpty(s);
+    }
+}
+");
+            VerifyBasicFix(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return String.Empty <> s
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return Not String.IsNullOrEmpty(s)
+    End Function
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1820_FixInequalityTestEmptyStringsUsingStringLengthComparisonOnRight()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return string.Empty != s;
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return 0 != s.Length;
+    }
+}
+", 1);
+
+            VerifyBasicFix(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return String.Empty <> s
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return 0 <> s.Length
+    End Function
+End Class
+", 1);
+
+        }
+        [Fact]
+        public void CA1820_FixForComparisonWithEmptyStringInFunctionArgument()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        G(_s == string.Empty);
+    }
+
+    public void G(bool comparison) {}
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        G(string.IsNullOrEmpty(_s));
+    }
+
+    public void G(bool comparison) {}
+}
+");
+
+            VerifyBasicFix(@"
+Public Class A
+    Private _s As String = String.Empty
+
+    Public Sub F()
+        G(_s = String.Empty)
+    End Sub
+
+    Public Sub G(comparison As Boolean)
+    End Sub
+End Class
+", @"
+Public Class A
+    Private _s As String = String.Empty
+
+    Public Sub F()
+        G(String.IsNullOrEmpty(_s))
+    End Sub
+
+    Public Sub G(comparison As Boolean)
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1820_FixForComparisonWithEmptyStringInTernaryOperator()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+
+    public int F()
+    {
+        return _s == string.Empty ? 1 : 0;
+    }
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+
+    public int F()
+    {
+        return string.IsNullOrEmpty(_s) ? 1 : 0;
+    }
+}
+");
+
+            // VB doesn't have the ternary operator, but we add this test for symmetry.
+            VerifyBasicFix(@"
+Public Class A
+    Private _s As String = String.Empty
+
+    Public Function F() As Integer
+        Return If(_s = String.Empty, 1, 0)
+    End Function
+End Class
+", @"
+Public Class A
+    Private _s As String = String.Empty
+
+    Public Function F() As Integer
+        Return If(String.IsNullOrEmpty(_s), 1, 0)
+    End Function
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1820_FixForComparisonWithEmptyStringInThrowStatement()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        throw _s != string.Empty ? new System.Exception() : new System.ArgumentException();
+    }
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        throw !string.IsNullOrEmpty(_s) ? new System.Exception() : new System.ArgumentException();
+    }
+}
+");
+        }
+
+        [Fact]
+        public void CA1820_FixForComparisonWithEmptyStringInCatchFilterClause()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        try { }
+        catch (System.Exception ex) when (_s != string.Empty) { }
+    }
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        try { }
+        catch (System.Exception ex) when (!string.IsNullOrEmpty(_s)) { }
+    }
+}
+");
+        }
+
+        [Fact]
+        public void CA1820_FixForComparisonWithEmptyStringInYieldReturnStatement()
+        {
+            VerifyCSharpFix(@"
+using System.Collections.Generic;
+
+public class A
+{
+    string _s = string.Empty;
+
+    public IEnumerable<bool> F()
+    {
+        yield return _s != string.Empty;
+    }
+}
+", @"
+using System.Collections.Generic;
+
+public class A
+{
+    string _s = string.Empty;
+
+    public IEnumerable<bool> F()
+    {
+        yield return !string.IsNullOrEmpty(_s);
+    }
+}
+");
+        }
+
+        [Fact]
+        public void CA1820_FixForComparisonWithEmptyStringInSwitchStatement()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        switch (_s != string.Empty)
+        {
+            default:
+                throw new System.NotImplementedException();
+        }
+    }
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        switch (!string.IsNullOrEmpty(_s))
+        {
+            default:
+                throw new System.NotImplementedException();
+        }
+    }
+}
+");
+        }
+
+        [Fact]
+        public void CA1820_FixForComparisonWithEmptyStringInForLoop()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        for (; _s != string.Empty; )
+        {
+            throw new System.Exception();
+        }
+    }
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        for (; !string.IsNullOrEmpty(_s); )
+        {
+            throw new System.Exception();
+        }
+    }
+}
+");
+        }
+
+        [Fact]
+        public void CA1820_FixForComparisonWithEmptyStringInWhileLoop()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        while (_s != string.Empty)
+        {
+        }
+    }
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        while (!string.IsNullOrEmpty(_s))
+        {
+        }
+    }
+}
+");
+        }
+
+        [Fact]
+        public void CA1820_FixForComparisonWithEmptyStringInDoWhileLoop()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        do
+        {
+        }
+        while (_s != string.Empty);
+    }
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+
+    public void F()
+    {
+        do
+        {
+        }
+        while (!string.IsNullOrEmpty(_s));
+    }
+}
+");
+        }
+
+        [Fact]
+        public void CA1820_MultilineFixTestEmptyStringsUsingIsNullOrEmpty()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+    public bool Compare(string s)
+    {
+        return s == string.Empty ||
+               s == _s;
+    }
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+    public bool Compare(string s)
+    {
+        return string.IsNullOrEmpty(s) ||
+               s == _s;
+    }
+}
+");
+            VerifyBasicFix(@"
+Public Class A
+    Private _s As String = String.Empty
+    Public Function Compare(s As String) As Boolean
+        Return s = String.Empty Or
+               s = _s
+    End Function
+End Class
+", @"
+Public Class A
+    Private _s As String = String.Empty
+    Public Function Compare(s As String) As Boolean
+        Return String.IsNullOrEmpty(s) Or
+               s = _s
+    End Function
+End Class
+");
+        }
+
+        [Fact]
+        public void CA1820_MultilineFixTestEmptyStringsUsingStringLength()
+        {
+            VerifyCSharpFix(@"
+public class A
+{
+    string _s = string.Empty;
+    public bool Compare(string s)
+    {
+        return s == string.Empty ||
+               s == _s;
+    }
+}
+", @"
+public class A
+{
+    string _s = string.Empty;
+    public bool Compare(string s)
+    {
+        return s.Length == 0 ||
+               s == _s;
+    }
+}
+", 1);
+            VerifyBasicFix(@"
+Public Class A
+    Private _s As String = String.Empty
+    Public Function Compare(s As String) As Boolean
+        Return s = String.Empty Or
+               s = _s
+    End Function
+End Class
+", @"
+Public Class A
+    Private _s As String = String.Empty
+    Public Function Compare(s As String) As Boolean
+        Return s.Length = 0 Or
+               s = _s
+    End Function
+End Class
+", 1);
+        }
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
             return new TestForEmptyStringsUsingStringLengthAnalyzer();

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForEmptyStringsUsingStringLengthTests.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForEmptyStringsUsingStringLengthTests.Fixer.cs
@@ -11,6 +11,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class TestForEmptyStringsUsingStringLengthFixerTests : CodeFixTestBase
     {
+        const int c_StringLengthCodeActionIndex = 1;
         [Fact]
         public void CA1820_FixTestEmptyStringsUsingIsNullOrEmpty()
         {
@@ -65,7 +66,7 @@ public class A
         return s.Length == 0;
     }
 }
-", 1);
+", c_StringLengthCodeActionIndex);
 
             VerifyBasicFix(@"
 Public Class A
@@ -79,7 +80,7 @@ Public Class A
         Return s.Length = 0
     End Function
 End Class
-", 1);
+", c_StringLengthCodeActionIndex);
         }
 
         [Fact]
@@ -137,7 +138,7 @@ public class A
         return 0 == s.Length;
     }
 }
-", 1);
+", c_StringLengthCodeActionIndex);
 
             VerifyBasicFix(@"
 Public Class A
@@ -151,7 +152,7 @@ Public Class A
         Return 0 = s.Length
     End Function
 End Class
-", 1);
+", c_StringLengthCodeActionIndex);
         }
 
         [Fact]
@@ -208,7 +209,7 @@ public class A
         return s.Length != 0;
     }
 }
-", 1);
+", c_StringLengthCodeActionIndex);
 
             VerifyBasicFix(@"
 Public Class A
@@ -222,7 +223,7 @@ Public Class A
         Return s.Length <> 0
     End Function
 End Class
-", 1);
+", c_StringLengthCodeActionIndex);
         }
 
         [Fact]
@@ -279,7 +280,7 @@ public class A
         return 0 != s.Length;
     }
 }
-", 1);
+", c_StringLengthCodeActionIndex);
 
             VerifyBasicFix(@"
 Public Class A
@@ -293,7 +294,7 @@ Public Class A
         Return 0 <> s.Length
     End Function
 End Class
-", 1);
+", c_StringLengthCodeActionIndex);
 
         }
         [Fact]
@@ -673,7 +674,7 @@ public class A
                s == _s;
     }
 }
-", 1);
+", c_StringLengthCodeActionIndex);
             VerifyBasicFix(@"
 Public Class A
     Private _s As String = String.Empty
@@ -690,7 +691,7 @@ Public Class A
                s = _s
     End Function
 End Class
-", 1);
+", c_StringLengthCodeActionIndex);
         }
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {

--- a/src/Microsoft.NetCore.Analyzers/VisualBasic/Runtime/BasicTestForEmptyStringsUsingStringLength.Fixer.vb
+++ b/src/Microsoft.NetCore.Analyzers/VisualBasic/Runtime/BasicTestForEmptyStringsUsingStringLength.Fixer.vb
@@ -4,6 +4,8 @@ Imports System.Composition
 Imports Microsoft.NetCore.Analyzers.Runtime
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
     ''' <summary>
@@ -12,6 +14,25 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
     <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
     Public NotInheritable Class BasicTestForEmptyStringsUsingStringLengthFixer
         Inherits TestForEmptyStringsUsingStringLengthFixer
+        Protected Overrides Function GetBinaryExpression(node As SyntaxNode) As SyntaxNode
+            Dim argumentSyntax = TryCast(node, ArgumentSyntax)
+            Return If(argumentSyntax IsNot Nothing, argumentSyntax.GetExpression(), node)
+        End Function
 
+        Protected Overrides Function IsEqualsOperator(node As SyntaxNode) As Boolean
+            Return node.IsKind(SyntaxKind.EqualsExpression)
+        End Function
+
+        Protected Overrides Function IsNotEqualsOperator(node As SyntaxNode) As Boolean
+            Return node.IsKind(SyntaxKind.NotEqualsExpression)
+        End Function
+
+        Protected Overrides Function GetLeftOperand(binaryExpressionSyntax As SyntaxNode) As SyntaxNode
+            Return DirectCast(binaryExpressionSyntax, BinaryExpressionSyntax).Left
+        End Function
+
+        Protected Overrides Function GetRightOperand(binaryExpressionSyntax As SyntaxNode) As SyntaxNode
+            Return DirectCast(binaryExpressionSyntax, BinaryExpressionSyntax).Right
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
much of the implementation and test cases mirrored what was done for the TestForNanCorrectly rule, which is very similar to testing for the empty string. The major difference we have is that the rule suggests two fixes: either use string.IsNullOrEmpty or test that string.Length == 0.

Fixes #2165 