### PR TITLE
Allow argument exceptions in accessors to use the associated property…

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/InstantiateArgumentExceptionsCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/InstantiateArgumentExceptionsCorrectly.cs
@@ -115,6 +115,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             }
             else if (IsParameterName(parameter) && !matchesParameter)
             {
+                // Allow argument exceptions in accessors to use the associated property symbol name.
+                if (MatchesAssociatedSymbol(targetSymbol, stringArgument))
+                {
+                    return;
+                }
+
                 format = s_localizableMessageIncorrectParameterName;
             }
 
@@ -209,5 +215,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             return false;
         }
+
+        private static bool MatchesAssociatedSymbol(ISymbol targetSymbol, string stringArgument)
+            => targetSymbol.IsAccessorMethod() &&
+            ((IMethodSymbol)targetSymbol).AssociatedSymbol?.Name == stringArgument;
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
@@ -589,6 +589,31 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }");
         }
 
+        [Fact, WorkItem(1561, "https://github.com/dotnet/roslyn-analyzers/issues/1561")]
+        public void ArgumentOutOfRangeException_PropertyName_DoesNotWarn()
+        {
+            VerifyCSharp(@"
+                using System;
+
+                public class Class1
+                {
+                    private int _size;
+                    public int Size
+                    {
+                        get => _size;
+                        set
+                        {
+                            if (value < 0)
+                            {
+                                throw new ArgumentOutOfRangeException(nameof(Size));
+                            }
+
+                            _size = value;
+                        }
+                    }
+                }");
+        }
+
         private static DiagnosticResult GetCSharpExpectedResult(int line, int column, string format, params string[] args)
         {
             string message = string.Format(format, args);


### PR DESCRIPTION
… symbol name.

Fixes #1561