### PR TITLE
Address follow up items from features/dataflow RI

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,7 @@
     <CodecovVersion>1.0.3</CodecovVersion>
 
     <!-- Roslyn -->
-    <MicrosoftCodeAnalysisVersion>2.9.0-beta8-63117-09</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>2.9.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftNetCompilersVersion>2.11.0-beta1-final</MicrosoftNetCompilersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyersVersion>2.9.0-beta1.19158.2+85a05d0e</MicrosoftCodeAnalysisFXCopAnalyersVersion>
     <MicrosoftCodeAnalysisAnalyersVersion>2.9.0-beta1.19158.2+85a05d0e</MicrosoftCodeAnalysisAnalyersVersion>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidDeadConditionalCode.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidDeadConditionalCode.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              s_localizableAlwaysTrueFalseOrNullMessage,
                                                                              DiagnosticCategory.Maintainability,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2180 tracks enabling the rule by default
                                                                              helpLinkUri: null, // TODO: Add helplink
                                                                              customTags: WellKnownDiagnosticTagsExtensions.DataflowAndTelemetry);
 
@@ -40,7 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                                                                              s_localizableNeverNullMessage,
                                                                              DiagnosticCategory.Maintainability,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2180 tracks enabling the rule by default
                                                                              helpLinkUri: null, // TODO: Add helplink
                                                                              customTags: WellKnownDiagnosticTagsExtensions.DataflowAndTelemetry);
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ValidateArgumentsOfPublicMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ValidateArgumentsOfPublicMethods.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);

--- a/src/Microsoft.NetCore.Analyzers/Core/Data/ReviewSqlQueriesForSecurityVulnerabilities.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Data/ReviewSqlQueriesForSecurityVulnerabilities.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.Data
                                                                              s_localizableMessageNoNonLiterals,
                                                                              DiagnosticCategory.Security,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2100-review-sql-queries-for-security-vulnerabilities",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2213-disposable-fields-should-be-disposed",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeObjectsBeforeLosingScope.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeObjectsBeforeLosingScope.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                         s_localizableNotDisposedMessage,
                                                                                         DiagnosticCategory.Reliability,
                                                                                         DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                                        isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
                                                                                         description: s_localizableDescription,
                                                                                         helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2000-dispose-objects-before-losing-scope",
                                                                                         customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);
@@ -42,7 +42,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                           s_localizableMayBeDisposedMessage,
                                                                                           DiagnosticCategory.Reliability,
                                                                                           DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                          isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                                          isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
                                                                                           description: s_localizableDescription,
                                                                                           helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2000-dispose-objects-before-losing-scope",
                                                                                           customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);
@@ -52,7 +52,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                         s_localizableNotDisposedOnExceptionPathsMessage,
                                                                                                         DiagnosticCategory.Reliability,
                                                                                                         DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                                                        isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
                                                                                                         description: s_localizableDescription,
                                                                                                         helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2000-dispose-objects-before-losing-scope",
                                                                                                         customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);
@@ -62,7 +62,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                           s_localizableMayBeDisposedOnExceptionPathsMessage,
                                                                                                           DiagnosticCategory.Reliability,
                                                                                                           DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                                          isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                                                          isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
                                                                                                           description: s_localizableDescription,
                                                                                                           helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2000-dispose-objects-before-losing-scope",
                                                                                                           customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Globalization,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);


### PR DESCRIPTION
Address follow up items from https://github.com/dotnet/roslyn-analyzers/pull/2190

Verified:
1. No AD0001 on consuming the locally generated 2.9.0-ci package
2. Explicitly enabling any flow-analysis rule in ruleset generates AD0001 as expected in VS2017. AD0001 is not generated on VS2019, unless the project references a 2.x.x or earlier version of Microsoft.Net.Compilers.
3. Adding the flow-analysis feature flag causes flow analysis rules to work as expected on VS2017

https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks reverting https://github.com/dotnet/roslyn-analyzers/commit/22b4d0db2a65cd9abbafb29bbe92a1e4209c621f