### PR TITLE
Fix dataflow walker when processing catch handler in presence of nest…

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -4094,6 +4094,86 @@ Class Test
 End Class");
         }
 
+        [Fact, WorkItem(2201, "https://github.com/dotnet/roslyn-analyzers/issues/2201")]
+        public void UsingStatementInTryCatch_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+
+class Test
+{
+    void M1()
+    {
+        try
+        {
+            using (var ms = new MemoryStream())
+            {
+            }
+        }
+        catch
+        {
+        }
+    }
+}");
+
+            VerifyBasic(@"
+Imports System.IO
+
+Class Test
+    Private Sub M1()
+        Try
+            Using ms = New MemoryStream()
+            End Using
+        Catch
+        End Try
+    End Sub
+End Class");
+        }
+
+        [Fact, WorkItem(2201, "https://github.com/dotnet/roslyn-analyzers/issues/2201")]
+        public void NestedTryFinallyInTryCatch_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System.IO;
+
+class Test
+{
+    void M1()
+    {
+        try
+        {
+            var ms = new MemoryStream();
+            try
+            {
+            }
+            finally
+            {
+                ms?.Dispose();
+            }
+        }
+        catch
+        {
+        }
+    }
+}");
+
+            VerifyBasic(@"
+Imports System.IO
+
+Class Test
+    Private Sub M1()
+        Try
+            Dim ms = New MemoryStream()
+            Try
+            Finally
+                ms?.Dispose()
+            End Try
+        Catch
+        End Try
+    End Sub
+End Class");
+        }
+
         [Fact]
         public void ReturnStatement_NoDiagnostic()
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -479,7 +479,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 }
             }
 
-            ControlFlowRegion MergeIntoCatchInputData(ControlFlowRegion tryAndCatchRegion, TAnalysisData dataToMerge, BasicBlock sourceBlock)
+            ControlFlowRegion TryGetReachableCatchRegionStartingHandler(ControlFlowRegion tryAndCatchRegion, BasicBlock sourceBlock)
             {
                 Debug.Assert(tryAndCatchRegion.Kind == ControlFlowRegionKind.TryAndCatch);
 
@@ -488,6 +488,17 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 // in which case a throw cannot enter the catch region. 
                 var catchRegion = tryAndCatchRegion.NestedRegions.FirstOrDefault(region => region.Kind == ControlFlowRegionKind.Catch || region.Kind == ControlFlowRegionKind.FilterAndHandler);
                 if (catchRegion == null || sourceBlock.Ordinal >= catchRegion.FirstBlockOrdinal)
+                {
+                    return null;
+                }
+
+                return catchRegion;
+            }
+
+            ControlFlowRegion MergeIntoCatchInputData(ControlFlowRegion tryAndCatchRegion, TAnalysisData dataToMerge, BasicBlock sourceBlock)
+            {
+                var catchRegion = TryGetReachableCatchRegionStartingHandler(tryAndCatchRegion, sourceBlock);
+                if (catchRegion == null)
                 {
                     return null;
                 }
@@ -651,7 +662,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     for (var i = branch.FinallyRegions.Length - 1; i >= 0; i--)
                     {
                         ControlFlowRegion finallyRegion = branch.FinallyRegions[i];
-                        UpdateFinallySuccessor(finallyRegion, successor);
+                        AddFinallySuccessor(finallyRegion, successor);
                         successor = new BranchWithInfo(destination: cfg.Blocks[finallyRegion.FirstBlockOrdinal]);
                     }
                 }
@@ -661,17 +672,46 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 {
                     foreach (var tryAndCatchRegion in branch.LeavingRegions.Where(region => region.Kind == ControlFlowRegionKind.TryAndCatch))
                     {
-                        var catchRegion = MergeIntoCatchInputData(tryAndCatchRegion, branchData, sourceBlock);
-                        if (catchRegion != null)
+                        // If we have any nested finally region inside this try-catch, then mark the catch region
+                        // as a successor of that nested finally region.
+                        // Otherwise, merge the current data directly into the catch region.
+
+                        var hasNestedFinally = false;
+                        if (branch.FinallyRegions.Length > 0)
                         {
-                            // We also need to enqueue the catch block into the worklist as there is no direct branch into catch.
-                            worklist.Add(catchRegion.FirstBlockOrdinal);
+                            var catchRegion = TryGetReachableCatchRegionStartingHandler(tryAndCatchRegion, sourceBlock);
+                            if (catchRegion != null)
+                            {
+                                for (var i = branch.FinallyRegions.Length - 1; i >= 0; i--)
+                                {
+                                    ControlFlowRegion finallyRegion = branch.FinallyRegions[i];
+                                    if (finallyRegion.LastBlockOrdinal < catchRegion.FirstBlockOrdinal)
+                                    {
+                                        var successor = new BranchWithInfo(destination: cfg.Blocks[catchRegion.FirstBlockOrdinal]);
+                                        AddFinallySuccessor(finallyRegion, successor);
+                                        hasNestedFinally = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (!hasNestedFinally)
+                        {
+                            // No nested finally regions inside this try-catch.
+                            // Merge the current data directly into the catch region.
+                            var catchRegion = MergeIntoCatchInputData(tryAndCatchRegion, branchData, sourceBlock);
+                            if (catchRegion != null)
+                            {
+                                // We also need to enqueue the catch block into the worklist as there is no direct branch into catch.
+                                worklist.Add(catchRegion.FirstBlockOrdinal);
+                            }
                         }
                     }
                 }
             }
 
-            void UpdateFinallySuccessor(ControlFlowRegion finallyRegion, BranchWithInfo successor)
+            void AddFinallySuccessor(ControlFlowRegion finallyRegion, BranchWithInfo successor)
             {
                 Debug.Assert(finallyRegion.Kind == ControlFlowRegionKind.Finally);
                 if (!finallyBlockSuccessorsMap.TryGetValue(finallyRegion.LastBlockOrdinal, out var lastBlockSuccessors))


### PR DESCRIPTION
…ed try/finally regions. We should walk the nested finally regions prior to the outer catch region(s).

Fixes #2201