### PR TITLE
Add a workaround to ensure we do not flag using declarations in Dispose rules

### DIFF
--- a/src/Utilities/FlowAnalysis/Extensions/BasicBlockExtensions.cs
+++ b/src/Utilities/FlowAnalysis/Extensions/BasicBlockExtensions.cs
@@ -165,5 +165,23 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         internal static int GetMaxSuccessorOrdinal(this BasicBlock basicBlock)
             => Math.Max(basicBlock.FallThroughSuccessor?.Destination?.Ordinal ?? -1,
                         basicBlock.ConditionalSuccessor?.Destination?.Ordinal ?? -1);
+
+        internal static IOperation GetPreviousOperationInBlock(this BasicBlock basicBlock, IOperation operation)
+        {
+            Debug.Assert(operation != null);
+
+            IOperation previousOperation = null;
+            foreach (var currentOperation in basicBlock.Operations)
+            {
+                if (operation == currentOperation)
+                {
+                    return previousOperation;
+                }
+
+                previousOperation = currentOperation;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -223,6 +223,20 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
             {
                 var value = base.Visit(operation, argument);
                 HandlePossibleEscapingOperation(operation, GetEscapedLocations(operation));
+
+                // HACK: Workaround for missing IOperation/CFG support for C# 'using' declarations
+                // https://github.com/dotnet/roslyn-analyzers/issues/2152
+                if (operation?.Kind == OperationKind.None &&
+                    operation.Syntax.GetFirstToken().ToString() == "using" &&
+                    operation.Language == LanguageNames.CSharp)
+                {
+                    var previousOperation = CurrentBasicBlock.GetPreviousOperationInBlock(operation);
+                    if (previousOperation is ISimpleAssignmentOperation simpleAssignment)
+                    {
+                        HandleDisposingOperation(disposingOperation: operation, disposedInstance: simpleAssignment.Value);
+                    }
+                }
+
                 return value;
             }
 


### PR DESCRIPTION
https://github.com/dotnet/roslyn-analyzers/issues/2152#issuecomment-473393239 tracks reverting this workaround once the IOperation/CFG support has been added for using declarations.