### PR TITLE
Unskip the C# unit test for validating dataflow in presence of anonymous t…

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
@@ -2918,8 +2918,8 @@ End Class",
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1568")]
-        public void FlowAnalysis_PointsTo_AnonymousObjectCreation_NoDiagnostic()
+        [Fact]
+        public void CSharp_FlowAnalysis_PointsTo_AnonymousObjectCreation_NoDiagnostic()
         {
             VerifyCSharp($@"
 {SetupCodeCSharp}
@@ -2948,7 +2948,12 @@ class Test
     }}
 }}
 ");
+        }
 
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1568")]
+        public void VisualBasic_FlowAnalysis_PointsTo_AnonymousObjectCreation_NoDiagnostic()
+        {
             VerifyBasic($@"
 {SetupCodeBasic}
 


### PR DESCRIPTION
…ype assignments

Anonymous type assignments still do not work for VisualBasic due to missing CFG support for IWithOperation

Tracking issue: https://github.com/dotnet/roslyn-analyzers/issues/1568