### PR TITLE
Change namespace for pooled object types (ArrayBuilder, PooledHashSet, PooledDictionary)

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -152,6 +152,29 @@ Default Value: `false`
 
 Example: `dotnet_code_quality.dispose_ownership_transfer_at_constructor = true`
 
+For example, consider the below code:
+```csharp
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+
+class Test
+{
+    DisposableOwnerType M1()
+    {
+        // Dispose ownership for allocation 'new A()' is assumed to be transferred to the returned 'DisposableOwnerType' instance
+        // only if 'dotnet_code_quality.dispose_ownership_transfer_at_constructor = true'.
+        // Otherwise, current method 'M1' has the dispose ownership for 'new A()', and it fires a CA2000 as a dispose leak for the below code.
+        return new DisposableOwnerType(new A());
+    }
+}
+```
+
 #### Configure execution of Copy analysis (tracks value and reference copies)
 Option Name: `copy_analysis`
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAPIUsageAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAPIUsageAnalyzer.cs
@@ -8,9 +8,9 @@ using Analyzer.Utilities.Extensions;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
-using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 {

--- a/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
@@ -87,7 +87,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.SymbolOpt.get -> Mic
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.Type.get -> Microsoft.CodeAnalysis.ITypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.WithMergedInstanceLocation(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntityToMerge) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>
-Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AddTrackedEntities(Microsoft.CodeAnalysis.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder) -> void
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AddTrackedEntities(Analyzer.Utilities.PooledObjects.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AnalysisEntityBasedPredicateAnalysisData() -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AnalysisEntityBasedPredicateAnalysisData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> data1, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> data2, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TValue> coreDataAnalysisDomain) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AnalysisEntityBasedPredicateAnalysisData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> fromData) -> void
@@ -103,7 +103,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysi
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.TryGetValue(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity key, out TValue value) -> bool
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.this[Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity key].get -> TValue
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>
-Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AddTrackedEntities(Microsoft.CodeAnalysis.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder, bool forInterproceduralAnalysis = false) -> void
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AddTrackedEntities(Analyzer.Utilities.PooledObjects.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder, bool forInterproceduralAnalysis = false) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AnalysisEntityDataFlowOperationVisitor(TAnalysisContext analysisContext) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyInterproceduralAnalysisResultHelper(System.Collections.Generic.IDictionary<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TAbstractAnalysisValue> resultToApply) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyMissingCurrentAnalysisDataForUnhandledExceptionData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TAbstractAnalysisValue> coreDataAtException, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TAbstractAnalysisValue> coreCurrentAnalysisData, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ThrownExceptionInfo throwBranchWithExceptionType) -> void
@@ -373,14 +373,14 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.Monitor.get -
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.SerializationInfo.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.Task.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.TryGetTypeByMetadataName(string fullTypeName, out Microsoft.CodeAnalysis.INamedTypeSymbol namedTypeSymbol) -> bool
-Microsoft.CodeAnalysis.PooledHashSet<T>
-Microsoft.CodeAnalysis.PooledHashSet<T>.Free() -> void
-Microsoft.CodeAnalysis.PooledHashSet<T>.ToImmutableAndFree() -> System.Collections.Immutable.ImmutableHashSet<T>
+Analyzer.Utilities.PooledObjects.PooledHashSet<T>
+Analyzer.Utilities.PooledObjects.PooledHashSet<T>.Free() -> void
+Analyzer.Utilities.PooledObjects.PooledHashSet<T>.ToImmutableAndFree() -> System.Collections.Immutable.ImmutableHashSet<T>
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisDomain<TAnalysisData>.Clone(TAnalysisData value) -> TAnalysisData
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisDomain<TAnalysisData>.Compare(TAnalysisData oldValue, TAnalysisData newValue) -> int
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisDomain<TAnalysisData>.Equals(TAnalysisData value1, TAnalysisData value2) -> bool
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisDomain<TAnalysisData>.Merge(TAnalysisData value1, TAnalysisData value2) -> TAnalysisData
-abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeHashCodePartsSpecific(Microsoft.CodeAnalysis.ArrayBuilder<int> builder) -> void
+abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeHashCodePartsSpecific(Analyzer.Utilities.PooledObjects.ArrayBuilder<int> builder) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ForkForInterproceduralAnalysis(Microsoft.CodeAnalysis.IMethodSymbol invokedMethod, Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph invokedCfg, Microsoft.CodeAnalysis.IOperation operation, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAnalysisResult pointsToAnalysisResultOpt, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis.CopyBlockAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis.CopyAbstractValue> copyAnalysisResultOpt, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisData<TAnalysisData, TAnalysisContext, TAbstractAnalysisValue> interproceduralAnalysisData) -> TAnalysisContext
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDomain<T>.Bottom.get -> T
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDomain<T>.Compare(T oldValue, T newValue, bool assertMonotonicity) -> int
@@ -394,7 +394,7 @@ abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractValueDomain<T>.Unk
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.Clone() -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.Compare(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> other, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TValue> coreDataAnalysisDomain) -> int
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.WithMergedData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> data, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TValue> coreDataAnalysisDomain) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>
-abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AddTrackedEntities(TAnalysisData analysisData, Microsoft.CodeAnalysis.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder, bool forInterproceduralAnalysis = false) -> void
+abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AddTrackedEntities(TAnalysisData analysisData, Analyzer.Utilities.PooledObjects.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder, bool forInterproceduralAnalysis = false) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyInterproceduralAnalysisResultCore(TAnalysisData resultData) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.GetAbstractValue(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity) -> TAbstractAnalysisValue
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.GetTrimmedCurrentAnalysisData(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> withEntities) -> TAnalysisData
@@ -405,7 +405,7 @@ abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOper
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityMapAbstractDomain<TValue>.AssertValidEntryForMergedMap(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity, TValue value) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityMapAbstractDomain<TValue>.CanSkipNewEntry(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity, TValue value) -> bool
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityMapAbstractDomain<TValue>.GetDefaultValue(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity) -> TValue
-abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T>.ComputeHashCodeParts(Microsoft.CodeAnalysis.ArrayBuilder<int> builder) -> void
+abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T>.ComputeHashCodeParts(Analyzer.Utilities.PooledObjects.ArrayBuilder<int> builder) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysis<TAnalysisData, TAnalysisContext, TAnalysisResult, TBlockAnalysisResult, TAbstractAnalysisValue>.ToBlockResult(Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, TAnalysisData blockAnalysisData) -> TBlockAnalysisResult
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysis<TAnalysisData, TAnalysisContext, TAnalysisResult, TBlockAnalysisResult, TAbstractAnalysisValue>.ToResult(TAnalysisContext analysisContext, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<TBlockAnalysisResult, TAbstractAnalysisValue> dataFlowAnalysisResult) -> TAnalysisResult
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyMissingCurrentAnalysisDataForUnhandledExceptionData(TAnalysisData dataAtException, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ThrownExceptionInfo throwBranchWithExceptionType) -> void
@@ -523,7 +523,7 @@ override Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.Value
 override Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysisData.Clone() -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue>
 override Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysisData.Compare(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue> other, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue> coreDataAnalysisDomain) -> int
 override Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysisData.WithMergedData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue> data, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue> coreDataAnalysisDomain) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue>
-override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeHashCodeParts(Microsoft.CodeAnalysis.ArrayBuilder<int> builder) -> void
+override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeHashCodeParts(Analyzer.Utilities.PooledObjects.ArrayBuilder<int> builder) -> void
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyInterproceduralAnalysisResult(TAnalysisData resultData, bool isLambdaOrLocalFunction, bool hasParameterWithDelegateType, TAnalysisResult interproceduralResult) -> void
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyPredicatedDataForEntity(TAnalysisData analysisData, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity predicatedEntity, bool trueData) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PredicateValueKind
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeAnalysisValueForEscapedRefOrOutArgument(Microsoft.CodeAnalysis.Operations.IArgumentOperation operation, TAbstractAnalysisValue defaultValue) -> TAbstractAnalysisValue
@@ -606,7 +606,7 @@ static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.Create(Micros
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.Create(Microsoft.CodeAnalysis.ISymbol symbolOpt, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractIndex> indices, Microsoft.CodeAnalysis.ITypeSymbol type, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAbstractValue instanceLocation, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity parentOpt) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.Create(Microsoft.CodeAnalysis.Operations.IInstanceReferenceOperation instanceReferenceOperation, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAbstractValue instanceLocation) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.CreateThisOrMeInstance(Microsoft.CodeAnalysis.INamedTypeSymbol typeSymbol, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAbstractValue instanceLocation) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity
-static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.GetChildAnalysisEntities(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity, Microsoft.CodeAnalysis.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> allEntities) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity>
+static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.GetChildAnalysisEntities(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity, Analyzer.Utilities.PooledObjects.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> allEntities) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity>
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.IsChildAnalysisEntity(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity entity, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity ancestorEntity) -> bool
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.IsChildAnalysisEntity(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity entity, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAbstractValue instanceLocation) -> bool
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T>.operator !=(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T> value1, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T> value2) -> bool
@@ -639,8 +639,8 @@ static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.SetAbstractDomain<T>.Default
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysis.GetOrComputeResult(Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph cfg, Microsoft.CodeAnalysis.ISymbol owningSymbol, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider wellKnownTypeProvider, Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions analyzerOptions, Microsoft.CodeAnalysis.DiagnosticDescriptor rule, System.Threading.CancellationToken cancellationToken, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisKind interproceduralAnalysisKind = Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisKind.None, bool pessimisticAnalysis = true, bool performPointsToAnalysis = true) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentBlockAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue>
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysis.GetOrComputeResult(Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph cfg, Microsoft.CodeAnalysis.ISymbol owningSymbol, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider wellKnownTypeProvider, Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions analyzerOptions, Microsoft.CodeAnalysis.DiagnosticDescriptor rule, System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis.CopyBlockAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis.CopyAbstractValue> copyAnalysisResultOpt, out Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAnalysisResult pointsToAnalysisResultOpt, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisKind interproceduralAnalysisKind = Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisKind.None, bool pessimisticAnalysis = true, bool performPointsToAnalysis = true, bool performCopyAnalysisIfNotUserConfigured = true, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisPredicate interproceduralAnalysisPredicateOpt = null) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentBlockAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue>
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.GetOrCreate(Microsoft.CodeAnalysis.Compilation compilation) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider
-static Microsoft.CodeAnalysis.PooledHashSet<T>.CreatePool() -> Microsoft.CodeAnalysis.ObjectPool<Microsoft.CodeAnalysis.PooledHashSet<T>>
-static Microsoft.CodeAnalysis.PooledHashSet<T>.GetInstance() -> Microsoft.CodeAnalysis.PooledHashSet<T>
+static Analyzer.Utilities.PooledObjects.PooledHashSet<T>.CreatePool() -> Analyzer.Utilities.PooledObjects.ObjectPool<Analyzer.Utilities.PooledObjects.PooledHashSet<T>>
+static Analyzer.Utilities.PooledObjects.PooledHashSet<T>.GetInstance() -> Analyzer.Utilities.PooledObjects.PooledHashSet<T>
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation.NoLocation -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation.Null -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue.Invalid -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue
@@ -715,58 +715,58 @@ Analyzer.Utilities.DisposeMethodKind.DisposeAsync = 3 -> Analyzer.Utilities.Disp
 Analyzer.Utilities.DisposeMethodKind.DisposeBool = 2 -> Analyzer.Utilities.DisposeMethodKind
 Analyzer.Utilities.DisposeMethodKind.DisposeCoreAsync = 4 -> Analyzer.Utilities.DisposeMethodKind
 Analyzer.Utilities.DisposeMethodKind.None = 0 -> Analyzer.Utilities.DisposeMethodKind
-Microsoft.CodeAnalysis.ArrayBuilder<T>
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Add(T item) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddMany(T item, int count) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddRange(Microsoft.CodeAnalysis.ArrayBuilder<T> items) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddRange(System.Collections.Immutable.ImmutableArray<T> items) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddRange(T[] items, int length) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddRange(T[] items, int start, int length) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddRange(params T[] items) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddRange<S>(System.Collections.Immutable.ImmutableArray<S> items) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.AddRange<U>(Microsoft.CodeAnalysis.ArrayBuilder<U> items) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Any() -> bool
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ArrayBuilder() -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ArrayBuilder(int size) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Clear() -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Clip(int limit) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Contains(T item) -> bool
-Microsoft.CodeAnalysis.ArrayBuilder<T>.CopyTo(T[] array, int start) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Count.get -> int
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Count.set -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.EnsureCapacity(int capacity) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.FindIndex(System.Predicate<T> match) -> int
-Microsoft.CodeAnalysis.ArrayBuilder<T>.FindIndex(int startIndex, System.Predicate<T> match) -> int
-Microsoft.CodeAnalysis.ArrayBuilder<T>.FindIndex(int startIndex, int count, System.Predicate<T> match) -> int
-Microsoft.CodeAnalysis.ArrayBuilder<T>.First() -> T
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Free() -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.IndexOf(T item) -> int
-Microsoft.CodeAnalysis.ArrayBuilder<T>.IndexOf(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) -> int
-Microsoft.CodeAnalysis.ArrayBuilder<T>.IndexOf(T item, int startIndex, int count) -> int
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Insert(int index, T item) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Last() -> T
-Microsoft.CodeAnalysis.ArrayBuilder<T>.RemoveAt(int index) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.RemoveDuplicates() -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.RemoveLast() -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ReverseContents() -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.SelectDistinct<S>(System.Func<T, S> selector) -> System.Collections.Immutable.ImmutableArray<S>
-Microsoft.CodeAnalysis.ArrayBuilder<T>.SetItem(int index, T value) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Sort() -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Sort(System.Collections.Generic.IComparer<T> comparer) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Sort(System.Comparison<T> compare) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.Sort(int startIndex, System.Collections.Generic.IComparer<T> comparer) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ToArray() -> T[]
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ToArrayAndFree() -> T[]
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ToDowncastedImmutable<U>() -> System.Collections.Immutable.ImmutableArray<U>
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ToImmutable() -> System.Collections.Immutable.ImmutableArray<T>
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ToImmutableAndFree() -> System.Collections.Immutable.ImmutableArray<T>
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ToImmutableOrNull() -> System.Collections.Immutable.ImmutableArray<T>
-Microsoft.CodeAnalysis.ArrayBuilder<T>.ZeroInit(int count) -> void
-Microsoft.CodeAnalysis.ArrayBuilder<T>.this[int index].get -> T
-Microsoft.CodeAnalysis.ArrayBuilder<T>.this[int index].set -> void
-Microsoft.CodeAnalysis.ObjectPool<T>
-static Microsoft.CodeAnalysis.ArrayBuilder<T>.GetInstance() -> Microsoft.CodeAnalysis.ArrayBuilder<T>
-static Microsoft.CodeAnalysis.ArrayBuilder<T>.GetInstance(int capacity) -> Microsoft.CodeAnalysis.ArrayBuilder<T>
-static Microsoft.CodeAnalysis.ArrayBuilder<T>.GetInstance(int capacity, T fillWithValue) -> Microsoft.CodeAnalysis.ArrayBuilder<T>
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Add(T item) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddMany(T item, int count) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(Analyzer.Utilities.PooledObjects.ArrayBuilder<T> items) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(System.Collections.Immutable.ImmutableArray<T> items) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(T[] items, int length) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(T[] items, int start, int length) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(params T[] items) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange<S>(System.Collections.Immutable.ImmutableArray<S> items) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange<U>(Analyzer.Utilities.PooledObjects.ArrayBuilder<U> items) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Any() -> bool
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ArrayBuilder() -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ArrayBuilder(int size) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Clear() -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Clip(int limit) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Contains(T item) -> bool
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.CopyTo(T[] array, int start) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Count.get -> int
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Count.set -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.EnsureCapacity(int capacity) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.FindIndex(System.Predicate<T> match) -> int
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.FindIndex(int startIndex, System.Predicate<T> match) -> int
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.FindIndex(int startIndex, int count, System.Predicate<T> match) -> int
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.First() -> T
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Free() -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.IndexOf(T item) -> int
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.IndexOf(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) -> int
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.IndexOf(T item, int startIndex, int count) -> int
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Insert(int index, T item) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Last() -> T
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.RemoveAt(int index) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.RemoveDuplicates() -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.RemoveLast() -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ReverseContents() -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.SelectDistinct<S>(System.Func<T, S> selector) -> System.Collections.Immutable.ImmutableArray<S>
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.SetItem(int index, T value) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Sort() -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Sort(System.Collections.Generic.IComparer<T> comparer) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Sort(System.Comparison<T> compare) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Sort(int startIndex, System.Collections.Generic.IComparer<T> comparer) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToArray() -> T[]
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToArrayAndFree() -> T[]
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToDowncastedImmutable<U>() -> System.Collections.Immutable.ImmutableArray<U>
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToImmutable() -> System.Collections.Immutable.ImmutableArray<T>
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToImmutableAndFree() -> System.Collections.Immutable.ImmutableArray<T>
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToImmutableOrNull() -> System.Collections.Immutable.ImmutableArray<T>
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ZeroInit(int count) -> void
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.this[int index].get -> T
+Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.this[int index].set -> void
+Analyzer.Utilities.PooledObjects.ObjectPool<T>
+static Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.GetInstance() -> Analyzer.Utilities.PooledObjects.ArrayBuilder<T>
+static Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.GetInstance(int capacity) -> Analyzer.Utilities.PooledObjects.ArrayBuilder<T>
+static Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.GetInstance(int capacity, T fillWithValue) -> Analyzer.Utilities.PooledObjects.ArrayBuilder<T>

--- a/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
@@ -5,6 +5,12 @@ Analyzer.Utilities.DisposeAnalysisHelper.IDisposable.get -> Microsoft.CodeAnalys
 Analyzer.Utilities.DisposeAnalysisHelper.IsDisposableCreationOrDisposeOwnershipTransfer(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation location, Microsoft.CodeAnalysis.IMethodSymbol containingMethod) -> bool
 Analyzer.Utilities.DisposeAnalysisHelper.Task.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Analyzer.Utilities.DisposeAnalysisHelper.TryGetOrComputeResult(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation> operationBlocks, Microsoft.CodeAnalysis.IMethodSymbol containingMethod, Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions analyzerOptions, Microsoft.CodeAnalysis.DiagnosticDescriptor rule, bool trackInstanceFields, bool trackExceptionPaths, System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysisResult disposeAnalysisResult, out Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAnalysisResult pointsToAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisPredicate interproceduralAnalysisPredicateOpt = null, bool defaultDisposeOwnershipTransferAtConstructor = false) -> bool
+Analyzer.Utilities.DisposeAnalysisKind
+Analyzer.Utilities.DisposeAnalysisKind.AllPaths = 0 -> Analyzer.Utilities.DisposeAnalysisKind
+Analyzer.Utilities.DisposeAnalysisKind.AllPathsOnlyNotDisposed = 1 -> Analyzer.Utilities.DisposeAnalysisKind
+Analyzer.Utilities.DisposeAnalysisKind.NonExceptionPaths = 2 -> Analyzer.Utilities.DisposeAnalysisKind
+Analyzer.Utilities.DisposeAnalysisKind.NonExceptionPathsOnlyNotDisposed = 3 -> Analyzer.Utilities.DisposeAnalysisKind
+Analyzer.Utilities.DisposeAnalysisKindExtensions
 Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions
 Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo
 Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo.BranchValueOpt.get -> Microsoft.CodeAnalysis.IOperation
@@ -580,6 +586,9 @@ override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVi
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<TKey, TValue>.Compare(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> oldValue, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> newValue) -> int
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<TKey, TValue>.Equals(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> value1, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> value2) -> bool
 static Analyzer.Utilities.DisposeAnalysisHelper.TryGetOrCreate(Microsoft.CodeAnalysis.Compilation compilation, out Analyzer.Utilities.DisposeAnalysisHelper disposeHelper) -> bool
+static Analyzer.Utilities.DisposeAnalysisKindExtensions.AreExceptionPathsAndMayBeNotDisposedViolationsEnabled(this Analyzer.Utilities.DisposeAnalysisKind disposeAnalysisKind) -> bool
+static Analyzer.Utilities.DisposeAnalysisKindExtensions.AreExceptionPathsEnabled(this Analyzer.Utilities.DisposeAnalysisKind disposeAnalysisKind) -> bool
+static Analyzer.Utilities.DisposeAnalysisKindExtensions.AreMayBeNotDisposedViolationsEnabled(this Analyzer.Utilities.DisposeAnalysisKind disposeAnalysisKind) -> bool
 static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.DescendantOperations(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.IOperation>
 static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.GetContainingRegionOfKind(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegionKind regionKind) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegion
 static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.IsContainedInRegionOfKind(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegionKind regionKind) -> bool

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUnusedPrivateFields.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUnusedPrivateFields.cs
@@ -3,6 +3,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;

--- a/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpDoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/CSharp/Runtime/CSharpDoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
@@ -67,8 +67,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
 
             SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-            var invocationOp = semanticModel.GetOperation(invocationNode) as IInvocationOperation;
-            if (invocationOp == null)
+            if (!(semanticModel.GetOperation(invocationNode) is IInvocationOperation invocationOp))
             {
                 return document;
             }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeObjectsBeforeLosingScope.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeObjectsBeforeLosingScope.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis;

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
@@ -12,9 +12,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
-using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
-using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
 {

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis;

--- a/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.Operations;

--- a/src/Utilities/Compiler/Extensions/ImmutableHashSetExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ImmutableHashSetExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license 
 
 using System.Linq;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace System.Collections.Immutable
 {

--- a/src/Utilities/Compiler/Extensions/PooledHashSetExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/PooledHashSetExtensions.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license 
 
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis;
 
-namespace Analyzer.Utilities.Extensions
+namespace Analyzer.Utilities.PooledObjects.Extensions
 {
     internal static class PooledHashSetExtensions
     {

--- a/src/Utilities/Compiler/PooledObjects/ArrayBuilder.Enumerator.cs
+++ b/src/Utilities/Compiler/PooledObjects/ArrayBuilder.Enumerator.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 #pragma warning disable CA1710 // Rename Microsoft.CodeAnalysis.ArrayBuilder<T> to end in 'Collection'.
 
-namespace Microsoft.CodeAnalysis
+namespace Analyzer.Utilities.PooledObjects
 {
     public partial class ArrayBuilder<T>
     {

--- a/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
+++ b/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 #pragma warning disable CA1710 // Rename Microsoft.CodeAnalysis.ArrayBuilder<T> to end in 'Collection'.
 #pragma warning disable CA1000 // Do not declare static members on generic types
 
-namespace Microsoft.CodeAnalysis
+namespace Analyzer.Utilities.PooledObjects
 {
     [DebuggerDisplay("Count = {Count,nq}")]
     [DebuggerTypeProxy(typeof(ArrayBuilder<>.DebuggerProxy))]

--- a/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
+++ b/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
@@ -18,7 +18,7 @@ using System.Threading;
 using System.Runtime.CompilerServices;
  
 #endif
-namespace Microsoft.CodeAnalysis
+namespace Analyzer.Utilities.PooledObjects
 {
     /// <summary>
     /// Generic implementation of object pooling pattern with predefined pool size limit. The main

--- a/src/Utilities/Compiler/PooledObjects/PooledDictionary.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledDictionary.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 #pragma warning disable CA1000 // Do not declare static members on generic types
 
-namespace Microsoft.CodeAnalysis
+namespace Analyzer.Utilities.PooledObjects
 {
     // Dictionary that can be recycled via an object pool
     // NOTE: these dictionaries always have the default comparer.

--- a/src/Utilities/Compiler/PooledObjects/PooledHashSet.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledHashSet.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 #pragma warning disable CA1000 // Do not declare static members on generic types
 #pragma warning disable CA2237 // Add [Serializable] to PooledHashSet as this type implements ISerializable
 
-namespace Microsoft.CodeAnalysis
+namespace Analyzer.Utilities.PooledObjects
 {
     // HashSet that can be recycled via an object pool
     // NOTE: these HashSets always have the default comparer.

--- a/src/Utilities/Compiler/WellKnownTypeProvider.cs
+++ b/src/Utilities/Compiler/WellKnownTypeProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T> - CacheBasedEquatable handles equality
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
@@ -6,6 +6,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
+using Analyzer.Utilities.PooledObjects.Extensions;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T> - CacheBasedEquatable handles equality
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisContext.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisHelper.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisHelper.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysisContext.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisContext.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/TrackedEntitiesBuilder.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/TrackedEntitiesBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorCollection.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorCollection.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetAbstractValueDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetAbstractValueDomain.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisContext.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/DllSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/DllSinks.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/FilePathInjectionSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/FilePathInjectionSinks.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/InformationDisclosureSources.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/InformationDisclosureSources.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/LdapSanitizers.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/LdapSanitizers.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/LdapSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/LdapSinks.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PrimitiveTypeConverterSanitizers.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PrimitiveTypeConverterSanitizers.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ProcessCommandSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ProcessCommandSinks.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/RedirectSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/RedirectSinks.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/RegexSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/RegexSinks.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SqlSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SqlSinks.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SymbolAccess.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SymbolAccess.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAbstractValue.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.Operations;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisContext.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataConfig.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataConfig.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebOutputSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebOutputSinks.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XPathSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XPathSinks.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XamlSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XamlSinks.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XmlSanitizers.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XmlSanitizers.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XmlSinks.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XmlSinks.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XssSanitizers.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XssSanitizers.cs
@@ -2,7 +2,8 @@
 
 using System.Collections.Immutable;
 using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis;
+using Analyzer.Utilities.PooledObjects;
+using Analyzer.Utilities.PooledObjects.Extensions;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Operations;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
@@ -2,6 +2,8 @@
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T>
 
+using Analyzer.Utilities.PooledObjects;
+
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
     public abstract partial class AbstractIndex

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T> - CacheBasedEquatable handles equality
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
@@ -2,6 +2,8 @@
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T> - CacheBasedEquatable handles equality
 
+using Analyzer.Utilities.PooledObjects;
+
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
     public abstract partial class AbstractIndex

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AddressSharedEntitiesProvider.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AddressSharedEntitiesProvider.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -6,6 +6,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
+using Analyzer.Utilities.PooledObjects.Extensions;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/ArgumentInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/ArgumentInfo.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/CacheBasedEquatable.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/CacheBasedEquatable.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;
@@ -2101,7 +2102,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                         return ImmutableDictionary<ISymbol, PointsToAbstractValue>.Empty;
                     }
 
-                    PooledHashSet<ISymbol> capturedVariables = cfg.OriginalOperation.GetCaptures(invokedMethod);
+                    var capturedVariables = cfg.OriginalOperation.GetCaptures(invokedMethod);
                     try
                     {
                         if (capturedVariables.Count == 0)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T>
 #pragma warning disable CA1710 // Rename DictionaryAnalysisData to end in 'Dictionary'

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/LValueFlowCapturesProvider.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/LValueFlowCapturesProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/PredicatedAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/PredicatedAnalysisData.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {

--- a/src/Utilities/FlowAnalysis/Options/DisposeAnalysisKind.cs
+++ b/src/Utilities/FlowAnalysis/Options/DisposeAnalysisKind.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using Analyzer.Utilities.Extensions;
 
 namespace Analyzer.Utilities
@@ -8,7 +7,7 @@ namespace Analyzer.Utilities
     /// <summary>
     /// Describes a group of effective <see cref="SymbolVisibility"/> for symbols.
     /// </summary>
-    internal enum DisposeAnalysisKind
+    public enum DisposeAnalysisKind
     {
         // NOTE: Below fields names are used in the .editorconfig specification
         //       for DisposeAnalysisKind option. Hence the names should *not* be modified,
@@ -43,7 +42,7 @@ namespace Analyzer.Utilities
         NonExceptionPathsOnlyNotDisposed,
     }
 
-    internal static class DisposeAnalysisKindExtensions
+    public static class DisposeAnalysisKindExtensions
     {
         public static bool AreExceptionPathsAndMayBeNotDisposedViolationsEnabled(this DisposeAnalysisKind disposeAnalysisKind)
             => disposeAnalysisKind.AreExceptionPathsEnabled() && disposeAnalysisKind.AreMayBeNotDisposedViolationsEnabled();


### PR DESCRIPTION
Namespace changed from `Microsoft.CodeAnalysis` to `Analyzer.Utilities.PooledObjects` to avoid name clashes with Roslyn's internal pooled object types when `Microsoft.CodeAnalysis.FlowAnalysis.Utilities` package is referenced in Roslyn IDE layers.