### PR TITLE
WIP: TypeConversionAllocationAnalyzer to use IOperation

### DIFF
--- a/src/PerformanceSensitiveAnalyzers/CSharp/TypeConversionAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/TypeConversionAllocationAnalyzer.cs
@@ -2,24 +2,19 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Threading;
 using Analyzer.Utilities;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers;
 
 namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
 {
-
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal sealed class TypeConversionAllocationAnalyzer : AbstractAllocationAnalyzer<SyntaxKind>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    internal sealed class TypeConversionAllocationAnalyzer : AbstractAllocationAnalyzer
     {
         public const string ValueTypeToReferenceTypeConversionRuleId = "HAA0601";
         public const string DelegateOnStructInstanceRuleId = "HAA0602";
         public const string MethodGroupAllocationRuleId = "HAA0603";
-        public const string ReadonlyMethodGroupAllocationRuleId = "HeapAnalyzerReadonlyMethodGroupAllocationRule";
 
         private static readonly LocalizableString s_localizableValueTypeToReferenceTypeConversionRuleTitle = new LocalizableResourceString(nameof(AnalyzersResources.ValueTypeToReferenceTypeConversionRuleTitle), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
         private static readonly LocalizableString s_localizableValueTypeToReferenceTypeConversionRuleMessage = new LocalizableResourceString(nameof(AnalyzersResources.ValueTypeToReferenceTypeConversionRuleMessage), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
@@ -29,9 +24,6 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
 
         private static readonly LocalizableString s_localizableMethodGroupAllocationRuleTitle = new LocalizableResourceString(nameof(AnalyzersResources.MethodGroupAllocationRuleTitle), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
         private static readonly LocalizableString s_localizableMethodGroupAllocationRuleMessage = new LocalizableResourceString(nameof(AnalyzersResources.MethodGroupAllocationRuleMessage), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
-
-        private static readonly LocalizableString s_localizableReadonlyMethodGroupAllocationRuleTitle = new LocalizableResourceString(nameof(AnalyzersResources.ReadonlyMethodGroupAllocationRuleTitle), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
-        private static readonly LocalizableString s_localizableReadonlyMethodGroupAllocationRuleMessage = new LocalizableResourceString(nameof(AnalyzersResources.ReadonlyMethodGroupAllocationRuleMessage), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
 
         internal static DiagnosticDescriptor ValueTypeToReferenceTypeConversionRule = new DiagnosticDescriptor(
             ValueTypeToReferenceTypeConversionRuleId,
@@ -57,294 +49,51 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        internal static DiagnosticDescriptor ReadonlyMethodGroupAllocationRule = new DiagnosticDescriptor(
-            ReadonlyMethodGroupAllocationRuleId,
-            s_localizableReadonlyMethodGroupAllocationRuleTitle,
-            s_localizableReadonlyMethodGroupAllocationRuleMessage,
-            DiagnosticCategory.Performance,
-            DiagnosticSeverity.Info,
-            isEnabledByDefault: true);
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ValueTypeToReferenceTypeConversionRule, DelegateOnStructInstanceRule, MethodGroupAllocationRule, ReadonlyMethodGroupAllocationRule);
-
-        protected override ImmutableArray<SyntaxKind> Expressions => ImmutableArray.Create(
-            SyntaxKind.SimpleAssignmentExpression,
-            SyntaxKind.ReturnStatement,
-            SyntaxKind.YieldReturnStatement,
-            SyntaxKind.CastExpression,
-            SyntaxKind.AsExpression,
-            SyntaxKind.CoalesceExpression,
-            SyntaxKind.ConditionalExpression,
-            SyntaxKind.ForEachStatement,
-            SyntaxKind.EqualsValueClause,
-            SyntaxKind.Argument,
-            SyntaxKind.ArrowExpressionClause,
-            SyntaxKind.Interpolation);
-
         private static readonly object[] EmptyMessageArgs = Array.Empty<object>();
 
-        protected override void AnalyzeNode(SyntaxNodeAnalysisContext context, in PerformanceSensitiveInfo info)
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+            ValueTypeToReferenceTypeConversionRule,
+            MethodGroupAllocationRule,
+            DelegateOnStructInstanceRule);
+
+        protected override ImmutableArray<OperationKind> Operations => ImmutableArray.Create(
+            OperationKind.Conversion,
+            OperationKind.Interpolation,
+            OperationKind.DelegateCreation);
+
+        protected override void AnalyzeNode(OperationAnalysisContext context, in PerformanceSensitiveInfo info)
         {
-            var node = context.Node;
-            var semanticModel = context.SemanticModel;
-            var cancellationToken = context.CancellationToken;
-            Action<Diagnostic> reportDiagnostic = context.ReportDiagnostic;
-            bool assignedToReadonlyFieldOrProperty =
-                (context.ContainingSymbol as IFieldSymbol)?.IsReadOnly == true ||
-                (context.ContainingSymbol as IPropertySymbol)?.IsReadOnly == true;
-
-            // this.fooObjCall(10);
-            // new myobject(10);
-            if (node is ArgumentSyntax)
+            if (context.Operation is IDelegateCreationOperation delegateCreation)
             {
-                ArgumentSyntaxCheck(node, semanticModel, assignedToReadonlyFieldOrProperty, reportDiagnostic, cancellationToken);
-            }
+                context.ReportDiagnostic(Diagnostic.Create(MethodGroupAllocationRule, context.Operation.Syntax.GetLocation(), EmptyMessageArgs));
 
-            // object foo { get { return 0; } }
-            if (node is ReturnStatementSyntax)
-            {
-                ReturnStatementExpressionCheck(node, semanticModel, reportDiagnostic, cancellationToken);
-                return;
-            }
-
-            // yield return 0
-            if (node is YieldStatementSyntax)
-            {
-                YieldReturnStatementExpressionCheck(node, semanticModel, reportDiagnostic, cancellationToken);
-                return;
-            }
-
-            // object a = x ?? 0;
-            // var a = 10 as object;
-            if (node is BinaryExpressionSyntax)
-            {
-                BinaryExpressionCheck(node, semanticModel, assignedToReadonlyFieldOrProperty, reportDiagnostic, cancellationToken);
-                return;
-            }
-
-            // for (object i = 0;;)
-            if (node is EqualsValueClauseSyntax)
-            {
-                EqualsValueClauseCheck(node, semanticModel, assignedToReadonlyFieldOrProperty, reportDiagnostic, cancellationToken);
-                return;
-            }
-
-            // object = true ? 0 : obj
-            if (node is ConditionalExpressionSyntax)
-            {
-                ConditionalExpressionCheck(node, semanticModel, reportDiagnostic, cancellationToken);
-                return;
-            }
-
-            // string a = $"{1}";
-            if (node is InterpolationSyntax)
-            {
-                InterpolationCheck(node, semanticModel, reportDiagnostic, cancellationToken);
-                return;
-            }
-
-            // var f = (object)
-            if (node is CastExpressionSyntax)
-            {
-                CastExpressionCheck(node, semanticModel, reportDiagnostic, cancellationToken);
-                return;
-            }
-
-            // object Foo => 1
-            if (node is ArrowExpressionClauseSyntax)
-            {
-                ArrowExpressionCheck(node, semanticModel, reportDiagnostic, cancellationToken);
-                return;
-            }
-        }
-
-        private static void ReturnStatementExpressionCheck(SyntaxNode node, SemanticModel semanticModel, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
-        {
-            var returnStatementExpression = node as ReturnStatementSyntax;
-            if (returnStatementExpression.Expression != null)
-            {
-                var returnConversionInfo = semanticModel.GetConversion(returnStatementExpression.Expression, cancellationToken);
-                CheckTypeConversion(returnConversionInfo, reportDiagnostic, returnStatementExpression.Expression.GetLocation());
-            }
-        }
-
-        private static void YieldReturnStatementExpressionCheck(SyntaxNode node, SemanticModel semanticModel, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
-        {
-            var yieldExpression = node as YieldStatementSyntax;
-            if (yieldExpression.Expression != null)
-            {
-                var returnConversionInfo = semanticModel.GetConversion(yieldExpression.Expression, cancellationToken);
-                CheckTypeConversion(returnConversionInfo, reportDiagnostic, yieldExpression.Expression.GetLocation());
-            }
-        }
-
-        private static void ArgumentSyntaxCheck(SyntaxNode node, SemanticModel semanticModel, bool isAssignmentToReadonly, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
-        {
-            var argument = node as ArgumentSyntax;
-            if (argument.Expression != null)
-            {
-                var argumentTypeInfo = semanticModel.GetTypeInfo(argument.Expression, cancellationToken);
-                var argumentConversionInfo = semanticModel.GetConversion(argument.Expression, cancellationToken);
-                CheckTypeConversion(argumentConversionInfo, reportDiagnostic, argument.Expression.GetLocation());
-                CheckDelegateCreation(argument.Expression, argumentTypeInfo, semanticModel, isAssignmentToReadonly, reportDiagnostic, argument.Expression.GetLocation(), cancellationToken);
-            }
-        }
-
-        private static void BinaryExpressionCheck(SyntaxNode node, SemanticModel semanticModel, bool isAssignmentToReadonly, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
-        {
-            var binaryExpression = node as BinaryExpressionSyntax;
-
-            // as expression
-            if (binaryExpression.IsKind(SyntaxKind.AsExpression) && binaryExpression.Left != null && binaryExpression.Right != null)
-            {
-                var leftT = semanticModel.GetTypeInfo(binaryExpression.Left, cancellationToken);
-                var rightT = semanticModel.GetTypeInfo(binaryExpression.Right, cancellationToken);
-
-                if (leftT.Type?.IsValueType == true && rightT.Type?.IsReferenceType == true)
+                if (delegateCreation.Target is IMethodReferenceOperation methodReference &&
+                    methodReference.Instance?.Type.IsValueType == true)
                 {
-                    reportDiagnostic(Diagnostic.Create(ValueTypeToReferenceTypeConversionRule, binaryExpression.Left.GetLocation(), EmptyMessageArgs));
+                    context.ReportDiagnostic(Diagnostic.Create(DelegateOnStructInstanceRule, methodReference.Syntax.GetLocation(), EmptyMessageArgs));
                 }
 
                 return;
             }
 
-            if (binaryExpression.Right != null)
+            if (context.Operation is IInterpolationOperation interpolation)
             {
-                var assignmentExprTypeInfo = semanticModel.GetTypeInfo(binaryExpression.Right, cancellationToken);
-                var assignmentExprConversionInfo = semanticModel.GetConversion(binaryExpression.Right, cancellationToken);
-                CheckTypeConversion(assignmentExprConversionInfo, reportDiagnostic, binaryExpression.Right.GetLocation());
-                CheckDelegateCreation(binaryExpression.Right, assignmentExprTypeInfo, semanticModel, isAssignmentToReadonly, reportDiagnostic, binaryExpression.Right.GetLocation(), cancellationToken);
+                if (interpolation.Expression.Type.IsValueType)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(ValueTypeToReferenceTypeConversionRule, interpolation.Expression.Syntax.GetLocation(), EmptyMessageArgs));
+                }
+
                 return;
             }
-        }
 
-        private static void InterpolationCheck(SyntaxNode node, SemanticModel semanticModel, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
-        {
-            var interpolation = node as InterpolationSyntax;
-            var typeInfo = semanticModel.GetTypeInfo(interpolation.Expression, cancellationToken);
-            if (typeInfo.Type?.IsValueType == true)
+            if (context.Operation.Type.IsReferenceType && context.Operation is IConversionOperation conversion)
             {
-                reportDiagnostic(Diagnostic.Create(ValueTypeToReferenceTypeConversionRule, interpolation.Expression.GetLocation(), EmptyMessageArgs));
-            }
-        }
-
-        private static void CastExpressionCheck(SyntaxNode node, SemanticModel semanticModel, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
-        {
-            var castExpression = node as CastExpressionSyntax;
-            if (castExpression.Expression != null)
-            {
-                var castTypeInfo = semanticModel.GetTypeInfo(castExpression, cancellationToken);
-                var expressionTypeInfo = semanticModel.GetTypeInfo(castExpression.Expression, cancellationToken);
-
-                if (castTypeInfo.Type?.IsReferenceType == true && expressionTypeInfo.Type?.IsValueType == true)
+                if (conversion.Operand.Type?.IsValueType == true && conversion.OperatorMethod == null)
                 {
-                    reportDiagnostic(Diagnostic.Create(ValueTypeToReferenceTypeConversionRule, castExpression.Expression.GetLocation(), EmptyMessageArgs));
-                }
-            }
-        }
-
-        private static void ConditionalExpressionCheck(SyntaxNode node, SemanticModel semanticModel, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
-        {
-            var conditionalExpression = node as ConditionalExpressionSyntax;
-
-            var trueExp = conditionalExpression.WhenTrue;
-            var falseExp = conditionalExpression.WhenFalse;
-
-            if (trueExp != null)
-            {
-                CheckTypeConversion(semanticModel.GetConversion(trueExp, cancellationToken), reportDiagnostic, trueExp.GetLocation());
-            }
-
-            if (falseExp != null)
-            {
-                CheckTypeConversion(semanticModel.GetConversion(falseExp, cancellationToken), reportDiagnostic, falseExp.GetLocation());
-            }
-        }
-
-        private static void EqualsValueClauseCheck(SyntaxNode node, SemanticModel semanticModel, bool isAssignmentToReadonly, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
-        {
-            var initializer = node as EqualsValueClauseSyntax;
-            if (initializer.Value != null)
-            {
-                var typeInfo = semanticModel.GetTypeInfo(initializer.Value, cancellationToken);
-                var conversionInfo = semanticModel.GetConversion(initializer.Value, cancellationToken);
-                CheckTypeConversion(conversionInfo, reportDiagnostic, initializer.Value.GetLocation());
-                CheckDelegateCreation(initializer.Value, typeInfo, semanticModel, isAssignmentToReadonly, reportDiagnostic, initializer.Value.GetLocation(), cancellationToken);
-            }
-        }
-
-
-        private static void ArrowExpressionCheck(SyntaxNode node, SemanticModel semanticModel, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
-        {
-            var syntax = node as ArrowExpressionClauseSyntax;
-
-            var typeInfo = semanticModel.GetTypeInfo(syntax.Expression, cancellationToken);
-            var conversionInfo = semanticModel.GetConversion(syntax.Expression, cancellationToken);
-            CheckTypeConversion(conversionInfo, reportDiagnostic, syntax.Expression.GetLocation());
-            CheckDelegateCreation(syntax, typeInfo, semanticModel, false, reportDiagnostic,
-                syntax.Expression.GetLocation(), cancellationToken);
-        }
-
-        private static void CheckTypeConversion(Conversion conversionInfo, Action<Diagnostic> reportDiagnostic, Location location)
-        {
-            if (conversionInfo.IsBoxing)
-            {
-                reportDiagnostic(Diagnostic.Create(ValueTypeToReferenceTypeConversionRule, location, EmptyMessageArgs));
-            }
-        }
-
-        private static void CheckDelegateCreation(SyntaxNode node, TypeInfo typeInfo, SemanticModel semanticModel, bool isAssignmentToReadonly, Action<Diagnostic> reportDiagnostic, Location location, CancellationToken cancellationToken)
-        {
-            // special case: method groups
-            if (typeInfo.ConvertedType?.TypeKind == TypeKind.Delegate)
-            {
-                // new Action<Foo>(MethodGroup); should skip this one
-                var insideObjectCreation = node?.Parent?.Parent?.Parent?.Kind() == SyntaxKind.ObjectCreationExpression;
-                if (node is ParenthesizedLambdaExpressionSyntax || node is SimpleLambdaExpressionSyntax ||
-                    node is AnonymousMethodExpressionSyntax || node is ObjectCreationExpressionSyntax ||
-                    insideObjectCreation)
-                {
-                    // skip this, because it's intended.
-                }
-                else
-                {
-                    if (node.IsKind(SyntaxKind.IdentifierName))
-                    {
-                        if (semanticModel.GetSymbolInfo(node, cancellationToken).Symbol is IMethodSymbol)
-                        {
-                            reportDiagnostic(Diagnostic.Create(MethodGroupAllocationRule, location, EmptyMessageArgs));
-                        }
-                    }
-                    else if (node.IsKind(SyntaxKind.SimpleMemberAccessExpression))
-                    {
-                        var memberAccess = node as MemberAccessExpressionSyntax;
-                        if (semanticModel.GetSymbolInfo(memberAccess.Name, cancellationToken).Symbol is IMethodSymbol)
-                        {
-                            if (isAssignmentToReadonly)
-                            {
-                                reportDiagnostic(Diagnostic.Create(ReadonlyMethodGroupAllocationRule, location, EmptyMessageArgs));
-                            }
-                            else
-                            {
-                                reportDiagnostic(Diagnostic.Create(MethodGroupAllocationRule, location, EmptyMessageArgs));
-                            }
-                        }
-                    }
-                    else if (node is ArrowExpressionClauseSyntax)
-                    {
-                        var arrowClause = node as ArrowExpressionClauseSyntax;
-                        if (semanticModel.GetSymbolInfo(arrowClause.Expression, cancellationToken).Symbol is IMethodSymbol)
-                        {
-                            reportDiagnostic(Diagnostic.Create(MethodGroupAllocationRule, location, EmptyMessageArgs));
-                        }
-                    }
+                    context.ReportDiagnostic(Diagnostic.Create(ValueTypeToReferenceTypeConversionRule, conversion.Operand.Syntax.GetLocation(), EmptyMessageArgs));
                 }
 
-                var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken).Symbol;
-                if (symbolInfo?.ContainingType?.IsValueType == true && !insideObjectCreation)
-                {
-                    reportDiagnostic(Diagnostic.Create(DelegateOnStructInstanceRule, location, EmptyMessageArgs));
-                }
+                return;
             }
         }
     }

--- a/src/PerformanceSensitiveAnalyzers/UnitTests/TypeConversionAllocationAnalyzerTests.cs
+++ b/src/PerformanceSensitiveAnalyzers/UnitTests/TypeConversionAllocationAnalyzerTests.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.PerformanceSensitive.Analyzers.UnitTests
         [Fact]
         public async Task TypeConversionAllocation_Argument()
         {
-            await VerifyCS.VerifyAnalyzerAsync(
-@"using System;
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
 using Roslyn.Utilities;
 
 public class MyObject
@@ -36,8 +36,8 @@ public class MyObject
         _ = new MyObject(10); // Allocation
     }
 }",
-                VerifyCS.Diagnostic(TypeConversionAllocationAnalyzer.ValueTypeToReferenceTypeConversionRule).WithLocation(17, 17),
-                VerifyCS.Diagnostic(TypeConversionAllocationAnalyzer.ValueTypeToReferenceTypeConversionRule).WithLocation(18, 26)
+                VerifyCS.Diagnostic(TypeConversionAllocationAnalyzer.ValueTypeToReferenceTypeConversionRule).WithLocation(18, 17),
+                VerifyCS.Diagnostic(TypeConversionAllocationAnalyzer.ValueTypeToReferenceTypeConversionRule).WithLocation(19, 26)
             );
         }
 
@@ -207,7 +207,7 @@ public class MyClass
         public async Task TypeConversionAllocation_BinaryExpression_ClassWithDelegates()
         {
             var sampleProgram =
-        @"using System;
+@"using System;
 using Roslyn.Utilities;
 
 public class MyClass
@@ -543,16 +543,16 @@ class Program
         }
 
 #if false
-[Fact]
-public void TypeConversionAllocation_InterpolatedStringWithString_NoWarning()
-{
-    var sampleProgram = @"string s = $""{1.ToString()}"";";
+        [Fact]
+        public void TypeConversionAllocation_InterpolatedStringWithString_NoWarning()
+        {
+            var sampleProgram = @"string s = $""{1.ToString()}"";";
 
-    var analyser = new TypeConversionAllocationAnalyzer();
-    var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.Interpolation));
+            var analyser = new TypeConversionAllocationAnalyzer();
+            var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.Interpolation));
 
-    Assert.Empty(info.Allocations);
-}
+            Assert.Empty(info.Allocations);
+        }
 #endif
 
         [Theory]


### PR DESCRIPTION
Change of the TypeConversionAllocationAnalyzer to use IOperation. It is nice to note that the TypeConversionAllocationAnalyzer.cs went from around 350 lines to 100. This PR uses the same AbstractAllocationAnalyzer code as #2214 but is not based off that branch as the diff added a lot of noise.

The code is still in the `Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers` project as moving it creates massive amount of noise in the diff. If the current changes are ok, I can move the resources etc as well.

Changes in logic:
* In the original code, the analyzer made difference between
       ```Func<object, string> func2 = fooObjCall;```
and 
        ```Func<object, string> func1 = new Func<object, string>(fooObjCall);```
where it warned for the former but not fot the latter. While this might make sense from an educational perspective, there is no difference in allocations between them, so both now generates a diagnostic.
* Removed ReadonlyMethodGroupAllocationRule and let it fall under MethodGroupAllocationRule. It was reported by @sharwell here https://github.com/Microsoft/RoslynClrHeapAllocationAnalyzer/issues/32 and might still be relevant to have, but I think it is quite unlikely that code where the scenario happens would be marked as performance sensitive.
* The conversion also fixed issue https://github.com/Microsoft/RoslynClrHeapAllocationAnalyzer/issues/66 which was reported after the analyzers were pulled from the RoslynClrHeapAllocationAnalyzer project. Added unit test to verify
* Made some of the larger unit tests more granular