### PR TITLE
NullRef fix for CA5368

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotAddSchemaByURL.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotAddSchemaByURL.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                 s_Message,
                 DiagnosticCategory.Security,
                 DiagnosticHelpers.DefaultDiagnosticSeverity,
-                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                isEnabledByDefault: false,    // https://github.com/dotnet/roslyn-analyzers/issues/2258
                 description: s_Description,
                 helpLinkUri: null,
                 customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableHttpHeaderChecking.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableHttpHeaderChecking.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                 s_Message,
                 DiagnosticCategory.Security,
                 DiagnosticHelpers.DefaultDiagnosticSeverity,
-                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                isEnabledByDefault: false,    // https://github.com/dotnet/roslyn-analyzers/issues/2258
                 description: s_Description,
                 helpLinkUri: null,
                 customTags: WellKnownDiagnosticTags.Telemetry);

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SetViewStateUserKey.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SetViewStateUserKey.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                 s_Message,
                 DiagnosticCategory.Security,
                 DiagnosticHelpers.DefaultDiagnosticSeverity,
-                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                isEnabledByDefault: false,    // https://github.com/dotnet/roslyn-analyzers/issues/2258
                 description: s_Description,
                 helpLinkUri: null,
                 customTags: WellKnownDiagnosticTags.Telemetry);
@@ -63,6 +63,9 @@ namespace Microsoft.NetCore.Analyzers.Security
                 {
                     return;
                 }
+
+                if (!System.Diagnostics.Debugger.IsAttached)
+                    System.Diagnostics.Debugger.Launch();
 
                 var objectTypeSymbol = WellKnownTypes.Object(compilation);
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SetViewStateUserKey.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SetViewStateUserKey.cs
@@ -64,9 +64,6 @@ namespace Microsoft.NetCore.Analyzers.Security
                     return;
                 }
 
-                if (!System.Diagnostics.Debugger.IsAttached)
-                    System.Diagnostics.Debugger.Launch();
-
                 var objectTypeSymbol = WellKnownTypes.Object(compilation);
 
                 compilationStartAnalysisContext.RegisterSymbolAction(symbolAnalysisContext =>
@@ -74,7 +71,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                     var classSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
                     var baseClassSymbol = classSymbol.BaseType;
 
-                    if (baseClassSymbol.Equals(pageTypeSymbol))
+                    if (pageTypeSymbol.Equals(baseClassSymbol))
                     {
                         var methods = classSymbol.GetMembers().OfType<IMethodSymbol>();
                         var setViewStateUserKeyInOnInit = SetViewStateUserKeyCorrectly(methods.FirstOrDefault(s => s.Name == "OnInit" &&

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetViewStateUserKeyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetViewStateUserKeyTests.cs
@@ -415,6 +415,45 @@ class TestClass : Page
 }");
         }
 
+        [Fact]
+        public void TestNotAPage_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Web.UI;
+
+class TestClass
+{
+    public Page Page { get; set; }
+
+    protected void OnInit (EventArgs e)
+    {
+    }
+
+    private void Page_Init (object sender, EventArgs e)
+    {
+    }
+}");
+        }
+
+        [Fact]
+        public void TestInterface_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Web.UI;
+
+interface ITestInterface
+{
+    Page Page { get; set; }
+
+    void OnInit(EventArgs e);
+
+    void Page_Init(object sender, EventArgs e);
+}");
+        }
+
+
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
             return new SetViewStateUserKey();

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetViewStateUserKeyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetViewStateUserKeyTests.cs
@@ -453,7 +453,6 @@ interface ITestInterface
 }");
         }
 
-
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
             return new SetViewStateUserKey();


### PR DESCRIPTION
- Temporarily disabling new rules.
- One NullReferenceException fix for SetViewStateUserKey (CA5368).