### PR TITLE
Analyze documentation comments

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,20 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!--
+      Make sure any documentation comments which are included in code get checked for syntax during the build, but do
+      not report warnings for missing comments.
+
+      CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'member' (but other parameters do)
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+      CS1712: Type parameter 'parameter' has no matching typeparam tag in the XML comment on 'type_or_member' (but other type parameters do)
+    -->
+    <NoWarn Condition="'$(Language)' == 'C#'">$(NoWarn),1573,1591,1712</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- We generate per-project assembly attributes files, so we can safely delete them when cleaning the project -->
     <TargetFrameworkMonikerAssemblyAttributesFileClean>true</TargetFrameworkMonikerAssemblyAttributesFileClean>
   </PropertyGroup>

--- a/src/MetaCompilation.Analyzers/UnitTests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/src/MetaCompilation.Analyzers/UnitTests/Helpers/DiagnosticVerifier.Helper.cs
@@ -51,7 +51,6 @@ namespace MetaCompilation.Analyzers.UnitTests
         /// </summary>
         /// <param name="analyzer">The analyzer to run on the documents</param>
         /// <param name="documents">The Documents that the analyzer will be run on</param>
-        /// <param name="spans">Optional TextSpan indicating where a Diagnostic will be found</param>
         /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
         protected static Diagnostic[] GetSortedDiagnosticsFromDocuments(DiagnosticAnalyzer analyzer, Document[] documents)
         {

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;

--- a/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/Microsoft.CodeAnalysis.FlowAnalysis.Utilities.csproj
+++ b/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/Microsoft.CodeAnalysis.FlowAnalysis.Utilities.csproj
@@ -9,7 +9,6 @@
     <PackageId>*$(MSBuildProjectFullPath)*</PackageId>
     <ExcludeInternalFlowAnalyses>true</ExcludeInternalFlowAnalyses>
     <ExcludeCodeMetricsUtilities>true</ExcludeCodeMetricsUtilities>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- RS0026: Avoud public API overloads with differences in optional parameters -->
     <NoWarn>$(NoWarn);RS0026</NoWarn>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotCallDangerousMethodsInDeserialization.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotCallDangerousMethodsInDeserialization.cs
@@ -205,12 +205,11 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                         });
 
-                    /// <summary>
-                    /// Analyze the method to find all the dangerous method it calls.
-                    /// </summary>
-                    /// <param name="methodSymbol">The symbol of the method to be analyzed</param>
-                    /// <param name="visited">All the method has been analyzed</param>
-                    /// <param name="results">The result is organized by &lt;method to be analyzed, dangerous method it calls&gt;</param>
+                    // Analyze the method to find all the dangerous method it calls.
+                    //
+                    // methodSymbol: The symbol of the method to be analyzed
+                    // visited: All the method has been analyzed
+                    // results: The result is organized by <method to be analyzed, dangerous method it calls>
                     void FindCalledDangerousMethod(IMethodSymbol methodSymbol, HashSet<IMethodSymbol> visited, Dictionary<IMethodSymbol, HashSet<IMethodSymbol>> results)
                     {
                         if (visited.Add(methodSymbol))

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableCertificateValidation.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableCertificateValidation.cs
@@ -162,7 +162,7 @@ namespace Microsoft.NetCore.Analyzers.Security
         /// <summary>
         /// Find every IReturnOperation in the method and get the value of return statement to determine if the method always return true.
         /// </summary>
-        /// <param name="operation">A method body in the form of explicit IOperations</param>
+        /// <param name="operations">A method body in the form of explicit IOperations</param>
         private static bool AlwaysReturnTrue(IEnumerable<IOperation> operations)
         {
             var hasReturnStatement = false;

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotReferSelfInSerializableClass.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotReferSelfInSerializableClass.cs
@@ -106,10 +106,9 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                         });
 
-                    /// <summary>
-                    /// Traverse from point to its descendants, save the information into a directed graph.
-                    /// </summary>
-                    /// <param name="point">The initial point</param>
+                    // Traverse from point to its descendants, save the information into a directed graph.
+                    //
+                    // point: The initial point
                     void DrawGraph(ITypeSymbol point)
                     {
                         // If the point has been visited, return;
@@ -178,61 +177,53 @@ namespace Microsoft.NetCore.Analyzers.Security
                         return result;
                     }
 
-                    /// <summary>
-                    /// Add a line to the graph.
-                    /// </summary>
-                    /// <param name="from">The start point of the line</param>
-                    /// <param name="to">The end point of the line</param>
-                    /// <param name="degree">The out degree of all vertices in the graph</param>
-                    /// <param name="graph">The graph</param>
+                    // Add a line to the graph.
+                    //
+                    // from: The start point of the line
+                    // to: The end point of the line
+                    // degree: The out degree of all vertices in the graph
+                    // graph: The graph
                     void AddLine(ISymbol from, ISymbol to, ConcurrentDictionary<ISymbol, int> degree, ConcurrentDictionary<ISymbol, ConcurrentDictionary<ISymbol, bool>> graph)
                     {
                         graph.AddOrUpdate(from, new ConcurrentDictionary<ISymbol, bool> { [to] = true }, (k, v) => { v[to] = true; return v; });
                         degree.AddOrUpdate(from, 1, (k, v) => v + 1);
                     }
 
-                    /// <summary>
-                    /// Add a point to the graph.
-                    /// </summary>
-                    /// <param name="point">The point to be added</param>
-                    /// <param name="degree">The out degree of all vertices in the graph</param>
-                    /// <param name="graph">The graph</param>
+                    // Add a point to the graph.
+                    //
+                    // point: The point to be added
+                    // degree: The out degree of all vertices in the graph
+                    // graph: The graph
                     bool AddPoint(ISymbol point, ConcurrentDictionary<ISymbol, int> degree, ConcurrentDictionary<ISymbol, ConcurrentDictionary<ISymbol, bool>> graph)
                     {
                         degree.TryAdd(point, 0);
                         return graph.TryAdd(point, new ConcurrentDictionary<ISymbol, bool>());
                     }
 
-                    /// <summary>
-                    /// Add a line to the forward graph and inverted graph unconditionally.
-                    /// </summary>
-                    /// <param name="from">The start point of the line</param>
-                    /// <param name="to">The end point of the line</param>
+                    // Add a line to the forward graph and inverted graph unconditionally.
+                    //
+                    // from: The start point of the line
+                    // to: The end point of the line
                     void AddLineToBothGraphs(ISymbol from, ISymbol to)
                     {
                         AddLine(from, to, outDegree, forwardGraph);
                         AddLine(to, from, inDegree, invertedGraph);
                     }
 
-                    /// <summary>
-                    /// Add a point to the forward graph and inverted graph unconditionally.
-                    /// </summary>
-                    /// <param name="point">The point to be added</param>
-                    /// <returns>
-                    /// <c>true</c> if <paramref name="point"/> is added to the forward graph successfully;
-                    /// otherwise <c>false</c>.
-                    /// </returns>
+                    // Add a point to the forward graph and inverted graph unconditionally.
+                    //
+                    // point: The point to be added
+                    // return: `true` if `point` is added to the forward graph successfully; otherwise `false`.
                     bool AddPointToBothGraphs(ISymbol point)
                     {
                         AddPoint(point, inDegree, invertedGraph);
                         return AddPoint(point, outDegree, forwardGraph);
                     }
 
-                    /// <summary>
-                    /// According to topological sorting, modify the degree of every vertex in the graph.
-                    /// </summary>
-                    /// <param name="degree">The in degree of all vertices in the graph</param>
-                    /// <param name="graph">The graph</param>
+                    // According to topological sorting, modify the degree of every vertex in the graph.
+                    //
+                    // degree: The in degree of all vertices in the graph
+                    // graph: The graph
                     void ModifyDegree(ConcurrentDictionary<ISymbol, int> degree, ConcurrentDictionary<ISymbol, ConcurrentDictionary<ISymbol, bool>> graph)
                     {
                         var stack = new Stack<ISymbol>(degree.Where(s => s.Value == 0).Select(s => s.Key));

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSerializeTypeWithPointerFields.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSerializeTypeWithPointerFields.cs
@@ -81,11 +81,11 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                         });
 
-                    /// <summary>
-                    /// Look for serialization of a type with valid pointer fields directly and indirectly.
-                    /// </summary>
-                    /// <param name="typeSymbol">The symbol of the type to be analyzed</param>
-                    /// <param name="relatedFieldSymbol">When relatedFieldSymbol is null, traverse all descendants of typeSymbol to find pointer fields; otherwise, traverse to find if relatedFieldSymbol is a pointer field</param>
+                    // Look for serialization of a type with valid pointer fields directly and indirectly.
+                    //
+                    // typeSymbol: The symbol of the type to be analyzed
+                    // relatedFieldSymbol: When relatedFieldSymbol is null, traverse all descendants of typeSymbol to
+                    //     find pointer fields; otherwise, traverse to find if relatedFieldSymbol is a pointer field
                     void LookForSerializationWithPointerFields(ITypeSymbol typeSymbol, IFieldSymbol relatedFieldSymbol)
                     {
                         if (typeSymbol is IPointerTypeSymbol pointerTypeSymbol)

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerBinaryFormatterMethods.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerBinaryFormatterMethods.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -9,8 +10,9 @@ using Microsoft.NetCore.Analyzers.Security.Helpers;
 namespace Microsoft.NetCore.Analyzers.Security
 {
     /// <summary>
-    /// For detecting deserialization with <see cref="System.Runtime.Serialization.Formatters.Binary.BinaryFormatter"/>.
+    /// For detecting deserialization with <see cref="T:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter"/>.
     /// </summary>
+    [SuppressMessage("Documentation", "CA1200:Avoid using cref tags with a prefix", Justification = "The comment references a type that is not referenced by this compilation.")]
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     class DoNotUseInsecureDeserializerBinaryFormatterMethods : DoNotUseInsecureDeserializerMethodsBase
     {

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerBinaryFormatterWithoutBinder.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerBinaryFormatterWithoutBinder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -9,8 +10,9 @@ using Microsoft.NetCore.Analyzers.Security.Helpers;
 namespace Microsoft.NetCore.Analyzers.Security
 {
     /// <summary>
-    /// For detecting deserialization with <see cref="System.Runtime.Serialization.Formatters.Binary.BinaryFormatter"/> when its Binder property is not set.
+    /// For detecting deserialization with <see cref="T:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter"/> when its Binder property is not set.
     /// </summary>
+    [SuppressMessage("Documentation", "CA1200:Avoid using cref tags with a prefix", Justification = "The comment references a type that is not referenced by this compilation.")]
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class DoNotUseInsecureDeserializerBinaryFormatterWithoutBinder : DoNotUseInsecureDeserializerWithoutBinderBase
     {

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethods.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethods.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -9,8 +10,9 @@ using Microsoft.NetCore.Analyzers.Security.Helpers;
 namespace Microsoft.NetCore.Analyzers.Security
 {
     /// <summary>
-    /// For detecting deserialization with <see cref="System.Runtime.Serialization.Formatters.Binary.NetDataContractSerializer"/>.
+    /// For detecting deserialization with <see cref="T:System.Runtime.Serialization.Formatters.Binary.NetDataContractSerializer"/>.
     /// </summary>
+    [SuppressMessage("Documentation", "CA1200:Avoid using cref tags with a prefix", Justification = "The comment references a type that is not referenced by this compilation.")]
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     class DoNotUseInsecureDeserializerNetDataContractSerializerMethods : DoNotUseInsecureDeserializerMethodsBase
     {

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -9,8 +10,9 @@ using Microsoft.NetCore.Analyzers.Security.Helpers;
 namespace Microsoft.NetCore.Analyzers.Security
 {
     /// <summary>
-    /// For detecting deserialization with <see cref="System.Runtime.Serialization.Formatters.Binary.NetDataContractSerializer"/> when its Binder property is not set.
+    /// For detecting deserialization with <see cref="T:System.Runtime.Serialization.Formatters.Binary.NetDataContractSerializer"/> when its Binder property is not set.
     /// </summary>
+    [SuppressMessage("Documentation", "CA1200:Avoid using cref tags with a prefix", Justification = "The comment references a type that is not referenced by this compilation.")]
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder : DoNotUseInsecureDeserializerWithoutBinderBase
     {

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
@@ -33,8 +34,9 @@ namespace Microsoft.NetCore.Analyzers.Security
         protected abstract string DeserializerTypeMetadataName { get; }
 
         /// <summary>
-        /// Name of the <see cref="System.Runtime.Serialization.SerializationBinder"/> property.
+        /// Name of the <see cref="T:System.Runtime.Serialization.SerializationBinder"/> property.
         /// </summary>
+        [SuppressMessage("Documentation", "CA1200:Avoid using cref tags with a prefix", Justification = "The comment references a type that is not referenced by this compilation.")]
         protected abstract string SerializationBinderPropertyMetadataName { get; }
 
         /// <summary>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/Helpers/SecurityHelpers.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/Helpers/SecurityHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 
@@ -39,8 +40,9 @@ namespace Microsoft.NetCore.Analyzers.Security.Helpers
         }
 
         /// <summary>
-        /// Deserialization methods for <see cref="System.Runtime.Serialization.Formatters.Binary.BinaryFormatter"/>.
+        /// Deserialization methods for <see cref="T:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter"/>.
         /// </summary>
+        [SuppressMessage("Documentation", "CA1200:Avoid using cref tags with a prefix", Justification = "The comment references a type that is not referenced by this compilation.")]
         public static readonly ImmutableHashSet<string> BinaryFormatterDeserializationMethods =
             ImmutableHashSet.Create(
                 StringComparer.Ordinal,
@@ -50,8 +52,9 @@ namespace Microsoft.NetCore.Analyzers.Security.Helpers
                 "UnsafeDeserializeMethodResponse");
 
         /// <summary>
-        /// Deserialization methods for <see cref="System.Runtime.Serialization.NetDataContractSerializer"/>.
+        /// Deserialization methods for <see cref="T:System.Runtime.Serialization.NetDataContractSerializer"/>.
         /// </summary>
+        [SuppressMessage("Documentation", "CA1200:Avoid using cref tags with a prefix", Justification = "The comment references a type that is not referenced by this compilation.")]
         public static readonly ImmutableHashSet<string> NetDataContractSerializerDeserializationMethods =
             ImmutableHashSet.Create(
                 StringComparer.Ordinal,

--- a/src/Utilities.UnitTests/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisTests.cs
+++ b/src/Utilities.UnitTests/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisTests.cs
@@ -46,7 +46,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         /// <summary>
         /// Verification helper.
         /// </summary>
-        /// <param name="source">C# source code, with /*&lt;bind&gt;*/ and /*&lt;/bind&gt*/ around the method block to be analyzed.</param>
+        /// <param name="source">C# source code, with /*&lt;bind&gt;*/ and /*&lt;/bind&gt;*/ around the method block to be analyzed.</param>
         /// <param name="propertySetAnalysisParameters">PropertySetAnalysis parameters.</param>
         /// <param name="expectedResults">Expected hazardous usages.</param>
         private void VerifyCSharp(

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/ConstructorMapper.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/ConstructorMapper.cs
@@ -50,7 +50,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         /// <summary>
         /// Initializes a <see cref="ConstructorMapper"/> that maps a constructor invocation's arguments' <see cref="ValueContentAbstractValue"/>s to <see cref="PropertySetAbstractValueKind"/>s for the properties being tracked by PropertySetAnalysis.
         /// </summary>
-        /// <param name="mapFromValueContentAbstractValueCallback">Callback that implements the mapping.</param>
+        /// <param name="mapFromValueContentAbstractValue">Callback that implements the mapping.</param>
         public ConstructorMapper(ValueContentAbstractValueCallback mapFromValueContentAbstractValue)
         {
             this.MapFromValueContentAbstractValue = mapFromValueContentAbstractValue ?? throw new ArgumentNullException(nameof(mapFromValueContentAbstractValue));
@@ -60,7 +60,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         /// <summary>
         /// Initializes a <see cref="ConstructorMapper"/> that maps a constructor invocation's arguments' <see cref="NullAbstractValue"/>s to <see cref="PropertySetAbstractValueKind"/>s for the properties being tracked by PropertySetAnalysis.
         /// </summary>
-        /// <param name="mapFromNullAbstractValueCallback">Callback that implements the mapping.</param>
+        /// <param name="mapFromNullAbstractValue">Callback that implements the mapping.</param>
         public ConstructorMapper(NullAbstractValueCallback mapFromNullAbstractValue)
         {
             this.MapFromNullAbstractValue = mapFromNullAbstractValue ?? throw new ArgumentNullException(nameof(mapFromNullAbstractValue));

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluator.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluator.cs
@@ -35,7 +35,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         /// Initializes a <see cref="HazardousUsageEvaluator"/> that evaluates a method invocation with an argument of the type being tracked by PropertySetAnalysis.
         /// </summary>
         /// <param name="instanceTypeName">Name of the instance that the method is invoked on.</param>
-        /// <param name="methodName">Name of the method within <see cref="instanceTypeName"/>.</param>
+        /// <param name="methodName">Name of the method within <paramref name="instanceTypeName"/>.</param>
         /// <param name="parameterNameOfPropertySetObject">Name of the method parameter containing the type being tracked by PropertySetAnalysis.</param>
         /// <param name="evaluator">Evaluation callback.</param>
         public HazardousUsageEvaluator(string instanceTypeName, string methodName, string parameterNameOfPropertySetObject, EvaluationCallback evaluator)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertyMapper.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertyMapper.cs
@@ -23,7 +23,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         /// <summary>
         /// Mapping from <see cref="NullAbstractValue"/> to a <see cref="PropertySetAbstractValueKind"/>
         /// </summary>
-        /// <param name="valueContentAbstractValue">Property's assigned value's <see cref="ValueContentAbstractValue"/>.</param>
+        /// <param name="nullAbstractValue">Property's assigned value's <see cref="ValueContentAbstractValue"/>.</param>
         /// <returns>What the property's assigned value should map to.</returns>
         public delegate PropertySetAbstractValueKind NullAbstractValueCallback(NullAbstractValue nullAbstractValue);
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -394,7 +394,6 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             /// <summary>
             /// Determines if the instance method call returns tainted data.
             /// </summary>
-            /// <param name="wellKnownTypeProvider">Well known types cache.</param>
             /// <param name="method">Instance method being called.</param>
             /// <returns>True if the method returns tainted data, false otherwise.</returns>
             private bool IsSanitizingMethod(IMethodSymbol method)


### PR DESCRIPTION
Prior to this change, this repository was treating `///` comments as `//` comments, resulting in many errors related to their usage and placement. This change updates the project config to treat `///` comments as documentation comments.