### PR TITLE
CA2009 VB analyzer false negative case fix

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.Fixer.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Operations;
@@ -62,17 +63,10 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
 
         private static Task<Document> RemoveRedundantCall(Document document, SyntaxNode root, SyntaxNode invocationNode, IInvocationOperation invocationOperation)
         {
-            var instance = GetInstance(invocationOperation).WithTriviaFrom(invocationNode);
+            var instance = invocationOperation.GetInstance().WithTriviaFrom(invocationNode);
             var newRoot = root.ReplaceNode(invocationNode, instance);
             var newDocument = document.WithSyntaxRoot(newRoot);
             return Task.FromResult(newDocument);
-        }
-
-        private static SyntaxNode GetInstance(IInvocationOperation invocationOperation)
-        {
-            return invocationOperation.TargetMethod.IsExtensionMethod && (invocationOperation.Language != LanguageNames.VisualBasic || invocationOperation.Instance == null) ?
-                invocationOperation.Arguments[0].Value.Syntax :
-                invocationOperation.Instance.Syntax;
         }
 
         // Needed for Telemetry (https://github.com/dotnet/roslyn-analyzers/issues/192)

--- a/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.Fixer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
 
         private static SyntaxNode GetInstance(IInvocationOperation invocationOperation)
         {
-            return invocationOperation.TargetMethod.IsExtensionMethod && invocationOperation.Language != LanguageNames.VisualBasic ?
+            return invocationOperation.TargetMethod.IsExtensionMethod && (invocationOperation.Language != LanguageNames.VisualBasic || invocationOperation.Instance == null) ?
                 invocationOperation.Arguments[0].Value.Syntax :
                 invocationOperation.Instance.Syntax;
         }

--- a/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
@@ -74,7 +74,7 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
                     // Do not flag invocations that take any explicit argument (comparer, converter, etc.)
                     // as they can potentially modify the contents of the resulting collection.
                     // See https://github.com/dotnet/roslyn/issues/23625 for language specific implementation below.
-                    var argumentsToSkip = targetMethod.IsExtensionMethod && invocation.Language != LanguageNames.VisualBasic ? 1 : 0;
+                    var argumentsToSkip = targetMethod.IsExtensionMethod && (invocation.Language != LanguageNames.VisualBasic || invocation.Instance == null) ? 1 : 0;
                     if (invocation.Arguments.Skip(argumentsToSkip).Any(arg => arg.ArgumentKind == ArgumentKind.Explicit))
                     {
                         return;

--- a/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
@@ -73,8 +73,7 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
 
                     // Do not flag invocations that take any explicit argument (comparer, converter, etc.)
                     // as they can potentially modify the contents of the resulting collection.
-                    // See https://github.com/dotnet/roslyn/issues/23625 for language specific implementation below.
-                    var argumentsToSkip = targetMethod.IsExtensionMethod && (invocation.Language != LanguageNames.VisualBasic || invocation.Instance == null) ? 1 : 0;
+                    var argumentsToSkip = invocation.IsExtensionMethodAndHasNoInstance() ? 1 : 0;
                     if (invocation.Arguments.Skip(argumentsToSkip).Any(arg => arg.ArgumentKind == ArgumentKind.Explicit))
                     {
                         return;

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.Fixer.cs
@@ -93,6 +93,8 @@ Class C
 	Public Sub M(p1 As IEnumerable(Of Integer), p2 As List(Of Integer), p3 As {collectionName}(Of Integer))
 		Dim a = p1.To{collectionName}().To{collectionName}()
 		Dim b = p3.To{collectionName}()
+		Dim c = ImmutableExtensions.To{collectionName}(ImmutableExtensions.To{collectionName}(p1))
+		Dim d = ImmutableExtensions.To{collectionName}(p3)
 	End Sub
 End Class";
 
@@ -104,6 +106,8 @@ Class C
 	Public Sub M(p1 As IEnumerable(Of Integer), p2 As List(Of Integer), p3 As {collectionName}(Of Integer))
 		Dim a = p1.To{collectionName}()
 		Dim b = p3
+		Dim c = ImmutableExtensions.To{collectionName}(p1)
+		Dim d = p3
 	End Sub
 End Class";
             VerifyBasicFix(new[] { initial, ImmutableCollectionsSource.Basic }, new[] { expected, ImmutableCollectionsSource.Basic }, referenceFlags: ReferenceFlags.RemoveImmutable);
@@ -157,6 +161,8 @@ Class C
 	Public Sub M(p1 As IEnumerable(Of KeyValuePair(Of Integer, Integer)), p2 As List(Of KeyValuePair(Of Integer, Integer)), p3 As {collectionName}(Of Integer, Integer))
 		Dim a = p1.To{collectionName}().To{collectionName}()
 		Dim b = p3.To{collectionName}()
+		Dim c = ImmutableExtensions.To{collectionName}(ImmutableExtensions.To{collectionName}(p1))
+		Dim d = ImmutableExtensions.To{collectionName}(p3)
 	End Sub
 End Class";
 
@@ -168,6 +174,8 @@ Class C
 	Public Sub M(p1 As IEnumerable(Of KeyValuePair(Of Integer, Integer)), p2 As List(Of KeyValuePair(Of Integer, Integer)), p3 As {collectionName}(Of Integer, Integer))
 		Dim a = p1.To{collectionName}()
 		Dim b = p3
+		Dim c = ImmutableExtensions.To{collectionName}(p1)
+		Dim d = p3
 	End Sub
 End Class";
             VerifyBasicFix(new[] { initial, ImmutableCollectionsSource.Basic }, new[] { expected, ImmutableCollectionsSource.Basic }, referenceFlags: ReferenceFlags.RemoveImmutable);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.cs
@@ -68,9 +68,15 @@ class C
         p2.To{collectionName}();
         p3.To{collectionName}(comparer); // Potentially modifies the collection
 
+        Extensions.To{collectionName}(p1);
+        Extensions.To{collectionName}(p2);
+        Extensions.To{collectionName}(p3, comparer); // Potentially modifies the collection
+
         // No dataflow
         IEnumerable<int> l1 = p3;
         l1.To{collectionName}();
+
+        Extensions.To{collectionName}(l1);
     }}
 }}
 ");
@@ -98,9 +104,15 @@ Class C
 		p2.To{collectionName}()
         p3.To{collectionName}(comparer) ' Potentially modifies the collection
 
+        Extensions.To{collectionName}(p1)
+        Extensions.To{collectionName}(p2)
+        Extensions.To{collectionName}(p3, comparer) ' Potentially modifies the collection
+
 		' No dataflow
 		Dim l1 As IEnumerable(Of Integer) = p3
 		l1.To{collectionName}()
+
+        Extensions.To{collectionName}(l1)
 	End Sub
 End Class
 ");
@@ -123,9 +135,9 @@ static class Extensions
      }}
 
     public static {collectionName}<TKey, TValue> To{collectionName}<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> items, IEqualityComparer<TKey> keyComparer)
-     {{
+    {{
          return default({collectionName}<TKey, TValue>);
-     }}
+    }}
 }}
 
 class C
@@ -137,9 +149,15 @@ class C
         p2.To{collectionName}();
         p3.To{collectionName}(keyComparer); // Potentially modifies the collection
 
+        Extensions.To{collectionName}(p1);
+        Extensions.To{collectionName}(p2);
+        Extensions.To{collectionName}(p3, keyComparer); // Potentially modifies the collection
+
         // No dataflow
         IEnumerable<KeyValuePair<int, int>> l1 = p3;
         l1.To{collectionName}();
+
+        Extensions.To{collectionName}(l1);
     }}
 }}
 ");
@@ -167,9 +185,15 @@ Class C
 		p2.To{collectionName}()
         p3.To{collectionName}(keyComparer) ' Potentially modifies the collection
 
+        Extensions.To{collectionName}(p1)
+        Extensions.To{collectionName}(p2)
+        Extensions.To{collectionName}(p3, keyComparer) ' Potentially modifies the collection
+
 		' No dataflow
 		Dim l1 As IEnumerable(Of KeyValuePair(Of Integer, Integer)) = p3
 		l1.To{collectionName}()
+
+        Extensions.To{collectionName}(l1)
 	End Sub
 End Class
 ");
@@ -201,6 +225,9 @@ class C
     {{
         p1.To{collectionName}().To{collectionName}();
         p3.To{collectionName}();
+
+        Extensions.To{collectionName}(Extensions.To{collectionName}(p1));
+        Extensions.To{collectionName}(p3);
     }}
 }}
 ", ImmutableCollectionsSource.CSharp },
@@ -208,7 +235,11 @@ class C
                 // Test0.cs(18,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
                 GetCSharpResultAt(17, 9, collectionName),
                 // Test0.cs(19,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-                GetCSharpResultAt(18, 9, collectionName));
+                GetCSharpResultAt(18, 9, collectionName),
+                // Test0.cs(20,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetCSharpResultAt(20, 9, collectionName),
+                // Test0.cs(21,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetCSharpResultAt(21, 9, collectionName));
 
             VerifyBasic(new[] { $@"
 Imports System.Collections.Generic
@@ -225,6 +256,9 @@ Class C
 	Public Sub M(p1 As IEnumerable(Of Integer), p2 As List(Of Integer), p3 As {collectionName}(Of Integer))
 		p1.To{collectionName}().To{collectionName}()
 		p3.To{collectionName}()
+
+		Extensions.To{collectionName}(Extensions.To{collectionName}(p1))
+		Extensions.To{collectionName}(p3)
 	End Sub
 End Class
 ", ImmutableCollectionsSource.Basic },
@@ -232,7 +266,11 @@ End Class
                 // Test0.vb(14,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
                 GetBasicResultAt(14, 3, collectionName),
                 // Test0.vb(15,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-                GetBasicResultAt(15, 3, collectionName));
+                GetBasicResultAt(15, 3, collectionName),
+                // Test0.vb(17,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetBasicResultAt(17, 3, collectionName),
+                // Test0.vb(18,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetBasicResultAt(18, 3, collectionName));
         }
 
         [Theory]
@@ -257,6 +295,9 @@ class C
     {{
         p1.To{collectionName}().To{collectionName}();
         p3.To{collectionName}();
+
+        Extensions.To{collectionName}(Extensions.To{collectionName}(p1));
+        Extensions.To{collectionName}(p3);
     }}
 }}
 ", ImmutableCollectionsSource.CSharp },
@@ -264,7 +305,11 @@ class C
                 // Test0.cs(18,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
                 GetCSharpResultAt(17, 9, collectionName),
                 // Test0.cs(19,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-                GetCSharpResultAt(18, 9, collectionName));
+                GetCSharpResultAt(18, 9, collectionName),
+                // Test0.cs(20,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetCSharpResultAt(20, 9, collectionName),
+                // Test0.cs(21,9): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetCSharpResultAt(21, 9, collectionName));
 
             VerifyBasic(new[] { $@"
 Imports System.Collections.Generic
@@ -281,6 +326,9 @@ Class C
 	Public Sub M(p1 As IEnumerable(Of KeyValuePair(Of Integer, Integer)), p2 As List(Of KeyValuePair(Of Integer, Integer)), p3 As {collectionName}(Of Integer, Integer))
 		p1.To{collectionName}().To{collectionName}()
 		p3.To{collectionName}()
+
+		Extensions.To{collectionName}(Extensions.To{collectionName}(p1))
+		Extensions.To{collectionName}(p3)
 	End Sub
 End Class
 ", ImmutableCollectionsSource.Basic },
@@ -288,7 +336,11 @@ End Class
                 // Test0.vb(14, 3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
                 GetBasicResultAt(14, 3, collectionName),
                 // Test0.vb(15,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-                GetBasicResultAt(15, 3, collectionName));
+                GetBasicResultAt(15, 3, collectionName),
+                // Test0.vb(17,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetBasicResultAt(17, 3, collectionName),
+                // Test0.vb(18,3): warning CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+                GetBasicResultAt(18, 3, collectionName));
         }
 
         #endregion

--- a/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
@@ -578,6 +578,18 @@ namespace Analyzer.Utilities.Extensions
 
             return false;
         }
+
+        public static bool IsExtensionMethodAndHasNoInstance(this IInvocationOperation invocationOperation)
+        {
+            // This method exists to abstract away the language specific differences between IInvocationOperation implementations
+            // See https://github.com/dotnet/roslyn/issues/23625 for more details
+            return invocationOperation.TargetMethod.IsExtensionMethod && (invocationOperation.Language != LanguageNames.VisualBasic || invocationOperation.Instance == null);
+        }
+
+        public static SyntaxNode GetInstance(this IInvocationOperation invocationOperation)
+        {
+            return invocationOperation.IsExtensionMethodAndHasNoInstance() ? invocationOperation.Arguments[0].Value.Syntax : invocationOperation.Instance.Syntax;
+        }
     }
 }
 


### PR DESCRIPTION
Addresses the issue - https://github.com/dotnet/roslyn-analyzers/issues/2283