### PR TITLE
Do not use XslTransform

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseXslTransform.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseXslTransform.cs
@@ -21,10 +21,6 @@ namespace Microsoft.NetCore.Analyzers.Security
             nameof(SystemSecurityCryptographyResources.DoNotUseXslTransformMessage),
             SystemSecurityCryptographyResources.ResourceManager,
             typeof(SystemSecurityCryptographyResources));
-        private static readonly LocalizableString s_Description = new LocalizableResourceString(
-            nameof(SystemSecurityCryptographyResources.DoNotUseXslTransformDescription),
-            SystemSecurityCryptographyResources.ResourceManager,
-            typeof(SystemSecurityCryptographyResources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
                 DiagnosticId,
@@ -33,7 +29,6 @@ namespace Microsoft.NetCore.Analyzers.Security
                 DiagnosticCategory.Security,
                 DiagnosticHelpers.DefaultDiagnosticSeverity,
                 isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
-                description: s_Description,
                 helpLinkUri: null,
                 customTags: WellKnownDiagnosticTags.Telemetry);
 
@@ -59,9 +54,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                 {
                     var objectCreationOperation = (IObjectCreationOperation)operationAnalysisContext.Operation;
 
-                    if (objectCreationOperation.Constructor
-                                                .ContainingType
-                                                .Equals(xslTransformTypeSymbol))
+                    if (xslTransformTypeSymbol.Equals(objectCreationOperation.Constructor.ContainingType))
                     {
                         operationAnalysisContext.ReportDiagnostic(
                             objectCreationOperation.CreateDiagnostic(

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseXslTransform.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotUseXslTransform.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.NetCore.Analyzers.Security
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class DoNotUseXslTransform : DiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "CA5374";
+        private static readonly LocalizableString s_Title = new LocalizableResourceString(
+            nameof(SystemSecurityCryptographyResources.DoNotUseXslTransform),
+            SystemSecurityCryptographyResources.ResourceManager,
+            typeof(SystemSecurityCryptographyResources));
+        private static readonly LocalizableString s_Message = new LocalizableResourceString(
+            nameof(SystemSecurityCryptographyResources.DoNotUseXslTransformMessage),
+            SystemSecurityCryptographyResources.ResourceManager,
+            typeof(SystemSecurityCryptographyResources));
+        private static readonly LocalizableString s_Description = new LocalizableResourceString(
+            nameof(SystemSecurityCryptographyResources.DoNotUseXslTransformDescription),
+            SystemSecurityCryptographyResources.ResourceManager,
+            typeof(SystemSecurityCryptographyResources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+                DiagnosticId,
+                s_Title,
+                s_Message,
+                DiagnosticCategory.Security,
+                DiagnosticHelpers.DefaultDiagnosticSeverity,
+                isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                description: s_Description,
+                helpLinkUri: null,
+                customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+
+            // Security analyzer - analyze and report diagnostics on generated code.
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+            context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+            {
+                var xslTransformTypeSymbol = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemXmlXslXslTransform);
+
+                if (xslTransformTypeSymbol == null)
+                {
+                    return;
+                }
+
+                compilationStartAnalysisContext.RegisterOperationAction(operationAnalysisContext =>
+                {
+                    var objectCreationOperation = (IObjectCreationOperation)operationAnalysisContext.Operation;
+
+                    if (objectCreationOperation.Constructor
+                                                .ContainingType
+                                                .Equals(xslTransformTypeSymbol))
+                    {
+                        operationAnalysisContext.ReportDiagnostic(
+                            objectCreationOperation.CreateDiagnostic(
+                                Rule));
+                    }
+                }, OperationKind.ObjectCreation);
+            });
+        }
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
@@ -240,11 +240,8 @@
   <data name="DoNotUseXslTransform" xml:space="preserve">
     <value>Do Not Use XslTransform</value>
   </data>
-  <data name="DoNotUseXslTransformDescription" xml:space="preserve">
-    <value>XslTransform may include dangerous external references.</value>
-  </data>
   <data name="DoNotUseXslTransformMessage" xml:space="preserve">
-    <value>Construct XslTransform</value>
+    <value>Do not use XslTransform. It does not restrict potentially dangerous external references.</value>
   </data>
   <data name="SetViewStateUserKey" xml:space="preserve">
     <value>Set ViewStateUserKey For Classes Derived From Page</value>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
@@ -237,6 +237,15 @@
   <data name="DoNotUseWeakCryptographicAlgorithmsMessage" xml:space="preserve">
     <value>{0} uses a weak cryptographic algorithm {1}</value>
   </data>
+  <data name="DoNotUseXslTransform" xml:space="preserve">
+    <value>Do Not Use XslTransform</value>
+  </data>
+  <data name="DoNotUseXslTransformDescription" xml:space="preserve">
+    <value>XslTransform may include dangerous external references.</value>
+  </data>
+  <data name="DoNotUseXslTransformMessage" xml:space="preserve">
+    <value>Construct XslTransform</value>
+  </data>
   <data name="SetViewStateUserKey" xml:space="preserve">
     <value>Set ViewStateUserKey For Classes Derived From Page</value>
   </data>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} používá slabý kryptografický algoritmus {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
@@ -202,6 +202,21 @@
         <target state="translated">"{0}" verwendet einen schwachen kryptografischen Algorithmus: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} usa un algoritmo criptográfico poco seguro {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} utilise un algorithme de chiffrement faible {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} usa un algoritmo di crittografia vulnerabile {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} が、脆弱な暗号アルゴリズム {1} を使用します</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0}이(가) 취약한 암호화 알고리즘 {1}을(를) 사용합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
@@ -202,6 +202,21 @@
         <target state="translated">Element {0} używa słabych algorytmów kryptograficznych {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} usa um algoritmo de criptografia fraco {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} использует слабый алгоритм шифрования {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} zayıf {1} kriptografik algoritmasını kullanıyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} 使用弱加密算法 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
@@ -207,14 +207,9 @@
         <target state="new">Do Not Use XslTransform</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotUseXslTransformDescription">
-        <source>XslTransform may include dangerous external references.</source>
-        <target state="new">XslTransform may include dangerous external references.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotUseXslTransformMessage">
-        <source>Construct XslTransform</source>
-        <target state="new">Construct XslTransform</target>
+        <source>Do not use XslTransform. It does not restrict potentially dangerous external references.</source>
+        <target state="new">Do not use XslTransform. It does not restrict potentially dangerous external references.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetViewStateUserKey">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
@@ -202,6 +202,21 @@
         <target state="translated">{0} 使用弱式密碼編譯演算法 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseXslTransform">
+        <source>Do Not Use XslTransform</source>
+        <target state="new">Do Not Use XslTransform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformDescription">
+        <source>XslTransform may include dangerous external references.</source>
+        <target state="new">XslTransform may include dangerous external references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseXslTransformMessage">
+        <source>Construct XslTransform</source>
+        <target state="new">Construct XslTransform</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SetViewStateUserKey">
         <source>Set ViewStateUserKey For Classes Derived From Page</source>
         <target state="new">Set ViewStateUserKey For Classes Derived From Page</target>

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseXslTransformTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseXslTransformTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.NetCore.Analyzers.Security.UnitTests
+{
+    public class DoNotUseXslTransformTests : DiagnosticAnalyzerTestBase
+    {
+        [Fact]
+        public void TestConstructXslTransformDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Xml.Xsl;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        new XslTransform();
+    }
+}",
+            GetCSharpResultAt(9, 9, DoNotUseXslTransform.Rule));
+        }
+
+        [Fact]
+        public void TestConstructNormalClassNoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Xml.Xsl;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        new TestClass();
+    }
+}");
+        }
+
+        [Fact]
+        public void TestInvokeMethodOfXslTransformNoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.Xml.Xsl;
+
+class TestClass
+{
+    public void TestMethod(XslTransform xslTransform)
+    {
+        xslTransform.Load(""url"");
+    }
+}");
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new DoNotUseXslTransform();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DoNotUseXslTransform();
+        }
+    }
+}

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -290,5 +290,6 @@ namespace Analyzer.Utilities
         public const string SystemXmlXPathXPathDocument = "System.Xml.XPath.XPathDocument";
         public const string SystemIODirectoryInfo = "System.IO.DirectoryInfo";
         public const string SystemIOLogLogStore = "System.IO.Log.LogStore";
+        public const string SystemXmlXslXslTransform = "System.Xml.Xsl.XslTransform";
     }
 }


### PR DESCRIPTION
This rule checks using constructor of XslTransform to create object. I don't check it's derived classes cause XslTransform is a sealed class.