### PR TITLE
Report CA1823 (AvoidUnusedPrivateFields) at symbol end

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUnusedPrivateFields.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUnusedPrivateFields.cs
@@ -112,19 +112,32 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                         },
                         OperationKind.FieldReference);
 
-                    compilationContext.RegisterCompilationEndAction(
-                        (compilationEndContext) =>
+                    // Private field reference information reaches a state of consistency as each type symbol completes
+                    // analysis. Reporting information at the end of each named type provides incremental analysis
+                    // support inside the IDE.
+                    compilationContext.RegisterSymbolStartAction(
+                        context =>
                         {
-                            foreach (IFieldSymbol maybeUnreferencedPrivateField in maybeUnreferencedPrivateFields.Keys)
+                            context.RegisterSymbolEndAction(context =>
                             {
-                                if (referencedPrivateFields.ContainsKey(maybeUnreferencedPrivateField))
+                                var namedType = (INamedTypeSymbol)context.Symbol;
+                                foreach (var member in namedType.GetMembers())
                                 {
-                                    continue;
-                                }
+                                    if (!(member is IFieldSymbol field))
+                                    {
+                                        continue;
+                                    }
 
-                                compilationEndContext.ReportDiagnostic(Diagnostic.Create(Rule, maybeUnreferencedPrivateField.Locations[0], maybeUnreferencedPrivateField.Name));
-                            }
-                        });
+                                    if (!maybeUnreferencedPrivateFields.ContainsKey(field) || referencedPrivateFields.ContainsKey(field))
+                                    {
+                                        continue;
+                                    }
+
+                                    context.ReportDiagnostic(Diagnostic.Create(Rule, field.Locations[0], field.Name));
+                                }
+                            });
+                        },
+                        SymbolKind.NamedType);
                 });
         }
 


### PR DESCRIPTION
This was previously a compilation end analyzer.

~~This change also fixes a race condition which could lead to the incorrect reporting of CA1823 on a field which is used.~~ This change moved to #2342. 