### PR TITLE
Fix false positives for Dispose rules

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
 
             context.RegisterCompilationStartAction(compilationContext =>
             {

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposableFieldsShouldBeDisposedTests.cs
@@ -2745,5 +2745,58 @@ public sealed class A : IDisposable
 }
 ");
         }
+
+        [Fact, WorkItem(2306, "https://github.com/dotnet/roslyn-analyzers/issues/2306")]
+        public void DisposableAllocationInConstructor_DisposedInGeneratedCodeFile_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+
+class B : IDisposable
+{
+    private readonly A a;
+    public B()
+    {
+        a = new A();
+    }
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("""", """")]
+    public void Dispose()
+    {
+        a.Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+    End Sub
+End Class
+
+Class B
+    Implements IDisposable
+
+    Private ReadOnly a As A
+    Sub New()
+        a = New A()
+    End Sub
+
+    <System.CodeDom.Compiler.GeneratedCodeAttribute("""", """")> _
+    Public Sub Dispose() Implements IDisposable.Dispose
+        a.Dispose()
+    End Sub
+End Class");
+        }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -486,6 +486,35 @@ class MyCollection
 ");
         }
 
+        [Fact, WorkItem(2245, "https://github.com/dotnet/roslyn-analyzers/issues/2245")]
+        public void OutDisposableArgument_StoredIntoField_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+
+class Test
+{
+    private A _a;
+    void M(out A param)
+    {
+        param = new A();
+    }
+
+    void Method()
+    {
+        M(out _a);  // This is considered as an escape of interprocedural disposable creation.
+    }
+}
+");
+        }
+
         [Fact]
         public void LocalWithMultipleDisposableAssignment_DisposeCallOnSome_Diagnostic()
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -336,14 +336,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
                 base.PostProcessArgument(operation, isEscaped);
                 if (isEscaped)
                 {
-                    PostProcessEscapedArgument();
-                }
-
-                return;
-
-                // Local functions.
-                void PostProcessEscapedArgument()
-                {
                     // Discover if a disposable object is being passed into the creation method for this new disposable object
                     // and if the new disposable object assumes ownership of that passed in disposable object.
                     if (IsDisposeOwnershipTransfer())
@@ -352,6 +344,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
                         HandlePossibleEscapingOperation(operation, pointsToValue.Locations);
                     }
                 }
+                else if (operation.Parameter.RefKind == RefKind.Out || operation.Parameter.RefKind == RefKind.Ref)
+                {
+                    HandlePossibleEscapingOperation(operation, GetEscapedLocations(operation));
+                }
+
+                return;
+
+                // Local functions.
 
                 bool IsDisposeOwnershipTransfer()
                 {


### PR DESCRIPTION
Fixes #2306: CA2213 (DisposableFieldsShouldBeDisposed)
1. https://github.com/dotnet/roslyn-analyzers/commit/ba955a4f1204771477e64be8c4ff68b554e7151c: Ensure that analysis is executed on generated code to account for Dispose implementation in generated code files.

Fixes #2245 (2 scenarios): CA2000 (DisposeObjectsBeforeLosingScope)
1. https://github.com/dotnet/roslyn-analyzers/commit/74dd361b5ee472f4aafd7eb91dc31755819c5056: Handle escaping of disposable creations through ref/out field arguments.
2. https://github.com/dotnet/roslyn-analyzers/commit/5f3209af3fe77d83a5f2df9b20ac8892bbf7cf91: Prevent false positives for disposable `out` arguments of invocations within conditional expression. We assume that an `out` argument of an invocation returning false within a conditional branch is invalid and does not require disposing.