### PR TITLE
Update FxCop analyzers VSIX (Microsoft Code Analysis VSIX) to work on…

### DIFF
--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/Microsoft.CodeAnalysis.FxCopAnalyzers.Setup.csproj
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/Microsoft.CodeAnalysis.FxCopAnalyzers.Setup.csproj
@@ -1,7 +1,7 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
@@ -29,7 +29,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.0.28729" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.CodeQuality.Analyzers\Setup\Microsoft.CodeQuality.Analyzers.Setup.csproj">
@@ -46,12 +46,6 @@
     </ProjectReference>
     <ProjectReference Include="..\..\Microsoft.NetCore.Analyzers\Setup\Microsoft.NetCore.Analyzers.Setup.csproj">
       <Name>Microsoft.NetCore.Analyzers.Setup</Name>
-      <VSIXSubPath>Vsixes</VSIXSubPath>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>VSIXContainerProjectOutputGroup</IncludeOutputGroupsInVSIX>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Text.Analyzers\Setup\Text.Analyzers.Setup.csproj">
-      <Name>Text.Analyzers.Setup</Name>
       <VSIXSubPath>Vsixes</VSIXSubPath>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <IncludeOutputGroupsInVSIX>VSIXContainerProjectOutputGroup</IncludeOutputGroupsInVSIX>

--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/ReleaseNotes.txt
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/ReleaseNotes.txt
@@ -1,2 +1,2 @@
-January 2018: v2.6.0 Official Release
-Requires Visual Studio 2017 15.5 or above.
+April 2019: v3.0.0 Official Release
+Requires Visual Studio 2019 RTW or later.

--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <Identity Id="4db2d63d-3320-4fbd-bf80-07f8d1500bd3" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft"  />
     <DisplayName>Microsoft Code Analysis 2019</DisplayName>
     <Description xml:space="preserve">Live code analysis rules and code fixes addressing API design, performance, security, and best practices for C# and Visual Basic.</Description>
-    <MoreInfo>https://go.microsoft.com/fwlink/?linkid=849061</MoreInfo>
+    <MoreInfo>https://docs.microsoft.com/en-us/visualstudio/code-quality/install-fxcop-analyzers?view=vs-2019#to-install-fxcop-analyzers-as-a-vsix</MoreInfo>
     <License>EULA.rtf</License>
     <ReleaseNotes>ReleaseNotes.txt</ReleaseNotes>
     <Icon>Icons\MsCodeAnalysisAnalyzer_72x.png</Icon>

--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="4db2d63d-3320-4fbd-bf80-07f8d1500bd3" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft"  />
-    <DisplayName>Microsoft Code Analysis 2017</DisplayName>
+    <DisplayName>Microsoft Code Analysis 2019</DisplayName>
     <Description xml:space="preserve">Live code analysis rules and code fixes addressing API design, performance, security, and best practices for C# and Visual Basic.</Description>
     <MoreInfo>https://go.microsoft.com/fwlink/?linkid=849061</MoreInfo>
     <License>EULA.rtf</License>
@@ -12,7 +12,7 @@
     <Tags>code analysis; roslyn; analyzer; analyzers; live; fxcop; code quality;</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27130.0,]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0.0.0,17.0.0.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -43,17 +43,8 @@
                 d:VsixSubPath="Vsixes"
                 Location="|Microsoft.NetCore.Analyzers.Setup;VSIXContainerProjectOutputGroup|"
                 Id="|Microsoft.NetCore.Analyzers.Setup;VSIXIdentifierProjectOutputGroup|" />
-    
-    <Dependency d:ProjectName="Text.Analyzers.Setup"
-                DisplayName="|Text.Analyzers.Setup;VSIXNameProjectOutputGroup|"
-                Version="[|%CurrentProject%;GetVsixVersion|,)"
-                d:Source="Project"
-                d:InstallSource="Embed"
-                d:VsixSubPath="Vsixes"
-                Location="|Text.Analyzers.Setup;VSIXContainerProjectOutputGroup|"
-                Id="|Text.Analyzers.Setup;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
… VS2019

Fixes #2034

TODOs:
1. ~~Create a new fwlink for the 2019 VSIX marketplace link and update the manifest~~ Using the docs link now.
2. Queue a new signed build with BUILDING_VSIX envinronment variable set to 'true', so we only enable a small subset of analyzers by default (matching the ones in 2017 VSIX)