### PR TITLE
CA1031 should not report diagnostic if catch block throws

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_Diagnostic_GeneralCatchThrowNew()
+        public void CSharp_NoDiagnostic_GeneralCatchThrowNew()
         {
             VerifyCSharp(@"
             using System;
@@ -203,12 +203,11 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                         }
                     }
                 }
-            }",
-            GetCA1031CSharpResultAt(18, 25, "TestMethod"));
+            }");
         }
 
         [Fact]
-        public void Basic_Diagnostic_GeneralCatchThrowNew()
+        public void Basic_NoDiagnostic_GeneralCatchThrowNew()
         {
             VerifyBasic(@"
             Imports System.IO
@@ -225,8 +224,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                     End Sub
                 End Class
             End Namespace
-            ",
-            GetCA1031BasicResultAt(10, 25, "TestMethod"));
+            ");
         }
 
         [Fact]
@@ -326,6 +324,100 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             End Namespace
             ",
             GetCA1031BasicResultAt(10, 25, "TestMethod"));
+        }
+
+        [Fact]
+        public void CSharp_NoDiagnostic_GenericExceptionRethrown()
+        {
+            VerifyCSharp(@"
+            using System;
+            using System.IO;
+
+            namespace TestNamespace
+            {
+                class TestClass
+                {
+                    public static void TestMethod()
+                    {
+                        try 
+                        {
+                            FileStream fileStream = new FileStream(""name"", FileMode.Create);
+                        }
+                        catch (Exception e)
+                        {
+                            throw e;
+                        }
+                    }
+                }
+            }");
+        }
+
+        [Fact]
+        public void Basic_NoDiagnostic_GenericExceptionRethrown()
+        {
+            VerifyBasic(@"
+            Imports System
+            Imports System.IO
+
+            Namespace TestNamespace
+                Class TestClass
+                    Public Shared Sub TestMethod()
+                        Try
+                            Dim fileStream As New FileStream(""name"", FileMode.Create)
+                        Catch e As Exception
+                            Throw e
+                        End Try
+                    End Sub
+                End Class
+            End Namespace
+            ");
+        }
+
+        [Fact]
+        public void CSharp_NoDiagnostic_ThrowNewWrapped()
+        {
+            VerifyCSharp(@"
+            using System;
+            using System.IO;
+
+            namespace TestNamespace
+            {
+                class TestClass
+                {
+                    public static void TestMethod()
+                    {
+                        try 
+                        {
+                            FileStream fileStream = new FileStream(""name"", FileMode.Create);
+                        }
+                        catch (Exception e)
+                        {
+                            throw new AggregateException(e);
+                        }
+                    }
+                }
+            }");
+        }
+
+        [Fact]
+        public void Basic_NoDiagnostic_ThrowNewWrapped()
+        {
+            VerifyBasic(@"
+            Imports System
+            Imports System.IO
+
+            Namespace TestNamespace
+                Class TestClass
+                    Public Shared Sub TestMethod()
+                        Try
+                            Dim fileStream As New FileStream(""name"", FileMode.Create)
+                        Catch e As Exception
+                            Throw New AggregateException(e)
+                        End Try
+                    End Sub
+                End Class
+            End Namespace
+            ");
         }
 
         [Fact]

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotCatchCorruptedStateExceptionsTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotCatchCorruptedStateExceptionsTests.cs
@@ -1253,9 +1253,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
                         }
                     }
                 }
-            }",
-            GetCA2153CSharpResultAt(19, 25, "TestNamespace.TestClass.TestMethod()", "System.Exception")
-            );
+            }");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
@@ -1276,9 +1274,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
                     End Sub
                 End Class
             End Namespace
-            ",
-            GetCA2153BasicResultAt(14, 25, "Public Shared Sub TestMethod()", "System.Exception")
-            );
+            ");
 
             await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
@@ -1300,9 +1296,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
                     End Function
                 End Class
             End Namespace
-            ",
-            GetCA2153BasicResultAt(14, 25, "Public Shared Function TestMethod() As Double", "System.Exception")
-            );
+            ");
         }
 
         [Fact]

--- a/src/Utilities/Compiler/DoNotCatchGeneralUnlessRethrown.cs
+++ b/src/Utilities/Compiler/DoNotCatchGeneralUnlessRethrown.cs
@@ -131,7 +131,7 @@ namespace Analyzer.Utilities
 
             public override void VisitThrow(IThrowOperation operation)
             {
-                if (operation.Exception == null && _seenRethrowInCatchClauses.Count > 0 && !_seenRethrowInCatchClauses.Peek())
+                if (_seenRethrowInCatchClauses.Count > 0 && !_seenRethrowInCatchClauses.Peek())
                 {
                     _seenRethrowInCatchClauses.Pop();
                     _seenRethrowInCatchClauses.Push(true);
@@ -147,7 +147,7 @@ namespace Analyzer.Utilities
 
             private static bool IsGenericCatch(ICatchClauseOperation operation)
             {
-                return operation.ExceptionType == null;
+                return operation.ExceptionDeclarationOrExpression == null;
             }
 
             private static bool MightBeFilteringBasedOnTheCaughtException(ICatchClauseOperation operation)


### PR DESCRIPTION
Fixes #2278

This changes the behavior to be more lenient, avoiding a diagnostic if the catch block contains any throw statement. Previously, we required a rethrow.