### PR TITLE
Conditionally disable unit tests for analyzers that do not ship as pa…

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.cs
@@ -41,6 +41,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                           helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1033-interface-methods-should-be-callable-by-child-types",
                                                                           customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
+        // Disable analyzer when building the FxCop analyzers VSIX as it gets unconditionally turned on by the default ManagedMinimumRecommended ruleset that ships with FxCop.
+        // Rule is not critical to ship in the analyzers VSIX.
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public sealed override void Initialize(AnalysisContext analysisContext)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -30,6 +30,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                          helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1001-types-that-own-disposable-fields-should-be-disposable",
                                                                          customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
+        // Disable analyzer when building the FxCop analyzers VSIX as it gets unconditionally turned on by the default ManagedMinimumRecommended ruleset that ships with FxCop.
+        // Rule is not critical to ship in the analyzers VSIX.
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext analysisContext)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.Fixer.cs
@@ -1,5 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#pragma warning disable IDE0055 // Formatting analyzer complains about bad formatting when "BUILDING_VSIX = true". Fixing the formatting leads to it complaining about bad formatting when "BUILDING_VSIX = false".
+
+#if !BUILDING_VSIX // Analyzer not supported in the Microsoft CodeAnalysis (FxCop analyzers) VSIX
+
 using System.Threading.Tasks;
 using Test.Utilities;
 using Xunit;
@@ -1209,6 +1213,8 @@ End Class
             await VerifyVB.VerifyCodeFixAsync(code, expectedFixedCode);
         }
 
-        #endregion 
+        #endregion
     }
 }
+
+#endif

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.Fixer.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#if !BUILDING_VSIX // Analyzer not supported in the Microsoft CodeAnalysis (FxCop analyzers) VSIX
+
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -233,3 +235,5 @@ End Class
         }
     }
 }
+
+#endif

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.cs
@@ -33,6 +33,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2242-test-for-nan-correctly",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
+        // Disable analyzer when building the FxCop analyzers VSIX as it gets unconditionally turned on by the default ManagedMinimumRecommended ruleset that ships with FxCop.
+        // Rule is not critical to ship in the analyzers VSIX.
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX ? ImmutableArray.Create(Rule) : ImmutableArray<DiagnosticDescriptor>.Empty;
 
         private readonly BinaryOperatorKind[] _comparisonOperators = new[]

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.Fixer.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#if !BUILDING_VSIX // Analyzer not supported in the Microsoft CodeAnalysis (FxCop analyzers) VSIX
+
 using System.Threading.Tasks;
 using Xunit;
 // Use the security verifiers since this diagnostic is reported in generated code
@@ -546,3 +548,5 @@ public class A
         }
     }
 }
+
+#endif

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DoNotMixAttributesFromDifferentVersionsOfMEFTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DoNotMixAttributesFromDifferentVersionsOfMEFTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -572,7 +573,7 @@ End Class
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, string attributeName, string typeName)
         {
-            return new DiagnosticResult(RoslynDiagnosticIds.MixedVersionsOfMefAttributesRuleId, DiagnosticSeverity.Warning)
+            return new DiagnosticResult(RoslynDiagnosticIds.MixedVersionsOfMefAttributesRuleId, DiagnosticHelpers.DefaultDiagnosticSeverity)
                 .WithLocation(line, column)
                 .WithMessageFormat(RoslynDiagnosticsAnalyzersResources.DoNotMixAttributesFromDifferentVersionsOfMEFMessage)
                 .WithArguments(attributeName, typeName);
@@ -580,7 +581,7 @@ End Class
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, string attributeName, string typeName)
         {
-            return new DiagnosticResult(RoslynDiagnosticIds.MixedVersionsOfMefAttributesRuleId, DiagnosticSeverity.Warning)
+            return new DiagnosticResult(RoslynDiagnosticIds.MixedVersionsOfMefAttributesRuleId, DiagnosticHelpers.DefaultDiagnosticSeverity)
                 .WithLocation(line, column)
                 .WithMessageFormat(RoslynDiagnosticsAnalyzersResources.DoNotMixAttributesFromDifferentVersionsOfMEFMessage)
                 .WithArguments(attributeName, typeName);

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/PartsExportedWithMEFv2MustBeMarkedAsSharedTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/PartsExportedWithMEFv2MustBeMarkedAsSharedTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -159,7 +160,7 @@ End Class
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, string typeName)
         {
-            return new DiagnosticResult(RoslynDiagnosticIds.MissingSharedAttributeRuleId, DiagnosticSeverity.Warning)
+            return new DiagnosticResult(RoslynDiagnosticIds.MissingSharedAttributeRuleId, DiagnosticHelpers.DefaultDiagnosticSeverity)
                 .WithLocation(line, column)
                 .WithMessageFormat(RoslynDiagnosticsAnalyzersResources.PartsExportedWithMEFv2MustBeMarkedAsSharedMessage)
                 .WithArguments(typeName);
@@ -167,7 +168,7 @@ End Class
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, string typeName)
         {
-            return new DiagnosticResult(RoslynDiagnosticIds.MissingSharedAttributeRuleId, DiagnosticSeverity.Warning)
+            return new DiagnosticResult(RoslynDiagnosticIds.MissingSharedAttributeRuleId, DiagnosticHelpers.DefaultDiagnosticSeverity)
                 .WithLocation(line, column)
                 .WithMessageFormat(RoslynDiagnosticsAnalyzersResources.PartsExportedWithMEFv2MustBeMarkedAsSharedMessage)
                 .WithArguments(typeName);


### PR DESCRIPTION
…rt of Microsoft Code Analysis (FxCop analyzers) VSIX when `BUILDING_VSIX` environment variable is true.