### PR TITLE
Fix GUID conflict between extensions

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="574abf23-083a-46c6-9aab-9db558ce883a" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="7ba185fb-b7f2-4015-bc49-576b2266193e" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Banned API Analyzers</DisplayName>
     <Description xml:space="preserve">Banned API Analyzers</Description>
   </Metadata>

--- a/src/PublicApiAnalyzers/Setup/source.extension.vsixmanifest
+++ b/src/PublicApiAnalyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="574abf23-083a-46c6-9aab-9db558ce883a" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="631e3e9b-f3de-4df9-99ab-a92a9fe778a1" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Public API Analyzers</DisplayName>
     <Description xml:space="preserve">Public API Analyzers</Description>
   </Metadata>


### PR DESCRIPTION
Three extensions were using the same ID. I changed the ID for the two most recently added extensions.