### PR TITLE
Just checking for null before calling Dispose()

### DIFF
--- a/src/Utilities/Compiler/Extensions/IEnumerableExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IEnumerableExtensions.cs
@@ -99,7 +99,7 @@ namespace Analyzer.Utilities.Extensions
         {
             foreach (var item in collection)
             {
-                item.Dispose();
+                item?.Dispose();
             }
         }
 


### PR DESCRIPTION
If DataFlowAnalysis.Run()'s try block throws an exception, and the finally block eventually calls IEnumerableExtensions.Dispose(), which may throw an null reference exception due to incomplete analysis, hiding the original exception.