### PR TITLE
Fix do not disable request validation

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableRequestValidation.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableRequestValidation.cs
@@ -6,6 +6,7 @@ using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 
 namespace Microsoft.NetCore.Analyzers.Security
 {
@@ -49,9 +50,12 @@ namespace Microsoft.NetCore.Analyzers.Security
             context.RegisterCompilationStartAction(
                 (CompilationStartAnalysisContext compilationStartAnalysisContext) =>
                 {
-                    var validateInputAttributeTypeSymbol = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemWebMvcValidateInputAttribute);
+                    var compilation = compilationStartAnalysisContext.Compilation;
+                    var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(compilationStartAnalysisContext.Compilation);
 
-                    if (validateInputAttributeTypeSymbol == null)
+                    if (!wellKnownTypeProvider.TryGetTypeByMetadataName(
+                                WellKnownTypeNames.SystemWebMvcValidateInputAttribute,
+                                out INamedTypeSymbol validateInputAttributeTypeSymbol))
                     {
                         return;
                     }

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableRequestValidation.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotDisableRequestValidation.cs
@@ -95,7 +95,6 @@ namespace Microsoft.NetCore.Analyzers.Security
                                 symbolAnalysisContext.ReportDiagnostic(
                                     symbol.CreateDiagnostic(
                                         Rule,
-                                        symbol is INamedTypeSymbol namedTypeSymbol ? namedTypeSymbol.TypeKind.ToString() : symbol.Kind.ToString(),
                                         symbol.Name));
                             }
                         }, SymbolKind.Method);

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
@@ -169,7 +169,7 @@
     <value>Request validation is a feature in ASP.NET that examines HTTP requests and determines whether they contain potentially dangerous content. This check adds protection from markup or code in the URL query string, cookies, or posted form values that might have been added for malicious purposes. So, it is generally desirable and should be left enabled for defense in depth.</value>
   </data>
   <data name="DoNotDisableRequestValidationMessage" xml:space="preserve">
-    <value>The {0} {1} has request validation disabled</value>
+    <value>{0} {1} has request validation disabled</value>
   </data>
   <data name="DoNotDisableSchUseStrongCrypto" xml:space="preserve">
     <value>Do Not Disable SChannel Use of Strong Crypto</value>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
@@ -169,7 +169,7 @@
     <value>Request validation is a feature in ASP.NET that examines HTTP requests and determines whether they contain potentially dangerous content. This check adds protection from markup or code in the URL query string, cookies, or posted form values that might have been added for malicious purposes. So, it is generally desirable and should be left enabled for defense in depth.</value>
   </data>
   <data name="DoNotDisableRequestValidationMessage" xml:space="preserve">
-    <value>{0} {1} has request validation disabled</value>
+    <value>{0} has request validation disabled</value>
   </data>
   <data name="DoNotDisableSchUseStrongCrypto" xml:space="preserve">
     <value>Do Not Disable SChannel Use of Strong Crypto</value>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SystemSecurityCryptographyResources.resx
@@ -169,7 +169,7 @@
     <value>Request validation is a feature in ASP.NET that examines HTTP requests and determines whether they contain potentially dangerous content. This check adds protection from markup or code in the URL query string, cookies, or posted form values that might have been added for malicious purposes. So, it is generally desirable and should be left enabled for defense in depth.</value>
   </data>
   <data name="DoNotDisableRequestValidationMessage" xml:space="preserve">
-    <value>The method {0} has request validation disabled</value>
+    <value>The {0} {1} has request validation disabled</value>
   </data>
   <data name="DoNotDisableSchUseStrongCrypto" xml:space="preserve">
     <value>Do Not Disable SChannel Use of Strong Crypto</value>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.cs.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.de.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.es.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.fr.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.it.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ja.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ko.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pl.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.pt-BR.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.ru.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.tr.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hans.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The method {0} has request validation disabled</source>
-        <target state="new">The method {0} has request validation disabled</target>
+        <source>The {0} {1} has request validation disabled</source>
+        <target state="new">The {0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>{0} {1} has request validation disabled</source>
-        <target state="new">{0} {1} has request validation disabled</target>
+        <source>{0} has request validation disabled</source>
+        <target state="new">{0} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/xlf/SystemSecurityCryptographyResources.zh-Hant.xlf
@@ -88,8 +88,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableRequestValidationMessage">
-        <source>The {0} {1} has request validation disabled</source>
-        <target state="new">The {0} {1} has request validation disabled</target>
+        <source>{0} {1} has request validation disabled</source>
+        <target state="new">{0} {1} has request validation disabled</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDisableSchUseStrongCrypto">

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableRequestValidationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableRequestValidationTests.cs
@@ -40,7 +40,7 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(7, 17, DoNotDisableRequestValidation.Rule, "Method", "TestActionMethod"));
+            GetCSharpResultAt(7, 17, DoNotDisableRequestValidation.Rule, "TestActionMethod"));
         }
 
         [Fact]
@@ -58,7 +58,7 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(9, 17, DoNotDisableRequestValidation.Rule, "Method", "TestActionMethod"));
+            GetCSharpResultAt(9, 17, DoNotDisableRequestValidation.Rule, "TestActionMethod"));
         }
 
         [Fact]
@@ -74,7 +74,7 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(5, 7, DoNotDisableRequestValidation.Rule, "Class", "TestControllerClass"));
+            GetCSharpResultAt(5, 7, DoNotDisableRequestValidation.Rule, "TestControllerClass"));
         }
 
         [Fact]
@@ -91,7 +91,7 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(8, 17, DoNotDisableRequestValidation.Rule, "Method", "TestActionMethod"));
+            GetCSharpResultAt(8, 17, DoNotDisableRequestValidation.Rule, "TestActionMethod"));
         }
 
         [Fact]

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableRequestValidationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableRequestValidationTests.cs
@@ -12,8 +12,6 @@ namespace Microsoft.NetCore.Analyzers.Security.UnitTests
         protected void VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
         {
             string validateInputAttributeCSharpSourceCode = @"
-using System.IO;
-
 namespace System.Web.Mvc
 {
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
@@ -33,7 +31,6 @@ namespace System.Web.Mvc
         public void TestLiteralAtActionLevelDiagnostic()
         {
             VerifyCSharpWithDependencies(@"
-using System;
 using System.Web.Mvc;
 
 class TestControllerClass
@@ -43,14 +40,13 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(8, 17, DoNotDisableRequestValidation.Rule, "TestActionMethod"));
+            GetCSharpResultAt(7, 17, DoNotDisableRequestValidation.Rule, "Method", "TestActionMethod"));
         }
 
         [Fact]
         public void TestConstAtActionLevelDiagnostic()
         {
             VerifyCSharpWithDependencies(@"
-using System;
 using System.Web.Mvc;
 
 class TestControllerClass
@@ -62,14 +58,13 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(10, 17, DoNotDisableRequestValidation.Rule, "TestActionMethod"));
+            GetCSharpResultAt(9, 17, DoNotDisableRequestValidation.Rule, "Method", "TestActionMethod"));
         }
 
         [Fact]
         public void TestLiteralAtControllerLevelDiagnostic()
         {
             VerifyCSharpWithDependencies(@"
-using System;
 using System.Web.Mvc;
 
 [ValidateInput(false)]
@@ -79,14 +74,30 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(6, 7, DoNotDisableRequestValidation.Rule, "TestControllerClass"));
+            GetCSharpResultAt(5, 7, DoNotDisableRequestValidation.Rule, "Class", "TestControllerClass"));
+        }
+
+        [Fact]
+        public void TestSetBothControllerLevelAndActionLevelDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web.Mvc;
+
+[ValidateInput(true)]
+class TestControllerClass
+{
+    [ValidateInput(false)]
+    public void TestActionMethod()
+    {
+    }
+}",
+            GetCSharpResultAt(8, 17, DoNotDisableRequestValidation.Rule, "Method", "TestActionMethod"));
         }
 
         [Fact]
         public void TestLiteralAtActionLevelNoDiagnostic()
         {
             VerifyCSharpWithDependencies(@"
-using System;
 using System.Web.Mvc;
 
 class TestControllerClass
@@ -102,7 +113,6 @@ class TestControllerClass
         public void TestConstAtActionLevelNoDiagnostic()
         {
             VerifyCSharpWithDependencies(@"
-using System;
 using System.Web.Mvc;
 
 class TestControllerClass
@@ -120,10 +130,39 @@ class TestControllerClass
         public void TestLiteralAtControllerLevelNoDiagnostic()
         {
             VerifyCSharpWithDependencies(@"
-using System;
 using System.Web.Mvc;
 
 [ValidateInput(true)]
+class TestControllerClass
+{
+    public void TestActionMethod()
+    {
+    }
+}");
+        }
+
+        [Fact]
+        public void TestSetBothControllerLevelAndActionLevelNoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web.Mvc;
+
+[ValidateInput(false)]
+class TestControllerClass
+{
+    [ValidateInput(true)]
+    public void TestActionMethod()
+    {
+    }
+}");
+        }
+
+        [Fact]
+        public void TestWithoutValidateInputAttributeNoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web.Mvc;
+
 class TestControllerClass
 {
     public void TestActionMethod()


### PR DESCRIPTION
1. The old message is "The method {1} has request validation disabled". However, it could be a class.
2. Add support for scenario like setting up the ValidateInput attribute for both method and its type.