### PR TITLE
Do not bail out upfront for non-async methods

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
@@ -55,10 +55,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                 context.RegisterOperationBlockStartAction(operationBlockStartContext =>
                 {
-                    if (operationBlockStartContext.OwningSymbol is IMethodSymbol method &&
-                        method.IsAsync)
+                    if (operationBlockStartContext.OwningSymbol is IMethodSymbol method)
                     {
-                        if (method.ReturnsVoid &&
+                        if (method.IsAsync &&
+                            method.ReturnsVoid &&
                             operationBlockStartContext.Options.GetBoolOptionValue(
                                 optionName: EditorConfigOptionNames.ExcludeAsyncVoidMethods,
                                 rule: Rule,

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
@@ -379,6 +379,27 @@ public class C
             VerifyCSharp(code, GetEditorConfigAdditionalFile(editorConfigText), compilationOptions, parseOptions: null, expected: GetCSharpResultAt(9, 15));
         }
 
+        [Fact, WorkItem(2393, "https://github.com/dotnet/roslyn-analyzers/issues/2393")]
+        public void CSharpSimpleAwaitTaskInLocalFunction()
+        {
+            var code = @"
+using System.Threading.Tasks;
+
+public class C
+{
+    public void M()
+    {
+        async Task CoreAsync()
+        {
+            Task t = null;
+            await t;
+        }
+    }
+}
+";
+            VerifyCSharp(code, GetCSharpResultAt(11, 19));
+        }
+
         private DiagnosticResult GetCSharpResultAt(int line, int column)
         {
             return GetCSharpResultAt(line, column, DoNotDirectlyAwaitATaskAnalyzer.RuleId, MicrosoftApiDesignGuidelinesAnalyzersResources.DoNotDirectlyAwaitATaskMessage);


### PR DESCRIPTION
We may miss out analyzing async lambdas/local functions defined in non-async methods.

Fixes #2393