### PR TITLE
Perf optimization for CA2213 analyzer (DisposableFieldsShouldBeDisposed)

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
+using System.Threading;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
@@ -62,6 +63,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 // Disposable fields with initializer at declaration must be disposed.
                 compilationContext.RegisterOperationAction(operationContext =>
                 {
+                    if (!ShouldAnalyze(operationContext.ContainingSymbol.ContainingType))
+                    {
+                        return;
+                    }
+
                     var initializedFields = ((IFieldInitializerOperation)operationContext.Operation).InitializedFields;
                     foreach (var field in initializedFields)
                     {
@@ -77,45 +83,54 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 // Instance fields initialized in constructor/method body with a locally created disposable object must be disposed.
                 compilationContext.RegisterOperationBlockStartAction(operationBlockStartContext =>
                 {
-                    if (!(operationBlockStartContext.OwningSymbol is IMethodSymbol containingMethod))
+                    if (!(operationBlockStartContext.OwningSymbol is IMethodSymbol containingMethod) ||
+                        !ShouldAnalyze(containingMethod.ContainingType))
                     {
                         return;
                     }
 
                     if (disposeAnalysisHelper.HasAnyDisposableCreationDescendant(operationBlockStartContext.OperationBlocks, containingMethod))
                     {
-                        if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext.OperationBlocks,
-                            containingMethod, operationBlockStartContext.Options, Rule, trackInstanceFields: false,
-                            trackExceptionPaths: false, operationBlockStartContext.CancellationToken,
-                            out var disposeAnalysisResult, out var pointsToAnalysisResult))
+                        PointsToAnalysisResult lazyPointsToAnalysisResult = null;
+
+                        operationBlockStartContext.RegisterOperationAction(operationContext =>
                         {
-                            Debug.Assert(disposeAnalysisResult != null);
-                            Debug.Assert(pointsToAnalysisResult != null);
+                            var fieldReference = (IFieldReferenceOperation)operationContext.Operation;
+                            var field = fieldReference.Field;
 
-                            operationBlockStartContext.RegisterOperationAction(operationContext =>
+                            // Only track instance fields on the current instance.
+                            if (field.IsStatic || fieldReference.Instance?.Kind != OperationKind.InstanceReference)
                             {
-                                var fieldReference = (IFieldReferenceOperation)operationContext.Operation;
-                                var field = fieldReference.Field;
+                                return;
+                            }
 
-                                // Only track instance fields on the current instance.
-                                if (field.IsStatic || fieldReference.Instance?.Kind != OperationKind.InstanceReference)
+                            // Check if this is a Disposable field that is not currently being tracked.
+                            if (fieldDisposeValueMap.ContainsKey(field) ||
+                                !disposeAnalysisHelper.GetDisposableFields(field.ContainingType).Contains(field))
+                            {
+                                return;
+                            }
+
+                            // We have a field reference for a disposable field.
+                            // Check if it is being assigned a locally created disposable object.
+                            if (fieldReference.Parent is ISimpleAssignmentOperation simpleAssignmentOperation &&
+                                simpleAssignmentOperation.Target == fieldReference)
+                            {
+                                if (lazyPointsToAnalysisResult == null)
                                 {
-                                    return;
+                                    if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext.OperationBlocks,
+                                        containingMethod, operationBlockStartContext.Options, Rule, trackInstanceFields: false,
+                                        trackExceptionPaths: false, operationBlockStartContext.CancellationToken,
+                                        out var disposeAnalysisResult, out var pointsToAnalysisResult))
+                                    {
+                                        Debug.Assert(pointsToAnalysisResult != null);
+                                        Interlocked.CompareExchange(ref lazyPointsToAnalysisResult, pointsToAnalysisResult, null);
+                                    }
                                 }
 
-                                // Check if this is a Disposable field that is not currently being tracked.
-                                if (fieldDisposeValueMap.ContainsKey(field) ||
-                                    !disposeAnalysisHelper.GetDisposableFields(field.ContainingType).Contains(field))
+                                if (lazyPointsToAnalysisResult != null)
                                 {
-                                    return;
-                                }
-
-                                // We have a field reference for a disposable field.
-                                // Check if it is being assigned a locally created disposable object.
-                                if (fieldReference.Parent is ISimpleAssignmentOperation simpleAssignmentOperation &&
-                                    simpleAssignmentOperation.Target == fieldReference)
-                                {
-                                    PointsToAbstractValue assignedPointsToValue = pointsToAnalysisResult[simpleAssignmentOperation.Value.Kind, simpleAssignmentOperation.Value.Syntax];
+                                    PointsToAbstractValue assignedPointsToValue = lazyPointsToAnalysisResult[simpleAssignmentOperation.Value.Kind, simpleAssignmentOperation.Value.Syntax];
                                     foreach (var location in assignedPointsToValue.Locations)
                                     {
                                         if (disposeAnalysisHelper.IsDisposableCreationOrDisposeOwnershipTransfer(location, containingMethod))
@@ -125,9 +140,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                         }
                                     }
                                 }
-                            },
-                            OperationKind.FieldReference);
-                        }
+                            }
+                        },
+                        OperationKind.FieldReference);
                     }
 
                     // Mark fields disposed in Dispose method(s).
@@ -194,6 +209,17 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         }
                     }
                 });
+
+                return;
+
+                // Local functions
+                bool ShouldAnalyze(INamedTypeSymbol namedType)
+                {
+                    // We only want to analyze types which are disposable (implement System.IDisposable directly or indirectly)
+                    // and have at least one disposable field.
+                    return namedType.IsDisposable(disposeAnalysisHelper.IDisposable) &&
+                        !disposeAnalysisHelper.GetDisposableFields(namedType).IsEmpty;
+                }
             });
         }
     }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
@@ -142,16 +142,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                     DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue> ComputeValueContentAnalysisResult()
                     {
-                        foreach (var operationRoot in operationBlockStartContext.OperationBlocks)
+                        var cfg = operationBlockStartContext.OperationBlocks.GetControlFlowGraph();
+                        if (cfg != null)
                         {
-                            IBlockOperation topmostBlock = operationRoot.GetTopmostParentBlock();
-                            if (topmostBlock != null)
-                            {
-                                var cfg = topmostBlock.GetEnclosingControlFlowGraph();
-                                var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(operationBlockStartContext.Compilation);
-                                return ValueContentAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
-                                    operationBlockStartContext.Options, Rule, operationBlockStartContext.CancellationToken);
-                            }
+                            var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(operationBlockStartContext.Compilation);
+                            return ValueContentAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
+                                operationBlockStartContext.Options, Rule, operationBlockStartContext.CancellationToken);
                         }
 
                         return null;

--- a/src/Utilities/FlowAnalysis/Extensions/OperationBlocksExtensions.cs
+++ b/src/Utilities/FlowAnalysis/Extensions/OperationBlocksExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Analyzer.Utilities.Extensions
+{
+    internal static partial class OperationBlocksExtensions
+    {
+        public static ControlFlowGraph GetControlFlowGraph(this ImmutableArray<IOperation> operationBlocks)
+        {
+            foreach (var operationRoot in operationBlocks)
+            {
+                IBlockOperation topmostBlock = operationRoot.GetTopmostParentBlock();
+                if (topmostBlock != null)
+                {
+                    return topmostBlock.GetEnclosingControlFlowGraph();
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Utilities/FlowAnalysis/FlowAnalysis.Utilities.projitems
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis.Utilities.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ControlFlowBranchExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ControlFlowConditionKindExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\IOperationExtensions_FlowAnalysis.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\OperationBlocksExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\CopyAnalysis\SetCopyAbstractValuePredicateKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PointsToAnalysis\PointsToAnalysisResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlowAnalysis\Analysis\PointsToAnalysis\TrackedEntitiesBuilder.cs" />

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisHelper.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisHelper.cs
@@ -103,20 +103,15 @@ namespace Analyzer.Utilities
             InterproceduralAnalysisPredicate interproceduralAnalysisPredicateOpt = null,
             bool defaultDisposeOwnershipTransferAtConstructor = false)
         {
-            foreach (var operationRoot in operationBlocks)
+            var cfg = operationBlocks.GetControlFlowGraph();
+            if (cfg != null)
             {
-                IBlockOperation topmostBlock = operationRoot.GetTopmostParentBlock();
-                if (topmostBlock != null)
-                {
-                    var cfg = topmostBlock.GetEnclosingControlFlowGraph();
-
-                    disposeAnalysisResult = DisposeAnalysis.GetOrComputeResult(cfg, containingMethod, _wellKnownTypeProvider,
-                        analyzerOptions, rule, _disposeOwnershipTransferLikelyTypes, trackInstanceFields,
-                        trackExceptionPaths, cancellationToken, out pointsToAnalysisResult,
-                        interproceduralAnalysisPredicateOpt: interproceduralAnalysisPredicateOpt,
-                        defaultDisposeOwnershipTransferAtConstructor: defaultDisposeOwnershipTransferAtConstructor);
-                    return true;
-                }
+                disposeAnalysisResult = DisposeAnalysis.GetOrComputeResult(cfg, containingMethod, _wellKnownTypeProvider,
+                    analyzerOptions, rule, _disposeOwnershipTransferLikelyTypes, trackInstanceFields,
+                    trackExceptionPaths, cancellationToken, out pointsToAnalysisResult,
+                    interproceduralAnalysisPredicateOpt: interproceduralAnalysisPredicateOpt,
+                    defaultDisposeOwnershipTransferAtConstructor: defaultDisposeOwnershipTransferAtConstructor);
+                return true;
             }
 
             disposeAnalysisResult = null;


### PR DESCRIPTION
Make sure we only analyze types that implement IDisposable and at least have one disposable field. Additionally, run DFA lazily only if required.

Fixes #2319