### PR TITLE
Revert "Turn off dataflow analysis based rules by default"

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ValidateArgumentsOfPublicMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ValidateArgumentsOfPublicMethods.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Design,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);

--- a/src/Microsoft.NetCore.Analyzers/Core/Data/ReviewSqlQueriesForSecurityVulnerabilities.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Data/ReviewSqlQueriesForSecurityVulnerabilities.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.Data
                                                                              s_localizableMessageNoNonLiterals,
                                                                              DiagnosticCategory.Security,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2100-review-sql-queries-for-security-vulnerabilities",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Usage,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2213-disposable-fields-should-be-disposed",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeObjectsBeforeLosingScope.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeObjectsBeforeLosingScope.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                         s_localizableNotDisposedMessage,
                                                                                         DiagnosticCategory.Reliability,
                                                                                         DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                        isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
+                                                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                                         description: s_localizableDescription,
                                                                                         helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2000-dispose-objects-before-losing-scope",
                                                                                         customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);
@@ -42,7 +42,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                           s_localizableMayBeDisposedMessage,
                                                                                           DiagnosticCategory.Reliability,
                                                                                           DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                          isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
+                                                                                          isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                                           description: s_localizableDescription,
                                                                                           helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2000-dispose-objects-before-losing-scope",
                                                                                           customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);
@@ -52,7 +52,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                         s_localizableNotDisposedOnExceptionPathsMessage,
                                                                                                         DiagnosticCategory.Reliability,
                                                                                                         DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                                        isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
+                                                                                                        isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                                                         description: s_localizableDescription,
                                                                                                         helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2000-dispose-objects-before-losing-scope",
                                                                                                         customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);
@@ -62,7 +62,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                           s_localizableMayBeDisposedOnExceptionPathsMessage,
                                                                                                           DiagnosticCategory.Reliability,
                                                                                                           DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                                                          isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
+                                                                                                          isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                                                           description: s_localizableDescription,
                                                                                                           helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2000-dispose-objects-before-losing-scope",
                                                                                                           customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableMessage,
                                                                              DiagnosticCategory.Globalization,
                                                                              DiagnosticHelpers.DefaultDiagnosticSeverity,
-                                                                             isEnabledByDefault: false, // https://github.com/dotnet/roslyn-analyzers/issues/2191 tracks enabling this rule by default.
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
                                                                              description: s_localizableDescription,
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopDataflowRule);


### PR DESCRIPTION
This reverts commit 22b4d0db2a65cd9abbafb29bbe92a1e4209c621f.

Fixes #2191 

We have already added the flow-analysis feature flag to the packages, so we do not need to disable these DFA rules by default.