### PR TITLE
Ensure that we don't flag CA2235 (MarkAllNonSerializableFields) for p…

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SerializationRulesDiagnosticAnalyzer.cs
@@ -266,6 +266,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             private bool IsSerializable(ITypeSymbol type)
             {
+                if (type.IsPrimitiveType())
+                {
+                    return true;
+                }
+
                 switch (type.TypeKind)
                 {
                     case TypeKind.Array:


### PR DESCRIPTION
…rimitive type fields

Fixes #2381
Fixes #2156
I am able to repro this for netstandard projects but not for netframework projects and also unable to repro it with a unit test. I validated with manual verification that it fixes the underlying bug.