### PR TITLE
Support xUnit extensibility model in CA1822

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             }
 
             // FxCop doesn't check for the fully qualified name for these attributes - so we'll do the same.
-            if (methodSymbol.GetAttributes().Any(attribute => skippedAttributes.Contains(attribute.AttributeClass)))
+            if (methodSymbol.GetAttributes().Any(attribute => skippedAttributes.Any(attr => attribute.AttributeClass.Inherits(attr))))
             {
                 return false;
             }
@@ -250,7 +250,6 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
             // XUnit attributes
             Add(WellKnownTypes.XunitFact(compilation));
-            Add(WellKnownTypes.XunitTheory(compilation));
 
             // NUnit Attributes
             Add(WellKnownTypes.NunitSetUp(compilation));

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -525,6 +525,7 @@ End Class
         [InlineData("Microsoft.VisualStudio.TestTools.UnitTesting.TestCleanup", MSTestAttributes.CSharp, MSTestAttributes.VisualBasic)]
         [InlineData("Xunit.Fact", XunitApis.CSharp, XunitApis.VisualBasic)]
         [InlineData("Xunit.Theory", XunitApis.CSharp, XunitApis.VisualBasic)]
+        [InlineData("CustomxUnit.WpfFact", XunitApis.CSharp, XunitApis.VisualBasic)]
         [InlineData("NUnit.Framework.OneTimeSetUp", NUnitApis.CSharp, NUnitApis.VisualBasic)]
         [InlineData("NUnit.Framework.OneTimeTearDown", NUnitApis.CSharp, NUnitApis.VisualBasic)]
         [InlineData("NUnit.Framework.SetUp", NUnitApis.CSharp, NUnitApis.VisualBasic)]

--- a/src/Test.Utilities/MinimalImplementations/XunitApis.cs
+++ b/src/Test.Utilities/MinimalImplementations/XunitApis.cs
@@ -105,6 +105,16 @@ namespace Xunit
         public virtual string DisplayName { get; set; }
         public virtual string Skip { get; set; }
     }
+}
+
+namespace CustomxUnit 
+{
+    using Xunit;
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WpfFactAttribute : FactAttribute
+    {
+    }
 }";
 
         public const string VisualBasic = @"
@@ -190,6 +200,14 @@ Namespace Xunit
         Inherits Attribute
         Public Overridable Property DisplayName As String
         Public Overridable Property Skip As String
+    End Class
+End Namespace
+
+Namespace CustomxUnit
+
+    <AttributeUsage(AttributeTargets.Method, AllowMultiple:=False)>
+    Public Class WpfFactAttribute
+        Inherits Xunit.FactAttribute
     End Class
 End Namespace
 ";


### PR DESCRIPTION
Unit tests are often arranged so, that they don't access instance
member. For any other members such behavior triggers CA1822
"Member does not access instance members and may be made static". Unit
tests are excluded from this rule.

The exclusion is implemented through unit tests attributes, such as `Fact` or
`TestMethod` etc, by directly comparing all method attributes with a list
of known test method attributes.

In xUnit framework one may extend unit test behavior by inheriting from
the `Fact` attribute. The Theory is one example. Currently, attributes
inherited from Fact do not allow exclusion of the test from the CA1822
rule, resulting in false warning.

Here we change the exclusion mechanism to check not only by directly
comparing attributes, but also through inheritance.