### PR TITLE
Update XliffTasks version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,6 +32,12 @@
     <TargetFrameworkMonikerAssemblyAttributesFileClean>true</TargetFrameworkMonikerAssemblyAttributesFileClean>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- The version of XliffTasks pulled in by Arcade is fairly old, so here we specify a newer version. -->
+    <!-- This should be removed when the version in Arcade catches up. -->
+    <XliffTasksVersion>1.0.0-beta.19253.2</XliffTasksVersion>
+  </PropertyGroup>
+
   <!-- Workaround to enable .editorconfig based analyzer configuration until dotnet compilers support .editorconfig based configuration -->
   <PropertyGroup>
     <SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/xlf/MicrosoftApiDesignGuidelinesAnalyzersResources.cs.xlf
@@ -944,12 +944,12 @@
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
         <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} vytváří výjimku typu {1\}, což je typ výjimky, která by neměla být ve vlastnosti vyvolána. Pokud se tato instance výjimky může vyvolat, použijte jiný typ výjimky, převeďte tuto vlastnost na metodu nebo změňte logiku této vlastnosti tak, aby už nevyvolávala výjimku.</target>
+        <target state="new">{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
         <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} vytváří výjimku typu {1\}, což je typ výjimky, která by neměla být v tomto typu metody vyvolána. Pokud se tato instance výjimky může vyvolat, buď použijte jiný typ výjimky, nebo změňte logiku této metody tak, aby už nevyvolávala výjimku.</target>
+        <target state="new">{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.cs.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">Pole, která se dají uvolnit, by se měla uvolňovat</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Metody Dispose by měly volat metodu Dispose základní třídy</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.de.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">Verwerfbare Felder verwerfen</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Dispose-Methoden müssen die Dispose-Funktion der Basisklasse aufrufen</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.es.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">Aplicar Dispose a los campos a los que se pueda</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Los métodos Dispose deben llamar a Dispose de clase base</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.fr.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">Les champs supprimables doivent l'être</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Les méthodes Dispose doivent appeler la méthode Dispose de la classe de base</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.it.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">I campi eliminabili devono essere eliminati</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">I metodi Dispose devono chiamare Dispose della classe di base</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ja.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">破棄可能なフィールドは破棄しなければなりません</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Dispose メソッドが基底クラスの Dispose を呼び出す必要があります</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ko.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">삭제 가능한 필드는 삭제해야 합니다.</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Dispose 메서드는 기본 클래스 Dispose를 호출해야 합니다.</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.pl.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">Pola możliwe do likwidacji powinny zostać zlikwidowane</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Metoda Dispose powinna wywoływać metodę Dispose klasy podstawowej</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.pt-BR.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">Campos descartáveis devem ser descartados</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Métodos Dispose devem chamar a classe base dispose</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.ru.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">Следует высвобождать высвобождаемые поля</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Методы Dispose должны вызывать базовый класс Dispose</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.tr.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">Atılabilir alanlar atılmalıdır</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Atma Yöntemleri Taban Sınıf Atmayı Çağırmalıdır</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.zh-Hans.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">应释放可释放的字段</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Dispose 方法应调用基类释放</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/xlf/SystemRuntimeAnalyzersResources.zh-Hant.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="DisposableFieldsShouldBeDisposedMessage">
         <source>'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</source>
-        <target state="needs-review-translation">可處置的欄位應受到處置</target>
+        <target state="new">'{0}' contains field '{1}' that is of IDisposable type '{2}', but it is never disposed. Change the Dispose method on '{0}' to call Close or Dispose on this field.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="DisposeMethodsShouldCallBaseClassDisposeMessage">
         <source>Ensure that method '{0}' calls '{1}' in all possible control flow paths.</source>
-        <target state="needs-review-translation">Dispose 方法應呼叫 Dispose 基底類別</target>
+        <target state="new">Ensure that method '{0}' calls '{1}' in all possible control flow paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="DisposableTypesShouldDeclareFinalizerTitle">


### PR DESCRIPTION
Update the version of XliffTasks used by dotnet/roslyn-analyzers. The version we're getting from the dotnet/arcade toolset is fairly old and is missing bug fixes and improved error reporting that can make it easier to track down XLF failures during a build.

A number of .xlf files have been updated by a newer features that detects when the `source` and `target` texts have different numbers of placeholders and resets the `target` text completely; this avoids string formatting exceptions at runtime.