### PR TITLE
Update the publisher name for our VSIXes to be "Microsoft DevLabs" in…

### DIFF
--- a/src/MetaCompilation.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/MetaCompilation.Analyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="5c6391a0-1c50-455e-af26-4625f610bc62" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft"/>
+    <Identity Id="5c6391a0-1c50-455e-af26-4625f610bc62" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs"/>
     <DisplayName>MetaCompilation Analyzers</DisplayName>
     <Description xml:space="preserve">This is a sample diagnostic extension for the .NET Compiler Platform ("Roslyn").</Description>
   </Metadata>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="41880BF7-B087-402F-AE29-18A367E9DF9B" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="41880BF7-B087-402F-AE29-18A367E9DF9B" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs" />
     <DisplayName>.NET Compiler Platform (Roslyn) Analyzers</DisplayName>
     <Description xml:space="preserve">Analyzers for .NET Compiler Platform (Roslyn) APIs.</Description>
   </Metadata>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="7ba185fb-b7f2-4015-bc49-576b2266193e" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="7ba185fb-b7f2-4015-bc49-576b2266193e" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs" />
     <DisplayName>Banned API Analyzers</DisplayName>
     <Description xml:space="preserve">Banned API Analyzers</Description>
   </Metadata>

--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/ReleaseNotes.txt
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/ReleaseNotes.txt
@@ -1,2 +1,2 @@
-April 2019: v3.0.0 Official Release
+May 2019: v3.0.0 Official Release
 Requires Visual Studio 2019 RTW or later.

--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="4db2d63d-3320-4fbd-bf80-07f8d1500bd3" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft"  />
+    <Identity Id="4db2d63d-3320-4fbd-bf80-07f8d1500bd3" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs"  />
     <DisplayName>Microsoft Code Analysis 2019</DisplayName>
     <Description xml:space="preserve">Live code analysis rules and code fixes addressing API design, performance, security, and best practices for C# and Visual Basic.</Description>
     <MoreInfo>https://docs.microsoft.com/en-us/visualstudio/code-quality/install-fxcop-analyzers?view=vs-2019#to-install-fxcop-analyzers-as-a-vsix</MoreInfo>

--- a/src/Microsoft.CodeQuality.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.CodeQuality.Analyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="81f388f0-1777-4c56-be8f-51f5f420037d" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="81f388f0-1777-4c56-be8f-51f5f420037d" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs" />
     <DisplayName>Microsoft.CodeQuality Analyzers</DisplayName>
     <Description xml:space="preserve">Microsoft.CodeQuality Analyzers</Description>
   </Metadata>

--- a/src/Microsoft.NetCore.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.NetCore.Analyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="8e93bd53-8b59-4c05-ae8a-b8e16de6a5d6" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="8e93bd53-8b59-4c05-ae8a-b8e16de6a5d6" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs" />
     <DisplayName>Microsoft.NetCore Analyzers</DisplayName>
     <Description xml:space="preserve">Analyzers for .NetCore APIs.</Description>
   </Metadata>

--- a/src/Microsoft.NetFramework.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Microsoft.NetFramework.Analyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="bed80bcf-3952-4747-8c03-6770eeeb1595" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="bed80bcf-3952-4747-8c03-6770eeeb1595" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs" />
     <DisplayName>Microsoft.NetFramework Analyzers</DisplayName>
     <Description xml:space="preserve">Analyzers for APIs specific to the full .NetFramework which are not present in .NetCore</Description>
   </Metadata>

--- a/src/PerformanceSensitiveAnalyzers/Setup/source.extension.vsixmanifest
+++ b/src/PerformanceSensitiveAnalyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="20ad7bf0-adc1-4fb0-8089-3dec89e40855" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="20ad7bf0-adc1-4fb0-8089-3dec89e40855" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs" />
     <DisplayName>PerformanceSensitive Analyzers</DisplayName>
     <Description xml:space="preserve">PerformanceSensitive Analyzers</Description>
   </Metadata>

--- a/src/PublicApiAnalyzers/Setup/source.extension.vsixmanifest
+++ b/src/PublicApiAnalyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="631e3e9b-f3de-4df9-99ab-a92a9fe778a1" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="631e3e9b-f3de-4df9-99ab-a92a9fe778a1" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs" />
     <DisplayName>Public API Analyzers</DisplayName>
     <Description xml:space="preserve">Public API Analyzers</Description>
   </Metadata>

--- a/src/Roslyn.Diagnostics.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Roslyn.Diagnostics.Analyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="574abf23-083a-46c6-9aab-9db558ce883a" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="574abf23-083a-46c6-9aab-9db558ce883a" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs" />
     <DisplayName>Roslyn.Diagnostics Analyzers</DisplayName>
     <Description xml:space="preserve">Roslyn.Diagnostics Analyzers</Description>
   </Metadata>

--- a/src/Text.Analyzers/Setup/source.extension.vsixmanifest
+++ b/src/Text.Analyzers/Setup/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="65c816b1-04f9-4b1a-b767-078f8ccd627e" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="65c816b1-04f9-4b1a-b767-078f8ccd627e" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft DevLabs" />
     <DisplayName>Text Analyzers</DisplayName>
     <Description xml:space="preserve">Text Analyzers</Description>
   </Metadata>


### PR DESCRIPTION
…stead of "Microsoft" as the prior VSIX was published with the former publisher name. Attempting to upload the new VSIX fails with this name mismatch.