### PR TITLE
Disable interprocedural analysis by default for CA2213, except when a…

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposableFieldsShouldBeDisposed.cs
@@ -121,7 +121,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                     var cfg = operationBlockStartContext.OperationBlocks.GetControlFlowGraph();
                                     var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(operationContext.Compilation);
                                     var interproceduralAnalysisConfig = InterproceduralAnalysisConfiguration.Create(
-                                        operationBlockStartContext.Options, Rule, InterproceduralAnalysisKind.ContextSensitive, operationBlockStartContext.CancellationToken);
+                                        operationBlockStartContext.Options, Rule, InterproceduralAnalysisKind.None, operationBlockStartContext.CancellationToken);
                                     var pointsToAnalysisResult = PointsToAnalysis.GetOrComputeResult(cfg,
                                         containingMethod, wellKnownTypeProvider, interproceduralAnalysisConfig,
                                         interproceduralAnalysisPredicateOpt: null,


### PR DESCRIPTION
…nalyzing the core Dispose method.

Hopefully this addresses https://github.com/dotnet/roslyn-analyzers/issues/2319#issuecomment-490145396. I do not have a repro or a trace to validate it though.