### PR TITLE
Fix points to analysis assert when argument value passed to a call mi…

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -10183,5 +10183,32 @@ class C
             // Test0.cs(10,22): warning CA2000: Call System.IDisposable.Dispose on object created by 'GetStream()' before all references to it are out of scope.
             GetCSharpResultAt(10, 22, "GetStream()"));
         }
+
+        [Fact]
+        public void PointsToAnalysisAssert_UninitializedLocalPassedToInvocation()
+        {
+            VerifyCSharp(@"
+using System;
+
+class C : IDisposable
+{
+    void M1()
+    {
+        IDisposable local;
+        M2(local);
+        local = new C();
+    }
+
+    void M2(IDisposable param)
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}", TestValidationMode.AllowCompileErrors,
+            // Test0.cs(10,17): warning CA2000: Call System.IDisposable.Dispose on object created by 'new C()' before all references to it are out of scope.
+            GetCSharpResultAt(10, 17, "new C()"));
+        }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -2102,6 +2102,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                         }
 
                         var argumentValue = GetCachedAbstractValue(argument);
+                        if (ReferenceEquals(argumentValue, ValueDomain.Bottom))
+                        {
+                            argumentValue = ValueDomain.UnknownOrMayBeValue;
+                        }
 
                         builder.Add(GetMappedParameterForArgument(argument), new ArgumentInfo<TAbstractAnalysisValue>(argument, argumentEntity, instanceLocation, argumentValue));
                         _pendingArgumentsToReset.Remove(argument);


### PR DESCRIPTION
…ght have undefined/bottom abstract value. I was only able to create a simple repro with errors, but it seems to be happening for error free real world code for invocation within catch block.