### PR TITLE
 Use MEF rules for export attribute inheritance

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/Core/ExportedPartsShouldHaveImportingConstructor.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ExportedPartsShouldHaveImportingConstructor.cs
@@ -46,8 +46,8 @@ namespace Roslyn.Diagnostics.Analyzers
                 var exportAttributeV1 = WellKnownTypes.MEFV1ExportAttribute(compilationContext.Compilation);
                 var importingConstructorAttributeV1 = WellKnownTypes.MEFV1ImportingConstructorAttribute(compilationContext.Compilation);
                 var exportAttributeV2 = WellKnownTypes.MEFV2ExportAttribute(compilationContext.Compilation);
+                var inheritedExportAttribute = WellKnownTypes.InheritedExportAttribute(compilationContext.Compilation);
                 var importingConstructorAttributeV2 = WellKnownTypes.MEFV2ImportingConstructorAttribute(compilationContext.Compilation);
-                var attributeUsageAttribute = WellKnownTypes.AttributeUsageAttribute(compilationContext.Compilation);
 
                 if (exportAttributeV1 is null && exportAttributeV2 is null)
                 {
@@ -68,22 +68,22 @@ namespace Roslyn.Diagnostics.Analyzers
                 compilationContext.RegisterSymbolAction(symbolContext =>
                 {
                     var namedType = (INamedTypeSymbol)symbolContext.Symbol;
-                    var namedTypeAttributes = namedType.GetApplicableAttributes(attributeUsageAttribute);
+                    var exportAttributes = namedType.GetApplicableExportAttributes(exportAttributeV1, exportAttributeV2, inheritedExportAttribute);
 
-                    AnalyzeSymbolForAttribute(ref symbolContext, exportAttributeV1, importingConstructorAttributeV1, namedType, namedTypeAttributes);
-                    AnalyzeSymbolForAttribute(ref symbolContext, exportAttributeV2, importingConstructorAttributeV2, namedType, namedTypeAttributes);
+                    AnalyzeSymbolForAttribute(ref symbolContext, exportAttributeV1, importingConstructorAttributeV1, namedType, exportAttributes);
+                    AnalyzeSymbolForAttribute(ref symbolContext, exportAttributeV2, importingConstructorAttributeV2, namedType, exportAttributes);
                 }, SymbolKind.NamedType);
             });
         }
 
-        private static void AnalyzeSymbolForAttribute(ref SymbolAnalysisContext context, INamedTypeSymbol exportAttributeOpt, INamedTypeSymbol importingConstructorAttribute, INamedTypeSymbol namedType, IEnumerable<AttributeData> namedTypeAttributes)
+        private static void AnalyzeSymbolForAttribute(ref SymbolAnalysisContext context, INamedTypeSymbol exportAttributeOpt, INamedTypeSymbol importingConstructorAttribute, INamedTypeSymbol namedType, IEnumerable<AttributeData> exportAttributes)
         {
             if (exportAttributeOpt is null)
             {
                 return;
             }
 
-            var exportAttributeApplication = namedTypeAttributes.FirstOrDefault(ad => ad.AttributeClass.DerivesFrom(exportAttributeOpt));
+            var exportAttributeApplication = exportAttributes.FirstOrDefault(ad => ad.AttributeClass.DerivesFrom(exportAttributeOpt));
             if (exportAttributeApplication is null)
             {
                 return;

--- a/src/Roslyn.Diagnostics.Analyzers/Core/ExportedPartsShouldHaveImportingConstructor.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ExportedPartsShouldHaveImportingConstructor.cs
@@ -43,10 +43,10 @@ namespace Roslyn.Diagnostics.Analyzers
 
             context.RegisterCompilationStartAction(compilationContext =>
             {
-                var exportAttributeV1 = compilationContext.Compilation.GetTypeByMetadataName("System.ComponentModel.Composition.ExportAttribute");
-                var importingConstructorAttributeV1 = compilationContext.Compilation.GetTypeByMetadataName("System.ComponentModel.Composition.ImportingConstructorAttribute");
-                var exportAttributeV2 = compilationContext.Compilation.GetTypeByMetadataName("System.Composition.ExportAttribute");
-                var importingConstructorAttributeV2 = compilationContext.Compilation.GetTypeByMetadataName("System.Composition.ImportingConstructorAttribute");
+                var exportAttributeV1 = WellKnownTypes.MEFV1ExportAttribute(compilationContext.Compilation);
+                var importingConstructorAttributeV1 = WellKnownTypes.MEFV1ImportingConstructorAttribute(compilationContext.Compilation);
+                var exportAttributeV2 = WellKnownTypes.MEFV2ExportAttribute(compilationContext.Compilation);
+                var importingConstructorAttributeV2 = WellKnownTypes.MEFV2ImportingConstructorAttribute(compilationContext.Compilation);
                 var attributeUsageAttribute = WellKnownTypes.AttributeUsageAttribute(compilationContext.Compilation);
 
                 if (exportAttributeV1 is null && exportAttributeV2 is null)

--- a/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
@@ -49,8 +49,8 @@ namespace Roslyn.Diagnostics.Analyzers
                 var exportAttributeV1 = WellKnownTypes.MEFV1ExportAttribute(compilationContext.Compilation);
                 var importingConstructorAttributeV1 = WellKnownTypes.MEFV1ImportingConstructorAttribute(compilationContext.Compilation);
                 var exportAttributeV2 = WellKnownTypes.MEFV2ExportAttribute(compilationContext.Compilation);
+                var inheritedExportAttribute = WellKnownTypes.InheritedExportAttribute(compilationContext.Compilation);
                 var importingConstructorAttributeV2 = WellKnownTypes.MEFV2ImportingConstructorAttribute(compilationContext.Compilation);
-                var attributeUsageAttribute = WellKnownTypes.AttributeUsageAttribute(compilationContext.Compilation);
 
                 if (exportAttributeV1 is null && exportAttributeV2 is null)
                 {
@@ -61,22 +61,22 @@ namespace Roslyn.Diagnostics.Analyzers
                 compilationContext.RegisterSymbolAction(symbolContext =>
                 {
                     var namedType = (INamedTypeSymbol)symbolContext.Symbol;
-                    var namedTypeAttributes = namedType.GetApplicableAttributes(attributeUsageAttribute);
+                    var exportAttributes = namedType.GetApplicableExportAttributes(exportAttributeV1, exportAttributeV2, inheritedExportAttribute);
 
-                    AnalyzeSymbolForAttribute(ref symbolContext, obsoleteAttribute, exportAttributeV1, importingConstructorAttributeV1, namedType, namedTypeAttributes);
-                    AnalyzeSymbolForAttribute(ref symbolContext, obsoleteAttribute, exportAttributeV2, importingConstructorAttributeV2, namedType, namedTypeAttributes);
+                    AnalyzeSymbolForAttribute(ref symbolContext, obsoleteAttribute, exportAttributeV1, importingConstructorAttributeV1, namedType, exportAttributes);
+                    AnalyzeSymbolForAttribute(ref symbolContext, obsoleteAttribute, exportAttributeV2, importingConstructorAttributeV2, namedType, exportAttributes);
                 }, SymbolKind.NamedType);
             });
         }
 
-        private static void AnalyzeSymbolForAttribute(ref SymbolAnalysisContext context, INamedTypeSymbol obsoleteAttribute, INamedTypeSymbol exportAttributeOpt, INamedTypeSymbol importingConstructorAttribute, INamedTypeSymbol namedType, IEnumerable<AttributeData> namedTypeAttributes)
+        private static void AnalyzeSymbolForAttribute(ref SymbolAnalysisContext context, INamedTypeSymbol obsoleteAttribute, INamedTypeSymbol exportAttributeOpt, INamedTypeSymbol importingConstructorAttribute, INamedTypeSymbol namedType, IEnumerable<AttributeData> exportAttributes)
         {
             if (exportAttributeOpt is null)
             {
                 return;
             }
 
-            if (!namedTypeAttributes.Any(ad => ad.AttributeClass.DerivesFrom(exportAttributeOpt)))
+            if (!exportAttributes.Any(ad => ad.AttributeClass.DerivesFrom(exportAttributeOpt)))
             {
                 return;
             }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
@@ -45,11 +45,11 @@ namespace Roslyn.Diagnostics.Analyzers
 
             context.RegisterCompilationStartAction(compilationContext =>
             {
-                var obsoleteAttribute = compilationContext.Compilation.GetTypeByMetadataName("System.ObsoleteAttribute");
-                var exportAttributeV1 = compilationContext.Compilation.GetTypeByMetadataName("System.ComponentModel.Composition.ExportAttribute");
-                var importingConstructorAttributeV1 = compilationContext.Compilation.GetTypeByMetadataName("System.ComponentModel.Composition.ImportingConstructorAttribute");
-                var exportAttributeV2 = compilationContext.Compilation.GetTypeByMetadataName("System.Composition.ExportAttribute");
-                var importingConstructorAttributeV2 = compilationContext.Compilation.GetTypeByMetadataName("System.Composition.ImportingConstructorAttribute");
+                var obsoleteAttribute = WellKnownTypes.ObsoleteAttribute(compilationContext.Compilation);
+                var exportAttributeV1 = WellKnownTypes.MEFV1ExportAttribute(compilationContext.Compilation);
+                var importingConstructorAttributeV1 = WellKnownTypes.MEFV1ImportingConstructorAttribute(compilationContext.Compilation);
+                var exportAttributeV2 = WellKnownTypes.MEFV2ExportAttribute(compilationContext.Compilation);
+                var importingConstructorAttributeV2 = WellKnownTypes.MEFV2ImportingConstructorAttribute(compilationContext.Compilation);
                 var attributeUsageAttribute = WellKnownTypes.AttributeUsageAttribute(compilationContext.Compilation);
 
                 if (exportAttributeV1 is null && exportAttributeV2 is null)

--- a/src/Roslyn.Diagnostics.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
@@ -52,8 +52,9 @@ namespace Roslyn.Diagnostics.Analyzers
                 {
                     var namedType = (INamedTypeSymbol)symbolContext.Symbol;
                     var namedTypeAttributes = namedType.GetApplicableAttributes(attributeUsageAttribute);
+                    var exportAttributes = namedType.GetApplicableExportAttributes(exportAttributeV1: null, exportAttribute, inheritedExportAttribute: null);
 
-                    var exportAttributeApplication = namedTypeAttributes.FirstOrDefault(ad => ad.AttributeClass.DerivesFrom(exportAttribute));
+                    var exportAttributeApplication = exportAttributes.FirstOrDefault();
 
                     if (exportAttributeApplication != null)
                     {

--- a/src/Roslyn.Diagnostics.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
@@ -39,7 +39,7 @@ namespace Roslyn.Diagnostics.Analyzers
 
             context.RegisterCompilationStartAction(compilationContext =>
             {
-                var exportAttribute = compilationContext.Compilation.GetTypeByMetadataName("System.Composition.ExportAttribute");
+                var exportAttribute = WellKnownTypes.MEFV2ExportAttribute(compilationContext.Compilation);
                 var attributeUsageAttribute = WellKnownTypes.AttributeUsageAttribute(compilationContext.Compilation);
 
                 if (exportAttribute == null)

--- a/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
@@ -15,7 +15,6 @@ namespace Roslyn.Diagnostics.Analyzers
     public abstract class SpecializedEnumerableCreationAnalyzer : DiagnosticAnalyzer
     {
         internal const string SpecializedCollectionsMetadataName = "Roslyn.Utilities.SpecializedCollections";
-        internal const string IEnumerableMetadataName = "System.Collections.Generic.IEnumerable`1";
         internal const string LinqEnumerableMetadataName = "System.Linq.Enumerable";
         internal const string EmptyMethodName = "Empty";
 
@@ -64,7 +63,7 @@ namespace Roslyn.Diagnostics.Analyzers
                         return;
                     }
 
-                    INamedTypeSymbol genericEnumerableSymbol = context.Compilation.GetTypeByMetadataName(IEnumerableMetadataName);
+                    INamedTypeSymbol genericEnumerableSymbol = WellKnownTypes.GenericIEnumerable(context.Compilation);
                     if (genericEnumerableSymbol == null)
                     {
                         return;

--- a/src/Roslyn.Diagnostics.Analyzers/Core/TestExportsShouldNotBeDiscoverable.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/TestExportsShouldNotBeDiscoverable.cs
@@ -44,8 +44,8 @@ namespace Roslyn.Diagnostics.Analyzers
 
             context.RegisterCompilationStartAction(compilationContext =>
             {
-                var exportAttributeV1 = compilationContext.Compilation.GetTypeByMetadataName("System.ComponentModel.Composition.ExportAttribute");
-                var exportAttributeV2 = compilationContext.Compilation.GetTypeByMetadataName("System.Composition.ExportAttribute");
+                var exportAttributeV1 = WellKnownTypes.MEFV1ExportAttribute(compilationContext.Compilation);
+                var exportAttributeV2 = WellKnownTypes.MEFV2ExportAttribute(compilationContext.Compilation);
                 var attributeUsageAttribute = WellKnownTypes.AttributeUsageAttribute(compilationContext.Compilation);
 
                 if (exportAttributeV1 is null && exportAttributeV2 is null)

--- a/src/Roslyn.Diagnostics.Analyzers/Core/TestExportsShouldNotBeDiscoverable.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/TestExportsShouldNotBeDiscoverable.cs
@@ -46,6 +46,7 @@ namespace Roslyn.Diagnostics.Analyzers
             {
                 var exportAttributeV1 = WellKnownTypes.MEFV1ExportAttribute(compilationContext.Compilation);
                 var exportAttributeV2 = WellKnownTypes.MEFV2ExportAttribute(compilationContext.Compilation);
+                var inheritedExportAttribute = WellKnownTypes.InheritedExportAttribute(compilationContext.Compilation);
                 var attributeUsageAttribute = WellKnownTypes.AttributeUsageAttribute(compilationContext.Compilation);
 
                 if (exportAttributeV1 is null && exportAttributeV2 is null)
@@ -57,22 +58,23 @@ namespace Roslyn.Diagnostics.Analyzers
                 compilationContext.RegisterSymbolAction(symbolContext =>
                 {
                     var namedType = (INamedTypeSymbol)symbolContext.Symbol;
+                    var exportAttributes = namedType.GetApplicableExportAttributes(exportAttributeV1, exportAttributeV2, inheritedExportAttribute);
                     var namedTypeAttributes = namedType.GetApplicableAttributes(attributeUsageAttribute);
 
-                    AnalyzeSymbolForAttribute(ref symbolContext, exportAttributeV1, namedType, namedTypeAttributes);
-                    AnalyzeSymbolForAttribute(ref symbolContext, exportAttributeV2, namedType, namedTypeAttributes);
+                    AnalyzeSymbolForAttribute(ref symbolContext, exportAttributeV1, namedType, exportAttributes, namedTypeAttributes);
+                    AnalyzeSymbolForAttribute(ref symbolContext, exportAttributeV2, namedType, exportAttributes, namedTypeAttributes);
                 }, SymbolKind.NamedType);
             });
         }
 
-        private static void AnalyzeSymbolForAttribute(ref SymbolAnalysisContext context, INamedTypeSymbol exportAttributeOpt, INamedTypeSymbol namedType, IEnumerable<AttributeData> namedTypeAttributes)
+        private static void AnalyzeSymbolForAttribute(ref SymbolAnalysisContext context, INamedTypeSymbol exportAttributeOpt, INamedTypeSymbol namedType, IEnumerable<AttributeData> exportAttributes, IEnumerable<AttributeData> namedTypeAttributes)
         {
             if (exportAttributeOpt is null)
             {
                 return;
             }
 
-            var exportAttributeApplication = namedTypeAttributes.FirstOrDefault(ad => ad.AttributeClass.DerivesFrom(exportAttributeOpt));
+            var exportAttributeApplication = exportAttributes.FirstOrDefault(ad => ad.AttributeClass.DerivesFrom(exportAttributeOpt));
             if (exportAttributeApplication is null)
             {
                 return;

--- a/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
@@ -207,6 +207,42 @@ namespace Analyzer.Utilities.Extensions
             }
         }
 
+        public static IEnumerable<AttributeData> GetApplicableExportAttributes(this INamedTypeSymbol type, INamedTypeSymbol exportAttributeV1, INamedTypeSymbol exportAttributeV2, INamedTypeSymbol inheritedExportAttribute)
+        {
+            var attributes = new List<AttributeData>();
+            var onlyIncludeInherited = false;
+
+            while (type != null)
+            {
+                var current = type.GetAttributes();
+                foreach (var attribute in current)
+                {
+                    if (attribute.AttributeClass.Inherits(inheritedExportAttribute))
+                    {
+                        attributes.Add(attribute);
+                    }
+                    else if (!onlyIncludeInherited)
+                    {
+                        if (attribute.AttributeClass.Inherits(exportAttributeV1)
+                            || attribute.AttributeClass.Inherits(exportAttributeV2))
+                        {
+                            attributes.Add(attribute);
+                        }
+                    }
+                }
+
+                if (inheritedExportAttribute is null)
+                {
+                    break;
+                }
+
+                type = type.BaseType;
+                onlyIncludeInherited = true;
+            }
+
+            return attributes;
+        }
+
         public static bool IsAttribute(this ITypeSymbol symbol)
         {
             for (INamedTypeSymbol b = symbol.BaseType; b != null; b = b.BaseType)

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -230,7 +230,9 @@ namespace Analyzer.Utilities
         public const string SystemRuntimeInteropServicesHandleRef = "System.Runtime.InteropServices.HandleRef";
         public const string SystemRuntimeSerializationDataMemberAttribute = "System.Runtime.Serialization.DataMemberAttribute";
         public const string SystemComponentModelCompositionExportAttribute = "System.ComponentModel.Composition.ExportAttribute";
+        public const string SystemComponentModelCompositionImportingConstructorAttribute = "System.ComponentModel.Composition.ImportingConstructorAttribute";
         public const string SystemCompositionExportAttribute = "System.Composition.ExportAttribute";
+        public const string SystemCompositionImportingConstructorAttribute = "System.Composition.ImportingConstructorAttribute";
         public const string SystemDiagnosticsContractsPureAttribute = "System.Diagnostics.Contracts.PureAttribute";
         public const string SystemComponentModelLocalizableAttribute = "System.ComponentModel.LocalizableAttribute";
         public const string SystemRuntimeSerializationOnSerializingAttribute = "System.Runtime.Serialization.OnSerializingAttribute";

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -230,6 +230,7 @@ namespace Analyzer.Utilities
         public const string SystemRuntimeInteropServicesHandleRef = "System.Runtime.InteropServices.HandleRef";
         public const string SystemRuntimeSerializationDataMemberAttribute = "System.Runtime.Serialization.DataMemberAttribute";
         public const string SystemComponentModelCompositionExportAttribute = "System.ComponentModel.Composition.ExportAttribute";
+        public const string SystemComponentModelCompositionInheritedExportAttribute = "System.ComponentModel.Composition.InheritedExportAttribute";
         public const string SystemComponentModelCompositionImportingConstructorAttribute = "System.ComponentModel.Composition.ImportingConstructorAttribute";
         public const string SystemCompositionExportAttribute = "System.Composition.ExportAttribute";
         public const string SystemCompositionImportingConstructorAttribute = "System.Composition.ImportingConstructorAttribute";

--- a/src/Utilities/Compiler/WellKnownTypes.cs
+++ b/src/Utilities/Compiler/WellKnownTypes.cs
@@ -413,6 +413,11 @@ namespace Analyzer.Utilities
             return compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemCompositionExportAttribute);
         }
 
+        public static INamedTypeSymbol InheritedExportAttribute(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemComponentModelCompositionInheritedExportAttribute);
+        }
+
         public static INamedTypeSymbol MEFV1ImportingConstructorAttribute(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemComponentModelCompositionImportingConstructorAttribute);

--- a/src/Utilities/Compiler/WellKnownTypes.cs
+++ b/src/Utilities/Compiler/WellKnownTypes.cs
@@ -413,6 +413,16 @@ namespace Analyzer.Utilities
             return compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemCompositionExportAttribute);
         }
 
+        public static INamedTypeSymbol MEFV1ImportingConstructorAttribute(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemComponentModelCompositionImportingConstructorAttribute);
+        }
+
+        public static INamedTypeSymbol MEFV2ImportingConstructorAttribute(Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemCompositionImportingConstructorAttribute);
+        }
+
         public static INamedTypeSymbol LocalizableAttribute(Compilation compilation)
         {
             return compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemComponentModelLocalizableAttribute);


### PR DESCRIPTION
`ExportAttribute` is not treated as inherited unless the attribute type inherits `InheritedExportAttribute`.