### PR TITLE
A pinch of ValueContentAnalysis for DoNotSetSwitch

### DIFF
--- a/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
@@ -363,6 +363,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContainsN
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContainsNonLiteralState.Undefined = 1 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContainsNonLiteralState
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue.IsLiteralState.get -> bool
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue.TryGetSingleLiteral<T>(out T literalValue) -> bool
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue.LiteralValues.get -> System.Collections.Immutable.ImmutableHashSet<object>
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue.NonLiteralState.get -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContainsNonLiteralState
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysis

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
@@ -138,7 +138,6 @@ class TestClass
 }");
         }
 
-        //Ideally, we would generate a diagnostic in this case.
         [Fact]
         public void TestSwitchNameVariableNoDiagnostic()
         {
@@ -152,7 +151,8 @@ class TestClass
         string switchName = ""Switch.System.Net.DontEnableSchUseStrongCrypto"";
         AppContext.SetSwitch(switchName, true);
     }
-}");
+}",
+            GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch"));
         }
 
         //Ideally, we would generate a diagnostic in this case.

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
@@ -133,7 +133,6 @@ class TestClass
 }");
         }
 
-        //Ideally, we would generate a diagnostic in this case.
         [Fact]
         public void TestSwitchNameVariableNoDiagnostic()
         {
@@ -147,7 +146,8 @@ class TestClass
         string switchName = ""Switch.System.ServiceModel.DisableUsingServicePointManagerSecurityProtocols"";
         AppContext.SetSwitch(switchName, true);
     }
-}");
+}",
+                GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch"));
         }
 
         //Ideally, we would generate a diagnostic in this case.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
@@ -205,6 +205,34 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
 
         public bool IsLiteralState => !LiteralValues.IsEmpty && NonLiteralState == ValueContainsNonLiteralState.No;
 
+        /// <summary>
+        /// For super simple cases: If this abstract value is a single literal, then get that literal value.
+        /// </summary>
+        /// <typeparam name="T">Type of the expected literal value.</typeparam>
+        /// <param name="literalValue">Literal value, or its default if not a single literal value.</param>
+        /// <returns>True if a literal value was found, false otherwise.</returns>
+        /// <remarks>If you're looking for null, you should be looking at <see cref="PointsToAnalysis"/>.</remarks>
+        public bool TryGetSingleLiteral<T>(out T literalValue)
+        {
+            if (!IsLiteralState || LiteralValues.Count != 1)
+            {
+                literalValue = default;
+                return false;
+            }
+
+            object o = LiteralValues.First();
+            if (o is T)
+            {
+                literalValue = (T)o;
+                return true;
+            }
+            else
+            {
+                literalValue = default;
+                return false;
+            }
+        }
+
         internal ValueContentAbstractValue IntersectLiteralValues(ValueContentAbstractValue value2)
         {
             Debug.Assert(IsLiteralState);


### PR DESCRIPTION
Someone wrote an example using a variable rather than a constant for the switch name, so just enabling those test cases and handling them with ValueContentAnalysis.