### PR TITLE
Add RestrictedInternalsVisibleToAnalyzer

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/CSharp/CSharpRestrictedInternalsVisibleToAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/CSharp/CSharpRestrictedInternalsVisibleToAnalyzer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.BannedApiAnalyzers;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class CSharpRestrictedInternalsVisibleToAnalyzer : RestrictedInternalsVisibleToAnalyzer<NameSyntax, SyntaxKind>
+    {
+        protected override ImmutableArray<SyntaxKind> NameSyntaxKinds =>
+            ImmutableArray.Create(
+                SyntaxKind.IdentifierName,
+                SyntaxKind.GenericName,
+                SyntaxKind.QualifiedName,
+                SyntaxKind.AliasQualifiedName);
+
+        protected override bool IsInTypeOnlyContext(NameSyntax node)
+            => SyntaxFacts.IsInTypeOnlyContext(node);
+    }
+}

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/BannedApiAnalyzerResources.resx
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/BannedApiAnalyzerResources.resx
@@ -139,7 +139,7 @@
     <value>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</value>
   </data>
   <data name="RestrictedInternalsVisibleToMessage" xml:space="preserve">
-    <value>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</value>
+    <value>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</value>
   </data>
   <data name="RestrictedInternalsVisibleToTitle" xml:space="preserve">
     <value>External access is prohibited to internal symbols outside the restricted namespace(s)</value>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/BannedApiAnalyzerResources.resx
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/BannedApiAnalyzerResources.resx
@@ -136,12 +136,12 @@
     <value>Do not used banned APIs</value>
   </data>
   <data name="RestrictedInternalsVisibleToDescription" xml:space="preserve">
-    <value>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</value>
+    <value>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</value>
   </data>
   <data name="RestrictedInternalsVisibleToMessage" xml:space="preserve">
-    <value>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</value>
+    <value>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</value>
   </data>
   <data name="RestrictedInternalsVisibleToTitle" xml:space="preserve">
-    <value>External access is prohibited to internal symbols outside the restricted namespace(s)</value>
+    <value>External access to internal symbols outside the restricted namespace(s) is prohibited</value>
   </data>
 </root>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/BannedApiAnalyzerResources.resx
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/BannedApiAnalyzerResources.resx
@@ -135,4 +135,13 @@
   <data name="SymbolIsBannedTitle" xml:space="preserve">
     <value>Do not used banned APIs</value>
   </data>
+  <data name="RestrictedInternalsVisibleToDescription" xml:space="preserve">
+    <value>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</value>
+  </data>
+  <data name="RestrictedInternalsVisibleToMessage" xml:space="preserve">
+    <value>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</value>
+  </data>
+  <data name="RestrictedInternalsVisibleToTitle" xml:space="preserve">
+    <value>External access is prohibited to internal symbols outside the restricted namespace(s)</value>
+  </data>
 </root>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
@@ -212,8 +212,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                     // Check if this namespace is explicitly marked as allowed through restricted IVT.
                     if (allowedNamespaces.Contains(currentNamespace.ToDisplayString()))
                     {
-                        var banned = namespaceToIsBannedMap.GetOrAdd(currentNamespace, false);
-                        Debug.Assert(!banned);
+                        MarkIsBanned(symbol.ContainingNamespace, currentNamespace, banned: false);
                         return false;
                     }
 
@@ -222,16 +221,28 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
                 // Otherwise, mark all the containing namespace names of the given symbol as banned
                 // and consider the given symbol as banned.
-                currentNamespace = symbol.ContainingNamespace;
+                MarkIsBanned(symbol.ContainingNamespace, currentNamespace, banned: true);
+                return true;
+            }
+
+            void MarkIsBanned(INamespaceSymbol startNamespace, INamespaceSymbol uptoNamespace, bool banned)
+            {
+                var currentNamespace = startNamespace;
                 while (currentNamespace != null)
                 {
-                    var isBanned = namespaceToIsBannedMap.GetOrAdd(currentNamespace, true);
-                    Debug.Assert(isBanned);
+                    var saved = namespaceToIsBannedMap.GetOrAdd(currentNamespace, banned);
+                    Debug.Assert(saved == banned);
+
+                    if (Equals(currentNamespace, uptoNamespace))
+                    {
+                        break;
+                    }
+
                     currentNamespace = currentNamespace.ContainingNamespace;
                 }
-
-                return true;
             }
         }
     }
 }
+
+

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
@@ -1,0 +1,236 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+using DiagnosticIds = Roslyn.Diagnostics.Analyzers.RoslynDiagnosticIds;
+
+namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
+{
+    public abstract class RestrictedInternalsVisibleToAnalyzer<TNameSyntax, TSyntaxKind> : DiagnosticAnalyzer
+        where TNameSyntax : SyntaxNode
+        where TSyntaxKind : struct
+    {
+        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            id: DiagnosticIds.RestrictedInternalsVisibleToRuleId,
+            title: BannedApiAnalyzerResources.RestrictedInternalsVisibleToTitle,
+            messageFormat: BannedApiAnalyzerResources.RestrictedInternalsVisibleToMessage,
+            category: "ApiDesign",
+            defaultSeverity: DiagnosticSeverity.Error,  // Force build break on invalid external access.
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+            description: BannedApiAnalyzerResources.RestrictedInternalsVisibleToDescription,
+            helpLinkUri: null, // TODO: Add help link
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        protected abstract ImmutableArray<TSyntaxKind> NameSyntaxKinds { get; }
+
+        protected abstract bool IsInTypeOnlyContext(TNameSyntax node);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+
+            // Analyzer needs to get callbacks for generated code, and might report diagnostics in generated code.
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
+        {
+            var restrictedInternalsVisibleToMap = GetRestrictedInternalsVisibleToMap(compilationContext.Compilation);
+            if (restrictedInternalsVisibleToMap.IsEmpty)
+            {
+                return;
+            }
+
+            var namespaceToIsBannedMap = new ConcurrentDictionary<INamespaceSymbol, /*isBanned*/bool>();
+
+            // Verify all explicit type name specifications in declarations and executable code.
+            compilationContext.RegisterSyntaxNodeAction(
+                context =>
+                {
+                    var name = (TNameSyntax)context.Node;
+                    if (!IsInTypeOnlyContext(name) ||
+                        name.Parent is TNameSyntax)
+                    {
+                        // Bail out if we are not in type only context or the parent is also a name
+                        // which will be analyzed separately.
+                        return;
+                    }
+
+                    var typeInfo = context.SemanticModel.GetTypeInfo(name, context.CancellationToken);
+                    VerifySymbol(typeInfo.Type as INamedTypeSymbol, name, context.ReportDiagnostic);
+                },
+                NameSyntaxKinds);
+
+            // Verify all member usages in executable code.
+            compilationContext.RegisterOperationAction(
+                context =>
+                {
+                    ISymbol symbol;
+                    switch (context.Operation)
+                    {
+                        case IObjectCreationOperation objectCreation:
+                            symbol = objectCreation.Constructor;
+                            break;
+                        case IInvocationOperation invocation:
+                            symbol = invocation.TargetMethod;
+                            break;
+                        case IMemberReferenceOperation memberReference:
+                            symbol = memberReference.Member;
+                            break;
+                        default:
+                            throw new NotImplementedException($"Unhandled OperationKind: {context.Operation.Kind}");
+                    }
+
+                    VerifySymbol(symbol, context.Operation.Syntax, context.ReportDiagnostic);
+                },
+                OperationKind.ObjectCreation,
+                OperationKind.Invocation,
+                OperationKind.EventReference,
+                OperationKind.FieldReference,
+                OperationKind.MethodReference,
+                OperationKind.PropertyReference);
+
+            return;
+
+            // Local functions.
+            static ImmutableDictionary<IAssemblySymbol, ImmutableSortedSet<string>> GetRestrictedInternalsVisibleToMap(Compilation compilation)
+            {
+                var restrictedInternalsVisibleToAttribute = compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.RestrictedInternalsVisibleToAttribute");
+                if (restrictedInternalsVisibleToAttribute == null)
+                {
+                    return ImmutableDictionary<IAssemblySymbol, ImmutableSortedSet<string>>.Empty;
+                }
+
+                var builder = ImmutableDictionary.CreateBuilder<IAssemblySymbol, ImmutableSortedSet<string>>();
+                foreach (var referencedAssemblySymbol in compilation.References.Select(compilation.GetAssemblyOrModuleSymbol).OfType<IAssemblySymbol>())
+                {
+                    // Check IVT
+                    if (!referencedAssemblySymbol.GivesAccessTo(compilation.Assembly))
+                    {
+                        continue;
+                    }
+
+                    var namespaceNameComparer = compilation.IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+                    var namespaceBuilder = ImmutableSortedSet.CreateBuilder(namespaceNameComparer);
+                    foreach (var assemblyAttribute in referencedAssemblySymbol.GetAttributes())
+                    {
+                        // Look for ctor: "RestrictedInternalsVisibleToAttribute(string assemblyName, params string[] namespaces)"
+                        if (!Equals(assemblyAttribute.AttributeClass, restrictedInternalsVisibleToAttribute) ||
+                            assemblyAttribute.AttributeConstructor.Parameters.Length != 2 ||
+                            assemblyAttribute.AttributeConstructor.Parameters[0].Type.SpecialType != SpecialType.System_String ||
+                            !(assemblyAttribute.AttributeConstructor.Parameters[1].Type is IArrayTypeSymbol arrayType) ||
+                            arrayType.Rank != 1 ||
+                            arrayType.ElementType.SpecialType != SpecialType.System_String ||
+                            !assemblyAttribute.AttributeConstructor.Parameters[1].IsParams)
+                        {
+                            continue;
+                        }
+
+                        // Ensure the Restricted IVT is for the current compilation's assembly.
+                        if (assemblyAttribute.ConstructorArguments.Length != 2 ||
+                            assemblyAttribute.ConstructorArguments[0].Kind != TypedConstantKind.Primitive ||
+                            !(assemblyAttribute.ConstructorArguments[0].Value is string assemblyName) ||
+                            !AssemblyIdentity.TryParseDisplayName(assemblyName, out var assemblyIdentity) ||
+                            AssemblyIdentityComparer.Default.Compare(assemblyIdentity, compilation.Assembly.Identity) == AssemblyIdentityComparer.ComparisonResult.NotEquivalent)
+                        {
+                            continue;
+                        }
+
+                        // Ensure second constructor argument is string array.
+                        if (assemblyAttribute.ConstructorArguments[1].Kind != TypedConstantKind.Array ||
+                            !(assemblyAttribute.ConstructorArguments[1].Values is var namespaceConstants))
+                        {
+                            continue;
+                        }
+
+                        // Add namespaces specified in the second constructor argument.
+                        foreach (TypedConstant namespaceConstant in namespaceConstants)
+                        {
+                            if (namespaceConstant.Kind == TypedConstantKind.Primitive &&
+                                namespaceConstant.Value is string namespaceName)
+                            {
+                                namespaceBuilder.Add(namespaceName);
+                            }
+                        }
+                    }
+
+                    if (namespaceBuilder.Count > 0)
+                    {
+                        builder.Add(referencedAssemblySymbol, namespaceBuilder.ToImmutable());
+                    }
+                }
+
+                return builder.ToImmutable();
+            }
+
+            void VerifySymbol(ISymbol symbol, SyntaxNode node, Action<Diagnostic> reportDiagnostic)
+            {
+                if (symbol != null &&
+                    IsBannedSymbol(symbol))
+                {
+                    var bannedSymbolDisplayString = symbol.ToDisplayString(SymbolDisplayFormats.QualifiedTypeAndNamespaceSymbolDisplayFormat);
+                    var restrictedNamespaces = string.Join(", ", restrictedInternalsVisibleToMap[symbol.ContainingAssembly]);
+                    var diagnostic = node.CreateDiagnostic(Rule, bannedSymbolDisplayString, restrictedNamespaces);
+                    reportDiagnostic(diagnostic);
+                }
+            }
+
+            bool IsBannedSymbol(ISymbol symbol)
+            {
+                // Check if the symbol belongs to an assembly to which this compilation has restricted internals access
+                // and it is an internal symbol.
+                if (!restrictedInternalsVisibleToMap.TryGetValue(symbol.ContainingAssembly, out var allowedNamespaces) ||
+                    symbol.GetResultantVisibility() != SymbolVisibility.Internal)
+                {
+                    return false;
+                }
+
+                // Walk up containing namespace chain to explicitly look for an allowed namespace
+                // with restricted internals access.
+                var currentNamespace = symbol.ContainingNamespace;
+                while (currentNamespace != null && !currentNamespace.IsGlobalNamespace)
+                {
+                    // Check if we have already computed whether this namespace is banned or not.
+                    if (namespaceToIsBannedMap.TryGetValue(currentNamespace, out var isBanned))
+                    {
+                        return isBanned;
+                    }
+
+                    // Check if this namespace is explicitly marked as allowed through restricted IVT.
+                    if (allowedNamespaces.Contains(currentNamespace.ToDisplayString()))
+                    {
+                        var banned = namespaceToIsBannedMap.GetOrAdd(currentNamespace, false);
+                        Debug.Assert(!banned);
+                        return false;
+                    }
+
+                    currentNamespace = currentNamespace.ContainingNamespace;
+                }
+
+                // Otherwise, mark all the containing namespace names of the given symbol as banned
+                // and consider the given symbol as banned.
+                currentNamespace = symbol.ContainingNamespace;
+                while (currentNamespace != null)
+                {
+                    var isBanned = namespaceToIsBannedMap.GetOrAdd(currentNamespace, true);
+                    Debug.Assert(isBanned);
+                    currentNamespace = currentNamespace.ContainingNamespace;
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
@@ -181,8 +181,9 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                     IsBannedSymbol(symbol))
                 {
                     var bannedSymbolDisplayString = symbol.ToDisplayString(SymbolDisplayFormats.QualifiedTypeAndNamespaceSymbolDisplayFormat);
+                    var assemblyName = symbol.ContainingAssembly.Name;
                     var restrictedNamespaces = string.Join(", ", restrictedInternalsVisibleToMap[symbol.ContainingAssembly]);
-                    var diagnostic = node.CreateDiagnostic(Rule, bannedSymbolDisplayString, restrictedNamespaces);
+                    var diagnostic = node.CreateDiagnostic(Rule, bannedSymbolDisplayString, assemblyName, restrictedNamespaces);
                     reportDiagnostic(diagnostic);
                 }
             }

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.cs.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Seznam zakázaných symbolů obsahuje duplicitu</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">Symbol se v tomto projektu označil jako zakázaný, měla by se místo něj použít nějaká alternativa.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.cs.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.de.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.de.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Liste gesperrter Symbole enthält ein Duplikat</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">Das Symbol wurde in diesem Projekt als gesperrt gekennzeichnet, und es muss stattdessen eine Alternative verwendet werden.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.es.xlf
@@ -17,6 +17,21 @@
         <target state="translated">La lista de símbolos prohibidos contiene un duplicado</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">El símbolo se ha marcado como prohibido en el proyecto y se debe usar uno alternativo en su lugar.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.es.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.fr.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.fr.xlf
@@ -17,6 +17,21 @@
         <target state="translated">La liste des symboles interdits contient un doublon</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">Le symbole a été marqué comme étant interdit dans ce projet. Un autre symbole doit être utilisé à la place.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.it.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.it.xlf
@@ -17,6 +17,21 @@
         <target state="translated">L'elenco dei simboli vietati contiene un duplicato</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">Il simbolo è stato contrassegnato come vietato in questo progetto ed è necessario usare un'alternativa.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ja.xlf
@@ -17,6 +17,21 @@
         <target state="translated">禁止されたシンボルの一覧に重複が含まれています</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">シンボルはこのプロジェクトで禁止とマークされているため、ほかのものを使用する必要があります。</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ja.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ko.xlf
@@ -17,6 +17,21 @@
         <target state="translated">금지된 기호 목록에 중복이 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">해당 기호는 이 프로젝트에서 금지됨으로 표시되었고 대체 항목을 대신 사용해야 합니다.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ko.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pl.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Lista zabronionych symboli zawiera duplikat</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">Symbol został oznaczony jako zabroniony w tym projekcie i zamiast niego powinien być używany alternatywny.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pl.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pt-BR.xlf
@@ -17,6 +17,21 @@
         <target state="translated">A lista de símbolos banidos contém uma duplicata</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">O símbolo foi marcado como banido neste projeto. Nesse caso, é necessário usar um símbolo alternativo.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.pt-BR.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ru.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.ru.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Список запрещенных символов содержит дубликат</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">Символ был помечен как запрещенный в этом проекте, вместо него следует использовать альтернативный вариант.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.tr.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Yasaklanan semboller listesi yinelenen bir öğe içeriyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">Sembol bu projede yasaklanan olarak işaretlendiğinden bunun yerine başka bir sembol kullanılması gerekiyor.</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.tr.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hans.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hans.xlf
@@ -17,6 +17,21 @@
         <target state="translated">禁用符号列表中包含重复项</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">此项目中已将该符号标记为禁用，应改为使用替换符号。</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hant.xlf
@@ -17,6 +17,21 @@
         <target state="translated">禁止的符號清單包含重複項目</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToDescription">
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToMessage">
+        <source>External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Access is only allowed to symbols in these restricted namespace(s): '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestrictedInternalsVisibleToTitle">
+        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
+        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">
         <source>The symbol has been marked as banned in this project, and an alternate should be used instead.</source>
         <target state="translated">符號已標示為在此專案中禁用，因此應改用替代符號。</target>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/xlf/BannedApiAnalyzerResources.zh-Hant.xlf
@@ -18,18 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToDescription">
-        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</source>
-        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute to limit access to internal symbols only within specified namespaces. Each referencing assembly is only allowed to access internal symbols within the restricted namespaces that the referenced assembly allows.</target>
+        <source>RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</source>
+        <target state="new">RestrictedInternalsVisibleToAttribute enables a restricted version of InternalsVisibleToAttribute that limits access to internal symbols to those within specified namespaces. Each referencing assembly can only access internal symbols defined in the restricted namespaces that the referenced assembly allows.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToMessage">
-        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</source>
-        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in following namespace(s): '{2}'</target>
+        <source>External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</source>
+        <target state="new">External access to internal symbol '{0}' is prohibited. Assembly '{1}' only allows access to internal symbols defined in the following namespace(s): '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="RestrictedInternalsVisibleToTitle">
-        <source>External access is prohibited to internal symbols outside the restricted namespace(s)</source>
-        <target state="new">External access is prohibited to internal symbols outside the restricted namespace(s)</target>
+        <source>External access to internal symbols outside the restricted namespace(s) is prohibited</source>
+        <target state="new">External access to internal symbols outside the restricted namespace(s) is prohibited</target>
         <note />
       </trans-unit>
       <trans-unit id="SymbolIsBannedDescription">

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
@@ -18,14 +18,14 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers.UnitTests
         {
             return new DiagnosticResult(CSharpRestrictedInternalsVisibleToAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithArguments(bannedSymbolName, restrictedNamespaces);
+                .WithArguments(bannedSymbolName, ApiProviderProjectName, restrictedNamespaces);
         }
 
         private static new DiagnosticResult GetBasicResultAt(int line, int column, string bannedSymbolName, string restrictedNamespaces)
         {
             return new DiagnosticResult(BasicRestrictedInternalsVisibleToAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithArguments(bannedSymbolName, restrictedNamespaces);
+                .WithArguments(bannedSymbolName, ApiProviderProjectName, restrictedNamespaces);
         }
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new BasicRestrictedInternalsVisibleToAnalyzer();

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers;
 using Xunit;
@@ -171,7 +172,7 @@ End Class";
 
             await VerifyBasicAsync(apiProviderSource, apiConsumerSource,
                 DiagnosticResult.CompilerError("BC30389")
-                    .WithLocation(3, 24)
+                    .WithLocation("Test0.vb", new LinePosition(2, 23), DiagnosticLocationOptions.IgnoreAdditionalLocations)
                     .WithMessage("'N1.C1' is not accessible in this context because it is 'Friend'."));
         }
 
@@ -261,7 +262,7 @@ End Class";
 
             await VerifyBasicAsync(apiProviderSource, apiConsumerSource,
                 new DiagnosticResult("BC30389", DiagnosticSeverity.Error)
-                    .WithLocation(3, 24)
+                    .WithLocation("Test0.vb", new LinePosition(2, 23), DiagnosticLocationOptions.IgnoreAdditionalLocations)
                     .WithMessage("'N1.C1' is not accessible in this context because it is 'Friend'."));
         }
 

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
@@ -1,0 +1,1864 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.BannedApiAnalyzers.UnitTests
+{
+    public class RestrictedInternalsVisibleToAnalyzerTests : DiagnosticAnalyzerTestBase
+    {
+        private static new DiagnosticResult GetCSharpResultAt(int line, int column, string bannedSymbolName, string restrictedNamespaces)
+        {
+            return new DiagnosticResult(CSharpRestrictedInternalsVisibleToAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(bannedSymbolName, restrictedNamespaces);
+        }
+
+        private static new DiagnosticResult GetBasicResultAt(int line, int column, string bannedSymbolName, string restrictedNamespaces)
+        {
+            return new DiagnosticResult(BasicRestrictedInternalsVisibleToAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(bannedSymbolName, restrictedNamespaces);
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new BasicRestrictedInternalsVisibleToAnalyzer();
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new CSharpRestrictedInternalsVisibleToAnalyzer();
+
+        private const string ApiProviderProjectName = nameof(ApiProviderProjectName);
+        private const string ApiConsumerProjectName = nameof(ApiConsumerProjectName);
+
+        private void Verify(string apiProviderSource, string apiConsumerSource, string restrictedInternalsVisibleToAttribute, string language, TestValidationMode validationMode, params DiagnosticResult[] expected)
+        {
+            var apiProviderProject = CreateProject(new[] { apiProviderSource + restrictedInternalsVisibleToAttribute }, language: language, referenceFlags: ReferenceFlags.RemoveCodeAnalysis, projectName: ApiProviderProjectName);
+            var apiConsumerProject = CreateProject(new[] { apiConsumerSource }, language: language, referenceFlags: ReferenceFlags.RemoveCodeAnalysis, addToSolution: apiProviderProject.Solution, projectName: ApiConsumerProjectName)
+                           .AddProjectReference(new ProjectReference(apiProviderProject.Id));
+
+            var analyzer = language == LanguageNames.CSharp ? GetCSharpDiagnosticAnalyzer() : GetBasicDiagnosticAnalyzer();
+            var diagnostics = GetSortedDiagnostics(analyzer, apiConsumerProject.Documents.ToArray(), validationMode: validationMode);
+            diagnostics.Verify(analyzer, GetDefaultPath(language), expected);
+        }
+
+        private void VerifyCSharp(string apiProviderSource, string apiConsumerSource, params DiagnosticResult[] expected)
+            => VerifyCSharp(apiProviderSource, apiConsumerSource, validationMode: default, expected);
+
+        private void VerifyCSharp(string apiProviderSource, string apiConsumerSource, TestValidationMode validationMode, params DiagnosticResult[] expected)
+        {
+            const string restrictedInternalsVisibleToAttribute = @"
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)]
+    internal class RestrictedInternalsVisibleToAttribute : System.Attribute
+    {
+        public RestrictedInternalsVisibleToAttribute(string assemblyName, params string[] restrictedNamespaces)
+        {
+        }
+    }
+}";
+
+            Verify(apiProviderSource, apiConsumerSource, restrictedInternalsVisibleToAttribute, LanguageNames.CSharp, validationMode, expected);
+        }
+
+        private void VerifyBasic(string apiProviderSource, string apiConsumerSource, params DiagnosticResult[] expected)
+            => VerifyBasic(apiProviderSource, apiConsumerSource, validationMode: default, expected);
+
+        private void VerifyBasic(string apiProviderSource, string apiConsumerSource, TestValidationMode validationMode, params DiagnosticResult[] expected)
+        {
+            const string restrictedInternalsVisibleToAttribute = @"
+Namespace System.Runtime.CompilerServices
+    <System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple:=True)>
+    Friend Class RestrictedInternalsVisibleToAttribute
+        Inherits System.Attribute
+
+        Public Sub New(ByVal assemblyName As String, ParamArray restrictedNamespaces As String())
+        End Sub
+    End Class
+End Namespace";
+
+            Verify(apiProviderSource, apiConsumerSource, restrictedInternalsVisibleToAttribute, LanguageNames.VisualBasic, validationMode, expected);
+        }
+
+        [Fact]
+        public void CSharp_NoIVT_NoRestrictedIVT_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+namespace N1
+{
+    internal class C1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource, TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void Basic_NoIVT_NoRestrictedIVT_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource, TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void CSharp_IVT_NoRestrictedIVT_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+
+namespace N1
+{
+    internal class C1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_NoRestrictedIVT_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_NoIVT_RestrictedIVT_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""NonExistentNamespace"")]
+
+namespace N1
+{
+    internal class C1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource, TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void Basic_NoIVT_RestrictedIVT_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""NonExistentNamespace"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource, TestValidationMode.AllowCompileErrors);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_BasicScenario_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+
+namespace N1
+{
+    internal class C1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_BasicScenario_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_BasicScenario_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    internal class C1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(4, 12, "N1.C1", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_BasicScenario_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(3, 24, "N1.C1", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_MultipleAttributes_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    internal class C1 { }
+}
+
+namespace N2
+{
+    internal class C2 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c1, N2.C2 c2)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_MultipleAttributes_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace
+
+Namespace N2
+    Friend Class C2
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c1 As N1.C1, c2 As N2.C2)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_MultipleAttributes_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    internal class C1 { }
+}
+
+namespace N2
+{
+    internal class C2 { }
+}
+
+namespace N3
+{
+    internal class C3 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c1, N2.C2 c2, N3.C3 c3)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(4, 32, "N3.C3", "N1, N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_MultipleAttributes_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace
+
+Namespace N2
+    Friend Class C2
+    End Class
+End Namespace
+
+Namespace N3
+    Friend Class C3
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c1 As N1.C1, c2 As N2.C2, c3 As N3.C3)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(3, 51, "N3.C3", "N1, N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_ProjectNameMismatch_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""XYZ"", ""NonExistentNamespace"")]
+
+namespace N1
+{
+    internal class C1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_ProjectNameMismatch_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""XYZ"", ""NonExistentNamespace"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_ProjectNameMismatch_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""XYZ"", ""N1"")]
+
+namespace N1
+{
+    internal class C1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(4, 12, "N1.C1", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_ProjectNameMismatch_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""XYZ"", ""N1"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(3, 24, "N1.C1", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_NoRestrictedNamespace_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"")]
+
+namespace N1
+{
+    internal class C1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_NoRestrictedNamespace_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_QualifiedNamespace_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1.N2"")]
+
+namespace N1
+{
+    namespace N2
+    {
+        internal class C1 { }
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.N2.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_QualifiedNamespace_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1.N2"")>
+
+Namespace N1
+    Namespace N2
+        Friend Class C1
+        End Class
+    End Namespace
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.N2.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_QualifiedNamespace_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1.N2"")]
+
+namespace N1
+{
+    namespace N2
+    {
+        internal class C1 { }
+    }
+
+    internal class C3 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.N2.C1 c1, N1.C3 c3)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(4, 25, "N1.C3", "N1.N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_QualifiedNamespace_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1.N2"")>
+
+Namespace N1
+    Namespace N2
+        Friend Class C1
+        End Class
+    End Namespace
+
+    Friend Class C3
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c1 As N1.N2.C1, c3 As N1.C3)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(3, 41, "N1.C3", "N1.N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_AncestorNamespace_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+
+namespace N1
+{
+    namespace N2
+    {
+        internal class C1 { }
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.N2.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_AncestorNamespace_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+
+Namespace N1
+    Namespace N2
+        Friend Class C1
+        End Class
+    End Namespace
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.N2.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_AncestorNamespace_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1.N2"")]
+
+namespace N1
+{
+    namespace N2
+    {
+        internal class C1 { }
+    }
+
+    internal class C2 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.N2.C1 c1, N1.C2 c2)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(4, 25, "N1.C2", "N1.N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_AncestorNamespace_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1.N2"")>
+
+Namespace N1
+    Namespace N2
+        Friend Class C1
+        End Class
+    End Namespace
+
+    Friend Class C2
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c1 As N1.N2.C1, c2 As N1.C2)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(3, 41, "N1.C2", "N1.N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_QualifiedAndAncestorNamespace_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"", ""N1.N2"")]
+
+namespace N1
+{
+    namespace N2
+    {
+        internal class C1 { }
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.N2.C1 c)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_QualifiedAndAncestorNamespace_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"", ""N1.N2"")>
+
+Namespace N1
+    Namespace N2
+        Friend Class C1
+        End Class
+    End Namespace
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.N2.C1)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_NestedType_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+
+namespace N1
+{
+    internal class C1 { internal class Nested { } }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c, N1.C1.Nested nested)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_NestedType_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+
+Namespace N1
+    Friend Class C1
+        Friend Class Nested
+        End Class
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1, nested As N1.C1.Nested)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_NestedType_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    public class C1 { internal class Nested { } }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c, N1.C1.Nested nested)
+    {
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(4, 21, "N1.C1.Nested", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_NestedType_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Public Class C1
+        Friend Class Nested
+        End Class
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1, nested As N1.C1.Nested)
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(3, 41, "N1.C1.Nested", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_UsageInAttributes_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+
+namespace N1
+{
+    internal class C1 : System.Attribute
+    {
+        public C1(object o) { }
+    }
+}";
+
+            var apiConsumerSource = @"
+[N1.C1(typeof(N1.C1))]
+class C2
+{
+    [N1.C1(typeof(N1.C1))]
+    private readonly int field;
+
+    [N1.C1(typeof(N1.C1))]
+    private int Property { [N1.C1(typeof(N1.C1))] get; }
+
+    [N1.C1(typeof(N1.C1))]
+    private event System.EventHandler X;
+
+    [N1.C1(typeof(N1.C1))]
+    [return: N1.C1(typeof(N1.C1))]
+    int M([N1.C1(typeof(N1.C1))]object c)
+    {
+        return 0;
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_UsageInAttributes_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+
+Namespace N1
+    Friend Class C1
+        Inherits System.Attribute
+        Public Sub New(obj As Object)
+        End Sub
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+<N1.C1(GetType(N1.C1))>
+Class C2
+    <N1.C1(GetType(N1.C1))>
+    Private ReadOnly field As Integer
+
+    <N1.C1(GetType(N1.C1))>
+    Private ReadOnly Property [Property] As Integer
+
+    <N1.C1(GetType(N1.C1))>
+    Private Event X As System.EventHandler
+
+    <N1.C1(GetType(N1.C1))>
+    Private Function M(<N1.C1(GetType(N1.C1))> ByVal c As Object) As <N1.C1(GetType(N1.C1))> Integer
+        Return 0
+    End Function
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_UsageInAttributes_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    internal class C1 : System.Attribute
+    {
+        public C1(object o) { }
+    }
+}";
+
+            var apiConsumerSource = @"
+[N1.C1(typeof(N1.C1))]      // 1, 2
+class C2
+{
+    [N1.C1(typeof(N1.C1))]      // 3, 4
+    private readonly int field;
+
+    [N1.C1(typeof(N1.C1))]      // 5, 6
+    private int Property { [N1.C1(typeof(N1.C1))] get; }    // 7, 8
+
+    [N1.C1(typeof(N1.C1))]      // 9, 10
+    private event System.EventHandler X;
+
+    [N1.C1(typeof(N1.C1))]      // 11, 12
+    [return: N1.C1(typeof(N1.C1))]      // 13, 14
+    int M([N1.C1(typeof(N1.C1))]object c)   // 15, 16
+    {
+        return 0;
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(2, 2, "N1.C1", "N2"),     // 1,
+                GetCSharpResultAt(2, 15, "N1.C1", "N2"),    // 2,
+                GetCSharpResultAt(5, 6, "N1.C1", "N2"),     // 3,
+                GetCSharpResultAt(5, 19, "N1.C1", "N2"),    // 4,
+                GetCSharpResultAt(8, 6, "N1.C1", "N2"),     // 5,
+                GetCSharpResultAt(8, 19, "N1.C1", "N2"),    // 6,
+                GetCSharpResultAt(9, 29, "N1.C1", "N2"),    // 7,
+                GetCSharpResultAt(9, 42, "N1.C1", "N2"),    // 8,
+                GetCSharpResultAt(11, 6, "N1.C1", "N2"),    // 9,
+                GetCSharpResultAt(11, 19, "N1.C1", "N2"),   // 10,
+                GetCSharpResultAt(14, 6, "N1.C1", "N2"),    // 11,
+                GetCSharpResultAt(14, 19, "N1.C1", "N2"),   // 12,
+                GetCSharpResultAt(15, 14, "N1.C1", "N2"),   // 13,
+                GetCSharpResultAt(15, 27, "N1.C1", "N2"),   // 14,
+                GetCSharpResultAt(16, 12, "N1.C1", "N2"),   // 15,
+                GetCSharpResultAt(16, 25, "N1.C1", "N2")    // 16
+                );
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_UsageInAttributes_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Friend Class C1
+        Inherits System.Attribute
+        Public Sub New(obj As Object)
+        End Sub
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+<N1.C1(GetType(N1.C1))>
+Class C2
+    <N1.C1(GetType(N1.C1))>
+    Private ReadOnly field As Integer
+
+    <N1.C1(GetType(N1.C1))>
+    Private ReadOnly Property [Property] As Integer
+
+    <N1.C1(GetType(N1.C1))>
+    Private Event X As System.EventHandler
+
+    <N1.C1(GetType(N1.C1))>
+    Private Function M(<N1.C1(GetType(N1.C1))> ByVal c As Object) As <N1.C1(GetType(N1.C1))> Integer
+        Return 0
+    End Function
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(2, 2, "N1.C1", "N2"),     // 1,
+                GetBasicResultAt(2, 16, "N1.C1", "N2"),    // 2,
+                GetBasicResultAt(4, 6, "N1.C1", "N2"),     // 3,
+                GetBasicResultAt(4, 20, "N1.C1", "N2"),    // 4,
+                GetBasicResultAt(7, 6, "N1.C1", "N2"),     // 5,
+                GetBasicResultAt(7, 20, "N1.C1", "N2"),    // 6,
+                GetBasicResultAt(10, 6, "N1.C1", "N2"),    // 7,
+                GetBasicResultAt(10, 20, "N1.C1", "N2"),   // 8,
+                GetBasicResultAt(13, 6, "N1.C1", "N2"),    // 9,
+                GetBasicResultAt(13, 20, "N1.C1", "N2"),   // 10,
+                GetBasicResultAt(14, 25, "N1.C1", "N2"),   // 11,
+                GetBasicResultAt(14, 39, "N1.C1", "N2"),   // 12,
+                GetBasicResultAt(14, 71, "N1.C1", "N2"),   // 13,
+                GetBasicResultAt(14, 85, "N1.C1", "N2")    // 14
+                );
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_UsageInDeclaration_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+
+namespace N1
+{
+    internal class C1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2 : N1.C1
+{
+    private readonly N1.C1 field;
+    private N1.C1 Property { get; }
+    private N1.C1 this[N1.C1 index] { get => null; }
+    N1.C1 M(N1.C1 c)
+    {
+        return null;
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_UsageInDeclaration_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Inherits N1.C1
+
+    Private ReadOnly field As N1.C1
+    Private ReadOnly Property [Property] As N1.C1
+
+    Private ReadOnly Property Item(index As N1.C1) As N1.C1
+        Get
+            Return Nothing
+        End Get
+    End Property
+
+    Private Function M(c As N1.C1) As N1.C1
+        Return Nothing
+    End Function
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_UsageInDeclaration_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    internal class C1 { }
+    internal class C2 { }
+    internal class C3 { }
+    internal class C4 { }
+    internal class C5 { }
+    internal class C6 { }
+    internal class C7 { }
+}";
+
+            var apiConsumerSource = @"
+class B : N1.C1
+{
+    private readonly N1.C2 field;
+    private N1.C3 Property { get; }
+    private N1.C4 this[N1.C5 index] { get => null; }
+    N1.C6 M(N1.C7 c)
+    {
+        return null;
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(2, 11, "N1.C1", "N2"),
+                GetCSharpResultAt(4, 22, "N1.C2", "N2"),
+                GetCSharpResultAt(5, 13, "N1.C3", "N2"),
+                GetCSharpResultAt(6, 13, "N1.C4", "N2"),
+                GetCSharpResultAt(6, 24, "N1.C5", "N2"),
+                GetCSharpResultAt(7, 5, "N1.C6", "N2"),
+                GetCSharpResultAt(7, 13, "N1.C7", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_UsageInDeclaration_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Friend Class C1
+    End Class
+    Friend Class C2
+    End Class
+    Friend Class C3
+    End Class
+    Friend Class C4
+    End Class
+    Friend Class C5
+    End Class
+    Friend Class C6
+    End Class
+    Friend Class C7
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class B
+    Inherits N1.C1
+
+    Private ReadOnly field As N1.C2
+    Private ReadOnly Property [Property] As N1.C3
+
+    Private ReadOnly Property Item(index As N1.C4) As N1.C5
+        Get
+            Return Nothing
+        End Get
+    End Property
+
+    Private Function M(c As N1.C6) As N1.C7
+        Return Nothing
+    End Function
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(3, 14, "N1.C1", "N2"),
+                GetBasicResultAt(5, 31, "N1.C2", "N2"),
+                GetBasicResultAt(6, 45, "N1.C3", "N2"),
+                GetBasicResultAt(8, 45, "N1.C4", "N2"),
+                GetBasicResultAt(8, 55, "N1.C5", "N2"),
+                GetBasicResultAt(14, 29, "N1.C6", "N2"),
+                GetBasicResultAt(14, 39, "N1.C7", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_UsageInExecutableCode_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+
+namespace N1
+{
+    internal class C1 : System.Attribute
+    {
+        public C1(object o) { }
+        public C1 GetC() => this;
+        public C1 GetC(C1 c) => c;
+        public object GetObject() => this;
+        public C1 Field;
+        public C1 Property { get; set; }
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    // Field initializer
+    private readonly N1.C1 field = new N1.C1(null);
+
+    // Property initializer
+    private N1.C1 Property { get; } = new N1.C1(null);
+
+    void M(object c)
+    {
+        var x = new N1.C1(null);    // Object creation
+        N1.C1 y = x.GetC();         // Invocation
+        var z = y.GetC(x);          // Parameter type
+        _ = (N1.C1)z.GetObject();   // Conversion
+        _ = z.Field;                // Field reference
+        _ = z.Property;             // Property reference
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_UsageInExecutableCode_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+
+Namespace N1
+    Friend Class C1
+        Inherits System.Attribute
+
+        Public Sub New(ByVal o As Object)
+        End Sub
+
+        Public Function GetC() As C1
+            Return Me
+        End Function
+
+        Public Function GetC(ByVal c As C1) As C1
+            Return c
+        End Function
+
+        Public Function GetObject() As Object
+            Return Me
+        End Function
+
+        Public Field As C1
+        Public Property [Property] As C1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private ReadOnly field As N1.C1 = New N1.C1(Nothing)
+    Private ReadOnly Property [Property] As N1.C1 = New N1.C1(Nothing)
+
+    Private Sub M(ByVal c As Object)
+        Dim x = New N1.C1(Nothing)
+        Dim y As N1.C1 = x.GetC()
+        Dim z = y.GetC(x)
+        Dim unused1 = CType(z.GetObject(), N1.C1)
+        Dim unused2 = z.Field
+        Dim unused3 = z.[Property]
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_PublicTypeInternalMember_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+
+namespace N1
+{
+    public class C1
+    {
+        internal int Field;
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    int M(N1.C1 c)
+    {
+        return c.Field;
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_PublicTypeInternalMember_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+
+Namespace N1
+    Public Class C1
+        Friend Field As Integer
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Function M(c As N1.C1) As Integer
+        Return c.Field
+    End Function
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_PublicTypeInternalField_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    public class C1
+    {
+        internal int Field;
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    int M(N1.C1 c)
+    {
+        return c.Field;
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(6, 16, "N1.C1.Field", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_PublicTypeInternalField_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Public Class C1
+        Friend Field As Integer
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Function M(c As N1.C1) As Integer
+        Return c.Field
+    End Function
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(4, 16, "N1.C1.Field", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_PublicTypeInternalMethod_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    public class C1
+    {
+        internal int Method() => 0;
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    int M(N1.C1 c)
+    {
+        return c.Method();
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(6, 16, "N1.C1.Method", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_PublicTypeInternalMethod_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Public Class C1
+        Friend Function Method() As Integer
+            Return 0
+        End Function
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Function M(c As N1.C1) As Integer
+        Return c.Method()
+    End Function
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(4, 16, "N1.C1.Method", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_PublicTypeInternalProperty_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    public class C1
+    {
+        internal int Property { get => 0; }
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    int M(N1.C1 c)
+    {
+        return c.Property;
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(6, 16, "N1.C1.Property", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_PublicTypeInternalProperty_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Public Class C1
+        Friend ReadOnly Property [Property] As Integer
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Function M(c As N1.C1) As Integer
+        Return c.[Property]
+    End Function
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(4, 16, "N1.C1.Property", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_PublicTypeInternalEvent_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    public class C1
+    {
+        internal event EventHandler Event;
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+        _ = c.Event;
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(6, 13, "N1.C1.Event", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_PublicTypeInternalEvent_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Public Class C1
+        Friend Event [Event] As EventHandler
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M(c As N1.C1)
+        Dim unused = c.[Event]
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource, TestValidationMode.AllowCompileErrors,
+                GetBasicResultAt(4, 22, "N1.C1.Event", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_PublicTypeInternalConstructor_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    public class C1
+    {
+        internal C1() { }
+    }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M()
+    {
+        var c = new N1.C1();
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(6, 17, "N1.C1.C1", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_PublicTypeInternalConstructor_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Public Class C1
+        Friend Sub New()
+        End Sub
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Sub M()
+        Dim c = New N1.C1()
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetBasicResultAt(4, 17, "N1.C1.New", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_Conversions_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    internal interface I1 { }
+    public class C1 : I1 { }
+}";
+
+            var apiConsumerSource = @"
+class C2
+{
+    void M(N1.C1 c)
+    {
+        _ = (N1.I1)c;       // Explicit
+        N1.I1 y = c;        // Implicit
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(6, 14, "N1.I1", "N2"),
+                GetCSharpResultAt(7, 9, "N1.I1", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_Conversions_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Friend Interface I1
+    End Interface
+
+    Public Class C1
+        Implements I1
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Class C2
+    Private Function M(c As N1.C1) As Integer
+        Dim x = CType(c, N1.I1)
+        Dim y As N1.I1 = c
+    End Function
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(4, 26, "N1.I1", "N2"),
+                GetCSharpResultAt(5, 18, "N1.I1", "N2"));
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_UsageInTypeArgument_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")]
+
+namespace N1
+{
+    internal class C1<T>
+    {
+        public C1<object> GetC1<U>() => null;
+    }
+
+    internal class C3 { }
+}";
+
+            var apiConsumerSource = @"
+using N1;
+class C2 : C1<C3>
+{
+    void M(C1<C3> c1, C1<object> c2)
+    {
+        _ = c2.GetC1<C3>();
+        _ = c2.GetC1<C1<C3>>();
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_UsageInTypeArgument_NoDiagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N1"")>
+
+Namespace N1
+    Friend Class C1(Of T)
+        Public Function GetC1(Of U)() As C1(Of Object)
+            Return Nothing
+        End Function
+    End Class
+
+    Friend Class C3
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Imports N1
+
+Class C2
+    Inherits C1(Of C3)
+
+    Private Sub M(ByVal c1 As C1(Of C3), ByVal c2 As C1(Of Object))
+        Dim unused1 = c2.GetC1(Of C3)()
+        Dim unused2 = c2.GetC1(Of C1(Of C3))()
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource);
+        }
+
+        [Fact]
+        public void CSharp_IVT_RestrictedIVT_UsageInTypeArgument_Diagnostic()
+        {
+            var apiProviderSource = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")]
+[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")]
+
+namespace N1
+{
+    internal class C3 { }
+    internal class C4 { }
+    internal class C5 { }
+    internal class C6 { }
+
+}
+
+namespace N2
+{
+    internal class C1<T>
+    {
+        public C1<object> GetC1<U>() => null;
+    }
+}
+";
+
+            var apiConsumerSource = @"
+using N1;
+using N2;
+
+class C2 : C1<C3>
+{
+    void M(C1<C4> c1, C1<object> c2)
+    {
+        _ = c2.GetC1<C5>();
+        _ = c2.GetC1<C1<C6>>();
+    }
+}";
+
+            VerifyCSharp(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(5, 15, "N1.C3", "N2"),
+                GetCSharpResultAt(7, 15, "N1.C4", "N2"),
+                GetCSharpResultAt(9, 22, "N1.C5", "N2"),
+                GetCSharpResultAt(10, 25, "N1.C6", "N2"));
+        }
+
+        [Fact]
+        public void Basic_IVT_RestrictedIVT_UsageInTypeArgument_Diagnostic()
+        {
+            var apiProviderSource = @"
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ApiConsumerProjectName"")>
+<Assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo(""ApiConsumerProjectName"", ""N2"")>
+
+Namespace N1
+    Friend Class C3
+    End Class
+    Friend Class C4
+    End Class
+    Friend Class C5
+    End Class
+    Friend Class C6
+    End Class
+End Namespace
+
+Namespace N2
+    Friend Class C1(Of T)
+        Public Function GetC1(Of U)() As C1(Of Object)
+            Return Nothing
+        End Function
+    End Class
+End Namespace";
+
+            var apiConsumerSource = @"
+Imports N1
+Imports N2
+
+Class C2
+    Inherits C1(Of C3)
+
+    Private Sub M(ByVal c1 As C1(Of C4), ByVal c2 As C1(Of Object))
+        Dim unused1 = c2.GetC1(Of C5)()
+        Dim unused2 = c2.GetC1(Of C1(Of C6))()
+    End Sub
+End Class";
+
+            VerifyBasic(apiProviderSource, apiConsumerSource,
+                GetCSharpResultAt(6, 20, "N1.C3", "N2"),
+                GetCSharpResultAt(8, 37, "N1.C4", "N2"),
+                GetCSharpResultAt(9, 35, "N1.C5", "N2"),
+                GetCSharpResultAt(10, 41, "N1.C6", "N2"));
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/VisualBasic/BasicRestrictedInternalsVisibleToAnalyzer.vb
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/VisualBasic/BasicRestrictedInternalsVisibleToAnalyzer.vb
@@ -1,0 +1,26 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.BannedApiAnalyzers
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+    Public Class BasicRestrictedInternalsVisibleToAnalyzer
+        Inherits RestrictedInternalsVisibleToAnalyzer(Of NameSyntax, SyntaxKind)
+
+        Protected Overrides ReadOnly Property NameSyntaxKinds As ImmutableArray(Of SyntaxKind)
+            Get
+                Return ImmutableArray.Create(
+                    SyntaxKind.IdentifierName,
+                    SyntaxKind.GenericName,
+                    SyntaxKind.QualifiedName)
+            End Get
+        End Property
+
+        Protected Overrides Function IsInTypeOnlyContext(node As NameSyntax) As Boolean
+            Return SyntaxFacts.IsInTypeOnlyContext(node)
+        End Function
+    End Class
+End Namespace

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
@@ -38,5 +38,6 @@ namespace Roslyn.Diagnostics.Analyzers
         public const string TestExportsShouldNotBeDiscoverableRuleId = "RS0032";
         public const string ImportingConstructorShouldBeObsoleteRuleId = "RS0033";
         public const string ExportedPartsShouldHaveImportingConstructorRuleId = "RS0034";
+        public const string RestrictedInternalsVisibleToRuleId = "RS0035";
     }
 }

--- a/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
@@ -340,9 +340,9 @@ namespace Test.Utilities
             return CreateProject(sources.ToFileAndSource(), language, referenceFlags, allowUnsafeCode: allowUnsafeCode).Documents.ToArray();
         }
 
-        protected static Project CreateProject(string[] sources, string language = LanguageNames.CSharp, ReferenceFlags referenceFlags = ReferenceFlags.None, Solution addToSolution = null)
+        protected static Project CreateProject(string[] sources, string language = LanguageNames.CSharp, ReferenceFlags referenceFlags = ReferenceFlags.None, Solution addToSolution = null, string projectName = TestProjectName)
         {
-            return CreateProject(sources.ToFileAndSource(), language, referenceFlags, addToSolution);
+            return CreateProject(sources.ToFileAndSource(), language, referenceFlags, addToSolution, projectName);
         }
 
         private static Project CreateProject(

--- a/src/Utilities/Compiler/SymbolDisplayFormats.cs
+++ b/src/Utilities/Compiler/SymbolDisplayFormats.cs
@@ -18,5 +18,18 @@ namespace Analyzer.Utilities
                 SymbolDisplayLocalOptions.IncludeType,
                 SymbolDisplayKindOptions.None,
                 SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+        public static readonly SymbolDisplayFormat QualifiedTypeAndNamespaceSymbolDisplayFormat = new SymbolDisplayFormat(
+                SymbolDisplayGlobalNamespaceStyle.Omitted,
+                SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+                SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                SymbolDisplayMemberOptions.IncludeContainingType,
+                SymbolDisplayDelegateStyle.NameOnly,
+                SymbolDisplayExtensionMethodStyle.InstanceMethod,
+                SymbolDisplayParameterOptions.None,
+                SymbolDisplayPropertyStyle.NameOnly,
+                SymbolDisplayLocalOptions.IncludeType,
+                SymbolDisplayKindOptions.None,
+                SymbolDisplayMiscellaneousOptions.None);
     }
 }


### PR DESCRIPTION
Allow assemblies to supply a _restricted_ version of InternalsVisibleTo assembly level attribute which restricts the allowed namespaces from which internal APIs can be accessed, instead of allowing access to all internal types from the assembly.

The analyzer expects that the API producer assembly's compilation (i.e. the referenced assembly's compilation) contains the attribute definition for the new `RestrictedInternalsVisibleToAttribute` with the following namespace and ctor signature:

```csharp
namespace System.Runtime.CompilerServices
{
    [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)]
    internal class RestrictedInternalsVisibleToAttribute : System.Attribute
    {
        // Restrict 'assemblyName' to only access internal types from 'restrictedNamespaces'
        public RestrictedInternalsVisibleToAttribute(string assemblyName, params string[] restrictedNamespaces)
        {
        }
    }
}
```

The referenced assembly can then provide following restricted IVT attribute specification:

```csharp
[assembly: System.Runtime.CompilerServices.RestrictedInternalsVisibleTo("ApiConsumerProjectName", "N1", "N2.N3")]
```

This indicates that the assembly would like to restrict the referencing assembly `ApiConsumerProjectName` to allow referencing internal APIs that are defined in namespaces `N1` and `N2.N3` in this assembly, but none other.

The new analyzer added in this PR is meant to be executed for the referencing assemblies and enforces these semantics by producing an error if it tries to access internal APIs outside the allowed namespaces. In the above example, if `ApiConsumerProjectName` tries to access an internal type `C4` defined in namespace `N4`, then the analyzer would produce the following error:

`External access to internal symbol 'N4.C4' is prohibited. Assembly 'ApiProducerProjectName' only allows access to internal symbols defined in following namespace(s): 'N1, N2.N3'`