### PR TITLE
#2496 Property self assignment protection

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidPropertySelfAssignment.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidPropertySelfAssignment.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
     public sealed class AvoidPropertySelfAssignment : DiagnosticAnalyzer
     {
-        internal const string RuleId = "CA1099";
+        internal const string RuleId = "CA2245";
 
         private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftQualityGuidelinesAnalyzersResources.AvoidPropertySelfAssignmentTitle), MicrosoftQualityGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftQualityGuidelinesAnalyzersResources));
         private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftQualityGuidelinesAnalyzersResources.AvoidPropertySelfAssignmentMessage), MicrosoftQualityGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftQualityGuidelinesAnalyzersResources));
@@ -23,7 +23,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
             s_localizableTitle,
             s_localizableMessage,
-            DiagnosticCategory.Design,
+            DiagnosticCategory.Usage,
             DiagnosticHelpers.DefaultDiagnosticSeverity,
             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             helpLinkUri: null);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidPropertySelfAssignment.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidPropertySelfAssignment.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
+{
+    /// <summary>
+    /// CA1099: Prevent properties from being assigned to themselves
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+
+    public sealed class AvoidPropertySelfAssignment : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA1099";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftQualityGuidelinesAnalyzersResources.AvoidPropertySelfAssignmentTitle), MicrosoftQualityGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftQualityGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftQualityGuidelinesAnalyzersResources.AvoidPropertySelfAssignmentMessage), MicrosoftQualityGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftQualityGuidelinesAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftQualityGuidelinesAnalyzersResources.AvoidPropertySelfAssignmentDescription), MicrosoftQualityGuidelinesAnalyzersResources.ResourceManager, typeof(MicrosoftQualityGuidelinesAnalyzersResources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
+            s_localizableTitle,
+            s_localizableMessage,
+            DiagnosticCategory.Design,
+            DiagnosticHelpers.DefaultDiagnosticSeverity,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultForVsixAndNuget,
+            description: s_localizableDescription,
+            helpLinkUri: "");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext analysisContext)
+        {
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            // You would need to register an operation action for OperationKind.SimpleAssignment
+            analysisContext.RegisterOperationAction(operationContext =>
+            {
+                //referencing the same property symbol and whose Instance is an IInstanceReferenceOperation whose ReferenceKind is InstanceReferenceKind.ContainingTypeInstance
+                var assignmentOperation = (IAssignmentOperation)operationContext.Operation;
+
+                var operationTarget = (IPropertyReferenceOperation)assignmentOperation?.Target;
+                if (operationTarget == null)
+                {
+                    return;
+                }
+
+                var operationValue = (IPropertyReferenceOperation)assignmentOperation.Value;
+                if (operationValue == null)
+                {
+                    return;
+                }
+
+                if (!Equals(operationTarget.Property, operationValue.Property))
+                {
+                    return;
+                }
+
+                var reference = (InstanceReferenceKind)operationTarget.Property.RefKind;
+                if (reference != InstanceReferenceKind.ContainingTypeInstance)
+                {
+                    return;
+                }
+
+                Diagnostic diagnostic = Diagnostic.Create(Rule, operationContext.Operation.Syntax.GetLocation(), operationTarget.Property.Name);
+                operationContext.ReportDiagnostic(diagnostic);
+
+            }, OperationKind.SimpleAssignment);
+        }
+    }
+}

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidPropertySelfAssignment.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidPropertySelfAssignment.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
@@ -38,10 +37,8 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            // You would need to register an operation action for OperationKind.SimpleAssignment
             analysisContext.RegisterOperationAction(operationContext =>
             {
-                //referencing the same property symbol and whose Instance is an IInstanceReferenceOperation whose ReferenceKind is InstanceReferenceKind.ContainingTypeInstance
                 var assignmentOperation = (IAssignmentOperation)operationContext.Operation;
 
                 var operationTarget = (IPropertyReferenceOperation)assignmentOperation?.Target;
@@ -50,8 +47,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                     return;
                 }
 
-                var operationValue = (IPropertyReferenceOperation)assignmentOperation.Value;
-                if (operationValue == null)
+                if (!(assignmentOperation.Value is IPropertyReferenceOperation operationValue))
                 {
                     return;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MicrosoftQualityGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MicrosoftQualityGuidelinesAnalyzersResources.resx
@@ -247,12 +247,9 @@
     <value>Some references to '{0}' could not be fixed, they should be fixed manually.</value>
   </data>
   <data name="AvoidPropertySelfAssignmentTitle" xml:space="preserve">
-    <value>Do not assign properties to themselves.</value>
+    <value>Do not assign a property to itself.</value>
   </data>
   <data name="AvoidPropertySelfAssignmentMessage" xml:space="preserve">
-    <value></value>
-  </data>
-  <data name="AvoidPropertySelfAssignmentDescription" xml:space="preserve">
-    <value></value>
+    <value>The property {0} should not be assigned to itself.</value>
   </data>
 </root>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MicrosoftQualityGuidelinesAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MicrosoftQualityGuidelinesAnalyzersResources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -245,5 +245,14 @@
   </data>
   <data name="MarkMembersAsStaticCodeFix_WarningAnnotation" xml:space="preserve">
     <value>Some references to '{0}' could not be fixed, they should be fixed manually.</value>
+  </data>
+  <data name="AvoidPropertySelfAssignmentTitle" xml:space="preserve">
+    <value>Do not assign properties to themselves.</value>
+  </data>
+  <data name="AvoidPropertySelfAssignmentMessage" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvoidPropertySelfAssignmentDescription" xml:space="preserve">
+    <value></value>
   </data>
 </root>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">Nastavit jako statickou</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.cs.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.de.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">Als statisch festlegen</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">Hacer estático</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.es.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">Rendre statique</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.fr.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.it.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">Imposta come statici</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">静的にする</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ja.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ko.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">정적으로 만들기</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">Ustaw jako statyczne</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.pl.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.pt-BR.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">Tornar estático</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">Сделать статическим</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.ru.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">Statik yap</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.tr.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANS" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">设为静态</target>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.zh-Hans.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANS" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.zh-Hant.xlf
@@ -2,9 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANT" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentMessage">
+        <source>The property {0} should not be assigned to itself.</source>
+        <target state="new">The property {0} should not be assigned to itself.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
-        <source>Do not assign properties to themselves.</source>
-        <target state="new">Do not assign properties to themselves.</target>
+        <source>Do not assign a property to itself.</source>
+        <target state="new">Do not assign a property to itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/xlf/MicrosoftQualityGuidelinesAnalyzersResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANT" original="../MicrosoftQualityGuidelinesAnalyzersResources.resx">
     <body>
+      <trans-unit id="AvoidPropertySelfAssignmentTitle">
+        <source>Do not assign properties to themselves.</source>
+        <target state="new">Do not assign properties to themselves.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MarkMembersAsStaticCodeFix">
         <source>Make static</source>
         <target state="translated">使其變成靜態</target>

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.Analyzers.QualityGuidelines;
@@ -22,121 +21,327 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.QualityGuidelines
         }
 
         [Fact]
-        public void AssignmentInConstructorWithNoArguments()
+        public void CSharpAssignmentInConstructorWithNoArguments()
         {
             VerifyCSharp(@"
 class C
 {
-    private string Property { get; set; }
+    private string P { get; set; }
     public C()
     {
-        Property = Property;
+        P = P;
     }
 }
 ",
-                GetCSharpResultAt(7, 9, "="));
+            GetCSharpResultAt(7, 13, "P"));
         }
 
-
         [Fact]
-        public void AssignmentInConstructorWithSimilarArgument()
+        public void CSharpAssignmentInConstructorUsingThisWithNoArguments()
         {
             VerifyCSharp(@"
 class C
 {
-    private string Property { get; set; }
-    public C(string property)
+    private string P { get; set; }
+    public C()
     {
-        Property = Property;
+        this.P = P;
     }
 }
 ",
-                GetCSharpResultAt(7, 9, "="));
+            GetCSharpResultAt(7, 18, "P"));
         }
 
+
         [Fact]
-        public void AssignmentInMethodWithoutArguments()
+        public void CSharpAssignmentInConstructorWithSimilarArgument()
         {
             VerifyCSharp(@"
 class C
 {
-    private string Property { get; set; }
-    public void Method()
+    private string P { get; set; }
+    public C(string p)
     {
-        Property = Property;
+        P = P;
     }
 }
 ",
-                GetCSharpResultAt(7, 9, "="));
+            GetCSharpResultAt(7, 13, "P"));
         }
 
         [Fact]
-        public void AssignmentInMethodWithSimilarArgumentName()
+        public void CSharpAssignmentInMethodWithoutArguments()
         {
             VerifyCSharp(@"
 class C
 {
-    private string Property { get; set; }
-    public void Method(string property)
+    private string P { get; set; }
+    public void CSharpMethod()
     {
-        Property = Property;
+        P = P;
     }
 }
 ",
-                GetCSharpResultAt(7, 9, "="));
+            GetCSharpResultAt(7, 13, "P"));
         }
 
         [Fact]
-        public void AdditionAssignmentOperatorDoesNotCauseDiagnosticToAppear()
+        public void CSharpAssignmentInMethodWithSimilarArgumentName()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private string P { get; set; }
+    public void CSharpMethod(string p)
+    {
+        P = P;
+    }
+}
+",
+            GetCSharpResultAt(7, 13, "P"));
+        }
+
+        [Fact]
+        public void CSharpAdditionAssignmentOperatorDoesNotCauseDiagnosticToAppear()
         {
             VerifyCSharp(@"
 class C
 {
     private int Property { get; set; }
-    public void Method(string property)
+    public void CSharpMethod(string p)
     {
         Property += 1;
     }
 }
-",
-                Array.Empty<DiagnosticResult>());
+");
         }
 
         [Fact]
-        public void NormalPropertyAssignmentDoesNotCauseDiagnosticToAppear()
+        public void CSharpNormalPropertyAssignmentDoesNotCauseDiagnosticToAppear()
         {
             VerifyCSharp(@"
 class C
 {
-    private string Property { get; set; }
-    public void Method(string property)
+    private string P { get; set; }
+    public void CSharpMethod(string p)
     {
-        Property = property;
+        P = p;
     }
 }
-",
-                Array.Empty<DiagnosticResult>());
+");
         }
 
         [Fact]
-        public void NormalVariableAssignmentDoesNotCauseDiagnosticToAppear()
+        public void CSharpNormalAssignmentOfTwoDifferentPropertiesDoesNotCauseDiagnosticToAppear()
         {
             VerifyCSharp(@"
 class C
 {
-    private string Property { get; set; }
-    public void Method(string property)
+    private string FirstP { get; set; }
+    private string SecondP { get; set; }
+    public C()
     {
-        var methodVariable = property;
+        FirstP = SecondP;
     }
 }
+");
+        }
+
+        [Fact]
+        public void CSharpNormalVariableAssignmentDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private string P { get; set; }
+    public void CSharpMethod(string p)
+    {
+        var methodVariable = p;
+    }
+}
+");
+        }
+
+        [Fact]
+        public void CSharpNormalAssignmentWithTwoDifferentInstancesDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyCSharp(@"
+internal class A
+{
+    public string P { get; set; } = ""value"";
+}
+
+class C
+{
+    public C()
+    {
+        var a = new A();
+        var b = new A();
+        a.P = b.P;
+    }
+}
+");
+        }
+
+        [Fact]
+        public void VbAssignmentInConstructorWithNoArguments()
+        {
+            VerifyBasic(@"
+Class C
+    Private Property [P] As String
+
+    Public Sub New()
+        [P] = [P]
+    End Sub
+End Class
 ",
-                Array.Empty<DiagnosticResult>());
+            GetBasicResultAt(6, 15, "P"));
+        }
+
+        [Fact]
+        public void VbAssignmentInConstructorUsingThisWithNoArguments()
+        {
+            VerifyBasic(@"
+Class C
+    Private Property [P] As String
+
+    Public Sub New()
+        Me.[P] = [P]
+    End Sub
+End Class
+",
+            GetBasicResultAt(6, 18, "P"));
+        }
+
+
+        [Fact]
+        public void VbAssignmentInConstructorWithSimilarArgument()
+        {
+            VerifyBasic(@"
+Class C
+    Private Property [P] As String
+
+    Public Sub New(ByVal [ctorArg] As String)
+        [P] = [P]
+    End Sub
+End Class
+",
+            GetBasicResultAt(6, 15, "P"));
+        }
+
+        [Fact]
+        public void VbAssignmentInMethodWithoutArguments()
+        {
+            VerifyBasic(@"
+Class C
+    Private Property [P] As String
+
+    Public Sub VbMethod()
+        [P] = [P]
+    End Sub
+End Class
+",
+            GetBasicResultAt(6, 15, "P"));
+        }
+
+        [Fact]
+        public void VbAssignmentInMethodWithSimilarArgumentName()
+        {
+            VerifyBasic(@"
+Class C
+    Private Property [P] As String
+
+    Public Sub VbMethod(ByVal [methodArg] As String)
+        [P] = [P]
+    End Sub
+End Class
+",
+            GetBasicResultAt(6, 15, "P"));
+        }
+
+        [Fact]
+        public void VbAdditionAssignmentOperatorDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyBasic(@"
+Class C
+    Private Property [P] As Integer
+
+    Public Sub VbMethod(ByVal [methodArg] As String)
+        [P] += 1
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void VbNormalPropertyAssignmentDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyBasic(@"
+Class C
+    Private Property [P] As String
+
+    Public Sub VbMethod(ByVal [methodArg] As String)
+        [P] = [methodArg]
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void VbNormalAssignmentOfTwoDifferentPropertiesDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyBasic(@"
+Class C
+    Private Property FirstP As String
+    Private Property SecondP As String
+
+    Public Sub New()
+        FirstP = SecondP
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void VbNormalVariableAssignmentDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyBasic(@"
+Class C
+    Private Property [P] As String
+
+    Public Sub VbMethod(ByVal [methodArg] As String)
+        Dim methodVariable = [methodArg]
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void VbNormalAssignmentWithTwoDifferentInstancesDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyBasic(@"
+Friend Class A
+    Public Property [P] As String = ""value""
+End Class
+
+Class C
+    Public Sub New()
+        Dim a = New A()
+        Dim b = New A()
+        a.[P] = b.[P]
+    End Sub
+End Class
+");
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
         {
             return GetCSharpResultAt(line, column, AvoidPropertySelfAssignment.Rule, symbolName);
+        }
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
+        {
+            return GetBasicResultAt(line, column, AvoidPropertySelfAssignment.Rule, symbolName);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.Analyzers.QualityGuidelines;
@@ -83,6 +84,54 @@ class C
 }
 ",
                 GetCSharpResultAt(7, 9, "="));
+        }
+
+        [Fact]
+        public void AdditionAssignmentOperatorDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private int Property { get; set; }
+    public void Method(string property)
+    {
+        Property += 1;
+    }
+}
+",
+                Array.Empty<DiagnosticResult>());
+        }
+
+        [Fact]
+        public void NormalPropertyAssignmentDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private string Property { get; set; }
+    public void Method(string property)
+    {
+        Property = property;
+    }
+}
+",
+                Array.Empty<DiagnosticResult>());
+        }
+
+        [Fact]
+        public void NormalVariableAssignmentDoesNotCauseDiagnosticToAppear()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private string Property { get; set; }
+    public void Method(string property)
+    {
+        var methodVariable = property;
+    }
+}
+",
+                Array.Empty<DiagnosticResult>());
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeQuality.Analyzers.QualityGuidelines;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeQuality.Analyzers.UnitTests.QualityGuidelines
+{
+    public partial class AvoidPropertySelfAssignmentTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new AvoidPropertySelfAssignment();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new AvoidPropertySelfAssignment();
+        }
+
+        [Fact]
+        public void AssignmentInConstructorWithNoArguments()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private string Property { get; set; }
+    public C()
+    {
+        Property = Property;
+    }
+}
+",
+                GetCSharpResultAt(7, 9, "="));
+        }
+
+
+        [Fact]
+        public void AssignmentInConstructorWithSimilarArgument()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private string Property { get; set; }
+    public C(string property)
+    {
+        Property = Property;
+    }
+}
+",
+                GetCSharpResultAt(7, 9, "="));
+        }
+
+        [Fact]
+        public void AssignmentInMethodWithoutArguments()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private string Property { get; set; }
+    public void Method()
+    {
+        Property = Property;
+    }
+}
+",
+                GetCSharpResultAt(7, 9, "="));
+        }
+
+        [Fact]
+        public void AssignmentInMethodWithSimilarArgumentName()
+        {
+            VerifyCSharp(@"
+class C
+{
+    private string Property { get; set; }
+    public void Method(string property)
+    {
+        Property = Property;
+    }
+}
+",
+                GetCSharpResultAt(7, 9, "="));
+        }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
+        {
+            return GetCSharpResultAt(line, column, AvoidPropertySelfAssignment.Rule, symbolName);
+        }
+    }
+}


### PR DESCRIPTION
This is related to issue #2496 

I've implemented a *rough draft* that I'll clean up before merging, and would like feedback on the following:
- Overall design, especially with checking context types.
- Opinions on diagnostic category. I chose ```DiagnosticCategory.Design```, but I'm open to other options
- Should this be enabled by default?
- How does this get a rule ID assigned?
- What do I need to do to write help information for the help URL field in ```DiagnosticDescriptor```? It looks like all of them reference the .NET website. 

Thanks for the help!