### PR TITLE
Fixes Metrics.targets missing quotes on filepath

### DIFF
--- a/nuget/Microsoft.CodeAnalysis.Metrics/Microsoft.CodeAnalysis.Metrics.targets
+++ b/nuget/Microsoft.CodeAnalysis.Metrics/Microsoft.CodeAnalysis.Metrics.targets
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <Target Name="Metrics">
-    <Exec Command='$(MetricsExeFolder)\$(MetricsExeName).exe /project:$(MSBuildProjectFullPath) /out:$(MetricsOutputFile)'
+    <Exec Command='&quot;$(MetricsExeFolder)\$(MetricsExeName).exe&quot; /project:$(MSBuildProjectFullPath) /out:$(MetricsOutputFile)'
           WorkingDirectory="$(MSBuildProjectDirectory)">
     </Exec>
   </Target>


### PR DESCRIPTION
Microsoft.CodeAnalysis.Metrics.targets fails if the MetricsExeFolder has folder with a space.

This Pull Request fixes this issue.