### PR TITLE
BannedApiAnalyzer should recognize invocations of user-defined conversion and operators.

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -114,6 +114,38 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                             VerifySymbol(context.ReportDiagnostic, memberReference.Member, context.Operation.Syntax);
                             VerifyType(context.ReportDiagnostic, memberReference.Member.ContainingType, context.Operation.Syntax);
                             break;
+
+                        case IConversionOperation conversion:
+                            if (conversion.OperatorMethod != null)
+                            {
+                                VerifySymbol(context.ReportDiagnostic, conversion.OperatorMethod, context.Operation.Syntax);
+                                VerifyType(context.ReportDiagnostic, conversion.OperatorMethod.ContainingType, context.Operation.Syntax);
+                            }
+                            break;
+
+                        case IUnaryOperation unary:
+                            if (unary.OperatorMethod != null)
+                            {
+                                VerifySymbol(context.ReportDiagnostic, unary.OperatorMethod, context.Operation.Syntax);
+                                VerifyType(context.ReportDiagnostic, unary.OperatorMethod.ContainingType, context.Operation.Syntax);
+                            }
+                            break;
+
+                        case IBinaryOperation binary:
+                            if (binary.OperatorMethod != null)
+                            {
+                                VerifySymbol(context.ReportDiagnostic, binary.OperatorMethod, context.Operation.Syntax);
+                                VerifyType(context.ReportDiagnostic, binary.OperatorMethod.ContainingType, context.Operation.Syntax);
+                            }
+                            break;
+
+                        case IIncrementOrDecrementOperation incrementOrDecrement:
+                            if (incrementOrDecrement.OperatorMethod != null)
+                            {
+                                VerifySymbol(context.ReportDiagnostic, incrementOrDecrement.OperatorMethod, context.Operation.Syntax);
+                                VerifyType(context.ReportDiagnostic, incrementOrDecrement.OperatorMethod.ContainingType, context.Operation.Syntax);
+                            }
+                            break;
                     }
                 },
                 OperationKind.ObjectCreation,
@@ -121,7 +153,12 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 OperationKind.EventReference,
                 OperationKind.FieldReference,
                 OperationKind.MethodReference,
-                OperationKind.PropertyReference);
+                OperationKind.PropertyReference,
+                OperationKind.Conversion,
+                OperationKind.UnaryOperator,
+                OperationKind.BinaryOperator,
+                OperationKind.Increment,
+                OperationKind.Decrement);
 
             compilationContext.RegisterSyntaxNodeAction(
                 context => VerifyDocumentationSyntax(context.ReportDiagnostic, GetReferenceSyntaxNodeFromXmlCref(context.Node), context),

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -309,6 +309,39 @@ class C
         }
 
         [Fact]
+        public async Task CSharp_BannedClass_Operators()
+        {
+            var source = @"
+class C
+{
+    public static implicit operator C(int i) => new C();
+    public static explicit operator C(float f) => new C();
+    public static C operator +(C c, int i) => c;
+    public static C operator ++(C c) => c;
+    public static C operator -(C c) => c;
+
+    void M()
+    {
+        C c = 0;        // implicit conversion.
+        c = (C)1.0f;    // Explicit conversion.
+        c = c + 1;      // Binary operator.
+        c++;            // Increment or decrement.
+        c = -c;         // Unary operator.
+    }
+}";
+            var bannedText = @"T:C";
+
+            await VerifyCSharpAsync(source, bannedText,
+                GetCSharpResultAt(4, 49, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C", ""),
+                GetCSharpResultAt(5, 51, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C", ""),
+                GetCSharpResultAt(12, 15, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C", ""),
+                GetCSharpResultAt(13, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C", ""),
+                GetCSharpResultAt(14, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C", ""),
+                GetCSharpResultAt(15, 9, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C", ""),
+                GetCSharpResultAt(16, 13, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C", ""));
+        }
+
+        [Fact]
         public async Task CSharp_BannedClass_Property()
         {
             var source = @"


### PR DESCRIPTION
Issue Details:
`BannedApiAnalyzer` currently only looks for direct invocations of member methods, but it does not recognize member invocations using conversion or operator syntax.

Fix Details:
Register actions for usage of conversion, unary operators, binary operators and increment/decrement operators which will verify the method being invoked (if present).