### PR TITLE
Redoing a pinch of ValueContentAnalysis to DoNotSetSwitch

### DIFF
--- a/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
@@ -363,6 +363,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContainsN
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContainsNonLiteralState.Undefined = 1 -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContainsNonLiteralState
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue.IsLiteralState.get -> bool
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue.TryGetSingleLiteral<T>(out T literalValue) -> bool
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue.LiteralValues.get -> System.Collections.Immutable.ImmutableHashSet<object>
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue.NonLiteralState.get -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContainsNonLiteralState
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysis

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
@@ -30,14 +30,14 @@ namespace Microsoft.NetCore.Analyzers.Security
             DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             helpLinkUri: null,
             descriptionResourceStringName: nameof(SystemSecurityCryptographyResources.DoNotDisableSchUseStrongCryptoDescription),
-            customTags: WellKnownDiagnosticTags.Telemetry);
+            customTags: WellKnownDiagnosticTagsExtensions.DataflowAndTelemetry);
         internal static DiagnosticDescriptor DoNotDisableSpmSecurityProtocolsRule = SecurityHelpers.CreateDiagnosticDescriptor(
             "CA5378",
             nameof(MicrosoftNetCoreSecurityResources.DoNotDisableUsingServicePointManagerSecurityProtocolsTitle),
             nameof(MicrosoftNetCoreSecurityResources.DoNotDisableUsingServicePointManagerSecurityProtocolsMessage),
             DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             helpLinkUri: null,
-            customTags: WellKnownDiagnosticTags.Telemetry);
+            customTags: WellKnownDiagnosticTagsExtensions.DataflowAndTelemetry);
 
         internal static ImmutableDictionary<string, (bool BadValue, DiagnosticDescriptor Rule)> BadSwitches =
             ImmutableDictionary.CreateRange(

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
@@ -6,8 +6,11 @@ using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.NetCore.Analyzers.Security.Helpers;
 
@@ -79,18 +82,24 @@ namespace Microsoft.NetCore.Analyzers.Security
                     return;
                 }
 
+                var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(compilationStartAnalysisContext.Compilation);
+
                 compilationStartAnalysisContext.RegisterOperationAction(operationAnalysisContext =>
                 {
                     var invocationOperation = (IInvocationOperation)operationAnalysisContext.Operation;
                     var methodSymbol = invocationOperation.TargetMethod;
 
-                    if (setSwitchMemberWithStringAndBoolParameter.Equals(methodSymbol))
+                    if (!setSwitchMemberWithStringAndBoolParameter.Equals(methodSymbol))
                     {
-                        var values = invocationOperation.Arguments.Select(s => s.Value.ConstantValue).ToArray();
+                        return;
+                    }
 
-                        if (values[0].HasValue &&
-                            values[1].HasValue &&
-                            values[0].Value is string switchName &&
+                    var values = invocationOperation.Arguments.Select(s => s.Value.ConstantValue).ToArray();
+
+                    if (values[0].HasValue &&
+                        values[1].HasValue)
+                    {
+                        if (values[0].Value is string switchName &&
                             BadSwitches.TryGetValue(switchName, out var pair) &&
                             pair.BadValue.Equals(values[1].Value))
                         {
@@ -100,7 +109,41 @@ namespace Microsoft.NetCore.Analyzers.Security
                                     methodSymbol.Name));
                         }
                     }
-                }, OperationKind.Invocation);
+                    else
+                    {
+                        var valueContentResult = ValueContentAnalysis.GetOrComputeResult(
+                            invocationOperation.GetEnclosingControlFlowGraph(),
+                            operationAnalysisContext.ContainingSymbol,
+                            wellKnownTypeProvider,
+                            InterproceduralAnalysisConfiguration.Create(
+                                operationAnalysisContext.Options,
+                                SupportedDiagnostics,
+                                InterproceduralAnalysisKind.None,   // Just looking for simple cases.
+                                operationAnalysisContext.CancellationToken),
+                            out _,
+                            out _);
+
+                        var switchNameValueContent = valueContentResult[
+                            OperationKind.Argument,
+                            invocationOperation.Arguments[0].Syntax];
+                        var switchValueValueContent = valueContentResult[
+                            OperationKind.Argument,
+                            invocationOperation.Arguments[1].Syntax];
+
+                        // Just check for simple cases with one possible literal value.
+                        if (switchNameValueContent.TryGetSingleLiteral<string>(out var switchName) &&
+                            switchValueValueContent.TryGetSingleLiteral<bool>(out var switchValue) &&
+                            BadSwitches.TryGetValue(switchName, out var pair) &&
+                            pair.BadValue.Equals(switchValue))
+                        {
+                            operationAnalysisContext.ReportDiagnostic(
+                                invocationOperation.CreateDiagnostic(
+                                    pair.Rule,
+                                    invocationOperation.TargetMethod.Name));
+                        }
+                    }
+                },
+                OperationKind.Invocation);
             });
         }
     }

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
@@ -111,7 +111,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                     }
                     else
                     {
-                        var valueContentResult = ValueContentAnalysis.GetOrComputeResult(
+                        var valueContentResult = ValueContentAnalysis.TryGetOrComputeResult(
                             invocationOperation.GetEnclosingControlFlowGraph(),
                             operationAnalysisContext.ContainingSymbol,
                             wellKnownTypeProvider,
@@ -122,6 +122,10 @@ namespace Microsoft.NetCore.Analyzers.Security
                                 operationAnalysisContext.CancellationToken),
                             out _,
                             out _);
+                        if (valueContentResult == null)
+                        {
+                            return;
+                        }
 
                         var switchNameValueContent = valueContentResult[
                             OperationKind.Argument,

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
@@ -111,7 +111,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                     }
                     else
                     {
-                        var valueContentResult = ValueContentAnalysis.GetOrComputeResult(
+                        var valueContentResult = ValueContentAnalysis.TryGetOrComputeResult(
                             invocationOperation.GetEnclosingControlFlowGraph(),
                             operationAnalysisContext.ContainingSymbol,
                             wellKnownTypeProvider,

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
@@ -138,7 +138,6 @@ class TestClass
 }");
         }
 
-        //Ideally, we would generate a diagnostic in this case.
         [Fact]
         public void TestSwitchNameVariableNoDiagnostic()
         {
@@ -152,7 +151,8 @@ class TestClass
         string switchName = ""Switch.System.Net.DontEnableSchUseStrongCrypto"";
         AppContext.SetSwitch(switchName, true);
     }
-}");
+}",
+            GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch"));
         }
 
         //Ideally, we would generate a diagnostic in this case.

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
@@ -139,6 +139,7 @@ class TestClass
         }
 
         [Fact]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         public void TestSwitchNameVariableNoDiagnostic()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
@@ -133,7 +133,6 @@ class TestClass
 }");
         }
 
-        //Ideally, we would generate a diagnostic in this case.
         [Fact]
         public void TestSwitchNameVariableNoDiagnostic()
         {
@@ -147,7 +146,8 @@ class TestClass
         string switchName = ""Switch.System.ServiceModel.DisableUsingServicePointManagerSecurityProtocols"";
         AppContext.SetSwitch(switchName, true);
     }
-}");
+}",
+                GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch"));
         }
 
         //Ideally, we would generate a diagnostic in this case.

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
@@ -134,6 +134,7 @@ class TestClass
         }
 
         [Fact]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         public void TestSwitchNameVariableNoDiagnostic()
         {
             VerifyCSharp(@"

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
@@ -221,9 +221,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
             }
 
             object o = LiteralValues.First();
-            if (o is T)
+            if (o is T v)
             {
-                literalValue = (T)o;
+                literalValue = v;
                 return true;
             }
             else

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
@@ -205,6 +205,34 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
 
         public bool IsLiteralState => !LiteralValues.IsEmpty && NonLiteralState == ValueContainsNonLiteralState.No;
 
+        /// <summary>
+        /// For super simple cases: If this abstract value is a single literal, then get that literal value.
+        /// </summary>
+        /// <typeparam name="T">Type of the expected literal value.</typeparam>
+        /// <param name="literalValue">Literal value, or its default if not a single literal value.</param>
+        /// <returns>True if a literal value was found, false otherwise.</returns>
+        /// <remarks>If you're looking for null, you should be looking at <see cref="PointsToAnalysis"/>.</remarks>
+        public bool TryGetSingleLiteral<T>(out T literalValue)
+        {
+            if (!IsLiteralState || LiteralValues.Count != 1)
+            {
+                literalValue = default;
+                return false;
+            }
+
+            object o = LiteralValues.First();
+            if (o is T)
+            {
+                literalValue = (T)o;
+                return true;
+            }
+            else
+            {
+                literalValue = default;
+                return false;
+            }
+        }
+
         internal ValueContentAbstractValue IntersectLiteralValues(ValueContentAbstractValue value2)
         {
             Debug.Assert(IsLiteralState);


### PR DESCRIPTION
Someone wrote an example using a variable rather than a constant for the switch name, so just enabling those test cases and handling them with ValueContentAnalysis.

This can wait until after 2.9.3.