### PR TITLE
Handle catch clauses without exception variable in CA1031

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypes.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypes.cs
@@ -35,9 +35,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
         }
 
-        protected override Diagnostic CreateDiagnostic(IMethodSymbol containingMethod, SyntaxNode catchNode)
+        protected override Diagnostic CreateDiagnostic(IMethodSymbol containingMethod, SyntaxToken catchKeyword)
         {
-            return catchNode.CreateDiagnostic(Rule, containingMethod.Name);
+            return catchKeyword.CreateDiagnostic(Rule, containingMethod.Name);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
@@ -650,6 +650,27 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             GetCA1031BasicResultAt(11, 29, "TestMethod"));
         }
 
+        [Fact, WorkItem(2518, "https://github.com/dotnet/roslyn-analyzers/issues/2518")]
+        public void CSharp_NoDiagnostic_SpecificExceptionWithoutVariable()
+        {
+            VerifyCSharp(@"
+            using System;
+
+            public class Class1
+            {
+                void M()
+                {
+                    try
+                    {
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Comment
+                    }
+                }
+            }");
+        }
+
         private static DiagnosticResult GetCA1031CSharpResultAt(int line, int column, string signature)
         {
             return GetCSharpResultAt(line, column, DoNotCatchGeneralExceptionTypesAnalyzer.Rule, signature);

--- a/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
+++ b/src/Microsoft.NetFramework.Analyzers/Core/DoNotCatchCorruptedStateExceptions.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
-using Microsoft.NetFramework.Analyzers.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -37,9 +35,9 @@ namespace Microsoft.NetFramework.Analyzers
         {
         }
 
-        protected override Diagnostic CreateDiagnostic(IMethodSymbol containingMethod, SyntaxNode catchNode)
+        protected override Diagnostic CreateDiagnostic(IMethodSymbol containingMethod, SyntaxToken catchKeyword)
         {
-            return catchNode.CreateDiagnostic(Rule, containingMethod.ToDisplayString());
+            return catchKeyword.CreateDiagnostic(Rule, containingMethod.ToDisplayString());
         }
     }
 }

--- a/src/Utilities/Compiler/DoNotCatchGeneralUnlessRethrown.cs
+++ b/src/Utilities/Compiler/DoNotCatchGeneralUnlessRethrown.cs
@@ -24,7 +24,7 @@ namespace Analyzer.Utilities
             _enablingMethodAttributeFullyQualifiedName = enablingMethodAttributeFullyQualifiedName;
         }
 
-        protected abstract Diagnostic CreateDiagnostic(IMethodSymbol containingMethod, SyntaxNode catchNode);
+        protected abstract Diagnostic CreateDiagnostic(IMethodSymbol containingMethod, SyntaxToken catchKeyword);
 
         public override void Initialize(AnalysisContext analysisContext)
         {
@@ -62,7 +62,7 @@ namespace Analyzer.Utilities
 
                         foreach (var catchClause in walker.CatchClausesForDisallowedTypesWithoutRethrow)
                         {
-                            operationBlockAnalysisContext.ReportDiagnostic(CreateDiagnostic(method, catchClause.Syntax));
+                            operationBlockAnalysisContext.ReportDiagnostic(CreateDiagnostic(method, catchClause.Syntax.GetFirstToken()));
                         }
                     }
                 });
@@ -142,12 +142,7 @@ namespace Analyzer.Utilities
 
             private bool IsCatchTooGeneral(ICatchClauseOperation operation)
             {
-                return IsGenericCatch(operation) || _disallowedCatchTypes.Any(type => operation.ExceptionType.Equals(type));
-            }
-
-            private static bool IsGenericCatch(ICatchClauseOperation operation)
-            {
-                return operation.ExceptionDeclarationOrExpression == null;
+                return _disallowedCatchTypes.Any(type => operation.ExceptionType.Equals(type));
             }
 
             private static bool MightBeFilteringBasedOnTheCaughtException(ICatchClauseOperation operation)


### PR DESCRIPTION
Fixes #2518
Also changed the diagnostic span to be just the catch keyword instead of the entire catch block.