### PR TITLE
Sanitized multiple-line string-literals by replacing with a space for CA1303

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
@@ -311,12 +311,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             var literals = new StringBuilder();
             foreach (string literal in literalValues.Order())
             {
+                // sanitize the literal to ensure it's not multiline
+                // replace any newline characters with a space
+                var sanitizedLiteral = literal.Replace(Environment.NewLine, " ");
+                sanitizedLiteral = sanitizedLiteral.Replace((char)13, ' ');
+                sanitizedLiteral = sanitizedLiteral.Replace((char)10, ' ');
+
                 if (literals.Length > 0)
                 {
                     literals.Append(", ");
                 }
 
-                literals.Append(literal);
+                literals.Append(sanitizedLiteral);
             }
 
             return literals.ToString();

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -186,6 +186,51 @@ End Class
         }
 
         [Fact]
+        public void ParameterWithLocalizableAttribute_MultipleLineStringLiteralArgument_Method_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System.ComponentModel;
+
+public class C
+{
+    public void M([LocalizableAttribute(true)] string param)
+    {
+    }
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        var str = ""a\na"";
+        c.M(str);
+    }
+}
+",
+                // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a a".
+                GetCSharpResultAt(16, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a a"));
+
+            VerifyBasic(@"
+Imports Microsoft.VisualBasic
+Imports System.ComponentModel
+
+Public Class C
+    Public Sub M(<LocalizableAttribute(True)> param As String)
+    End Sub
+End Class
+
+Public Class Test
+    Public Sub M1(c As C)
+        Dim str = ""a"" & vbCrLf & ""a""
+        c.M(str)
+    End Sub
+End Class
+",
+                // Test0.vb(13,13): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a a".
+                GetBasicResultAt(13, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String)", "a a"));
+        }
+
+        [Fact]
         public void ParameterWithLocalizableAttribute_StringLiteralArgument_Method_Diagnostic()
         {
             VerifyCSharp(@"


### PR DESCRIPTION
Fix for issue #2574 where string literals that contain new line characters cause the project to not build with a CSC.exe code 1 error.

The fix replaces and newlines in the literals with a space