### PR TITLE
Fix bunch of CA1062 (ValidateArgmentsOfPublicMethods) false positives

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -2341,6 +2341,38 @@ Public Class Test
 End Class");
         }
 
+        [Fact, WorkItem(2504, "https://github.com/dotnet/roslyn-analyzers/issues/2504")]
+        public void ValidatedInInvokedMethod_Generic_02_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public int X;
+}
+
+public class Test
+{
+    public void M1(C c)
+    {
+        M2(c); // Validation method
+        var x = c.X;    // No diagnostic here.
+    }
+
+    private static T M2<T>(T c)
+    {
+        if (c == null)
+        {
+            throw new ArgumentNullException(nameof(c));
+        }
+
+        return c;
+    }
+}
+");
+        }
+
         [Fact]
         public void MaybeValidatedInInvokedMethod_Diagnostic()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -5409,6 +5409,60 @@ public class C
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Theory, WorkItem(2369, "https://github.com/dotnet/roslyn-analyzers/issues/2369")]
+        [InlineData("IsNullOrWhiteSpace")]
+        [InlineData("IsNullOrEmpty")]
+        public void StringNullCheckApis_02(string apiName)
+        {
+            VerifyCSharp($@"
+using System;
+
+public class C
+{{
+    public static void A(string input)
+    {{
+        if (string.{apiName}(input))
+        {{
+            throw new ArgumentException(""Invalid input"", nameof(input));
+        }}
+
+        B(input);
+    }}
+
+    private static void B(string input)
+    {{
+        var x = input.Length;
+    }}
+}}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Theory, WorkItem(2369, "https://github.com/dotnet/roslyn-analyzers/issues/2369")]
+        [InlineData("IsNullOrWhiteSpace")]
+        [InlineData("IsNullOrEmpty")]
+        public void StringNullCheckApis_03(string apiName)
+        {
+            VerifyCSharp($@"
+using System;
+
+public class C
+{{
+    public static void A(string input)
+    {{
+        if (!string.{apiName}(input))
+        {{
+            B(input);
+        }}
+    }}
+
+    private static void B(string input)
+    {{
+        var x = input.Length;
+    }}
+}}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact]
         public void NamedArgumentInDifferentOrder()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -5463,6 +5463,65 @@ public class C
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact, WorkItem(2582, "https://github.com/dotnet/roslyn-analyzers/issues/2582")]
+        public void StringEmptyFieldIsNonNull()
+        {
+            VerifyCSharp($@"
+using System;
+
+public class Class1
+{{
+    public Class1(int num) {{ }}
+
+    public Class1(string name)
+        : this((name ?? string.Empty).Length) // Ensure no CA1062 here
+    {{
+    }}
+}}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact, WorkItem(2582, "https://github.com/dotnet/roslyn-analyzers/issues/2582")]
+        public void ArrayEmptyMethodIsNonNull()
+        {
+            VerifyCSharp($@"
+using System;
+
+public class Class1
+{{
+    public Class1(int num) {{ }}
+
+    public Class1(int[] arr)
+        : this((arr ?? Array.Empty<int>()).Length) // Ensure no CA1062 here
+    {{
+    }}
+}}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact, WorkItem(2582, "https://github.com/dotnet/roslyn-analyzers/issues/2582")]
+        public void ImmutableCreationMethodIsNonNull()
+        {
+            VerifyCSharp($@"
+using System.Collections.Immutable;
+
+public class Class1
+{{
+    public Class1(int num) {{ }}
+
+    public Class1(ImmutableDictionary<int, int> map)
+        : this((map ?? ImmutableDictionary.Create<int, int>()).Count) // Ensure no CA1062 here
+    {{
+    }}
+
+    public Class1(ImmutableHashSet<int> set)
+        : this((set ?? ImmutableHashSet.CreateRange(new[] {{ 1, 2 }})).Count) // Ensure no CA1062 here
+    {{
+    }}
+}}");
+        }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact]
         public void NamedArgumentInDifferentOrder()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -5550,5 +5550,27 @@ public class C
             // Test0.cs(13,12): warning CA1062: In externally visible method 'void C.M(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(13, 12, "void C.M(C c1, C c2)", "c2"));
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact, WorkItem(2528, "https://github.com/dotnet/roslyn-analyzers/issues/2528")]
+        public void ParamArrayIsNotFlagged()
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public void M(params int[] p)
+    {
+        var x = p.Length;
+    }
+}");
+
+            VerifyBasic(@"
+Public Class C
+    Public Sub M(ParamArray p As Integer())
+        Dim x = p.Length
+    End Sub
+End Class
+");
+        }
     }
 }

--- a/src/Utilities.UnitTests/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisTests.cs
+++ b/src/Utilities.UnitTests/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisTests.cs
@@ -295,7 +295,7 @@ class TestClass
         }
 
         [Fact]
-        public void TestTypeToTrack_HazardousIfStringIsNull_StringEmpty_MaybeFlagged()
+        public void TestTypeToTrack_HazardousIfStringIsNull_StringEmpty_Flagged()
         {
             VerifyCSharp(@"
 using System;
@@ -305,12 +305,12 @@ class TestClass
     void TestMethod()
     /*<bind>*/{
         TestTypeToTrack t = new TestTypeToTrack();
-        t.AString = String.Empty;   // Ideally String.Empty would be NullAbstractValue.NonNull.
+        t.AString = String.Empty;
         t.Method();
     }/*</bind>*/
 }",
                 TestTypeToTrack_HazardousIfStringIsNonNull,
-                (10, 9, "void TestTypeToTrack.Method()", HazardousUsageEvaluationResult.MaybeFlagged));
+                (10, 9, "void TestTypeToTrack.Method()", HazardousUsageEvaluationResult.Flagged));
         }
 
         [Fact]
@@ -471,7 +471,7 @@ class TestClass
         }
 
         [Fact]
-        public void TestTypeToTrackWithConstructor_HazardousIfStringIsNull_StringEmpty_MaybeFlagged()
+        public void TestTypeToTrackWithConstructor_HazardousIfStringIsNull_StringEmpty_Flagged()
         {
             VerifyCSharp(@"
 using System;
@@ -480,12 +480,12 @@ class TestClass
 {
     void TestMethod()
     /*<bind>*/{
-        TestTypeToTrackWithConstructor t = new TestTypeToTrackWithConstructor(default(TestEnum), null, String.Empty);   // Ideally String.Empty would be NullAbstractValue.NonNull.
+        TestTypeToTrackWithConstructor t = new TestTypeToTrackWithConstructor(default(TestEnum), null, String.Empty);
         t.Method();
     }/*</bind>*/
 }",
                 TestTypeToTrackWithConstructor_HazardousIfStringIsNonNull,
-                (9, 9, "void TestTypeToTrack.Method()", HazardousUsageEvaluationResult.MaybeFlagged));
+                (9, 9, "void TestTypeToTrack.Method()", HazardousUsageEvaluationResult.Flagged));
         }
 
         [Fact]

--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -534,5 +534,19 @@ namespace Analyzer.Utilities.Extensions
                 }
             }
         }
+
+        /// <summary>
+        /// Returns true if this is a bool returning static method whose name starts with "IsNull"
+        /// with a single parameter whose type is not a value type.
+        /// For example, "static bool string.IsNullOrEmpty()"
+        /// </summary>
+        public static bool IsArgumentNullCheckMethod(this IMethodSymbol method)
+        {
+            return method.IsStatic &&
+                method.ReturnType.SpecialType == SpecialType.System_Boolean &&
+                method.Name.StartsWith("IsNull", StringComparison.Ordinal) &&
+                method.Parameters.Length == 1 &&
+                !method.Parameters[0].Type.IsValueType;
+        }
     }
 }

--- a/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -539,6 +539,21 @@ namespace Analyzer.Utilities.Extensions
         {
             switch (symbol.Kind)
             {
+                case SymbolKind.Local:
+                    return ((ILocalSymbol)symbol).Type;
+
+                case SymbolKind.Parameter:
+                    return ((IParameterSymbol)symbol).Type;
+
+                default:
+                    return GetMemerType(symbol);
+            }
+        }
+
+        public static ITypeSymbol GetMemerType(this ISymbol symbol)
+        {
+            switch (symbol.Kind)
+            {
                 case SymbolKind.Event:
                     return ((IEventSymbol)symbol).Type;
 
@@ -551,14 +566,23 @@ namespace Analyzer.Utilities.Extensions
                 case SymbolKind.Property:
                     return ((IPropertySymbol)symbol).Type;
 
-                case SymbolKind.Local:
-                    return ((ILocalSymbol)symbol).Type;
-
-                case SymbolKind.Parameter:
-                    return ((IParameterSymbol)symbol).Type;
-
                 default:
                     return null;
+            }
+        }
+
+        public static bool IsReadOnlyFieldOrProperty(this ISymbol symbol)
+        {
+            switch (symbol)
+            {
+                case IFieldSymbol field:
+                    return field.IsReadOnly;
+
+                case IPropertySymbol property:
+                    return property.IsReadOnly;
+
+                default:
+                    return false;
             }
         }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
@@ -337,6 +337,19 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
                         }
                     }
                 }
+
+                // Mark arguments passed to parameters with ValidatedNotNullAttribute as validated
+                foreach (var argument in arguments)
+                {
+                    var notValidatedLocations = GetNotValidatedLocations(argument);
+                    if (notValidatedLocations.Any())
+                    {
+                        if (HasValidatedNotNullAttribute(argument.Parameter))
+                        {
+                            MarkValidatedLocations(argument);
+                        }
+                    }
+                }
             }
 
             private void ProcessLambdaOrLocalFunctionInvocation(IMethodSymbol targetMethod, IOperation invocation)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
@@ -279,14 +279,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
             {
                 Debug.Assert(!targetMethod.IsLambdaOrLocalFunctionOrDelegate());
 
-                if (targetMethod.ContainingType.SpecialType == SpecialType.System_String)
+                if (targetMethod.IsArgumentNullCheckMethod())
                 {
-                    if (targetMethod.IsStatic &&
-                        targetMethod.Name.StartsWith("IsNull", StringComparison.Ordinal) &&
-                        targetMethod.Parameters.Length == 1 &&
-                        arguments.Length == 1)
+                    if (arguments.Length == 1)
                     {
-                        // string.IsNullOrXXX check.
+                        // "static bool SomeType.IsNullXXX(obj)" check.
                         MarkValidatedLocations(arguments[0]);
                     }
                 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -907,7 +907,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                     (method.ContainingType.IsStatic ||
                      method.ContainingType.SpecialType != SpecialType.None ||
                      method.ReturnType is INamedTypeSymbol namedType &&
-                     method.ContainingType.DerivesFromOrImplementsAnyConstructionOf(namedType));
+                     method.ContainingType.DerivesFromOrImplementsAnyConstructionOf(namedType.OriginalDefinition));
             }
 
             /// <summary>
@@ -928,7 +928,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                     (symbol.IsReadOnlyFieldOrProperty() || symbol.Kind == SymbolKind.Method) &&
                     (symbol.ContainingType.SpecialType != SpecialType.None ||
                      symbol.GetMemerType() is INamedTypeSymbol namedType &&
-                     symbol.ContainingType.DerivesFromOrImplementsAnyConstructionOf(namedType));
+                     symbol.ContainingType.DerivesFromOrImplementsAnyConstructionOf(namedType.OriginalDefinition));
             }
 
             public override PointsToAbstractValue VisitInvocation_LocalFunction(

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -881,7 +881,54 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                     HandleEscapingOperation(originalOperation, visitedArguments[0].Value);
                 }
 
-                return VisitInvocationCommon(originalOperation, visitedInstance);
+                var value = VisitInvocationCommon(originalOperation, visitedInstance);
+
+                if (IsSpecialFactoryOrEmptyMethod(method) &&
+                    !TryGetInterproceduralAnalysisResult(originalOperation, out _))
+                {
+                    return value.MakeNonNull();
+                }
+
+                return value;
+            }
+
+            private static bool IsSpecialFactoryOrEmptyMethod(IMethodSymbol method)
+                => IsSpecialFactoryMethod(method) || IsSpecialEmptyMember(method);
+
+            /// <summary>
+            /// Returns true if this special static factory method whose name starts with "Create", such that 
+            /// method's containing type is static OR a special type OR derives from or is same as the type of the field/property/method return.
+            /// For example: class SomeType { static SomeType CreateXXX(...); }
+            /// </summary>
+            private static bool IsSpecialFactoryMethod(IMethodSymbol method)
+            {
+                return method.IsStatic &&
+                    method.Name.StartsWith("Create", StringComparison.Ordinal) &&
+                    (method.ContainingType.IsStatic ||
+                     method.ContainingType.SpecialType != SpecialType.None ||
+                     method.ReturnType is INamedTypeSymbol namedType &&
+                     method.ContainingType.DerivesFromOrImplementsAnyConstructionOf(namedType));
+            }
+
+            /// <summary>
+            /// Returns true if this special member symbol named "Empty", such that one of the following is true:
+            ///  1. It is a static method with no parameters or
+            ///  2. It is a static readonly property or
+            ///  3. It is static readonly field
+            /// and symbol's containing type is a special type or derives from or is same as the type of the field/property/method return.
+            /// For example:
+            ///  1. class SomeType { static readonly SomeType Empty; }
+            ///  2. class SomeType { static readonly SomeType Empty { get; } }
+            ///  3. class SomeType { static SomeType Empty(); }
+            /// </summary>
+            private static bool IsSpecialEmptyMember(ISymbol symbol)
+            {
+                return symbol.IsStatic &&
+                    symbol.Name.Equals("Empty", StringComparison.Ordinal) &&
+                    (symbol.IsReadOnlyFieldOrProperty() || symbol.Kind == SymbolKind.Method) &&
+                    (symbol.ContainingType.SpecialType != SpecialType.None ||
+                     symbol.GetMemerType() is INamedTypeSymbol namedType &&
+                     symbol.ContainingType.DerivesFromOrImplementsAnyConstructionOf(namedType));
             }
 
             public override PointsToAbstractValue VisitInvocation_LocalFunction(
@@ -951,12 +998,28 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             public override PointsToAbstractValue VisitFieldReference(IFieldReferenceOperation operation, object argument)
             {
                 var value = base.VisitFieldReference(operation, argument);
+
+                // "class SomeType { static readonly SomeType Empty; }"
+                if (IsSpecialEmptyMember(operation.Field) &&
+                    value.NullState != NullAbstractValue.Null)
+                {
+                    return value.MakeNonNull();
+                }
+
                 return GetValueBasedOnInstanceOrReferenceValue(operation.Instance, operation, value);
             }
 
             public override PointsToAbstractValue VisitPropertyReference(IPropertyReferenceOperation operation, object argument)
             {
                 var value = base.VisitPropertyReference(operation, argument);
+
+                // "class SomeType { static SomeType Empty { get; } }"
+                if (IsSpecialEmptyMember(operation.Property) &&
+                    value.NullState != NullAbstractValue.Null)
+                {
+                    return value.MakeNonNull();
+                }
+
                 return GetValueBasedOnInstanceOrReferenceValue(operation.Instance, operation, value);
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 => ShouldBeTracked(parameter.Type) ?
                     PointsToAbstractValue.Create(
                         AbstractLocation.CreateSymbolLocation(parameter, DataFlowAnalysisContext.InterproceduralAnalysisDataOpt?.CallStack),
-                        mayBeNull: true) :
+                        mayBeNull: !parameter.IsParams) :
                     PointsToAbstractValue.NoLocation;
 
             protected override void EscapeValueForParameterOnExit(IParameterSymbol parameter, AnalysisEntity analysisEntity)
@@ -883,7 +883,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
                 var value = VisitInvocationCommon(originalOperation, visitedInstance);
 
-                if (IsSpecialFactoryOrEmptyMethod(method) &&
+                if (IsSpecialEmptyOrFactoryMethod(method) &&
                     !TryGetInterproceduralAnalysisResult(originalOperation, out _))
                 {
                     return value.MakeNonNull();
@@ -892,7 +892,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 return value;
             }
 
-            private static bool IsSpecialFactoryOrEmptyMethod(IMethodSymbol method)
+            private static bool IsSpecialEmptyOrFactoryMethod(IMethodSymbol method)
                 => IsSpecialFactoryMethod(method) || IsSpecialEmptyMember(method);
 
             /// <summary>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -73,7 +73,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             }
         }
 
-        internal static bool ShouldBeTracked(ITypeSymbol typeSymbol) => typeSymbol.IsReferenceTypeOrNullableValueType();
+        internal static bool ShouldBeTracked(ITypeSymbol typeSymbol) => typeSymbol.IsReferenceTypeOrNullableValueType() ||
+            typeSymbol is ITypeParameterSymbol typeParameter && !typeParameter.IsValueType;
 
         internal static bool ShouldBeTracked(AnalysisEntity analysisEntity)
             => ShouldBeTracked(analysisEntity.Type) || analysisEntity.IsLValueFlowCaptureEntity || analysisEntity.IsThisOrMeInstance;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -1378,8 +1378,19 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     break;
 
                 case IInvocationOperation invocation:
-                    // Predicate analysis for different equality comparison methods.
+                    // Predicate analysis for different equality comparison methods and argument null check methods.
                     Debug.Assert(invocation.Type.SpecialType == SpecialType.System_Boolean);
+
+                    if (invocation.TargetMethod.IsArgumentNullCheckMethod())
+                    {
+                        // Predicate analysis for null checks.
+                        if (invocation.Arguments.Length == 1)
+                        {
+                            predicateValueKind = SetValueForIsNullComparisonOperator(invocation.Arguments[0].Value, equals: FlowBranchConditionKind == ControlFlowConditionKind.WhenTrue, targetAnalysisData: targetAnalysisData);
+                        }
+
+                        break;
+                    }
 
                     IOperation leftOperand = null;
                     IOperation rightOperand = null;
@@ -2631,7 +2642,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 // Predicate analysis for different equality compare method invocations.
                 if (PredicateAnalysis &&
                     operation.Type.SpecialType == SpecialType.System_Boolean &&
-                    targetMethod.Name.EndsWith("Equals", StringComparison.Ordinal))
+                    (targetMethod.Name.EndsWith("Equals", StringComparison.Ordinal) ||
+                     targetMethod.IsArgumentNullCheckMethod()))
                 {
                     PerformPredicateAnalysis(operation);
                 }


### PR DESCRIPTION
I recommend reviewing commit by commit - each commit has very minor product fixes

1. https://github.com/dotnet/roslyn-analyzers/commit/38dc20a0a5570e19c37dd5d81647feeab1bdabfd: Handle argument null check methods in the PredicateAnalysis done with in core dataflow operation visitor. Fixes #2369
2. https://github.com/dotnet/roslyn-analyzers/commit/1ebfb476a05e4912c86f55c1daac026987b1b649: Special case few more field/property/methods that return non-null instances. Fixes #2582
   1. static readonly members named "Empty"
   2. static factory methods whose name starts with "Create"
3. https://github.com/dotnet/roslyn-analyzers/commit/c5dd3e42f2ede6888f15b88c310b091a57cd35b6: Ensure param arrays are always assumed to be non-null. Fixes #2528
4. https://github.com/dotnet/roslyn-analyzers/commit/0fe87eafe53f0a26cd3459ba7a326ff36d66b321: Mark arguments passed to parameters with ValidatedNotNullAttribute as validated. Fixes #2525
5. https://github.com/dotnet/roslyn-analyzers/commit/e03910f2751734e19992d2c107634813b8f3b009: Make sure we track points to values for type parameters with no value type constraint. Fixes #2504