### PR TITLE
Fix couple more issues for CA1062 (ValidateAgumentsOfPublicMethods)

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -86,6 +86,28 @@ Default Value: `false`
 
 Example: `dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = true`
 
+### Null check validation methods
+Option Name: `null_check_validation_methods`
+
+Configurable Rules: [CA1062](https://docs.microsoft.com/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods)
+
+Option Values: Names of null check validation methods (separated by '~') that validate arguments passed to the method are non-null for CA1062 (https://docs.microsoft.com/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods).
+Allowed method name formats:
+  1. Method name only (includes all methods with the name, regardless of the containing type or namespace)
+  2. Fully qualified names in the symbol's documentation ID format: https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format
+     with an optional "M:" prefix.
+
+Default Value: None
+
+Examples:
+
+| Option Value | Summary |
+| --- | --- |
+|`dotnet_code_quality.null_check_validation_methods = Validate` | Matches all methods named 'Validate' in the compilation
+|`dotnet_code_quality.null_check_validation_methods = Validate1~Validate2` | Matches all methods named either 'Validate1' or 'Validate2' in the compilation
+|`dotnet_code_quality.null_check_validation_methods = NS.MyType.Validate(ParamType)` | Matches specific method 'Validate' with given fully qualified signature
+|`dotnet_code_quality.null_check_validation_methods = NS1.MyType1.Validate1(ParamType),NS2.MyType2.Validate2(ParamType)` | Matches specific methods 'Validate1' and 'Validate2' with respective fully qualified signature
+ 
 ### Dataflow analysis
 
 Configurable Rules: [CA1062](https://docs.microsoft.com/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods), [CA1303](https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters), [CA1508](../src/Microsoft.CodeQuality.Analyzers/Microsoft.CodeQuality.Analyzers.md#ca1508-avoid-dead-conditional-code), [CA2000](https://docs.microsoft.com/visualstudio/code-quality/ca2000-dispose-objects-before-losing-scope), [CA2100](https://docs.microsoft.com/visualstudio/code-quality/ca2100-review-sql-queries-for-security-vulnerabilities), [CA2213](https://docs.microsoft.com/visualstudio/code-quality/ca2213-disposable-fields-should-be-disposed), Taint analysis rules

--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -106,7 +106,7 @@ Examples:
 |`dotnet_code_quality.null_check_validation_methods = Validate` | Matches all methods named 'Validate' in the compilation
 |`dotnet_code_quality.null_check_validation_methods = Validate1~Validate2` | Matches all methods named either 'Validate1' or 'Validate2' in the compilation
 |`dotnet_code_quality.null_check_validation_methods = NS.MyType.Validate(ParamType)` | Matches specific method 'Validate' with given fully qualified signature
-|`dotnet_code_quality.null_check_validation_methods = NS1.MyType1.Validate1(ParamType),NS2.MyType2.Validate2(ParamType)` | Matches specific methods 'Validate1' and 'Validate2' with respective fully qualified signature
+|`dotnet_code_quality.null_check_validation_methods = NS1.MyType1.Validate1(ParamType)~NS2.MyType2.Validate2(ParamType)` | Matches specific methods 'Validate1' and 'Validate2' with respective fully qualified signature
  
 ### Dataflow analysis
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ValidateArgumentsOfPublicMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/ValidateArgumentsOfPublicMethods.cs
@@ -49,6 +49,30 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                         return;
                     }
 
+                    // Bail out for protected members of sealed classes if the entire overridden method chain
+                    // is defined in the same assembly.
+                    if (containingMethod.IsOverride &&
+                        containingMethod.ContainingType.IsSealed)
+                    {
+                        var overriddenMethod = containingMethod.OverriddenMethod;
+                        var hasAssemblyMismatch = false;
+                        while (overriddenMethod != null)
+                        {
+                            if (!Equals(overriddenMethod.ContainingAssembly, containingMethod.ContainingAssembly))
+                            {
+                                hasAssemblyMismatch = true;
+                                break;
+                            }
+
+                            overriddenMethod = overriddenMethod.OverriddenMethod;
+                        }
+
+                        if (!hasAssemblyMismatch)
+                        {
+                            return;
+                        }
+                    }
+
                     // Bail out early if we have no parameter references in the method body. 
                     if (!operationBlockContext.OperationBlocks.HasAnyOperationDescendant(OperationKind.ParameterReference))
                     {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -1932,6 +1932,78 @@ public class C
             GetCSharpResultAt(14, 13, "void C.M1(C c1, C c2)", "c2"));
         }
 
+        [Theory, WorkItem(2578, "https://github.com/dotnet/roslyn-analyzers/issues/2578")]
+        // Match by method name
+        [InlineData(@"dotnet_code_quality.interprocedural_analysis_kind = None
+                      dotnet_code_quality.null_check_validation_methods = Validate")]
+        // Match multiple methods by method documentation ID
+        [InlineData(@"dotnet_code_quality.interprocedural_analysis_kind = None
+                      dotnet_code_quality.null_check_validation_methods = C.Validate(C)~Helper`1.Validate(C)~Helper`1.Validate``1(C,``0)")]
+        // Match multiple methods by method documentation ID with "M:" prefix
+        [InlineData(@"dotnet_code_quality.interprocedural_analysis_kind = None
+                      dotnet_code_quality.null_check_validation_methods = M:C.Validate(C)~M:Helper`1.Validate(C)~M:Helper`1.Validate``1(C,``0)")]
+        public void NullCheckValidationMethod_ConfiguredInEditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
+        {
+            VerifyCSharp(@"
+public class C
+{
+    public void M1(C c1, C c2, C c3, C c4, C c5, C c6)
+    {
+        Validate(c1);
+        var x = c1.ToString(); // No diagnostic
+
+        Helper<int>.Validate(c2);
+        x = c2.ToString(); // No diagnostic
+
+        Helper<int>.Validate<object>(c3, null);
+        x = c3.ToString(); // No diagnostic
+
+        NoValidate(c4);
+        x = c4.ToString(); // Diagnostic
+
+        Helper<int>.NoValidate(c5);
+        x = c5.ToString(); // Diagnostic
+
+        Helper<int>.NoValidate<object>(c6, null);
+        x = c6.ToString(); // Diagnostic
+    }
+
+    private static void Validate(C c)
+    {
+    }
+
+    private static void NoValidate(C c)
+    {
+    }
+}
+
+internal static class Helper<T>
+{
+    internal static void Validate(C c)
+    {
+    }
+
+    internal static void NoValidate(C c)
+    {
+    }
+
+    internal static void Validate<U>(C c, U u)
+    {
+    }
+
+    internal static void NoValidate<U>(C c, U u)
+    {
+    }
+}
+", GetEditorConfigAdditionalFile(editorConfigText),
+            // Test0.cs(16,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c4' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(16, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c4"),
+            // Test0.cs(19,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c5' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(19, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c5"),
+            // Test0.cs(22,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c6' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+            GetCSharpResultAt(22, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c6"));
+        }
+
         [Fact, WorkItem(1707, "https://github.com/dotnet/roslyn-analyzers/issues/1707")]
         public void HazardousUsageInInvokedMethod_PrivateMethod_Generic_Diagnostic()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -5640,5 +5640,25 @@ Public Class C
 End Class
 ");
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact, WorkItem(2269, "https://github.com/dotnet/roslyn-analyzers/issues/2269")]
+        public void ProtectedMemberOfSealedClassNotFlagged()
+        {
+            VerifyCSharp(@"
+using System;
+
+public abstract class A
+{
+    public bool CheckMe() => IsType(GetType());
+
+    protected abstract bool IsType(Type type);
+}
+
+public sealed class B : A
+{
+    protected override bool IsType(Type type) => type.Namespace == nameof(System);
+}");
+        }
     }
 }

--- a/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -535,7 +535,7 @@ namespace Analyzer.Utilities.Extensions
             return false;
         }
 
-        public static ITypeSymbol GetMemerOrLocalOrParameterType(this ISymbol symbol)
+        public static ITypeSymbol GetMemberOrLocalOrParameterType(this ISymbol symbol)
         {
             switch (symbol.Kind)
             {

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Analyzer.Utilities.PooledObjects;
 
 #pragma warning disable RS1012 // Start action has no registered actions.
 
@@ -112,6 +113,29 @@ namespace Analyzer.Utilities
         {
             var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(cancellationToken);
             return analyzerConfigOptions.GetOptionValue(optionName, rule, uint.TryParse, defaultValue);
+        }
+
+        public static ImmutableArray<string> GetSeparatedStringOptionValue(
+            this AnalyzerOptions options,
+            string optionName,
+            DiagnosticDescriptor rule,
+            CancellationToken cancellationToken)
+        {
+            var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(cancellationToken);
+            return analyzerConfigOptions.GetOptionValue<ImmutableArray<string>>(optionName, rule, TryParse, defaultValue: ImmutableArray<string>.Empty);
+
+            // Local functions.
+            bool TryParse(string s, out ImmutableArray<string> parts)
+            {
+                if (string.IsNullOrEmpty(s))
+                {
+                    parts = ImmutableArray<string>.Empty;
+                    return false;
+                }
+
+                parts = s.Split('~').ToImmutableArray();
+                return true;
+            }
         }
 
         private static CategorizedAnalyzerConfigOptions GetOrComputeCategorizedAnalyzerConfigOptions(

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -32,5 +32,14 @@ namespace Analyzer.Utilities
         /// Boolean option to configure if single letter type parameter names are not flagged for CA1715 (https://docs.microsoft.com/visualstudio/code-quality/ca1715-identifiers-should-have-correct-prefix).
         /// </summary>
         public const string ExcludeSingleLetterTypeParameters = "exclude_single_letter_type_parameters";
+
+        /// <summary>
+        /// String option to configure names of null check validation methods (separated by '~') that validate arguments passed to the method are non-null for CA1062 (https://docs.microsoft.com/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods).
+        /// Allowed method name formats:
+        ///   1. Method name only (includes all methods with the name, regardless of the containing type or namespace)
+        ///   2. Fully qualified names in the symbol's documentation ID format: https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format
+        ///      with an optional "M:" prefix.
+        /// </summary>
+        public const string NullCheckValidationMethods = "null_check_validation_methods";
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.ParameterValidationDataFlowOperationVisitor.cs
@@ -338,13 +338,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
                     }
                 }
 
-                // Mark arguments passed to parameters with ValidatedNotNullAttribute as validated
+
+                // Mark arguments passed to parameters of null check validation methods as validated.
+                // Also mark arguments passed to parameters with ValidatedNotNullAttribute as validated.
+                var isNullCheckValidationMethod = DataFlowAnalysisContext.IsNullCheckValidationMethod(targetMethod.OriginalDefinition);
                 foreach (var argument in arguments)
                 {
                     var notValidatedLocations = GetNotValidatedLocations(argument);
                     if (notValidatedLocations.Any())
                     {
-                        if (HasValidatedNotNullAttribute(argument.Parameter))
+                        if (isNullCheckValidationMethod || HasValidatedNotNullAttribute(argument.Parameter))
                         {
                             MarkValidatedLocations(argument);
                         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysisContext.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
@@ -26,6 +30,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
             WellKnownTypeProvider wellKnownTypeProvider,
             ControlFlowGraph controlFlowGraph,
             ISymbol owningSymbol,
+            ImmutableHashSet<string> nullCheckValidationMethodNames,
+            ImmutableHashSet<IMethodSymbol> nullCheckValidationMethodSymbols,
             InterproceduralAnalysisConfiguration interproceduralAnalysisConfig,
             bool pessimisticAnalysis,
             PointsToAnalysisResult pointsToAnalysisResultOpt,
@@ -40,6 +46,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
                   interproceduralAnalysisPredicateOpt: null)
         {
             TrackHazardousParameterUsages = trackHazardousParameterUsages;
+            NullCheckValidationMethodNames = nullCheckValidationMethodNames;
+            NullCheckValidationMethodSymbols = nullCheckValidationMethodSymbols;
         }
 
         public static ParameterValidationAnalysisContext Create(
@@ -47,13 +55,29 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
             WellKnownTypeProvider wellKnownTypeProvider,
             ControlFlowGraph controlFlowGraph,
             ISymbol owningSymbol,
+            ImmutableArray<string> nullCheckValidationMethods,
             InterproceduralAnalysisConfiguration interproceduralAnalysisConfig,
             bool pessimisticAnalysis,
             PointsToAnalysisResult pointsToAnalysisResultOpt,
             Func<ParameterValidationAnalysisContext, ParameterValidationAnalysisResult> tryGetOrComputeAnalysisResult)
         {
+            var nullCheckValidationMethodNames = nullCheckValidationMethods.IsEmpty ?
+                ImmutableHashSet<string>.Empty :
+                nullCheckValidationMethods.Where(s => !s.Contains("."))
+                    .ToImmutableHashSet(wellKnownTypeProvider.Compilation.IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+
+            var nullCheckValidationMethodSymbols = nullCheckValidationMethods.IsEmpty ?
+                ImmutableHashSet<IMethodSymbol>.Empty :
+                nullCheckValidationMethods.Where(s => s.Contains("."))
+                    .Select(s => s.StartsWith("M:", StringComparison.Ordinal) ? s : "M:" + s)
+                    .SelectMany(s => DocumentationCommentId.GetSymbolsForDeclarationId(s, wellKnownTypeProvider.Compilation))
+                    .OfType<IMethodSymbol>()
+                    .WhereNotNull()
+                    .ToImmutableHashSet();
+
             return new ParameterValidationAnalysisContext(
-                valueDomain, wellKnownTypeProvider, controlFlowGraph, owningSymbol, interproceduralAnalysisConfig,
+                valueDomain, wellKnownTypeProvider, controlFlowGraph, owningSymbol,
+                nullCheckValidationMethodNames, nullCheckValidationMethodSymbols, interproceduralAnalysisConfig,
                 pessimisticAnalysis, pointsToAnalysisResultOpt, tryGetOrComputeAnalysisResult, parentControlFlowGraphOpt: null,
                 interproceduralAnalysisDataOpt: null, trackHazardousParameterUsages: false);
         }
@@ -74,7 +98,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
             // Do not invoke any interprocedural analysis more than one level down.
             // We only care about analyzing validation methods.
             return new ParameterValidationAnalysisContext(
-                ValueDomain, WellKnownTypeProvider, invokedCfg, invokedMethod, InterproceduralAnalysisConfiguration,
+                ValueDomain, WellKnownTypeProvider, invokedCfg, invokedMethod,
+                NullCheckValidationMethodNames, NullCheckValidationMethodSymbols, InterproceduralAnalysisConfiguration,
                 PessimisticAnalysis, pointsToAnalysisResultOpt, TryGetOrComputeAnalysisResult, ControlFlowGraph,
                 interproceduralAnalysisData, TrackHazardousParameterUsages);
         }
@@ -82,15 +107,22 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
         public ParameterValidationAnalysisContext WithTrackHazardousParameterUsages()
             => new ParameterValidationAnalysisContext(
                 ValueDomain, WellKnownTypeProvider, ControlFlowGraph,
-                OwningSymbol, InterproceduralAnalysisConfiguration, PessimisticAnalysis,
+                OwningSymbol, NullCheckValidationMethodNames, NullCheckValidationMethodSymbols,
+                InterproceduralAnalysisConfiguration, PessimisticAnalysis,
                 PointsToAnalysisResultOpt, TryGetOrComputeAnalysisResult, ParentControlFlowGraphOpt,
                 InterproceduralAnalysisDataOpt, trackHazardousParameterUsages: true);
 
         public bool TrackHazardousParameterUsages { get; }
 
+        private ImmutableHashSet<string> NullCheckValidationMethodNames { get; }
+        private ImmutableHashSet<IMethodSymbol> NullCheckValidationMethodSymbols { get; }
+        public bool IsNullCheckValidationMethod(IMethodSymbol method)
+            => NullCheckValidationMethodSymbols.Contains(method) || NullCheckValidationMethodNames.Contains(method.Name);
         protected override void ComputeHashCodePartsSpecific(ArrayBuilder<int> builder)
         {
             builder.Add(TrackHazardousParameterUsages.GetHashCode());
+            builder.Add(HashUtilities.Combine(NullCheckValidationMethodNames));
+            builder.Add(HashUtilities.Combine(NullCheckValidationMethodSymbols));
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public static AbstractLocation CreateThisOrMeLocation(INamedTypeSymbol namedTypeSymbol, ImmutableStack<IOperation> creationCallStackOpt)
             => Create(creationOpt: null, creationCallStackOpt: creationCallStackOpt, analysisEntityOpt: null, symbolOpt: namedTypeSymbol, captureIdOpt: null, locationType: namedTypeSymbol);
         public static AbstractLocation CreateSymbolLocation(ISymbol symbol, ImmutableStack<IOperation> creationCallStackOpt)
-            => Create(creationOpt: null, creationCallStackOpt: creationCallStackOpt, analysisEntityOpt: null, symbolOpt: symbol, captureIdOpt: null, locationType: symbol.GetMemerOrLocalOrParameterType());
+            => Create(creationOpt: null, creationCallStackOpt: creationCallStackOpt, analysisEntityOpt: null, symbolOpt: symbol, captureIdOpt: null, locationType: symbol.GetMemberOrLocalOrParameterType());
         public static AbstractLocation CreateFlowCaptureLocation(InterproceduralCaptureId captureId, ITypeSymbol locationType, ImmutableStack<IOperation> creationCallStackOpt)
             => Create(creationOpt: null, creationCallStackOpt: creationCallStackOpt, analysisEntityOpt: null, symbolOpt: null, captureIdOpt: captureId, locationType: locationType);
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
             var indices = ImmutableArray<AbstractIndex>.Empty;
             IOperation instance = null;
-            var type = symbol.GetMemerOrLocalOrParameterType();
+            var type = symbol.GetMemberOrLocalOrParameterType();
             Debug.Assert(type != null);
 
             return TryCreate(symbol, indices, type, instance, out analysisEntity);


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn-analyzers/commit/757591f8b5dbcea7365750ce66ff4c0367dfbf28: Do not flag CA1062 for protected members of sealed classes if the entire overridden method chain is defined in the same assembly. Fixes #2269
2. https://github.com/dotnet/roslyn-analyzers/commit/6539472700e2b31a1eefb9cf08f41da0d98e589b: Add editorconfig option to allow specifying method names or signatures for null check validation methods. Fixes #2578
**Option Name:** `null_check_validation_methods`
**Option Values:** Names of null check validation methods (separated by '~') that validate arguments passed to the method are non-null for [CA1062](https://docs.microsoft.com/visualstudio/code-quality/ca1062-validate-arguments-of-public-methods).
Allowed method name formats:
    1. Method name only (includes all methods with the name, regardless of the containing type or namespace)
    2. Fully qualified names in the symbol's documentation ID format: https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format with an optional "M:" prefix.