### PR TITLE
Defensive check for NRE in #2502

### DIFF
--- a/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -484,7 +484,7 @@ namespace Analyzer.Utilities.Extensions
             }
 
             return symbol.IsOverride &&
-                symbol.GetOverriddenMember().IsOverrideOrImplementationOfInterfaceMember(interfaceMember);
+                symbol.GetOverriddenMember()?.IsOverrideOrImplementationOfInterfaceMember(interfaceMember) == true;
         }
 
         /// <summary>


### PR DESCRIPTION
I haven't been able to create a repro for #2502, so just adding a defensive check based on the callstack in the bug
Fixes #2502