### PR TITLE
Fix bugs for ca5360

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotCallDangerousMethodsInDeserialization.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotCallDangerousMethodsInDeserialization.cs
@@ -135,7 +135,15 @@ namespace Microsoft.NetCore.Analyzers.Security
 
                                 operationBlockStartAnalysisContext.RegisterOperationAction(operationContext =>
                                 {
-                                    calledMethods.TryAdd((operationContext.Operation as IInvocationOperation).TargetMethod, true);
+                                    var calledMethodSymbol = (operationContext.Operation as IInvocationOperation).TargetMethod.OriginalDefinition;
+                                    calledMethods.TryAdd(calledMethodSymbol, true);
+
+                                    if (!calledMethodSymbol.IsInSource() ||
+                                        calledMethodSymbol.ContainingType.TypeKind == TypeKind.Interface ||
+                                        calledMethodSymbol.IsAbstract)
+                                    {
+                                        callGraph.TryAdd(calledMethodSymbol, new ConcurrentDictionary<IMethodSymbol, bool>());
+                                    }
                                 }, OperationKind.Invocation);
                             }
                         });

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
@@ -1307,6 +1307,81 @@ End Namespace",
         }
 
         [Fact]
+        public void TestUsingGenericwithTypeSpecifiedDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text;
+
+[Serializable()]
+public class TestGenericClass<T>
+{
+    private T memberInGeneric;
+
+    public void TestGenericMethod()
+    {
+        var path = ""C:\\"";
+        var bytes = new byte[] {0x20, 0x20, 0x20};
+        File.WriteAllBytes(path, bytes);
+    }
+}
+
+[Serializable()]
+public class TestClass : IDeserializationCallback 
+{
+    private TestGenericClass<int> member;
+
+    void IDeserializationCallback.OnDeserialization(Object sender) 
+    {
+        member.TestGenericMethod();
+    }
+}",
+            GetCSharpResultAt(26, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
+        }
+
+        [Fact]
+        public void TestUsingInterfaceDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text;
+
+interface TestInterface
+{
+    void TestInterfaceMethod();
+}
+
+[Serializable()]
+public class TestInterfaceImplement : TestInterface
+{
+    public void TestInterfaceMethod()
+    {
+        var path = ""C:\\"";
+        var bytes = new byte[] {0x20, 0x20, 0x20};
+        File.WriteAllBytes(path, bytes);
+    }
+}
+
+[Serializable()]
+public class TestClass : IDeserializationCallback 
+{
+    private TestInterfaceImplement member;
+
+    void IDeserializationCallback.OnDeserialization(Object sender) 
+    {
+        member.TestInterfaceMethod();
+    }
+}",
+            GetCSharpResultAt(29, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
+        }
+
+        [Fact]
         public void TestFinalizeDiagnostic()
         {
             VerifyCSharp(@"
@@ -2142,6 +2217,114 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace");
+        }
+
+        [Fact]
+        public void TestUsingGenericwithTypeSpecifiedNoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+[Serializable()]
+public class TestGenericClass<T>
+{
+    private T memberInGeneric;
+
+    public void TestGenericMethod()
+    {
+    }
+}
+
+[Serializable()]
+public class TestClass : IDisposable
+{
+    private TestGenericClass<int> member;
+    bool disposed = false;
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);           
+    }
+    
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposed)
+        {
+            return; 
+        }
+      
+        if (disposing) 
+        {
+        }
+      
+        disposed = true;
+    }
+
+    private void TestMethod()
+    {
+        member.TestGenericMethod();
+    }
+}");
+        }
+
+        [Fact]
+        public void TestUsingInterfaceNoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+interface TestInterface
+{
+    void TestInterfaceMethod();
+}
+
+[Serializable()]
+public class TestInterfaceImplement : TestInterface
+{
+    public void TestInterfaceMethod()
+    {
+        var path = ""C:\\"";
+        var bytes = new byte[] {0x20, 0x20, 0x20};
+        File.WriteAllBytes(path, bytes);
+    }
+}
+
+[Serializable()]
+public class TestClass : IDisposable
+{
+    private TestInterface member;
+    bool disposed = false;
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);           
+    }
+    
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposed)
+        {
+            return; 
+        }
+      
+        if (disposing) 
+        {
+        }
+      
+        disposed = true;
+    }
+
+    private void TestMethod()
+    {
+        member.TestInterfaceMethod();
+    }
+}");
         }
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()


### PR DESCRIPTION
Fix CA5360 to deal with scenarios blow:
1. Using a generic type with a type specified.
2. Using a class which implements a interface.
3. Using a derived class of a abstract class.