### PR TITLE
Improve CA1062 perf (ValidateArgumentsOfPublicMethods) by turning off…

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -781,7 +781,7 @@ End Class",
         }
 
         [Fact]
-        public void ConditionalButDefiniteNonNullAssigned_BeforeHazardousUsages_NoDiagnostic()
+        public void ConditionalButDefiniteNonNullAssigned_BeforeHazardousUsages_NoDiagnostic_CopyAnalysis()
         {
             VerifyCSharp(@"
 public class C
@@ -843,7 +843,7 @@ public class Test
         var z = c.X;
     }
 }
-");
+", GetEditorConfigToEnableCopyAnalysis());
 
             VerifyBasic(@"
 Public Class C
@@ -896,7 +896,7 @@ Public Class Test
         Dim z = c.X
     End Sub
 
-End Class");
+End Class", GetEditorConfigToEnableCopyAnalysis());
         }
 
         [Fact]
@@ -1244,7 +1244,7 @@ End Class");
         }
 
         [Fact]
-        public void ContractCheck_NoDiagnostic()
+        public void ContractCheck_NoDiagnostic_CopyAnalysis()
         {
             VerifyCSharp(@"
 public class C
@@ -1289,7 +1289,7 @@ public class Test
         var z = c.X;
     }
 }
-");
+", GetEditorConfigToEnableCopyAnalysis());
 
             VerifyBasic(@"
 Public Class C
@@ -1329,7 +1329,7 @@ Public Class Test
         Dim z = c.X
     End Sub
 End Class
-");
+", GetEditorConfigToEnableCopyAnalysis());
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.cs
@@ -41,12 +41,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
         {
             var interproceduralAnalysisConfig = InterproceduralAnalysisConfiguration.Create(
                    analyzerOptions, rule, interproceduralAnalysisKind, cancellationToken, defaultMaxInterproceduralMethodCallChain);
+            var performCopyAnalysis = analyzerOptions.GetCopyAnalysisOption(rule, defaultValue: false, cancellationToken);
             var nullCheckValidationMethods = analyzerOptions.GetSeparatedStringOptionValue(
                 EditorConfigOptionNames.NullCheckValidationMethods,
                 rule,
                 cancellationToken);
             return GetOrComputeHazardousParameterUsages(topmostBlock, compilation, owningSymbol,
-                nullCheckValidationMethods, interproceduralAnalysisConfig, pessimisticAnalysis);
+                nullCheckValidationMethods, interproceduralAnalysisConfig, performCopyAnalysis, pessimisticAnalysis);
         }
 
         private static ImmutableDictionary<IParameterSymbol, SyntaxNode> GetOrComputeHazardousParameterUsages(
@@ -55,6 +56,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
             ISymbol owningSymbol,
             ImmutableArray<string> nullCheckValidationMethods,
             InterproceduralAnalysisConfiguration interproceduralAnalysisConfig,
+            bool performCopyAnalysis,
             bool pessimisticAnalysis = true)
         {
             Debug.Assert(topmostBlock != null);
@@ -62,7 +64,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
             var cfg = topmostBlock.GetEnclosingControlFlowGraph();
             var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(compilation);
             var pointsToAnalysisResult = PointsToAnalysis.PointsToAnalysis.TryGetOrComputeResult(cfg, owningSymbol, wellKnownTypeProvider,
-                interproceduralAnalysisConfig, interproceduralAnalysisPredicateOpt: null, pessimisticAnalysis);
+                interproceduralAnalysisConfig, interproceduralAnalysisPredicateOpt: null, pessimisticAnalysis, performCopyAnalysis);
             if (pointsToAnalysisResult != null)
             {
                 var result = TryGetOrComputeResult(cfg, owningSymbol, wellKnownTypeProvider,


### PR DESCRIPTION
… copy analysis by default

Copy analysis is known to have performance issues in some cases, and we have turned it off by default for all the existing analyzers. This was the only remaining rule where it was still on by default.
This should fix the performance concern raise in #2576

Fixes #2576