### PR TITLE
Extend tainted data analysis

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotAddArchiveItemPathToTheTargetFileSystemPathTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotAddArchiveItemPathToTheTargetFileSystemPathTests.cs
@@ -136,9 +136,8 @@ class TestClass
             GetCSharpResultAt(9, 24, 9, 37, "FileInfo.FileInfo(string fileName)", "void TestClass.TestMethod(ZipArchiveEntry zipArchiveEntry)", "string ZipArchiveEntry.FullName", "void TestClass.TestMethod(ZipArchiveEntry zipArchiveEntry)"));
         }
 
-        //Ideally, we wouldn't generate a diagnostic in this case.
         [Fact]
-        public void Test_Sanitizer_String_StartsWith_Diagnostic()
+        public void Test_Sanitizer_String_StartsWith_NoDiagnostic()
         {
             VerifyCSharpWithDependencies(@"
 using System;
@@ -155,8 +154,7 @@ class TestClass
             zipArchiveEntry.ExtractToFile(destinationFileName);
         }
     }
-}",
-            GetCSharpResultAt(13, 13, 9, 35, "void ZipFileExtensions.ExtractToFile(ZipArchiveEntry source, string destinationFileName)", "void TestClass.TestMethod(ZipArchiveEntry zipArchiveEntry)", "string ZipArchiveEntry.FullName", "void TestClass.TestMethod(ZipArchiveEntry zipArchiveEntry)"));
+}");
         }
 
         [Fact]

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -81,7 +81,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             bool isInterface,
             bool isConstructorSanitizing,
             string[] sanitizingMethods,
-            string[] sanitizingParameterMethods = null)
+            string[] sanitizingInstanceMethods = null)
         {
             SanitizerInfo info = new SanitizerInfo(
                 fullTypeName,
@@ -89,7 +89,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 isConstructorSanitizing: isConstructorSanitizing,
                 sanitizingMethods: sanitizingMethods?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty,
-                sanitizingParameterMethods: sanitizingParameterMethods?.ToImmutableHashSet(StringComparer.Ordinal)
+                sanitizingInstanceMethods: sanitizingInstanceMethods?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty);
             builder.Add(info);
         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -81,7 +81,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             bool isInterface,
             bool isConstructorSanitizing,
             string[] sanitizingMethods,
-            string[] sanitizingInstanceMethods = null)
+            string[] sanitizingParameterMethods = null)
         {
             SanitizerInfo info = new SanitizerInfo(
                 fullTypeName,
@@ -89,7 +89,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 isConstructorSanitizing: isConstructorSanitizing,
                 sanitizingMethods: sanitizingMethods?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty,
-                sanitizingInstanceMethods: sanitizingInstanceMethods?.ToImmutableHashSet(StringComparer.Ordinal)
+                sanitizingParameterMethods: sanitizingParameterMethods?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty);
             builder.Add(info);
         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -81,7 +81,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             bool isInterface,
             bool isConstructorSanitizing,
             string[] sanitizingMethods,
-            string[] sanitizingMethods_Instance = null)
+            string[] sanitizingInstanceMethods = null)
         {
             SanitizerInfo info = new SanitizerInfo(
                 fullTypeName,
@@ -89,7 +89,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 isConstructorSanitizing: isConstructorSanitizing,
                 sanitizingMethods: sanitizingMethods?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty,
-                sanitizingMethods_Instance: sanitizingMethods_Instance?.ToImmutableHashSet(StringComparer.Ordinal)
+                sanitizingInstanceMethods: sanitizingInstanceMethods?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty);
             builder.Add(info);
         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -80,13 +80,16 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             string fullTypeName,
             bool isInterface,
             bool isConstructorSanitizing,
-            string[] sanitizingMethods)
+            string[] sanitizingMethods,
+            string[] sanitizingMethods_Instance = null)
         {
             SanitizerInfo info = new SanitizerInfo(
                 fullTypeName,
                 isInterface: isInterface,
                 isConstructorSanitizing: isConstructorSanitizing,
                 sanitizingMethods: sanitizingMethods?.ToImmutableHashSet(StringComparer.Ordinal)
+                    ?? ImmutableHashSet<string>.Empty,
+                sanitizingMethods_Instance: sanitizingMethods_Instance?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty);
             builder.Add(info);
         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
@@ -10,13 +10,13 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
     /// </summary>
     internal sealed class SanitizerInfo : ITaintedDataInfo, IEquatable<SanitizerInfo>
     {
-        public SanitizerInfo(string fullTypeName, bool isInterface, bool isConstructorSanitizing, ImmutableHashSet<string> sanitizingMethods, ImmutableHashSet<string> sanitizingParameterMethods)
+        public SanitizerInfo(string fullTypeName, bool isInterface, bool isConstructorSanitizing, ImmutableHashSet<string> sanitizingMethods, ImmutableHashSet<string> sanitizingInstanceMethods)
         {
             FullTypeName = fullTypeName ?? throw new ArgumentNullException(nameof(fullTypeName));
             IsInterface = isInterface;
             IsConstructorSanitizing = isConstructorSanitizing;
             SanitizingMethods = sanitizingMethods ?? throw new ArgumentNullException(nameof(sanitizingMethods));
-            SanitizingParameterMethods = sanitizingParameterMethods ?? throw new ArgumentNullException(nameof(sanitizingParameterMethods));
+            SanitizingInstanceMethods = sanitizingInstanceMethods ?? throw new ArgumentNullException(nameof(sanitizingInstanceMethods));
         }
 
         /// <summary>
@@ -42,12 +42,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <summary>
         /// Methods that untaint tainted instance.
         /// </summary>
-        public ImmutableHashSet<string> SanitizingParameterMethods { get; }
+        public ImmutableHashSet<string> SanitizingInstanceMethods { get; }
 
         public override int GetHashCode()
         {
             return HashUtilities.Combine(this.SanitizingMethods,
-                HashUtilities.Combine(this.SanitizingParameterMethods,
+                HashUtilities.Combine(this.SanitizingInstanceMethods,
                 HashUtilities.Combine(StringComparer.Ordinal.GetHashCode(this.FullTypeName),
                 this.IsConstructorSanitizing.GetHashCode())));
         }
@@ -63,7 +63,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 && this.FullTypeName == other.FullTypeName
                 && this.IsConstructorSanitizing == other.IsConstructorSanitizing
                 && this.SanitizingMethods == other.SanitizingMethods
-                && this.SanitizingParameterMethods == other.SanitizingParameterMethods;
+                && this.SanitizingInstanceMethods == other.SanitizingInstanceMethods;
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
@@ -10,13 +10,13 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
     /// </summary>
     internal sealed class SanitizerInfo : ITaintedDataInfo, IEquatable<SanitizerInfo>
     {
-        public SanitizerInfo(string fullTypeName, bool isInterface, bool isConstructorSanitizing, ImmutableHashSet<string> sanitizingMethods, ImmutableHashSet<string> sanitizingInstanceMethods)
+        public SanitizerInfo(string fullTypeName, bool isInterface, bool isConstructorSanitizing, ImmutableHashSet<string> sanitizingMethods, ImmutableHashSet<string> sanitizingParameterMethods)
         {
             FullTypeName = fullTypeName ?? throw new ArgumentNullException(nameof(fullTypeName));
             IsInterface = isInterface;
             IsConstructorSanitizing = isConstructorSanitizing;
             SanitizingMethods = sanitizingMethods ?? throw new ArgumentNullException(nameof(sanitizingMethods));
-            SanitizingInstanceMethods = sanitizingInstanceMethods ?? throw new ArgumentNullException(nameof(sanitizingInstanceMethods));
+            SanitizingParameterMethods = sanitizingParameterMethods ?? throw new ArgumentNullException(nameof(sanitizingParameterMethods));
         }
 
         /// <summary>
@@ -42,12 +42,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <summary>
         /// Methods that untaint tainted instance.
         /// </summary>
-        public ImmutableHashSet<string> SanitizingInstanceMethods { get; }
+        public ImmutableHashSet<string> SanitizingParameterMethods { get; }
 
         public override int GetHashCode()
         {
             return HashUtilities.Combine(this.SanitizingMethods,
-                HashUtilities.Combine(this.SanitizingInstanceMethods,
+                HashUtilities.Combine(this.SanitizingParameterMethods,
                 HashUtilities.Combine(StringComparer.Ordinal.GetHashCode(this.FullTypeName),
                 this.IsConstructorSanitizing.GetHashCode())));
         }
@@ -63,7 +63,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 && this.FullTypeName == other.FullTypeName
                 && this.IsConstructorSanitizing == other.IsConstructorSanitizing
                 && this.SanitizingMethods == other.SanitizingMethods
-                && this.SanitizingInstanceMethods == other.SanitizingInstanceMethods;
+                && this.SanitizingParameterMethods == other.SanitizingParameterMethods;
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
@@ -10,13 +10,13 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
     /// </summary>
     internal sealed class SanitizerInfo : ITaintedDataInfo, IEquatable<SanitizerInfo>
     {
-        public SanitizerInfo(string fullTypeName, bool isInterface, bool isConstructorSanitizing, ImmutableHashSet<string> sanitizingMethods, ImmutableHashSet<string> sanitizingMethods_Instance)
+        public SanitizerInfo(string fullTypeName, bool isInterface, bool isConstructorSanitizing, ImmutableHashSet<string> sanitizingMethods, ImmutableHashSet<string> sanitizingInstanceMethods)
         {
             FullTypeName = fullTypeName ?? throw new ArgumentNullException(nameof(fullTypeName));
             IsInterface = isInterface;
             IsConstructorSanitizing = isConstructorSanitizing;
             SanitizingMethods = sanitizingMethods ?? throw new ArgumentNullException(nameof(sanitizingMethods));
-            SanitizingMethods_Instance = sanitizingMethods_Instance ?? throw new ArgumentNullException(nameof(sanitizingMethods_Instance));
+            SanitizingInstanceMethods = sanitizingInstanceMethods ?? throw new ArgumentNullException(nameof(sanitizingInstanceMethods));
         }
 
         /// <summary>
@@ -39,13 +39,17 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public ImmutableHashSet<string> SanitizingMethods { get; }
 
-        public ImmutableHashSet<string> SanitizingMethods_Instance { get; }
+        /// <summary>
+        /// Methods that untaint tainted instance.
+        /// </summary>
+        public ImmutableHashSet<string> SanitizingInstanceMethods { get; }
 
         public override int GetHashCode()
         {
             return HashUtilities.Combine(this.SanitizingMethods,
+                HashUtilities.Combine(this.SanitizingInstanceMethods,
                 HashUtilities.Combine(StringComparer.Ordinal.GetHashCode(this.FullTypeName),
-                this.IsConstructorSanitizing.GetHashCode()));
+                this.IsConstructorSanitizing.GetHashCode())));
         }
 
         public override bool Equals(object obj)
@@ -58,7 +62,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             return other != null
                 && this.FullTypeName == other.FullTypeName
                 && this.IsConstructorSanitizing == other.IsConstructorSanitizing
-                && this.SanitizingMethods == other.SanitizingMethods;
+                && this.SanitizingMethods == other.SanitizingMethods
+                && this.SanitizingInstanceMethods == other.SanitizingInstanceMethods;
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
@@ -10,12 +10,13 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
     /// </summary>
     internal sealed class SanitizerInfo : ITaintedDataInfo, IEquatable<SanitizerInfo>
     {
-        public SanitizerInfo(string fullTypeName, bool isInterface, bool isConstructorSanitizing, ImmutableHashSet<string> sanitizingMethods)
+        public SanitizerInfo(string fullTypeName, bool isInterface, bool isConstructorSanitizing, ImmutableHashSet<string> sanitizingMethods, ImmutableHashSet<string> sanitizingMethods_Instance)
         {
             FullTypeName = fullTypeName ?? throw new ArgumentNullException(nameof(fullTypeName));
             IsInterface = isInterface;
             IsConstructorSanitizing = isConstructorSanitizing;
             SanitizingMethods = sanitizingMethods ?? throw new ArgumentNullException(nameof(sanitizingMethods));
+            SanitizingMethods_Instance = sanitizingMethods_Instance ?? throw new ArgumentNullException(nameof(sanitizingMethods_Instance));
         }
 
         /// <summary>
@@ -37,6 +38,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// Methods that untaint tainted data.
         /// </summary>
         public ImmutableHashSet<string> SanitizingMethods { get; }
+
+        public ImmutableHashSet<string> SanitizingMethods_Instance { get; }
 
         public override int GetHashCode()
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -433,7 +433,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             {
                 foreach (SanitizerInfo sanitizerInfo in this.DataFlowAnalysisContext.SanitizerInfos.GetInfosForType(method.ContainingType))
                 {
-                    if (sanitizerInfo.SanitizingInstanceMethods.Contains(method.MetadataName))
+                    if (sanitizerInfo.SanitizingParameterMethods.Contains(method.MetadataName))
                     {
                         return true;
                     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -182,6 +182,14 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
                 if (AnalysisEntityFactory.TryCreate(operation, out AnalysisEntity analysisEntity))
                 {
+                    if (operation.Parent is IInvocationOperation invocationOperation &&
+                    this.IsSanitizingMethod_Argument(invocationOperation.TargetMethod))
+                    {
+                        this.CurrentAnalysisData.SetAbstractValue(analysisEntity, TaintedDataAbstractValue.NotTainted);
+
+                        return TaintedDataAbstractValue.NotTainted;
+                    }
+
                     return this.CurrentAnalysisData.TryGetValue(analysisEntity, out TaintedDataAbstractValue value) ? value : defaultValue;
                 }
 
@@ -407,6 +415,19 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                     }
 
                     if (sanitizerInfo.SanitizingMethods.Contains(method.MetadataName))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            private bool IsSanitizingMethod_Argument(IMethodSymbol method)
+            {
+                foreach (SanitizerInfo sanitizerInfo in this.DataFlowAnalysisContext.SanitizerInfos.GetInfosForType(method.ContainingType))
+                {
+                    if (sanitizerInfo.SanitizingMethods_Instance.Contains(method.MetadataName))
                     {
                         return true;
                     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -232,7 +232,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 {
                     return TaintedDataAbstractValue.CreateTainted(method, originalOperation.Syntax, this.OwningSymbol);
                 }
-                else if (this.IsSanitizingMethod_Instance(method))
+                else if (this.IsSanitizingInstanceMethod(method))
                 {
                     if (AnalysisEntityFactory.TryCreate(visitedInstance, out AnalysisEntity analysisEntity))
                     {
@@ -424,11 +424,16 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 return false;
             }
 
-            private bool IsSanitizingMethod_Instance(IMethodSymbol method)
+            /// <summary>
+            /// Determines if untaint the instance after calling the method.
+            /// </summary>
+            /// <param name="method">Instance method being called.</param>
+            /// <returns>True if untaint the instance, false otherwise.</returns>
+            private bool IsSanitizingInstanceMethod(IMethodSymbol method)
             {
                 foreach (SanitizerInfo sanitizerInfo in this.DataFlowAnalysisContext.SanitizerInfos.GetInfosForType(method.ContainingType))
                 {
-                    if (sanitizerInfo.SanitizingMethods_Instance.Contains(method.MetadataName))
+                    if (sanitizerInfo.SanitizingInstanceMethods.Contains(method.MetadataName))
                     {
                         return true;
                     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -232,7 +232,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 {
                     return TaintedDataAbstractValue.CreateTainted(method, originalOperation.Syntax, this.OwningSymbol);
                 }
-                else if (this.IsSanitizingInstanceMethod(method))
+                else if (visitedInstance != null && this.IsSanitizingInstanceMethod(method))
                 {
                     if (AnalysisEntityFactory.TryCreate(visitedInstance, out AnalysisEntity analysisEntity))
                     {
@@ -433,7 +433,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             {
                 foreach (SanitizerInfo sanitizerInfo in this.DataFlowAnalysisContext.SanitizerInfos.GetInfosForType(method.ContainingType))
                 {
-                    if (sanitizerInfo.SanitizingParameterMethods.Contains(method.MetadataName))
+                    if (sanitizerInfo.SanitizingInstanceMethods.Contains(method.MetadataName))
                     {
                         return true;
                     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ZipSlipSanitizers.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ZipSlipSanitizers.cs
@@ -29,6 +29,9 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 isConstructorSanitizing: false,
                 sanitizingMethods: new[] {
                     "Substring",
+                },
+                sanitizingMethods_Instance: new[] {
+                    "StartsWith",
                 });
 
             SanitizerInfos = builder.ToImmutableAndFree();

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ZipSlipSanitizers.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ZipSlipSanitizers.cs
@@ -30,7 +30,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 sanitizingMethods: new[] {
                     "Substring",
                 },
-                sanitizingMethods_Instance: new[] {
+                sanitizingInstanceMethods: new[] {
                     "StartsWith",
                 });
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ZipSlipSanitizers.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ZipSlipSanitizers.cs
@@ -30,7 +30,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 sanitizingMethods: new[] {
                     "Substring",
                 },
-                sanitizingParameterMethods: new[] {
+                sanitizingInstanceMethods: new[] {
                     "StartsWith",
                 });
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ZipSlipSanitizers.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ZipSlipSanitizers.cs
@@ -30,7 +30,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 sanitizingMethods: new[] {
                     "Substring",
                 },
-                sanitizingInstanceMethods: new[] {
+                sanitizingParameterMethods: new[] {
                     "StartsWith",
                 });
 


### PR DESCRIPTION
 static ZipSlipSanitizers()
        {
            var builder = PooledHashSet<SanitizerInfo>.GetInstance();

            builder.AddSanitizerInfo(
                WellKnownTypeNames.SystemString,
                isInterface: false,
                isConstructorSanitizing: false,
                sanitizingMethods: new[] {
                    "Substring",
                },
                sanitizingParameterMethods: new[] {
                    "StartsWith",
                });

            SanitizerInfos = builder.ToImmutableAndFree();
        }
In this example above, If a stringA is tainted, it will be not tainted after calling stringA.StartsWith("start").