### PR TITLE
Use assembly name instead of assembly identity for comparing restrict…

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
@@ -142,8 +142,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                     if (assemblyAttribute.ConstructorArguments.Length != 2 ||
                         assemblyAttribute.ConstructorArguments[0].Kind != TypedConstantKind.Primitive ||
                         !(assemblyAttribute.ConstructorArguments[0].Value is string assemblyName) ||
-                        !AssemblyIdentity.TryParseDisplayName(assemblyName, out var assemblyIdentity) ||
-                        AssemblyIdentityComparer.Default.Compare(assemblyIdentity, compilation.Assembly.Identity) == AssemblyIdentityComparer.ComparisonResult.NotEquivalent)
+                        !string.Equals(assemblyName, compilation.Assembly.Name, StringComparison.OrdinalIgnoreCase))
                     {
                         continue;
                     }


### PR DESCRIPTION
…ed IVT access

This keeps the attribute application simpler, and we already have the assembly identity validation from IVT.
Verified that StanCore.csproj fails with RS0035 errors with this change applied locally.