### PR TITLE
Fix incorrect rule number in comment

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidPropertySelfAssignment.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AvoidPropertySelfAssignment.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 {
     /// <summary>
-    /// CA1099: Prevent properties from being assigned to themselves
+    /// CA2245: Prevent properties from being assigned to themselves
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 


### PR DESCRIPTION
@mavasani realized I missed updating the comment when I changed the rule. This should correct that.