### PR TITLE
Fixes for CA1801 (ReviewUnusedParameters)

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.resx
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/MicrosoftMaintainabilityAnalyzersResources.resx
@@ -133,7 +133,7 @@
     <value>Review unused parameters</value>
   </data>
   <data name="ReviewUnusedParametersDescription" xml:space="preserve">
-    <value>A method signature includes a parameter that is not used in the method body.</value>
+    <value>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</value>
   </data>
   <data name="ReviewUnusedParametersMessage" xml:space="preserve">
     <value>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</value>

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.cs
@@ -3,7 +3,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
@@ -175,8 +174,8 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
             public UnusedParametersAnalyzer(IMethodSymbol method, UnusedParameterDictionary finalUnusedParameters)
             {
-                // Initialization: Assume all parameters are unused.
-                _unusedParameters = new HashSet<IParameterSymbol>(method.Parameters);
+                // Initialization: Assume all parameters are unused, except the ones with special discard name.
+                _unusedParameters = new HashSet<IParameterSymbol>(method.Parameters.Where(p => !p.IsSymbolWithSpecialDiscardName()));
                 _finalUnusedParameters = finalUnusedParameters;
                 _method = method;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.cs.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">Podpis metody obsahuje parametr, který se nepoužívá v těle metody.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">Podpis metody obsahuje parametr, který se nepoužívá v těle metody.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.de.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">Eine Methodensignatur enthält einen Parameter, der im Methodentext nicht verwendet wird.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">Eine Methodensignatur enthält einen Parameter, der im Methodentext nicht verwendet wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.es.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">Una signatura de método incluye un parámetro que no se usa en el cuerpo del método.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">Una signatura de método incluye un parámetro que no se usa en el cuerpo del método.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.fr.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">Une signature de méthode inclut un paramètre qui n'est pas utilisé dans le corps de la méthode.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">Une signature de méthode inclut un paramètre qui n'est pas utilisé dans le corps de la méthode.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.it.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">Una firma di metodo include un parametro non usato nel corpo del metodo.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">Una firma di metodo include un parametro non usato nel corpo del metodo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ja.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">メソッドのシグネチャに、メソッドの本体で使用されていないパラメーターが含まれています。</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">メソッドのシグネチャに、メソッドの本体で使用されていないパラメーターが含まれています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ko.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">메서드 시그니처가 메서드 본문에서 사용하지 않는 매개 변수를 포함합니다.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">메서드 시그니처가 메서드 본문에서 사용하지 않는 매개 변수를 포함합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pl.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">Sygnatura metody zawiera parametr, który nie jest używany w treści metody.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">Sygnatura metody zawiera parametr, który nie jest używany w treści metody.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.pt-BR.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">Uma assinatura de método inclui um parâmetro não usado no corpo do método.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">Uma assinatura de método inclui um parâmetro não usado no corpo do método.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.ru.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">Сигнатура метода содержит параметр, который не используется в теле метода.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">Сигнатура метода содержит параметр, который не используется в теле метода.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.tr.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">Yöntem imzası yöntem gövdesinde kullanılmayan bir parametre içeriyor.</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">Yöntem imzası yöntem gövdesinde kullanılmayan bir parametre içeriyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hans.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">方法签名包括一个未在方法体中使用的参数。</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">方法签名包括一个未在方法体中使用的参数。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/xlf/MicrosoftMaintainabilityAnalyzersResources.zh-Hant.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersDescription">
-        <source>A method signature includes a parameter that is not used in the method body.</source>
-        <target state="translated">方法簽章包括並未用於方法主體中的參數。</target>
+        <source>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</source>
+        <target state="needs-review-translation">方法簽章包括並未用於方法主體中的參數。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -784,6 +784,29 @@ End Class
 ");
         }
 
+        [Fact]
+        [WorkItem(2466, "https://github.com/dotnet/roslyn-analyzers/issues/2466")]
+        public void NoDiagnosticUsedLocalFunctionParameters()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public void M()
+    {
+        LocalFunction(0);
+        return;
+
+        void LocalFunction(int x)
+        {
+            Console.WriteLine(x);
+        }
+    }
+}
+");
+        }
+
         #endregion
 
         #region Unit tests for analyzer diagnostic(s)
@@ -912,6 +935,50 @@ static class C
 ",
     // Test0.cs(4,49): warning CA1801: Parameter anotherParam of method ExtensionMethod is never used. Remove the parameter or use it in the method body.
     GetCSharpUnusedParameterResultAt(4, 49, "anotherParam", "ExtensionMethod"));
+        }
+
+        [Fact]
+        [WorkItem(2466, "https://github.com/dotnet/roslyn-analyzers/issues/2466")]
+        public void DiagnosticForUnusedLocalFunctionParameters_01()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public void M()
+    {
+        LocalFunction(0);
+        return;
+
+        void LocalFunction(int x)
+        {
+        }
+    }
+}",
+            // Test0.cs(11,32): warning CA1801: Parameter x of method LocalFunction is never used. Remove the parameter or use it in the method body.
+            GetCSharpUnusedParameterResultAt(11, 32, "x", "LocalFunction"));
+        }
+
+        [Fact]
+        [WorkItem(2466, "https://github.com/dotnet/roslyn-analyzers/issues/2466")]
+        public void DiagnosticForUnusedLocalFunctionParameters_02()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public void M()
+    {
+        // Flag unused parameter even if LocalFunction is unused.
+        void LocalFunction(int x)
+        {
+        }
+    }
+}",
+            // Test0.cs(9,32): warning CA1801: Parameter x of method LocalFunction is never used. Remove the parameter or use it in the method body.
+            GetCSharpUnusedParameterResultAt(9, 32, "x", "LocalFunction"));
         }
 
         #endregion

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -757,6 +757,33 @@ Public Class C
 End Class");
         }
 
+        [Fact]
+        [WorkItem(2589, "https://github.com/dotnet/roslyn-analyzers/issues/2589")]
+        [WorkItem(2593, "https://github.com/dotnet/roslyn-analyzers/issues/2593")]
+        public void NoDiagnosticDiscardParameterNames()
+        {
+            VerifyCSharp(@"
+using System;
+
+public class C
+{
+    public void M(int _, int _1, int _4)
+    {
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Public Class C
+    ' _ is not an allowed identifier in VB.
+    Public Sub M(_1 As Integer, _2 As Integer, _4 As Integer)
+    End Sub
+End Class
+");
+        }
+
         #endregion
 
         #region Unit tests for analyzer diagnostic(s)

--- a/src/Test.Utilities/WorkItemAttribute.cs
+++ b/src/Test.Utilities/WorkItemAttribute.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Test.Utilities
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
     public class WorkItemAttribute : Attribute
     {
         public WorkItemAttribute(int id, string source)

--- a/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -619,5 +619,14 @@ namespace Analyzer.Utilities.Extensions
 
         public static bool IsLambdaOrLocalFunction(this ISymbol symbol)
             => (symbol as IMethodSymbol)?.IsLambdaOrLocalFunction() == true;
+
+        /// <summary>
+        /// Returns true for symbols whose name starts with an underscore and
+        /// are optionally followed by an integer, such as '_', '_1', '_2', etc.
+        /// These symbols can be treated as special discard symbol names.
+        /// </summary>
+        public static bool IsSymbolWithSpecialDiscardName(this ISymbol symbol)
+            => symbol?.Name.StartsWith("_", StringComparison.Ordinal) == true &&
+               (symbol.Name.Length == 1 || uint.TryParse(symbol.Name.Substring(1), out _));
     }
 }


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn-analyzers/commit/97d6b44dc23aad5413e99181294e2fcb8ef1b416: Bail out on discard symbol names.
Fixes #2589
Fixes #2593
Fixes #2465
Fixes #1359

2. https://github.com/dotnet/roslyn-analyzers/commit/9255c80106d85526c03dc7aad524fd6c7d3a6215: Analyze local function parameters.
Fixes #2466