### PR TITLE
Fix another CA2000 false positive

### DIFF
--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
@@ -47,8 +47,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
             Debug.Assert(Kind != DisposeAbstractValueKind.NotDisposable);
             Debug.Assert(Kind != DisposeAbstractValueKind.Unknown);
 
-            var kind = this.Kind > DisposeAbstractValueKind.Escaped ? this.Kind : DisposeAbstractValueKind.Escaped;
-            return new DisposeAbstractValue(DisposingOrEscapingOperations.Add(escapingOperation), kind);
+            return new DisposeAbstractValue(ImmutableHashSet.Create(escapingOperation), DisposeAbstractValueKind.Escaped);
         }
 
         [Conditional("DEBUG")]


### PR DESCRIPTION
Ensure that an escaping operation, such as a return statement, changes the dispose kind to escaped even for allocations which are currently maybe disposed state

Fixes #2637