### PR TITLE
Release notes util

### DIFF
--- a/src/ReleaseNotesUtil/AnalyzerAssemblyLoader.cs
+++ b/src/ReleaseNotesUtil/AnalyzerAssemblyLoader.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace ReleaseNotesUtil
+{
+    internal sealed class AnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
+    {
+        public static IAnalyzerAssemblyLoader Instance = new AnalyzerAssemblyLoader();
+
+        private AnalyzerAssemblyLoader() { }
+
+        public void AddDependencyLocation(string fullPath)
+        {
+        }
+
+        public Assembly LoadFromPath(string fullPath)
+        {
+            return Assembly.LoadFrom(fullPath);
+        }
+    }
+}

--- a/src/ReleaseNotesUtil/CategoryThenIdComparer.cs
+++ b/src/ReleaseNotesUtil/CategoryThenIdComparer.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ReleaseNotesUtil
+{
+    /// <summary>
+    /// Comparer for sorting rules by category, then by ID.
+    /// </summary>
+    internal class CategoryThenIdComparer : IComparer<RuleInfo>
+    {
+        public static CategoryThenIdComparer Instance = new CategoryThenIdComparer();
+
+        public int Compare(RuleInfo x, RuleInfo y)
+        {
+            int c = String.Compare(x.Category, y.Category, StringComparison.InvariantCulture);
+            if (c != 0)
+            {
+                return c;
+            }
+
+            return String.Compare(x.Id, y.Id, StringComparison.InvariantCulture);
+        }
+    }
+}

--- a/src/ReleaseNotesUtil/DiagnosticIdComparer.cs
+++ b/src/ReleaseNotesUtil/DiagnosticIdComparer.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace ReleaseNotesUtil
+{
+    internal class DiagnosticIdComparer : IEqualityComparer<DiagnosticDescriptor>
+    {
+        public static readonly DiagnosticIdComparer Instance = new DiagnosticIdComparer();
+
+        public bool Equals(DiagnosticDescriptor x, DiagnosticDescriptor y)
+        {
+            return StringComparer.Ordinal.Equals(x.Id, y.Id);
+        }
+
+        public int GetHashCode(DiagnosticDescriptor obj)
+        {
+            return StringComparer.Ordinal.GetHashCode(obj.Id);
+        }
+    }
+}

--- a/src/ReleaseNotesUtil/FixerExtensions.cs
+++ b/src/ReleaseNotesUtil/FixerExtensions.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+
+namespace ReleaseNotesUtil
+{
+    public static class FixerExtensions
+    {
+        /// <summary>
+        /// Get all the <see cref="CodeFixProvider"/>s that are implemented in the given <see cref="AnalyzerFileReference"/>
+        /// </summary>
+        /// <returns>An array of <see cref="CodeFixProvider"/>s</returns>
+        public static ImmutableArray<CodeFixProvider> GetFixers(this AnalyzerFileReference analyzerFileReference)
+        {
+            if (analyzerFileReference == null)
+            {
+                return ImmutableArray<CodeFixProvider>.Empty;
+            }
+
+            ImmutableArray<CodeFixProvider>.Builder builder = null;
+
+            try
+            {
+                Assembly analyzerAssembly = analyzerFileReference.GetAssembly();
+                IEnumerable<TypeInfo> typeInfos = analyzerAssembly.DefinedTypes;
+
+                foreach (TypeInfo typeInfo in typeInfos)
+                {
+                    if (typeInfo.IsSubclassOf(typeof(CodeFixProvider)))
+                    {
+                        try
+                        {
+                            ExportCodeFixProviderAttribute attribute = typeInfo.GetCustomAttribute<ExportCodeFixProviderAttribute>();
+                            if (attribute != null)
+                            {
+                                builder = builder ?? ImmutableArray.CreateBuilder<CodeFixProvider>();
+                                var fixer = (CodeFixProvider)Activator.CreateInstance(typeInfo.AsType());
+                                if (HasImplementation(fixer))
+                                {
+                                    builder.Add(fixer);
+                                }
+                            }
+                        }
+                        catch
+                        {
+                        }
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return builder != null ? builder.ToImmutable() : ImmutableArray<CodeFixProvider>.Empty;
+        }
+
+        /// <summary>
+        /// Check the method body of the Initialize method of an analyzer and if that's empty,
+        /// then the analyzer hasn't been implemented yet.
+        /// </summary>
+        private static bool HasImplementation(CodeFixProvider fixer)
+        {
+            MethodInfo method = fixer.GetType().GetTypeInfo().GetMethod("RegisterCodeFixesAsync");
+            AsyncStateMachineAttribute stateMachineAttr = method?.GetCustomAttribute<AsyncStateMachineAttribute>();
+            MethodInfo moveNextMethod = stateMachineAttr?.StateMachineType.GetTypeInfo().GetDeclaredMethod("MoveNext");
+            if (moveNextMethod != null)
+            {
+                MethodBody body = moveNextMethod.GetMethodBody();
+                int? ilInstructionCount = body?.GetILAsByteArray()?.Count();
+                return ilInstructionCount != 177;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/ReleaseNotesUtil/GenDiffNotes.cmd
+++ b/src/ReleaseNotesUtil/GenDiffNotes.cmd
@@ -1,0 +1,9 @@
+REM GenDiffNotes scratchDir nugetSource fxCopAnalyzersOldVersion fxCopAnalyzersNewVersion
+mkdir %1
+pushd %1
+nuget.exe install -source %2 Microsoft.CodeAnalysis.FxCopAnalyzers -version %3
+nuget.exe install -source %2 Microsoft.CodeAnalysis.FxCopAnalyzers -version %4
+popd
+dotnet.exe ReleaseNotesUtil.dll getrulesjson %1 %3 %1\%3-rules.json
+dotnet.exe ReleaseNotesUtil.dll getrulesjson %1 %4 %1\%4-rules.json
+dotnet.exe ReleaseNotesUtil.dll diffrules %1\%3-rules.json %1\%4-rules.json %1\%3_%4-notes.md

--- a/src/ReleaseNotesUtil/GenDiffNotes.cmd
+++ b/src/ReleaseNotesUtil/GenDiffNotes.cmd
@@ -1,9 +1,41 @@
-REM GenDiffNotes scratchDir nugetSource fxCopAnalyzersOldVersion fxCopAnalyzersNewVersion
-mkdir %1
-pushd %1
-nuget.exe install -source %2 Microsoft.CodeAnalysis.FxCopAnalyzers -version %3
-nuget.exe install -source %2 Microsoft.CodeAnalysis.FxCopAnalyzers -version %4
+@echo off
+REM GenDiffNotes.cmd scratchDir nugetSource fxCopAnalyzersOldVersion fxCopAnalyzersNewVersion
+REM Ex: GenDiffNotes.cmd C:\scratch nuget.org 2.6.3 2.9.0
+
+if [%1]==[] goto usage
+if [%2]==[] goto usage
+if [%3]==[] goto usage
+if [%4]==[] goto usage
+
+set SCRATCHDIR=%1
+set NUGETSOURCE=%2
+set OLDVERSION=%3
+set NEWVERSION=%4
+
+set DIFFNOTES=%SCRATCHDIR%\%OLDVERSION%_%NEWVERSION%-notes.md
+
+@echo on
+mkdir %SCRATCHDIR%
+pushd %SCRATCHDIR%
+nuget.exe install -source %NUGETSOURCE% Microsoft.CodeAnalysis.FxCopAnalyzers -version %OLDVERSION%
+nuget.exe install -source %NUGETSOURCE% Microsoft.CodeAnalysis.FxCopAnalyzers -version %NEWVERSION%
 popd
-dotnet.exe ReleaseNotesUtil.dll getrulesjson %1 %3 %1\%3-rules.json
-dotnet.exe ReleaseNotesUtil.dll getrulesjson %1 %4 %1\%4-rules.json
-dotnet.exe ReleaseNotesUtil.dll diffrules %1\%3-rules.json %1\%4-rules.json %1\%3_%4-notes.md
+dotnet.exe ReleaseNotesUtil.dll getrulesjson %SCRATCHDIR% %OLDVERSION% %SCRATCHDIR%\%OLDVERSION%-rules.json
+dotnet.exe ReleaseNotesUtil.dll getrulesjson %SCRATCHDIR% %NEWVERSION% %SCRATCHDIR%\%NEWVERSION%-rules.json
+dotnet.exe ReleaseNotesUtil.dll diffrules %SCRATCHDIR%\%OLDVERSION%-rules.json %SCRATCHDIR%\%NEWVERSION%-rules.json %DIFFNOTES%
+@echo off
+
+echo.
+echo.
+
+if exist "%DIFFNOTES%" (
+    echo Added/Removed notes in %DIFFNOTES%
+) else (
+    echo Guess something went wrong
+)
+
+goto :eof
+
+:usage
+echo Usage: %0 scratchDir nugetSource fxCopAnalyzersOldVersion fxCopAnalyzersNewVersion
+echo Example: %0 C:\scratch nuget.org 2.6.3 2.9.0

--- a/src/ReleaseNotesUtil/Program.cs
+++ b/src/ReleaseNotesUtil/Program.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ReleaseNotesUtil
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            if (!((args.Length == 4 && args[0] == "getrulesjson")
+                  || (args.Length == 4 && args[0] == "diffrules")))
+            {
+                PrintUsage();
+                return;
+            }
+
+            string command = args[0];
+            switch (command)
+            {
+                case "getrulesjson":
+                    GetRulesJson(args[1], args[2], args[3]);
+                    break;
+
+                case "diffrules":
+                    DiffRules(args[1], args[2], args[3]);
+                    break;
+
+                default:
+                    throw new ArgumentException($"Unhandled command {command}");
+            }
+        }
+
+        private static void PrintUsage()
+        {
+            Console.WriteLine("Usage: ReleaseNoteUtil command commandArgs ...");
+            Console.WriteLine("  getrulesjson pathToNugetInstalledPackages fxCopAnalyzersVersion out.json");
+            Console.WriteLine("  diffrules old.json new.json out.md");
+        }
+
+        private static void GetRulesJson(string nugetInstalledPackagesPath, string version, string outputPath)
+        {
+            IEnumerable<string> dllPaths = GetFxCopAnalyzerBinaries(nugetInstalledPackagesPath, version);
+            RuleFileContent ruleFileContent = new RuleFileContent();
+            ruleFileContent.Rules = GetRules(dllPaths);
+            WriteRuleFileContent(ruleFileContent, outputPath);
+        }
+
+        private static void DiffRules(string oldRulesJsonPath, string newRulesJsonPath, string outputPath)
+        {
+            RuleFileContent oldContent = ReadRuleFileContent(oldRulesJsonPath);
+            RuleFileContent newContent = ReadRuleFileContent(newRulesJsonPath);
+            Dictionary<string, RuleInfo> oldRulesById = oldContent.Rules.ToDictionary(r => r.Id);
+            Dictionary<string, RuleInfo> newRulesById = newContent.Rules.ToDictionary(r => r.Id);
+            IEnumerable<RuleInfo> addedRules =
+                newContent.Rules
+                    .Where(r => !oldRulesById.ContainsKey(r.Id))
+                    .OrderByDescending(r => r.Category + " " + r.Id);
+            IEnumerable<RuleInfo> removedRules =
+                oldContent.Rules
+                    .Where(r => !newRulesById.ContainsKey(r.Id))
+                    .OrderByDescending(r => r.Category + " " + r.Id);
+            StringBuilder sb = new StringBuilder();
+            GenerateRulesDiffMarkdown(sb, "### Added", addedRules);
+            GenerateRulesDiffMarkdown(sb, "### Removed", removedRules);
+            File.WriteAllText(outputPath, sb.ToString());
+        }
+
+        private static void WriteRuleFileContent(RuleFileContent ruleFileContent, string outputPath)
+        {
+            DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(RuleFileContent));
+            using (FileStream fs = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                serializer.WriteObject(fs, ruleFileContent);
+            }
+        }
+
+        private static RuleFileContent ReadRuleFileContent(string path)
+        {
+            DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(RuleFileContent));
+            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                return (RuleFileContent)serializer.ReadObject(fs);
+            }
+
+        }
+
+        private static void GenerateRulesDiffMarkdown(StringBuilder sb, string heading, IEnumerable<RuleInfo> rules)
+        {
+            if (!rules.Any())
+            {
+                return;
+            }
+
+            sb.AppendLine(heading);
+            string previousCategory = null;
+            foreach (RuleInfo rule in rules)
+            {
+                if (rule.Category != previousCategory)
+                {
+                    sb.AppendLine($"- {rule.Category}");
+                    previousCategory = rule.Category;
+                }
+
+                sb.AppendLine($"  - {rule.IdWithHelpLinkMarkdown}: {rule.Title} -- {rule.DescriptionOrMessageFormatMarkdown}");
+            }
+        }
+
+        private static IEnumerable<string> GetFxCopAnalyzerBinaries(string nugetInstalledPackagesPath, string version)
+        {
+            if (!Directory.Exists(nugetInstalledPackagesPath))
+            {
+                throw new ArgumentException($"'{nugetInstalledPackagesPath}' is not a directory or doesn't exist");
+            }
+
+            string[] roslynAnalyzerPackages = new string[] {
+                "Microsoft.CodeQuality.Analyzers",
+                "Microsoft.NetCore.Analyzers",
+                "Microsoft.NetFramework.Analyzers" };
+            foreach (string roslynAnalyzerPackage in roslynAnalyzerPackages)
+            {
+                string packageWithVersion = $"{roslynAnalyzerPackage}.{version}";
+                string baseDll = $"{roslynAnalyzerPackage}.dll";
+                yield return Path.Combine(
+                    nugetInstalledPackagesPath,
+                    packageWithVersion,
+                    "analyzers",
+                    "dotnet",
+                    "cs",
+                    baseDll);
+                yield return Path.Combine(
+                    nugetInstalledPackagesPath,
+                    packageWithVersion,
+                    "analyzers",
+                    "dotnet",
+                    "cs",
+                    baseDll.Replace(".Analyzers.dll", ".CSharp.Analyzers.dll", StringComparison.Ordinal));
+                yield return Path.Combine(
+                    nugetInstalledPackagesPath,
+                    packageWithVersion,
+                    "analyzers",
+                    "dotnet",
+                    "vb",
+                    baseDll.Replace(".Analyzers.dll", ".VisualBasic.Analyzers.dll", StringComparison.Ordinal));
+            }
+
+            yield return Path.Combine(
+                nugetInstalledPackagesPath,
+                $"Microsoft.CodeAnalysis.VersionCheckAnalyzer.{version}",
+                "analyzers",
+                "dotnet",
+                "Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll");
+        }
+
+        private static List<RuleInfo> GetRules(IEnumerable<string> dllPaths)
+        {
+            List<RuleInfo> ruleInfos = new List<RuleInfo>();
+            foreach (string dllPath in dllPaths)
+            {
+                AnalyzerFileReference analyzerFileReference = new AnalyzerFileReference(
+                    dllPath,
+                    AnalyzerAssemblyLoader.Instance);
+                ImmutableArray<DiagnosticAnalyzer> analyzers = analyzerFileReference.GetAnalyzersForAllLanguages();
+                IEnumerable<DiagnosticDescriptor> descriptors =
+                    analyzers
+                        .SelectMany(a => a.SupportedDiagnostics)
+                        .Distinct(DiagnosticIdComparer.Instance);
+                HashSet<string> fixableDiagnosticIds =
+                    analyzerFileReference
+                        .GetFixers()
+                        .SelectMany(fixer => fixer.FixableDiagnosticIds).ToHashSet();
+                Console.WriteLine($"{dllPath} has {analyzers.Count()} analyzers, {descriptors.Count()} diagnostics, and {fixableDiagnosticIds.Count} fixers");
+                foreach (DiagnosticDescriptor descriptor in descriptors)
+                {
+                    if (ruleInfos.Any(r => r.Id == descriptor.Id))
+                    {
+                        continue;
+                    }
+
+                    ruleInfos.Add(
+                        new RuleInfo(
+                            descriptor.Id,
+                            descriptor.Title.ToString(),
+                            descriptor.Category,
+                            descriptor.IsEnabledByDefault,
+                            fixableDiagnosticIds.Contains(descriptor.Id),
+                            descriptor.MessageFormat.ToString(),
+                            descriptor.Description.ToString(),
+                            descriptor.HelpLinkUri));
+                }
+            }
+
+            return ruleInfos;
+        }
+
+        private static void AnalyzerFileReference_AnalyzerLoadFailed(object sender, AnalyzerLoadFailureEventArgs e)
+        {
+            Console.WriteLine($"Analyzer load failed: ErrorCode: {e.ErrorCode} Message: {e.Message} Exception:{e.Exception}");
+        }
+    }
+}

--- a/src/ReleaseNotesUtil/ReleaseNotesUtil.csproj
+++ b/src/ReleaseNotesUtil/ReleaseNotesUtil.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">  
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="GenDiffNotes.cmd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/ReleaseNotesUtil/RuleFileContent.cs
+++ b/src/ReleaseNotesUtil/RuleFileContent.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace ReleaseNotesUtil
+{
+    [DataContract]
+    internal class RuleFileContent
+    {
+        [DataMember]
+        public List<RuleInfo> Rules { get; set; }
+    }
+}

--- a/src/ReleaseNotesUtil/RuleInfo.cs
+++ b/src/ReleaseNotesUtil/RuleInfo.cs
@@ -11,12 +11,12 @@ namespace ReleaseNotesUtil
     [DataContract]
     internal class RuleInfo
     {
-        public RuleInfo(string id, string title, string category, bool enabledByDefault, bool hasCodeFix, string messageFormat, string description, string helpLink)
+        public RuleInfo(string id, string title, string category, bool isEnabledByDefault, bool hasCodeFix, string messageFormat, string description, string helpLink)
         {
             Id = id ?? throw new ArgumentNullException(nameof(id));
             Title = title ?? throw new ArgumentNullException(nameof(title));
             Category = category ?? throw new ArgumentNullException(nameof(category));
-            EnabledByDefault = enabledByDefault;
+            IsEnabledByDefault = isEnabledByDefault;
             HasCodeFix = hasCodeFix;
             MessageFormat = messageFormat ?? throw new ArgumentNullException(nameof(messageFormat));
             Description = description;
@@ -37,7 +37,7 @@ namespace ReleaseNotesUtil
         public string Category { get; set; }
 
         [DataMember]
-        public bool EnabledByDefault { get; set; }
+        public bool IsEnabledByDefault { get; set; }
 
         [DataMember]
         public bool HasCodeFix { get; set; }

--- a/src/ReleaseNotesUtil/RuleInfo.cs
+++ b/src/ReleaseNotesUtil/RuleInfo.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace ReleaseNotesUtil
+{
+    /// <summary>
+    /// Info that we care about from a DiagnosticDescriptor.
+    /// </summary>
+    [DataContract]
+    internal class RuleInfo
+    {
+        public RuleInfo(string id, string title, string category, bool enabledByDefault, bool hasCodeFix, string messageFormat, string description, string helpLink)
+        {
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+            Title = title ?? throw new ArgumentNullException(nameof(title));
+            Category = category ?? throw new ArgumentNullException(nameof(category));
+            EnabledByDefault = enabledByDefault;
+            HasCodeFix = hasCodeFix;
+            MessageFormat = messageFormat ?? throw new ArgumentNullException(nameof(messageFormat));
+            Description = description;
+            HelpLink = helpLink;
+        }
+
+        public RuleInfo()
+        {
+        }
+
+        [DataMember]
+        public string Id { get; set; }
+
+        [DataMember]
+        public string Title { get; set; }
+
+        [DataMember]
+        public string Category { get; set; }
+
+        [DataMember]
+        public bool EnabledByDefault { get; set; }
+
+        [DataMember]
+        public bool HasCodeFix { get; set; }
+
+        [DataMember]
+        public string MessageFormat { get; set; }
+
+        [DataMember]
+        public string Description { get; set; }
+
+        [DataMember]
+        public string HelpLink { get; set; }
+
+        // Computed properties.
+        public string IdWithHelpLinkMarkdown
+        {
+            get
+            {
+                return !String.IsNullOrWhiteSpace(this.HelpLink)
+                    ? $"[{this.Id}]({this.HelpLink})"
+                    : this.Id;
+            }
+        }
+
+        public string DescriptionOrMessageFormatMarkdown
+        {
+            get
+            {
+                return !String.IsNullOrWhiteSpace(this.Description)
+                    ? this.Description
+                    : this.MessageFormat;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Generates a list of added/removed rules from analyzer binaries for release notes.

Fixes #2601 

If the format looks fine, I'll edit the previous 2.9.x releases.