### PR TITLE
Couple of fixes to Restricted IVT analyzer

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
@@ -90,6 +90,18 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                         case IMemberReferenceOperation memberReference:
                             symbol = memberReference.Member;
                             break;
+                        case IConversionOperation conversion:
+                            symbol = conversion.OperatorMethod;
+                            break;
+                        case IUnaryOperation unary:
+                            symbol = unary.OperatorMethod;
+                            break;
+                        case IBinaryOperation binary:
+                            symbol = binary.OperatorMethod;
+                            break;
+                        case IIncrementOrDecrementOperation incrementOrDecrement:
+                            symbol = incrementOrDecrement.OperatorMethod;
+                            break;
                         default:
                             throw new NotImplementedException($"Unhandled OperationKind: {context.Operation.Kind}");
                     }
@@ -102,7 +114,12 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 OperationKind.EventReference,
                 OperationKind.FieldReference,
                 OperationKind.MethodReference,
-                OperationKind.PropertyReference);
+                OperationKind.PropertyReference,
+                OperationKind.Conversion,
+                OperationKind.UnaryOperator,
+                OperationKind.BinaryOperator,
+                OperationKind.Increment,
+                OperationKind.Decrement);
         }
 
         private static ImmutableDictionary<IAssemblySymbol, ImmutableSortedSet<string>> GetRestrictedInternalsVisibleToMap(Compilation compilation)

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
@@ -199,7 +199,8 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
         {
             // Check if the symbol belongs to an assembly to which this compilation has restricted internals access
             // and it is an internal symbol.
-            if (!restrictedInternalsVisibleToMap.TryGetValue(symbol.ContainingAssembly, out var allowedNamespaces) ||
+            if (symbol.ContainingAssembly == null ||
+                !restrictedInternalsVisibleToMap.TryGetValue(symbol.ContainingAssembly, out var allowedNamespaces) ||
                 symbol.GetResultantVisibility() != SymbolVisibility.Internal)
             {
                 return false;


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn-analyzers/commit/be936b6eacfb8cd8dbcb41d97aaced02b0a4172d: Guard against NRE in RestrictedIVT analyzer for symbol without a ContainingAssembly: I was unable to get a repro, but likely occurred for erroneous code. Fixes #2651
2. https://github.com/dotnet/roslyn-analyzers/commit/a471727ad856cfdaf6dd240a1e2689ffe8d98550: Handle few more OperationKinds in Restricted IVT analyzer. Fixes #2655