### PR TITLE
Implement semmle rule "HttpOnlyCookie.ql" into Roslyn

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
@@ -1119,4 +1119,13 @@
   <data name="DoNotUseCountAsyncWhenAnyAsyncCanBeUsedTitle" xml:space="preserve">
     <value>Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used</value>
   </data>
+  <data name="SetHttpOnlyForHttpCookie" xml:space="preserve">
+    <value>Set HttpOnly to true for HttpCookie</value>
+  </data>
+  <data name="SetHttpOnlyForHttpCookieDescription" xml:space="preserve">
+    <value>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</value>
+  </data>
+  <data name="SetHttpOnlyForHttpCookieMessage" xml:space="preserve">
+    <value>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</value>
+  </data>
 </root>

--- a/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
@@ -1123,7 +1123,7 @@
     <value>Set HttpOnly to true for HttpCookie</value>
   </data>
   <data name="SetHttpOnlyForHttpCookieDescription" xml:space="preserve">
-    <value>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</value>
+    <value>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</value>
   </data>
   <data name="SetHttpOnlyForHttpCookieMessage" xml:space="preserve">
     <value>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</value>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SetHttpOnlyForHttpCookie.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SetHttpOnlyForHttpCookie.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     {
         // TODO Lingxia Chen: Help links URLs.
         internal static DiagnosticDescriptor Rule = SecurityHelpers.CreateDiagnosticDescriptor(
-            "CA5393",
+            "CA5396",
             typeof(MicrosoftNetCoreAnalyzersResources),
             nameof(MicrosoftNetCoreAnalyzersResources.SetHttpOnlyForHttpCookie),
             nameof(MicrosoftNetCoreAnalyzersResources.SetHttpOnlyForHttpCookieMessage),

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SetHttpOnlyForHttpCookie.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SetHttpOnlyForHttpCookie.cs
@@ -1,0 +1,200 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis;
+using Analyzer.Utilities.PooledObjects;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.NetCore.Analyzers.Security.Helpers;
+
+namespace Microsoft.NetCore.Analyzers.Security
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    class SetHttpOnlyForHttpCookie : DiagnosticAnalyzer
+    {
+        // TODO Lingxia Chen: Help links URLs.
+        internal static DiagnosticDescriptor Rule = SecurityHelpers.CreateDiagnosticDescriptor(
+            "CA5393",
+            typeof(MicrosoftNetCoreAnalyzersResources),
+            nameof(MicrosoftNetCoreAnalyzersResources.SetHttpOnlyForHttpCookie),
+            nameof(MicrosoftNetCoreAnalyzersResources.SetHttpOnlyForHttpCookieMessage),
+            false,
+            helpLinkUri: null,
+            descriptionResourceStringName: nameof(MicrosoftNetCoreAnalyzersResources.SetHttpOnlyForHttpCookieDescription),
+            customTags: WellKnownDiagnosticTagsExtensions.DataflowAndTelemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(
+                Rule);
+
+        private static readonly ConstructorMapper ConstructorMapper = new ConstructorMapper(
+            (IMethodSymbol constructorMethod,
+            IReadOnlyList<PointsToAbstractValue> argumentPointsToAbstractValues) =>
+            {
+                return PropertySetAbstractValue.GetInstance(PropertySetAbstractValueKind.Flagged);
+            });
+
+        // If HttpOnly is set explictly, the callbacks of OperationKind.SimpleAssignment can cover that case.
+        // Otherwise, using PropertySetAnalysis to cover the case where HttpCookie object is returned without initializing or assgining HttpOnly property.
+        private static readonly PropertyMapperCollection PropertyMappers = new PropertyMapperCollection(
+            new PropertyMapper(
+                "HttpOnly",
+                (PointsToAbstractValue pointsToAbstractValue) =>
+                   PropertySetAbstractValueKind.Unflagged));
+
+        private static readonly HazardousUsageEvaluatorCollection HazardousUsageEvaluators = new HazardousUsageEvaluatorCollection(
+                    new HazardousUsageEvaluator(
+                        HazardousUsageEvaluatorKind.Return,
+                        PropertySetCallbacks.HazardousIfAllFlaggedAndAtLeastOneKnown),
+                    new HazardousUsageEvaluator(
+                        HazardousUsageEvaluatorKind.Argument,
+                        PropertySetCallbacks.HazardousIfAllFlaggedAndAtLeastOneKnown));
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+
+            // Security analyzer - analyze and report diagnostics on generated code.
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+            context.RegisterCompilationStartAction(
+                (CompilationStartAnalysisContext compilationStartAnalysisContext) =>
+                {
+                    WellKnownTypeProvider wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(compilationStartAnalysisContext.Compilation);
+
+                    if (!wellKnownTypeProvider.TryGetTypeByMetadataName(WellKnownTypeNames.SystemWebHttpCookie, out INamedTypeSymbol httpCookieSymbol))
+                    {
+                        return;
+                    }
+
+                    PooledHashSet<(IOperation Operation, ISymbol ContainingSymbol)> rootOperationsNeedingAnalysis = PooledHashSet<(IOperation, ISymbol)>.GetInstance();
+
+                    compilationStartAnalysisContext.RegisterOperationBlockStartAction(
+                        (OperationBlockStartAnalysisContext operationBlockStartAnalysisContext) =>
+                        {
+                            ISymbol owningSymbol = operationBlockStartAnalysisContext.OwningSymbol;
+
+                            if (owningSymbol.IsConfiguredToSkipAnalysis(
+                                    operationBlockStartAnalysisContext.Options,
+                                    Rule,
+                                    operationBlockStartAnalysisContext.Compilation,
+                                    operationBlockStartAnalysisContext.CancellationToken))
+                            {
+                                return;
+                            }
+
+                            operationBlockStartAnalysisContext.RegisterOperationAction(
+                                (OperationAnalysisContext operationAnalysisContext) =>
+                                {
+                                    ISimpleAssignmentOperation simpleAssignmentOperation =
+                                        (ISimpleAssignmentOperation)operationAnalysisContext.Operation;
+
+                                    if (simpleAssignmentOperation.Target is IPropertyReferenceOperation propertyReferenceOperation &&
+                                        httpCookieSymbol.Equals(propertyReferenceOperation.Property.ContainingType) &&
+                                        propertyReferenceOperation.Property.Name == "HttpOnly" &&
+                                        simpleAssignmentOperation.Value.ConstantValue.HasValue &&
+                                        simpleAssignmentOperation.Value.ConstantValue.Value.Equals(false))
+                                    {
+                                        operationAnalysisContext.ReportDiagnostic(
+                                            simpleAssignmentOperation.CreateDiagnostic(
+                                                Rule));
+                                    }
+                                },
+                                OperationKind.SimpleAssignment);
+
+                            operationBlockStartAnalysisContext.RegisterOperationAction(
+                                (OperationAnalysisContext operationAnalysisContext) =>
+                                {
+                                    IReturnOperation returnOperation = (IReturnOperation)operationAnalysisContext.Operation;
+
+                                    if (httpCookieSymbol.Equals(returnOperation.ReturnedValue?.Type))
+                                    {
+                                        lock (rootOperationsNeedingAnalysis)
+                                        {
+                                            rootOperationsNeedingAnalysis.Add(
+                                                (returnOperation.GetRoot(), operationAnalysisContext.ContainingSymbol));
+                                        }
+                                    }
+                                },
+                                OperationKind.Return);
+
+                            operationBlockStartAnalysisContext.RegisterOperationAction(
+                                (OperationAnalysisContext operationAnalysisContext) =>
+                                {
+                                    IArgumentOperation argumentOperation = (IArgumentOperation)operationAnalysisContext.Operation;
+
+                                    if (httpCookieSymbol.Equals(argumentOperation.Value.Type))
+                                    {
+                                        lock (rootOperationsNeedingAnalysis)
+                                        {
+                                            rootOperationsNeedingAnalysis.Add(
+                                                (argumentOperation.GetRoot(), operationAnalysisContext.ContainingSymbol));
+                                        }
+                                    }
+                                },
+                                OperationKind.Argument);
+                        });
+
+                    compilationStartAnalysisContext.RegisterCompilationEndAction(
+                        (CompilationAnalysisContext compilationAnalysisContext) =>
+                        {
+                            PooledDictionary<(Location Location, IMethodSymbol Method), HazardousUsageEvaluationResult> allResults = null;
+
+                            try
+                            {
+                                lock (rootOperationsNeedingAnalysis)
+                                {
+                                    if (!rootOperationsNeedingAnalysis.Any())
+                                    {
+                                        return;
+                                    }
+
+                                    allResults = PropertySetAnalysis.BatchGetOrComputeHazardousUsages(
+                                        compilationAnalysisContext.Compilation,
+                                        rootOperationsNeedingAnalysis,
+                                        compilationAnalysisContext.Options,
+                                        WellKnownTypeNames.SystemWebHttpCookie,
+                                        ConstructorMapper,
+                                        PropertyMappers,
+                                        HazardousUsageEvaluators,
+                                        InterproceduralAnalysisConfiguration.Create(
+                                            compilationAnalysisContext.Options,
+                                            SupportedDiagnostics,
+                                            defaultInterproceduralAnalysisKind: InterproceduralAnalysisKind.ContextSensitive,
+                                            cancellationToken: compilationAnalysisContext.CancellationToken));
+                                }
+
+                                if (allResults == null)
+                                {
+                                    return;
+                                }
+
+                                foreach (KeyValuePair<(Location Location, IMethodSymbol Method), HazardousUsageEvaluationResult> kvp
+                                    in allResults)
+                                {
+                                    if (kvp.Value == HazardousUsageEvaluationResult.Flagged)
+                                    {
+                                        compilationAnalysisContext.ReportDiagnostic(
+                                            Diagnostic.Create(
+                                                Rule,
+                                                kvp.Key.Location));
+                                    }
+                                }
+                            }
+                            finally
+                            {
+                                rootOperationsNeedingAnalysis.Free();
+                                allResults?.Free();
+                            }
+                        });
+                });
+        }
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Podle deklarace ve vašem kódu bude mít návratový typ metody P/Invoke {0} na platformách {2} šířku {1} bajtů. To není správné, protože skutečná nativní deklarace tohoto rozhraní API naznačuje, že na platformách {2} by měl mít šířku {3} bajtů. Nahlédněte do dokumentace k sadě MSDN Platform SDK. Pomůže vám určit datový typ, který byste měli použít místo {4}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">Zadání zařazení pro argumenty řetězce P/Invoke</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Gemäß der Deklaration in Ihrem Code ist der Rückgabetyp von P/Invoke "{0}" auf {2}-Plattformen {1} Byte breit. Das ist nicht korrekt, da in der eigentlichen nativen Deklaration dieser API für {3}-Plattformen eine Sollbreite von {2} Byte angegeben ist. In der MSDN-Dokumentation zum Plattform-SDK finden Sie Informationen zum Ermitteln des Datentyps, den Sie anstatt "{4}" verwenden sollten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">Marshalling für P/Invoke-Zeichenfolgenargumente angeben</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Como se declara en el código, el valor devuelto de P/Invoke {0} será de {1} bytes en {2} plataformas. Esto no es correcto puesto que la declaración nativa actual de esta API indica que debería ser de {3} bytes en {2} plataformas. Consulte la documentación de Platform SDK de MSDN para obtener ayuda para determinar qué tipo de datos debería utilizarse en lugar de {4}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">Especificar cálculo de referencias para argumentos de cadena P/Invoke</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Comme il est déclaré dans votre code, le type de retour de P/Invoke {0} est de {1} octets sur les plateformes {2}. Cela n'est pas correct, car la déclaration native réelle de cette API indique qu'elle doit être de {3} octets sur les plateformes {2}. Consultez la documentation du kit Platform SDK sur MSDN pour déterminer le type de données à utiliser à la place de {4}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">Spécifier le marshaling pour les arguments de chaîne P/Invoke</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Come dichiarato nel codice, il valore del tipo restituito di P/Invoke {0} sarà pari a {1} byte sulle piattaforme {2}. Questo non è corretto perché l'effettiva dichiarazione nativa di questa API indica che deve essere pari a {3} byte sulle piattaforme {2}. Consultare la documentazione di MSDN Platform SDK per informazioni su come determinare il tipo di dati da usare al posto di {4}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">Specificare il marshalling per gli argomenti stringa P/Invoke</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -152,6 +152,21 @@
         <target state="translated">コードで宣言されているとおり、P/Invoke {0} の戻り値の型は {2} プラットフォームで {1} バイトになります。この API の実際のネイティブ宣言は {2} プラットフォームで {3} バイトでなければならないことを示しているため、この状態は正しくありません。{4} の代わりにどのデータ型を使用する必要があるかを判断するには、MSDN のプラットフォーム SDK ドキュメントを参照してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">P/Invoke 文字列引数に対してマーシャリングを指定します</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -152,6 +152,21 @@
         <target state="translated">코드에 선언된 것처럼 P/Invoke {0}의 반환 형식은 {2} 플랫폼에서 {1}바이트가 됩니다. 이 API의 실제 네이티브 선언에 따르면 {2} 플랫폼에서 {3}바이트여야 하므로 잘못된 상황입니다. {4} 대신 사용할 데이터 형식을 결정하려면 MSDN Platform SDK 문서를 참조하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">P/Invoke 문자열 인수에 대해 마샬링을 지정하세요.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Zgodnie z deklaracją w kodzie typ zwracany metody P/Invoke {0} będzie mieć szerokość {1} bajtów na platformach {2}. Ta wartość jest niepoprawna, ponieważ rzeczywista natywna deklaracja tego interfejsu API wskazuje, że powinien on mieć szerokość {3} bajtów na platformach {2}. Pomoc dotyczącą określania typu danych, którego należy użyć zamiast {4}, zawiera dokumentacja zestawu SDK platformy MSDN.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">Określ kierowanie dla argumentów ciągu P/Invoke</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Conforme declarado em seu código, o tipo de retorno de P/Invoke {0} terá {1} bytes nas plataformas {2}. Isso não está correto, já que a declaração nativa real desta API indica que ele deve ter {3} bytes nas plataformas {2}. Consulte a documentação do SDK da Plataforma MSDN para obter ajuda para determinar que tipo de dados deve ser usado em vez de {4}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">Especificar marshaling para argumentos de cadeias de caracteres P/Invoke</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Как объявлено в вашем коде, тип возвращаемого значения для P/Invoke {0} будет иметь размер {1} байт для платформ {2}. Это неправильно, так как текущее объявление в машинном коде для данного API указывает, что его размер должен быть {3} байт для платформ {2}. Обратитесь к документации по пакету SDK для платформы MSDN и выясните, какой тип данных следует использовать вместо {4}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">Укажите маршалинг для строковых аргументов P/Invoke</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Kodunuzda bildirildiği gibi, P/Invoke {0} öğesinin dönüş türü {2} platformlarında {1} bayt genişliğinde olacaktır. Bu API’nin gerçek yerel bildirimi {2} platformlarında {3} genişliğinde olması gerektiğini bildirdiğinden, bu doğru değildir. {4} yerine hangi veri türünün kullanılması gerektiğini belirleme hakkında yardım için MSDN Platform SDK’sı belgelerine başvurun.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">P/Invoke dize bağımsız değişkenleri için sıralamayı belirtme</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -152,6 +152,21 @@
         <target state="translated">如代码中所声明的，P/Invoke {0} 的返回类型在 {2} 平台上的字节宽度将为 {1}。这是不正确的，因为此 API 的实际本机声明表明该返回类型在 {2} 平台上的字节宽度应为 {3}。请参考 MSDN Platform SDK 文档来获取帮助，确定应使用哪种数据类型来代替 {4}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">指定对 P/Invoke 字符串参数进行封送处理</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieDescription">
-        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
-        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <source>As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</source>
+        <target state="new">As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.</target>
         <note />
       </trans-unit>
       <trans-unit id="SetHttpOnlyForHttpCookieMessage">

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -152,6 +152,21 @@
         <target state="translated">因為其宣告於您的程式碼中，因此 P/Invoke {0} 的傳回型別在 {2} 平台上將會是 {1} 個位元組寬。但這是錯誤的，因為此 API 的實際原生宣告指出，其在 {2} 平台上應為 {3} 個位元組寬。請參閱 MSDN Platform SDK 文件中的說明，決定應使用何種資料類型來取代 {4}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookie">
+        <source>Set HttpOnly to true for HttpCookie</source>
+        <target state="new">Set HttpOnly to true for HttpCookie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieDescription">
+        <source>Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</source>
+        <target state="new">Websites that use cookies must specify HttpOnly for all cookies containing sensitive information that are not explicitly required by legitimate scripts in the webpage. Eg. Of sensitive cookies are those used in authentication, authorization, session management or that otherwise contain PII.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetHttpOnlyForHttpCookieMessage">
+        <source>HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</source>
+        <target state="new">HttpCookie.HttpOnly is set to false or not set at all when using an HttpCookie. Ensure security sensitive cookies are marked as HttpOnly to prevent malicious scripts from stealing the cookies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifyMarshalingForPInvokeStringArgumentsTitle">
         <source>Specify marshaling for P/Invoke string arguments</source>
         <target state="translated">指定 P/Invoke 字串引數的封送處理</target>

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetHttpOnlyForHttpCookieTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetHttpOnlyForHttpCookieTests.cs
@@ -1,0 +1,377 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.NetCore.Analyzers.Security.UnitTests
+{
+    public class SetHttpOnlyForHttpCookieTests : DiagnosticAnalyzerTestBase
+    {
+        protected void VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
+        {
+            string httpCookieCSharpSourceCode = @"
+namespace System.Web
+{
+    public sealed class HttpCookie
+    {
+        public HttpCookie (string name)
+        {
+        }
+
+        public HttpCookie (string name, string value)
+        {
+        }
+        
+        public bool HttpOnly { get; set; }
+    }
+}";
+            this.VerifyCSharp(
+                new[] { source, httpCookieCSharpSourceCode }.ToFileAndSource(),
+                expected);
+        }
+
+        [Fact]
+        public void Test_AssignHttpOnlyWithFalse_Diagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+        httpCookie.HttpOnly = false;
+    }
+}",
+            GetCSharpResultAt(9, 9, SetHttpOnlyForHttpCookie.Rule));
+        }
+
+        [Fact]
+        public void Test_AssignHttpOnlyWithFalsePossibly_Diagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+        Random r = new Random();
+
+        if (r.Next(6) == 4)
+        {
+            httpCookie.HttpOnly = false;
+        }
+    }
+}",
+            GetCSharpResultAt(14, 13, SetHttpOnlyForHttpCookie.Rule));
+        }
+
+        [Fact]
+        public void Test_ReturnHttpCookieWithFalseHttpOnly_Diagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public HttpCookie TestMethod(HttpCookie httpCookie)
+    {
+        httpCookie.HttpOnly = false;
+
+        return httpCookie;
+    }
+}",
+            GetCSharpResultAt(8, 9, SetHttpOnlyForHttpCookie.Rule));
+        }
+
+        [Fact]
+        public void Test_ReturnHttpCookie_WithoutSettingHttpOnly_Diagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public HttpCookie TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+
+        return httpCookie;
+    }
+}",
+            GetCSharpResultAt(10, 16, SetHttpOnlyForHttpCookie.Rule));
+        }
+
+        [Fact]
+        public void Test_PassHttpCookieAsAParamter_WithoutSettingHttpOnly_Diagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+        TestMethod2(httpCookie);
+    }
+
+    public void TestMethod2(HttpCookie httpCookie)
+    {
+    }
+}",
+            GetCSharpResultAt(9, 21, SetHttpOnlyForHttpCookie.Rule));
+        }
+
+        [Fact]
+        public void Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsFalse_Diagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+        httpCookie.HttpOnly = false;
+        TestMethod2(httpCookie);
+    }
+
+    public void TestMethod2(HttpCookie httpCookie)
+    {
+    }
+}",
+            GetCSharpResultAt(9, 9, SetHttpOnlyForHttpCookie.Rule));
+        }
+
+        [Fact]
+        public void Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsFalsePossibly_Diagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+        Random r = new Random();
+
+        if (r.Next(6) == 4)
+        {
+            httpCookie.HttpOnly = false;
+        }
+
+        TestMethod2(httpCookie);
+    }
+
+    public void TestMethod2(HttpCookie httpCookie)
+    {
+    }
+}",
+            GetCSharpResultAt(14, 13, SetHttpOnlyForHttpCookie.Rule));
+        }
+
+        [Fact]
+        public void Test_CreateHttpCookieWithNullArguments_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(null, null);
+    }
+}");
+        }
+
+        [Fact]
+        public void Test_AssignHttpOnlyWithTrue_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+        httpCookie.HttpOnly = true;
+    }
+}");
+        }
+
+        [Fact]
+        public void Test_JustObjectCreation_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+    }
+}");
+        }
+
+        [Fact]
+        public void Test_AssignHttpOnlyWithTruePossibly_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+        Random r = new Random();
+
+        if (r.Next(6) == 4)
+        {
+            httpCookie.HttpOnly = true;
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void Test_ReturnHttpCookieWithUnkownHttpOnly_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public HttpCookie TestMethod(HttpCookie httpCookie)
+    {
+        return httpCookie;
+    }
+}");
+        }
+
+        [Fact]
+        public void Test_ReturnHttpCookieWithTrueHttpOnly_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public HttpCookie TestMethod(HttpCookie httpCookie)
+    {
+        httpCookie.HttpOnly = true;
+
+        return httpCookie;
+    }
+}");
+        }
+
+        [Fact]
+        public void Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsTrue_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+        httpCookie.HttpOnly = true;
+        TestMethod2(httpCookie);
+    }
+
+    public HttpCookie TestMethod2(HttpCookie httpCookie)
+    {
+        return httpCookie;
+    }
+}");
+        }
+
+        [Fact]
+        public void Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsTruePossibly_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        var httpCookie = new HttpCookie(""cookieName"");
+        Random r = new Random();
+
+        if (r.Next(6) == 4)
+        {
+            httpCookie.HttpOnly = true;
+        }
+
+        TestMethod2(httpCookie);
+    }
+
+    public void TestMethod2(HttpCookie httpCookie)
+    {
+    }
+}");
+        }
+
+        [Fact]
+        public void Test_PassHttpCookieWithNullValue_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public void TestMethod()
+    {
+        TestMethod2(null);
+    }
+
+    public void TestMethod2(HttpCookie httpCookie)
+    {
+    }
+}");
+        }
+
+        [Fact]
+        public void Test_ReturnNull_NoDiagnostic()
+        {
+            VerifyCSharpWithDependencies(@"
+using System.Web;
+
+class TestClass
+{
+    public HttpCookie TestMethod(HttpCookie httpCookie)
+    {
+        return null;
+    }
+}");
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new SetHttpOnlyForHttpCookie();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SetHttpOnlyForHttpCookie();
+        }
+    }
+}

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluator.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluator.cs
@@ -61,10 +61,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         /// <param name="evaluator">Evaluation callback.</param>
         public HazardousUsageEvaluator(HazardousUsageEvaluatorKind kind, EvaluationCallback evaluator)
         {
-            if (kind != HazardousUsageEvaluatorKind.Return && kind != HazardousUsageEvaluatorKind.Initialization)
+            if (kind != HazardousUsageEvaluatorKind.Return && kind != HazardousUsageEvaluatorKind.Initialization && kind != HazardousUsageEvaluatorKind.Argument)
             {
                 throw new ArgumentException(
-                    "kind must be Return or Initialization.  Use other constructors for Invocation.",
+                    "kind must be Return or Initialization or Argument.  Use other constructors for Invocation.",
                     nameof(kind));
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorCollection.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorCollection.cs
@@ -73,6 +73,13 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 out hazardousUsageEvaluator);
         }
 
+        internal bool TryGetArgumentHazardousUsageEvaluator(out HazardousUsageEvaluator hazardousUsageEvaluator)
+        {
+            return this.HazardousUsageEvaluators.TryGetValue(
+                (HazardousUsageEvaluatorKind.Argument, null, null, null),
+                out hazardousUsageEvaluator);
+        }
+
         internal ImmutableDictionary<INamedTypeSymbol, string> GetTypeToNameMapping(WellKnownTypeProvider wellKnownTypeProvider)
         {
             PooledDictionary<INamedTypeSymbol, string> pooledDictionary = PooledDictionary<INamedTypeSymbol, string>.GetInstance();

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorKind.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorKind.cs
@@ -21,5 +21,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         /// Evaluated at field and property initialization, or field or property asssignments.
         /// </summary>
         Initialization,
+
+        /// <summary>
+        /// Evaluated at argument passing.
+        /// </summary>
+        Argument,
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
@@ -454,6 +454,22 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
             {
                 PropertySetAbstractValue baseValue = base.VisitInvocation_NonLambdaOrDelegateOrLocalFunction(method, visitedInstance, visitedArguments, invokedAsDelegate, originalOperation, defaultValue);
 
+                if (this.DataFlowAnalysisContext.HazardousUsageEvaluators.TryGetArgumentHazardousUsageEvaluator(
+                            out HazardousUsageEvaluator argumentHazardousUsageEvaluator))
+                {
+                    foreach (IArgumentOperation visitedArgument in visitedArguments)
+                    {
+                        if (this.TrackedTypeSymbol.Equals(visitedArgument.Value.Type))
+                        {
+                            this.EvaluatePotentialHazardousUsage(
+                                visitedArgument.Value.Syntax,
+                                null,
+                                visitedArgument.Value,
+                                (PropertySetAbstractValue abstractValue) => argumentHazardousUsageEvaluator.ValueEvaluator(abstractValue));
+                        }
+                    }
+                }
+
                 // If we have a HazardousUsageEvaluator for a method within the tracked type,
                 // or for a method within a different type.
                 IOperation propertySetInstance = visitedInstance;


### PR DESCRIPTION
Those scenarios are flagged with diagnostics:
1. HttpCookie.HttpOnly is set to false explicitly.
2. Return a httpCookie whose HttpOnly property is not set. The default value of HttpOnly is false.
3. Create a HttpCookie whose name is x-ms-cpim-trans and value is Invalid_Base64_String.