### PR TITLE
Handle unsupported CFG/DFA requests for attribute code blocks gracefully

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotSetSwitch.cs
@@ -116,10 +116,10 @@ namespace Microsoft.NetCore.Analyzers.Security
                                     methodSymbol.Name));
                         }
                     }
-                    else
+                    else if (invocationOperation.TryGetEnclosingControlFlowGraph(out var cfg))
                     {
                         var valueContentResult = ValueContentAnalysis.TryGetOrComputeResult(
-                            invocationOperation.GetEnclosingControlFlowGraph(),
+                            cfg,
                             operationAnalysisContext.ContainingSymbol,
                             operationAnalysisContext.Options,
                             wellKnownTypeProvider,

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
@@ -101,12 +101,17 @@ namespace Microsoft.NetCore.Analyzers.Security
                                             out evaluateWithValueContentAnalysis))
                                         {
                                             IOperation rootOperation = operationAnalysisContext.Operation.GetRoot();
+                                            if (!rootOperation.TryGetEnclosingControlFlowGraph(out var cfg))
+                                            {
+                                                return;
+                                            }
+
                                             PointsToAnalysisResult pointsToAnalysisResult;
                                             ValueContentAnalysisResult valueContentAnalysisResultOpt;
                                             if (evaluateWithPointsToAnalysis != null)
                                             {
                                                 pointsToAnalysisResult = PointsToAnalysis.TryGetOrComputeResult(
-                                                    rootOperation.GetEnclosingControlFlowGraph(),
+                                                    cfg,
                                                     owningSymbol,
                                                     operationAnalysisContext.Options,
                                                     WellKnownTypeProvider.GetOrCreate(operationAnalysisContext.Compilation),
@@ -136,7 +141,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                             if (evaluateWithValueContentAnalysis != null)
                                             {
                                                 valueContentAnalysisResultOpt = ValueContentAnalysis.TryGetOrComputeResult(
-                                                    rootOperation.GetEnclosingControlFlowGraph(),
+                                                    cfg,
                                                     owningSymbol,
                                                     operationAnalysisContext.Options,
                                                     WellKnownTypeProvider.GetOrCreate(operationAnalysisContext.Compilation),
@@ -213,8 +218,13 @@ namespace Microsoft.NetCore.Analyzers.Security
 
                                             foreach (IOperation rootOperation in rootOperationsNeedingAnalysis)
                                             {
+                                                if (!rootOperation.TryGetEnclosingControlFlowGraph(out var cfg))
+                                                {
+                                                    continue;
+                                                }
+
                                                 TaintedDataAnalysisResult taintedDataAnalysisResult = TaintedDataAnalysis.TryGetOrComputeResult(
-                                                    rootOperation.GetEnclosingControlFlowGraph(),
+                                                    cfg,
                                                     operationBlockAnalysisContext.Compilation,
                                                     operationBlockAnalysisContext.OwningSymbol,
                                                     operationBlockAnalysisContext.Options,

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/UseContainerLevelAccessPolicy.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/UseContainerLevelAccessPolicy.cs
@@ -138,30 +138,34 @@ namespace Microsoft.NetCore.Analyzers.Security
 
                                 if (argumentOperation != null)
                                 {
-                                    var interproceduralAnalysisConfig = InterproceduralAnalysisConfiguration.Create(
-                                                                            operationBlockStartContext.Options,
-                                                                            SupportedDiagnostics,
-                                                                            defaultInterproceduralAnalysisKind: InterproceduralAnalysisKind.None,
-                                                                            cancellationToken: operationBlockStartContext.CancellationToken,
-                                                                            defaultMaxInterproceduralMethodCallChain: 1);
-                                    var pointsToAnalysisResult = PointsToAnalysis.TryGetOrComputeResult(
-                                                                    invocationOperation.GetTopmostParentBlock().GetEnclosingControlFlowGraph(),
-                                                                    owningSymbol,
-                                                                    operationBlockStartContext.Options,
-                                                                    wellKnownTypeProvider,
-                                                                    interproceduralAnalysisConfig,
-                                                                    interproceduralAnalysisPredicateOpt: null,
-                                                                    false);
-                                    if (pointsToAnalysisResult == null)
+                                    var cfg = invocationOperation.GetTopmostParentBlock()?.GetEnclosingControlFlowGraph();
+                                    if (cfg != null)
                                     {
-                                        return;
-                                    }
+                                        var interproceduralAnalysisConfig = InterproceduralAnalysisConfiguration.Create(
+                                                                                operationBlockStartContext.Options,
+                                                                                SupportedDiagnostics,
+                                                                                defaultInterproceduralAnalysisKind: InterproceduralAnalysisKind.None,
+                                                                                cancellationToken: operationBlockStartContext.CancellationToken,
+                                                                                defaultMaxInterproceduralMethodCallChain: 1);
+                                        var pointsToAnalysisResult = PointsToAnalysis.TryGetOrComputeResult(
+                                                                        cfg,
+                                                                        owningSymbol,
+                                                                        operationBlockStartContext.Options,
+                                                                        wellKnownTypeProvider,
+                                                                        interproceduralAnalysisConfig,
+                                                                        interproceduralAnalysisPredicateOpt: null,
+                                                                        false);
+                                        if (pointsToAnalysisResult == null)
+                                        {
+                                            return;
+                                        }
 
-                                    var pointsToAbstractValue = pointsToAnalysisResult[argumentOperation.Kind, argumentOperation.Syntax];
+                                        var pointsToAbstractValue = pointsToAnalysisResult[argumentOperation.Kind, argumentOperation.Syntax];
 
-                                    if (pointsToAbstractValue.NullState != NullAbstractValue.Null)
-                                    {
-                                        return;
+                                        if (pointsToAbstractValue.NullState != NullAbstractValue.Null)
+                                        {
+                                            return;
+                                        }
                                     }
                                 }
 

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotHardCodeEncryptionKeyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotHardCodeEncryptionKeyTests.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -387,6 +388,23 @@ class TestClass
         SymmetricAlgorithm rijn = SymmetricAlgorithm.Create();
         rijn.CreateEncryptor(key, someOtherBytesForIV);
     }
+}");
+        }
+
+        [Fact, WorkItem(2723, "https://github.com/dotnet/roslyn-analyzers/issues/2723")]
+        public void Test_ArrayInitializerInAttribute()
+        {
+            VerifyCSharpWithDependencies(@"
+using System;
+
+class MyAttr : Attribute
+{
+    public MyAttr (byte[] array) { }
+}
+
+[MyAttr(new byte[]{ 1 })]
+class C
+{
 }");
         }
 

--- a/src/Utilities.UnitTests/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisTests.cs
+++ b/src/Utilities.UnitTests/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Remoting;
 using System.Threading;
@@ -68,6 +69,9 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 operation != null,
                 $"Could not find code block to analyze.  Does your test code have {StartString} and {EndString} around the braces of block to analyze?");
             ISymbol symbol = model.GetDeclaredSymbol(syntaxNode.Parent) ?? model.GetSymbolInfo(syntaxNode.Parent).Symbol;
+            var success = operation.TryGetEnclosingControlFlowGraph(out var cfg);
+            Debug.Assert(success);
+            Debug.Assert(cfg != null);
 
 #pragma warning disable CA1508 // Avoid dead conditional code - https://github.com/dotnet/roslyn-analyzers/issues/2180
             using (var cancellationSource = new CancellationTokenSource())
@@ -76,7 +80,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 DiagnosticDescriptor dummy = new DiagnosticDescriptor("fakeId", null, null, "fakeagory", DiagnosticSeverity.Info, true);
                 PropertySetAnalysisResult result =
                     PropertySetAnalysis.GetOrComputeResult(
-                        operation.GetEnclosingControlFlowGraph(),
+                        cfg,
                         compilation,
                         symbol,
                         new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty),

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
@@ -30,6 +31,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
             bool performPointsToAnalysis = true,
             bool exceptionPathsAnalysis = false)
         {
+            if (cfg == null)
+            {
+                Debug.Fail("Expected non-null CFG");
+                return null;
+            }
+
             var pointsToAnalysisResultOpt = performPointsToAnalysis ?
                 PointsToAnalysis.PointsToAnalysis.TryGetOrComputeResult(cfg, owningSymbol, analyzerOptions, wellKnownTypeProvider, interproceduralAnalysisConfig,
                     interproceduralAnalysisPredicateOpt, pessimisticAnalysis, performCopyAnalysis: false, exceptionPathsAnalysis) :

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.cs
@@ -81,7 +81,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
             bool performCopyAnalysis,
             out PointsToAnalysisResult pointsToAnalysisResult)
         {
-            Debug.Assert(cfg != null);
             Debug.Assert(wellKnownTypeProvider.IDisposable != null);
             Debug.Assert(owningSymbol != null);
 
@@ -90,6 +89,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
                 interproceduralAnalysisPredicateOpt, PessimisticAnalysis, performCopyAnalysis, exceptionPathsAnalysis);
             if (pointsToAnalysisResult == null)
             {
+                return null;
+            }
+
+            if (cfg == null)
+            {
+                Debug.Fail("Expected non-null CFG");
                 return null;
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -57,6 +57,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 CopyAnalysis.CopyAnalysis.TryGetOrComputeResult(cfg, owningSymbol, analyzerOptions, wellKnownTypeProvider, interproceduralAnalysisConfig,
                     interproceduralAnalysisPredicateOpt, pessimisticAnalysis, performPointsToAnalysis: true, exceptionPathsAnalysis) :
                 null;
+
+            if (cfg == null)
+            {
+                Debug.Fail("Expected non-null CFG");
+                return null;
+            }
+
             var analysisContext = PointsToAnalysisContext.Create(PointsToAbstractValueDomain.Default, wellKnownTypeProvider, cfg,
                 owningSymbol, analyzerOptions, interproceduralAnalysisConfig, pessimisticAnalysis, exceptionPathsAnalysis, copyAnalysisResultOpt,
                 TryGetOrComputeResultForAnalysisContext, interproceduralAnalysisPredicateOpt);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
+using System.Diagnostics;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {
@@ -51,6 +52,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             TaintedDataSymbolMap<SinkInfo> taintedSinkInfos,
             InterproceduralAnalysisConfiguration interproceduralAnalysisConfig)
         {
+            if (cfg == null)
+            {
+                Debug.Fail("Expected non-null CFG");
+                return null;
+            }
+
             WellKnownTypeProvider wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(compilation);
             ValueContentAnalysisResult valueContentAnalysisResult = null;
             CopyAnalysisResult copyAnalysisResult = null;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.cs
@@ -83,6 +83,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
                 PointsToAnalysis.PointsToAnalysis.TryGetOrComputeResult(cfg, owningSymbol, analyzerOptions, wellKnownTypeProvider, out copyAnalysisResultOpt,
                     interproceduralAnalysisConfig, interproceduralAnalysisPredicateOpt, pessimisticAnalysis, performCopyAnalysis) :
                 null;
+
+            if (cfg == null)
+            {
+                Debug.Fail("Expected non-null CFG");
+                return null;
+            }
+
             var analysisContext = ValueContentAnalysisContext.Create(
                 ValueContentAbstractValueDomain.Default, wellKnownTypeProvider, cfg, owningSymbol, analyzerOptions,
                 interproceduralAnalysisConfig, pessimisticAnalysis, copyAnalysisResultOpt,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         private TAnalysisResult Run(TAnalysisContext analysisContext)
         {
             var cfg = analysisContext.ControlFlowGraph;
-            if (!cfg.SupportsFlowAnalysis())
+            if (cfg?.SupportsFlowAnalysis() != true)
             {
                 return default;
             }


### PR DESCRIPTION
[ControlFlowGraph.Create](http://source.roslyn.io/#q=ControlFlowGraph.Create) API has overloads for all operation block roots, except for attribute code blocks, which have OperationKind.None as the root operation. Compiler does not support CFG creation for attribute blocks, but it is likely that some of our current/future DFA analyzers may not have an explicit check and bail out for attribute blocks. So, we are now much more defensive in handling CFG/DFA requests for such attribute blocks and bail out gracefully instead of throwing not supported/NRE exception.

Fixes #2723