### PR TITLE
Adding analyzer to check SerializationBinders for properly throwing exceptions on unrecognized types

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
@@ -1074,4 +1074,10 @@
   <data name="JsonNetMaybeInsecureSerializerTitle" xml:space="preserve">
     <value>Ensure that JsonSerializer has a secure configuration when deserializing</value>
   </data>
+  <data name="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle" xml:space="preserve">
+    <value>Do not overload SerializationBinder without throwing an exception for unexpected types.</value>
+  </data>
+  <data name="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage" xml:space="preserve">
+    <value>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</value>
+  </data>
 </root>

--- a/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
@@ -1075,7 +1075,7 @@
     <value>Ensure that JsonSerializer has a secure configuration when deserializing</value>
   </data>
   <data name="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle" xml:space="preserve">
-    <value>Do not overload SerializationBinder without throwing an exception for unexpected types.</value>
+    <value>Do not overload SerializationBinder without throwing an exception for unexpected types</value>
   </data>
   <data name="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage" xml:space="preserve">
     <value>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</value>

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotOverloadDeserializationBinderWithoutThrowingAnException.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotOverloadDeserializationBinderWithoutThrowingAnException.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -21,11 +21,11 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// <remarks>
     /// 
     /// </remarks>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class DoNotOverloadSerializationBinderWithoutThrowingAnException : DiagnosticAnalyzer
     {
         protected string OverloadingClassMetadataName { get; }
-        enum cacheState
+        enum CacheState
         {
             Absent,
             InProgress,
@@ -39,7 +39,7 @@ namespace Microsoft.NetCore.Analyzers.Security
             nameof(MicrosoftNetCoreAnalyzersResources.DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage),
             DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
             helpLinkUri: null,
-            customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
+            customTags: WellKnownDiagnosticTags.Telemetry);
 
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create<DiagnosticDescriptor>(
@@ -47,33 +47,39 @@ namespace Microsoft.NetCore.Analyzers.Security
 
         public sealed override void Initialize(AnalysisContext context)
         {
-
             context.EnableConcurrentExecution();
-
             // Security analyzer - analyze and report diagnostics on generated code.
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
             context.RegisterCompilationStartAction(
                 (CompilationStartAnalysisContext compilationStartAnalysisContext) =>
                 {
-                    Dictionary<IMethodSymbol, cacheState> methodCache = new Dictionary<IMethodSymbol, cacheState>();
+                    Dictionary<IMethodSymbol, CacheState> methodCache = new Dictionary<IMethodSymbol, CacheState>();
+                    WellKnownTypeProvider typeProvider = WellKnownTypeProvider.GetOrCreate(compilationStartAnalysisContext.Compilation);
+                    INamedTypeSymbol SerializationBinder = null;
+                    if (!typeProvider.TryGetTypeByMetadataName("System.Runtime.Serialization.SerializationBinder", out SerializationBinder))
+                    {
+                        System.Diagnostics.Debug.Fail("Unable to find System.Runtime.Serialization.SerializationBinder threw WellKnownTypeProvider");
+                        return;
+                    }
+
                     compilationStartAnalysisContext.RegisterSymbolAction(
                         (SymbolAnalysisContext symbolAnalysisContext) =>
                         {
                             IMethodSymbol msym = (IMethodSymbol)symbolAnalysisContext.Symbol;
                             if (msym.Name == "BindToType")
                             {
-                                if (isStandardSerBinder(msym.ContainingType))
+                                if (ITypeSymbolExtensions.Inherits(msym.ContainingType, SerializationBinder))
                                 {
                                     IBlockOperation msymOps = msym.GetTopmostOperationBlock(compilationStartAnalysisContext.Compilation);
-                                    methodCache[msym] = cacheState.InProgress;
+                                    methodCache[msym] = CacheState.InProgress;
                                     if (!hasThrow(msymOps.Operations))
                                     {
                                         symbolAnalysisContext.ReportDiagnostic(
                                             Diagnostic.Create(
                                                 DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule,
                                                 msym.Locations[0],
-                                                msym.ToDisplayString(
+                                                msym.ContainingType.ToDisplayString(
                                                     SymbolDisplayFormat.MinimallyQualifiedFormat)));
                                     }
                                 }
@@ -85,50 +91,58 @@ namespace Microsoft.NetCore.Analyzers.Security
                     {
                         if (ops == null)
                         {
-                            return false; //never happens, left for comprehensiveness
+                            //doesn't happen, but just in case
+                            System.Diagnostics.Debug.Fail("hasThrow called on null value. It should be called on an IEnumerable of IOperations.");
+                            return false;
                         }
+
                         foreach (IOperation op in ops)
                         {
-                            if (op == null) { continue; }
+                            if (op == null)
+                            {
+                                continue;
+                            }
                             if (op.Kind == OperationKind.Invocation)
                             {
                                 IMethodSymbol func = ((IInvocationOperation)op).TargetMethod;
-                                cacheState methodState = cacheState.Absent;
+                                CacheState methodState = CacheState.Absent;
                                 if (!methodCache.TryGetValue(func, out methodState))
                                 {
-                                    methodState = cacheState.Absent;
+                                    methodState = CacheState.Absent;
                                 }
-                                if (methodState == cacheState.PresentTrue)
+                                if (methodState == CacheState.PresentTrue)
                                 {
                                     return true; //we've done this before
                                 }
-                                if (methodState == cacheState.PresentFalse)
+                                if (methodState == CacheState.PresentFalse)
                                 {
                                     continue; //no need to go here again
                                 }
-                                if (methodState == cacheState.InProgress)
+                                if (methodState == CacheState.InProgress)
                                 {
                                     continue; //avoid recursive functions causing a loop
                                 }
-                                methodCache[func] = cacheState.InProgress;
+                                methodCache[func] = CacheState.InProgress;
                                 IBlockOperation funcOps = func.GetTopmostOperationBlock(compilationStartAnalysisContext.Compilation);
                                 if (funcOps == null)
                                 {
                                     //function's source is in another assembly, and we cannot scan it
                                     //we will assume in this case that, even if this function throws an exception, it's probably not one we care about
-                                    methodCache[func] = cacheState.PresentFalse;
+                                    methodCache[func] = CacheState.PresentFalse;
                                     continue;
                                 }
                                 if (hasThrow(funcOps.Operations))
                                 {
-                                    methodCache[func] = cacheState.PresentTrue;
+                                    methodCache[func] = CacheState.PresentTrue;
                                     return true;
                                 }
                             }
+
                             if (op.Kind == OperationKind.Throw)
                             {
                                 return true;
                             }
+
                             if (hasThrow(op.Descendants()))
                             {
                                 return true;
@@ -137,36 +151,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                         return false;
                     }
 
-
                 }
             );
         }
-
-        bool isStandardSerBinder(INamedTypeSymbol sb)
-        {
-            if (sb == null) { return false; }
-            INamedTypeSymbol parent = sb;
-            while (true)
-            {
-                if (parent == null)
-                {
-                    return false; //reached object without finding serializationBinder
-                }
-                if (parent.Name == "SerializationBinder")
-                {
-                    if (parent.ContainingNamespace == null) { return false; }
-                    if (parent.ContainingNamespace.Name != "Serialization") { return false; }
-                    INamespaceSymbol SysRunSer = parent.ContainingNamespace;
-                    if (SysRunSer.ContainingNamespace == null) { return false; }
-                    if (SysRunSer.ContainingNamespace.Name != "Runtime") { return false; }
-                    INamespaceSymbol SysRun = SysRunSer.ContainingNamespace;
-                    if (SysRun.ContainingNamespace == null) { return false; }
-                    if (SysRun.ContainingNamespace.Name != "System") { return false; }
-                    return true;
-                }
-                parent = parent.BaseType;
-            }
-        }
-
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotOverloadDeserializationBinderWithoutThrowingAnException.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotOverloadDeserializationBinderWithoutThrowingAnException.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.NetCore.Analyzers.Security.Helpers;
+
+namespace Microsoft.NetCore.Analyzers.Security
+{
+    /// <summary>
+    /// Checks overloads of the serialization binder's BindToType method
+    /// to check whether they properly throw an exception
+    /// </summary>
+    /// <remarks>
+    /// 
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DoNotOverloadSerializationBinderWithoutThrowingAnException : DiagnosticAnalyzer
+    {
+        protected string OverloadingClassMetadataName { get; }
+        enum cacheState
+        {
+            Absent,
+            InProgress,
+            PresentTrue,
+            PresentFalse
+        };
+
+        internal static DiagnosticDescriptor DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule = SecurityHelpers.CreateDiagnosticDescriptor(
+            "CA2340",
+            nameof(MicrosoftNetCoreAnalyzersResources.DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle),
+            nameof(MicrosoftNetCoreAnalyzersResources.DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage),
+            DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+            helpLinkUri: null,
+            customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
+
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create<DiagnosticDescriptor>(
+                DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule);
+
+        public sealed override void Initialize(AnalysisContext context)
+        {
+
+            context.EnableConcurrentExecution();
+
+            // Security analyzer - analyze and report diagnostics on generated code.
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+            context.RegisterCompilationStartAction(
+                (CompilationStartAnalysisContext compilationStartAnalysisContext) =>
+                {
+                    Dictionary<IMethodSymbol, cacheState> methodCache = new Dictionary<IMethodSymbol, cacheState>();
+                    compilationStartAnalysisContext.RegisterSymbolAction(
+                        (SymbolAnalysisContext symbolAnalysisContext) =>
+                        {
+                            IMethodSymbol msym = (IMethodSymbol)symbolAnalysisContext.Symbol;
+                            if (msym.Name == "BindToType")
+                            {
+                                if (isStandardSerBinder(msym.ContainingType))
+                                {
+                                    IBlockOperation msymOps = msym.GetTopmostOperationBlock(compilationStartAnalysisContext.Compilation);
+                                    methodCache[msym] = cacheState.InProgress;
+                                    if (!hasThrow(msymOps.Operations))
+                                    {
+                                        symbolAnalysisContext.ReportDiagnostic(
+                                            Diagnostic.Create(
+                                                DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule,
+                                                msym.Locations[0],
+                                                msym.ToDisplayString(
+                                                    SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                                    }
+                                }
+                            }
+                        }
+                    , SymbolKind.Method);
+
+                    bool hasThrow(IEnumerable<Microsoft.CodeAnalysis.IOperation> ops)
+                    {
+                        if (ops == null)
+                        {
+                            return false; //never happens, left for comprehensiveness
+                        }
+                        foreach (IOperation op in ops)
+                        {
+                            if (op == null) { continue; }
+                            if (op.Kind == OperationKind.Invocation)
+                            {
+                                IMethodSymbol func = ((IInvocationOperation)op).TargetMethod;
+                                cacheState methodState = cacheState.Absent;
+                                if (!methodCache.TryGetValue(func, out methodState))
+                                {
+                                    methodState = cacheState.Absent;
+                                }
+                                if (methodState == cacheState.PresentTrue)
+                                {
+                                    return true; //we've done this before
+                                }
+                                if (methodState == cacheState.PresentFalse)
+                                {
+                                    continue; //no need to go here again
+                                }
+                                if (methodState == cacheState.InProgress)
+                                {
+                                    continue; //avoid recursive functions causing a loop
+                                }
+                                methodCache[func] = cacheState.InProgress;
+                                IBlockOperation funcOps = func.GetTopmostOperationBlock(compilationStartAnalysisContext.Compilation);
+                                if (funcOps == null)
+                                {
+                                    //function's source is in another assembly, and we cannot scan it
+                                    //we will assume in this case that, even if this function throws an exception, it's probably not one we care about
+                                    methodCache[func] = cacheState.PresentFalse;
+                                    continue;
+                                }
+                                if (hasThrow(funcOps.Operations))
+                                {
+                                    methodCache[func] = cacheState.PresentTrue;
+                                    return true;
+                                }
+                            }
+                            if (op.Kind == OperationKind.Throw)
+                            {
+                                return true;
+                            }
+                            if (hasThrow(op.Descendants()))
+                            {
+                                return true;
+                            }
+                        }
+                        return false;
+                    }
+
+
+                }
+            );
+        }
+
+        bool isStandardSerBinder(INamedTypeSymbol sb)
+        {
+            if (sb == null) { return false; }
+            INamedTypeSymbol parent = sb;
+            while (true)
+            {
+                if (parent == null)
+                {
+                    return false; //reached object without finding serializationBinder
+                }
+                if (parent.Name == "SerializationBinder")
+                {
+                    if (parent.ContainingNamespace == null) { return false; }
+                    if (parent.ContainingNamespace.Name != "Serialization") { return false; }
+                    INamespaceSymbol SysRunSer = parent.ContainingNamespace;
+                    if (SysRunSer.ContainingNamespace == null) { return false; }
+                    if (SysRunSer.ContainingNamespace.Name != "Runtime") { return false; }
+                    INamespaceSymbol SysRun = SysRunSer.ContainingNamespace;
+                    if (SysRun.ContainingNamespace == null) { return false; }
+                    if (SysRun.ContainingNamespace.Name != "System") { return false; }
+                    return true;
+                }
+                parent = parent.BaseType;
+            }
+        }
+
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotOverloadDeserializationBinderWithoutThrowingAnException.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotOverloadDeserializationBinderWithoutThrowingAnException.cs
@@ -18,13 +18,9 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// Checks overloads of the serialization binder's BindToType method
     /// to check whether they properly throw an exception
     /// </summary>
-    /// <remarks>
-    /// 
-    /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class DoNotOverloadSerializationBinderWithoutThrowingAnException : DiagnosticAnalyzer
     {
-        protected string OverloadingClassMetadataName { get; }
         enum CacheState
         {
             Absent,
@@ -56,10 +52,9 @@ namespace Microsoft.NetCore.Analyzers.Security
                 {
                     Dictionary<IMethodSymbol, CacheState> methodCache = new Dictionary<IMethodSymbol, CacheState>();
                     WellKnownTypeProvider typeProvider = WellKnownTypeProvider.GetOrCreate(compilationStartAnalysisContext.Compilation);
-                    INamedTypeSymbol SerializationBinder = null;
-                    if (!typeProvider.TryGetTypeByMetadataName("System.Runtime.Serialization.SerializationBinder", out SerializationBinder))
+                    INamedTypeSymbol serializationBinder = null;
+                    if (!typeProvider.TryGetTypeByMetadataName(WellKnownTypeNames.SystemRuntimeSerializationSerializationBinder, out serializationBinder))
                     {
-                        System.Diagnostics.Debug.Fail("Unable to find System.Runtime.Serialization.SerializationBinder threw WellKnownTypeProvider");
                         return;
                     }
 
@@ -69,18 +64,23 @@ namespace Microsoft.NetCore.Analyzers.Security
                             IMethodSymbol msym = (IMethodSymbol)symbolAnalysisContext.Symbol;
                             if (msym.Name == "BindToType")
                             {
-                                if (ITypeSymbolExtensions.Inherits(msym.ContainingType, SerializationBinder))
+                                if (msym.ContainingType.Inherits(serializationBinder))
                                 {
                                     IBlockOperation msymOps = msym.GetTopmostOperationBlock(compilationStartAnalysisContext.Compilation);
                                     methodCache[msym] = CacheState.InProgress;
                                     if (!hasThrow(msymOps.Operations))
                                     {
+                                        methodCache[msym] = CacheState.PresentTrue;
                                         symbolAnalysisContext.ReportDiagnostic(
                                             Diagnostic.Create(
                                                 DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule,
                                                 msym.Locations[0],
                                                 msym.ContainingType.ToDisplayString(
                                                     SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                                    }
+                                    else
+                                    {
+                                        methodCache[msym] = CacheState.PresentFalse;
                                     }
                                 }
                             }
@@ -92,7 +92,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                         if (ops == null)
                         {
                             //doesn't happen, but just in case
-                            System.Diagnostics.Debug.Fail("hasThrow called on null value. It should be called on an IEnumerable of IOperations.");
+                            Debug.Fail("hasThrow called on null value. It should be called on an IEnumerable of IOperations.");
                             return false;
                         }
 
@@ -102,14 +102,16 @@ namespace Microsoft.NetCore.Analyzers.Security
                             {
                                 continue;
                             }
+
                             if (op.Kind == OperationKind.Invocation)
                             {
                                 IMethodSymbol func = ((IInvocationOperation)op).TargetMethod;
-                                CacheState methodState = CacheState.Absent;
+                                CacheState methodState;
                                 if (!methodCache.TryGetValue(func, out methodState))
                                 {
                                     methodState = CacheState.Absent;
                                 }
+
                                 if (methodState == CacheState.PresentTrue)
                                 {
                                     return true; //we've done this before
@@ -122,6 +124,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                 {
                                     continue; //avoid recursive functions causing a loop
                                 }
+
                                 methodCache[func] = CacheState.InProgress;
                                 IBlockOperation funcOps = func.GetTopmostOperationBlock(compilationStartAnalysisContext.Compilation);
                                 if (funcOps == null)

--- a/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotOverloadDeserializationBinderWithoutThrowingAnException.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Security/DoNotOverloadDeserializationBinderWithoutThrowingAnException.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
@@ -50,7 +51,7 @@ namespace Microsoft.NetCore.Analyzers.Security
             context.RegisterCompilationStartAction(
                 (CompilationStartAnalysisContext compilationStartAnalysisContext) =>
                 {
-                    Dictionary<IMethodSymbol, CacheState> methodCache = new Dictionary<IMethodSymbol, CacheState>();
+                    ConcurrentDictionary<IMethodSymbol, CacheState> methodCache = new ConcurrentDictionary<IMethodSymbol, CacheState>();
                     WellKnownTypeProvider typeProvider = WellKnownTypeProvider.GetOrCreate(compilationStartAnalysisContext.Compilation);
                     INamedTypeSymbol serializationBinder = null;
                     if (!typeProvider.TryGetTypeByMetadataName(WellKnownTypeNames.SystemRuntimeSerializationSerializationBinder, out serializationBinder))

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../MicrosoftNetCoreAnalyzersResources.resx">
     <body>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionMessage">
+        <source>The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</source>
+        <target state="new">The {0}'s BindToType() method might not be throwing exceptions for unexpected types. If you're using a SerializationBinder to restrict types as a mitigation against deserialization attacks, then you need to throw exceptions for unexpected types. Returning 'null' in C# or 'Nothing' in Visual Basic allows deserialization of the type using the default serialization functions, which opens the code to injection of arbitrary information, including code, by providing compromised data to the deserializer. Throwing an exception will prevent deserialization of unrecognized types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTitle">
+        <source>Do not overload SerializationBinder without throwing an exception for unexpected types</source>
+        <target state="new">Do not overload SerializationBinder without throwing an exception for unexpected types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonNetInsecureSerializerMessage">
         <source>When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</source>
         <target state="new">When deserializing untrusted input, allowing arbitrary types to be deserialized is insecure. When using deserializing JsonSerializer, use TypeNameHandling.None, or for values other than None, restrict deserialized types with a SerializationBinder.</target>

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTest.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTest.cs
@@ -178,7 +178,7 @@ sealed class Version1ToVersion2DeserializationBinder : SerializationBinder
 }
 
             ",
-            GetCSharpResultAt(135, 26, DoNotOverloadSerializationBinderWithoutThrowingAnException.DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule));
+            GetCSharpResultAt(135, 26, DoNotOverloadSerializationBinderWithoutThrowingAnException.DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule, "Version1ToVersion2DeserializationBinder"));
         }
 
         [Fact]
@@ -672,7 +672,7 @@ sealed class Version1ToVersion2DeserializationBinder : SerializationBinder
         return pointlessRecursiveFunction(assemVer1, typeName, 0);
     }
 }
-            ", GetCSharpResultAt(148, 26, DoNotOverloadSerializationBinderWithoutThrowingAnException.DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule));
+            ", GetCSharpResultAt(148, 26, DoNotOverloadSerializationBinderWithoutThrowingAnException.DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule, "Version1ToVersion2DeserializationBinder"));
         }
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTest.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTest.cs
@@ -1,0 +1,688 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.NetCore.Analyzers.Security.UnitTests
+{
+    public class DoNotOverloadSerializationBinderWithoutThrowingAnExceptionTests : DiagnosticAnalyzerTestBase
+    {
+        [Fact]
+        public void TestReturningNullFromBindToTypeDiagnostic()
+        {
+            VerifyCSharp(@"
+//from https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.serializationbinder?view=netframework-4.8
+//this has been reported
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Reflection;
+using System.Security.Permissions;
+
+
+class App 
+{
+    [STAThread]
+    static void Main() 
+    {
+        System.Console.WriteLine(""This program wasn't supposed to get through compilation. It overloads a serialization binder but doesn't throw an exception, which has security risks."");
+        Serialize();
+        Deserialize();
+    }
+
+    static void Serialize() 
+    {
+        // To serialize the objects, you must first open a stream for writing. 
+        // Use a file stream here.
+        FileStream fs = new FileStream(""DataFile.dat"", FileMode.Create);
+
+        try 
+        {
+            // Construct a BinaryFormatter and use it 
+            // to serialize the data to the stream.
+            BinaryFormatter formatter = new BinaryFormatter();
+
+            // Construct a Version1Type object and serialize it.
+            Version1Type obj = new Version1Type();
+            obj.x = 123;
+            formatter.Serialize(fs, obj);
+        }
+        catch (SerializationException e) 
+        {
+            Console.WriteLine(""Failed to serialize. Reason: "" + e.Message);
+            throw;
+        }
+        finally 
+        {
+            fs.Close();
+        }
+    }
+
+   
+    static void Deserialize() 
+    {
+        // Declare the Version2Type reference.
+        Version2Type obj = null;
+
+        // Open the file containing the data that you want to deserialize.
+        FileStream fs = new FileStream(""DataFile.dat"", FileMode.Open);
+        try 
+        {
+            // Construct a BinaryFormatter and use it 
+            // to deserialize the data from the stream.
+            BinaryFormatter formatter = new BinaryFormatter();
+
+            // Construct an instance of our the
+            // Version1ToVersion2TypeSerialiationBinder type.
+            // This Binder type can deserialize a Version1Type  
+            // object to a Version2Type object.
+            formatter.Binder = new Version1ToVersion2DeserializationBinder();
+
+            obj = (Version2Type) formatter.Deserialize(fs);
+        }
+        catch (SerializationException e) 
+        {
+            Console.WriteLine(""Failed to deserialize. Reason: "" + e.Message);
+            throw;
+        }
+        finally 
+        {
+            fs.Close();
+        }
+
+        // To prove that a Version2Type object was deserialized, 
+        // display the object's type and fields to the console.
+        Console.WriteLine(""Type of object deserialized: "" + obj.GetType());
+        Console.WriteLine(""x = {0}, name = {1}"", obj.x, obj.name);
+    }
+}
+
+
+[Serializable]
+class Version1Type 
+{
+    public Int32 x;
+}
+
+
+[Serializable]
+class Version2Type : ISerializable 
+{
+    public Int32 x;
+    public String name;
+   
+    // The security attribute demands that code that calls
+    // this method have permission to perform serialization.
+    [SecurityPermissionAttribute(SecurityAction.Demand,SerializationFormatter=true)]
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) 
+    {
+        info.AddValue(""x"", x);
+        info.AddValue(""name"", name);
+    }
+
+    // The security attribute demands that code that calls  
+    // this method have permission to perform serialization.
+    [SecurityPermissionAttribute(SecurityAction.Demand,SerializationFormatter=true)]
+    private Version2Type(SerializationInfo info, StreamingContext context) 
+    {
+        x = info.GetInt32(""x"");
+        try 
+        {
+            name = info.GetString(""name"");
+        }
+        catch (SerializationException) 
+        {
+            // The ""name"" field was not serialized because Version1Type 
+            // did not contain this field.
+            // Set this field to a reasonable default value.
+            name = ""Reasonable default value"";
+        }
+    }
+}
+
+
+sealed class Version1ToVersion2DeserializationBinder : SerializationBinder 
+{
+    public override Type BindToType(string assemblyName, string typeName) 
+    {
+        Type typeToDeserialize = null;
+
+        // For each assemblyName/typeName that you want to deserialize to
+        // a different type, set typeToDeserialize to the desired type.
+        String assemVer1 = Assembly.GetExecutingAssembly().FullName;
+        String typeVer1 = ""Version1Type"";
+
+        if (assemblyName == assemVer1 && typeName == typeVer1) 
+        {
+            // To use a type from a different assembly version, 
+            // change the version number.
+            // To do this, uncomment the following line of code.
+            // assemblyName = assemblyName.Replace(""1.0.0.0"", ""2.0.0.0"");
+
+            // To use a different type from the same assembly, 
+            // change the type name.
+            typeName = ""Version2Type"";
+        }
+
+        // The following line of code returns the type.
+        typeToDeserialize = Type.GetType(String.Format(""{0}, {1}"", 
+            typeName, assemblyName));
+
+        return typeToDeserialize;
+    }
+}
+
+            ",
+            GetCSharpResultAt(135, 26, DoNotOverloadSerializationBinderWithoutThrowingAnException.DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule));
+        }
+
+        [Fact]
+        public void TestCatchingNullAndThrowingAnExceptionNoDiagnostic()
+        {
+            VerifyCSharp(@"
+//fixed version of previous case
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Reflection;
+using System.Security.Permissions;
+
+
+class App 
+{
+    [STAThread]
+    static void Main() 
+    {
+        System.Console.WriteLine(""This program should pass compilation. It overloads a serialization binder and throws an exception."");
+        Serialize();
+        Deserialize();
+    }
+
+    static void Serialize() 
+    {
+        // To serialize the objects, you must first open a stream for writing. 
+        // Use a file stream here.
+        FileStream fs = new FileStream(""DataFile.dat"", FileMode.Create);
+
+        try 
+        {
+            // Construct a BinaryFormatter and use it 
+            // to serialize the data to the stream.
+            BinaryFormatter formatter = new BinaryFormatter();
+
+            // Construct a Version1Type object and serialize it.
+            Version1Type obj = new Version1Type();
+            obj.x = 123;
+            formatter.Serialize(fs, obj);
+        }
+        catch (SerializationException e) 
+        {
+            Console.WriteLine(""Failed to serialize. Reason: "" + e.Message);
+            throw;
+        }
+        finally 
+        {
+            fs.Close();
+        }
+    }
+
+   
+    static void Deserialize() 
+    {
+        // Declare the Version2Type reference.
+        Version2Type obj = null;
+
+        // Open the file containing the data that you want to deserialize.
+        FileStream fs = new FileStream(""DataFile.dat"", FileMode.Open);
+        try 
+        {
+            // Construct a BinaryFormatter and use it 
+            // to deserialize the data from the stream.
+            BinaryFormatter formatter = new BinaryFormatter();
+
+            // Construct an instance of our the
+            // Version1ToVersion2TypeSerialiationBinder type.
+            // This Binder type can deserialize a Version1Type  
+            // object to a Version2Type object.
+            formatter.Binder = new Version1ToVersion2DeserializationBinder();
+
+            obj = (Version2Type) formatter.Deserialize(fs);
+        }
+        catch (SerializationException e) 
+        {
+            Console.WriteLine(""Failed to deserialize. Reason: "" + e.Message);
+            throw;
+        }
+        finally 
+        {
+            fs.Close();
+        }
+
+        // To prove that a Version2Type object was deserialized, 
+        // display the object's type and fields to the console.
+        Console.WriteLine(""Type of object deserialized: "" + obj.GetType());
+        Console.WriteLine(""x = {0}, name = {1}"", obj.x, obj.name);
+    }
+}
+
+
+[Serializable]
+class Version1Type 
+{
+    public Int32 x;
+}
+
+
+[Serializable]
+class Version2Type : ISerializable 
+{
+    public Int32 x;
+    public String name;
+   
+    // The security attribute demands that code that calls
+    // this method have permission to perform serialization.
+    [SecurityPermissionAttribute(SecurityAction.Demand,SerializationFormatter=true)]
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) 
+    {
+        info.AddValue(""x"", x);
+        info.AddValue(""name"", name);
+    }
+
+    // The security attribute demands that code that calls  
+    // this method have permission to perform serialization.
+    [SecurityPermissionAttribute(SecurityAction.Demand,SerializationFormatter=true)]
+    private Version2Type(SerializationInfo info, StreamingContext context) 
+    {
+        x = info.GetInt32(""x"");
+        try 
+        {
+            name = info.GetString(""name"");
+        }
+        catch (SerializationException) 
+        {
+            // The ""name"" field was not serialized because Version1Type 
+            // did not contain this field.
+            // Set this field to a reasonable default value.
+            name = ""Reasonable default value"";
+        }
+    }
+}
+
+
+sealed class Version1ToVersion2DeserializationBinder : SerializationBinder 
+{
+    public override Type BindToType(string assemblyName, string typeName) 
+    {
+        Type typeToDeserialize = null;
+
+        // For each assemblyName/typeName that you want to deserialize to
+        // a different type, set typeToDeserialize to the desired type.
+        String assemVer1 = Assembly.GetExecutingAssembly().FullName;
+        String typeVer1 = ""Version1Type"";
+
+        if (assemblyName == assemVer1 && typeName == typeVer1) 
+        {
+            // To use a type from a different assembly version, 
+            // change the version number.
+            // To do this, uncomment the following line of code.
+            // assemblyName = assemblyName.Replace(""1.0.0.0"", ""2.0.0.0"");
+
+            // To use a different type from the same assembly, 
+            // change the type name.
+            typeName = ""Version2Type"";
+        }
+
+        // The following line of code returns the type.
+        typeToDeserialize = Type.GetType(String.Format(""{0}, {1}"", 
+            typeName, assemblyName));
+
+        if (typeToDeserialize == null) {
+            throw new SerializationException();
+        }
+        
+        return typeToDeserialize;
+    }
+}
+            ");
+        }
+
+        [Fact]
+        public void TestSubfunctionImplementsBindToTypeNoDiagnostic()
+        {
+            VerifyCSharp(@"
+//recursive version of previous case
+//not the way you'd really do that, but I want to check things
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Reflection;
+using System.Security.Permissions;
+
+
+class App 
+{
+    [STAThread]
+    static void Main() 
+    {
+        System.Console.WriteLine(""This program is designed to pass compilation tests. It throws an exception as it should, but does that through some extra complexity."");
+        Serialize();
+        Deserialize();
+    }
+
+    static void Serialize() 
+    {
+        // To serialize the objects, you must first open a stream for writing. 
+        // Use a file stream here.
+        FileStream fs = new FileStream(""DataFile.dat"", FileMode.Create);
+
+        try 
+        {
+            // Construct a BinaryFormatter and use it 
+            // to serialize the data to the stream.
+            BinaryFormatter formatter = new BinaryFormatter();
+
+            // Construct a Version1Type object and serialize it.
+            Version1Type obj = new Version1Type();
+            obj.x = 123;
+            formatter.Serialize(fs, obj);
+        }
+        catch (SerializationException e) 
+        {
+            Console.WriteLine(""Failed to serialize. Reason: "" + e.Message);
+            throw;
+        }
+        finally 
+        {
+            fs.Close();
+        }
+    }
+
+   
+    static void Deserialize() 
+    {
+        // Declare the Version2Type reference.
+        Version2Type obj = null;
+
+        // Open the file containing the data that you want to deserialize.
+        FileStream fs = new FileStream(""DataFile.dat"", FileMode.Open);
+        try 
+        {
+            // Construct a BinaryFormatter and use it 
+            // to deserialize the data from the stream.
+            BinaryFormatter formatter = new BinaryFormatter();
+
+            // Construct an instance of our the
+            // Version1ToVersion2TypeSerialiationBinder type.
+            // This Binder type can deserialize a Version1Type  
+            // object to a Version2Type object.
+            formatter.Binder = new Version1ToVersion2DeserializationBinder();
+
+            obj = (Version2Type) formatter.Deserialize(fs);
+        }
+        catch (SerializationException e) 
+        {
+            Console.WriteLine(""Failed to deserialize. Reason: "" + e.Message);
+            throw;
+        }
+        finally 
+        {
+            fs.Close();
+        }
+
+        // To prove that a Version2Type object was deserialized, 
+        // display the object's type and fields to the console.
+        Console.WriteLine(""Type of object deserialized: "" + obj.GetType());
+        Console.WriteLine(""x = {0}, name = {1}"", obj.x, obj.name);
+    }
+}
+
+
+[Serializable]
+class Version1Type 
+{
+    public Int32 x;
+}
+
+
+[Serializable]
+class Version2Type : ISerializable 
+{
+    public Int32 x;
+    public String name;
+   
+    // The security attribute demands that code that calls
+    // this method have permission to perform serialization.
+    [SecurityPermissionAttribute(SecurityAction.Demand,SerializationFormatter=true)]
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) 
+    {
+        info.AddValue(""x"", x);
+        info.AddValue(""name"", name);
+    }
+
+    // The security attribute demands that code that calls  
+    // this method have permission to perform serialization.
+    [SecurityPermissionAttribute(SecurityAction.Demand,SerializationFormatter=true)]
+    private Version2Type(SerializationInfo info, StreamingContext context) 
+    {
+        x = info.GetInt32(""x"");
+        try 
+        {
+            name = info.GetString(""name"");
+        }
+        catch (SerializationException) 
+        {
+            // The ""name"" field was not serialized because Version1Type 
+            // did not contain this field.
+            // Set this field to a reasonable default value.
+            name = ""Reasonable default value"";
+        }
+    }
+}
+
+
+sealed class Version1ToVersion2DeserializationBinder : SerializationBinder 
+{
+    string[] typenames = new string[2];
+    
+    public override Type BindToType(string assemblyName, string typeName) 
+    {
+        String assemVer1 = Assembly.GetExecutingAssembly().FullName;
+        typenames[0]=""Version1Type"";
+        typenames[1] = ""Version2Type"";
+        return pointlessRecursiveFunction(assemVer1, typeName, 0);
+    }
+    Type pointlessRecursiveFunction(string assemblyName, string typeName, int offset=0) {
+        try {
+            if (typeName == typenames[offset]) {
+                return Type.GetType(String.Format(""{0}, {1}"", 
+                typenames[offset+1], assemblyName));
+            }
+        }
+        catch (IndexOutOfRangeException) {
+                throw new SerializationException();
+        }
+        return pointlessRecursiveFunction(typeName, assemblyName, offset+2);
+    }
+}
+            ");
+        }
+
+        [Fact]
+        public void TestReturningNullFromSubfunctionDiagnostic()
+        {
+            VerifyCSharp(@"
+//version where another function is involved but it's still broken
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Reflection;
+using System.Security.Permissions;
+
+
+class App 
+{
+    [STAThread]
+    static void Main() 
+    {
+        System.Console.WriteLine(""This program is designed to pass compilation tests. It throws an exception as it should, but does that through some extra complexity."");
+        Serialize();
+        Deserialize();
+    }
+
+    static void Serialize() 
+    {
+        // To serialize the objects, you must first open a stream for writing. 
+        // Use a file stream here.
+        FileStream fs = new FileStream(""DataFile.dat"", FileMode.Create);
+
+        try 
+        {
+            // Construct a BinaryFormatter and use it 
+            // to serialize the data to the stream.
+            BinaryFormatter formatter = new BinaryFormatter();
+
+            // Construct a Version1Type object and serialize it.
+            Version1Type obj = new Version1Type();
+            obj.x = 123;
+            formatter.Serialize(fs, obj);
+        }
+        catch (SerializationException e) 
+        {
+            Console.WriteLine(""Failed to serialize. Reason: "" + e.Message);
+            throw;
+        }
+        finally 
+        {
+            fs.Close();
+        }
+    }
+
+   
+    static void Deserialize() 
+    {
+        // Declare the Version2Type reference.
+        Version2Type obj = null;
+
+        // Open the file containing the data that you want to deserialize.
+        FileStream fs = new FileStream(""DataFile.dat"", FileMode.Open);
+        try 
+        {
+            // Construct a BinaryFormatter and use it 
+            // to deserialize the data from the stream.
+            BinaryFormatter formatter = new BinaryFormatter();
+
+            // Construct an instance of our the
+            // Version1ToVersion2TypeSerialiationBinder type.
+            // This Binder type can deserialize a Version1Type  
+            // object to a Version2Type object.
+            formatter.Binder = new Version1ToVersion2DeserializationBinder();
+
+            obj = (Version2Type) formatter.Deserialize(fs);
+        }
+        catch (SerializationException e) 
+        {
+            Console.WriteLine(""Failed to deserialize. Reason: "" + e.Message);
+            throw;
+        }
+        finally 
+        {
+            fs.Close();
+        }
+
+        // To prove that a Version2Type object was deserialized, 
+        // display the object's type and fields to the console.
+        Console.WriteLine(""Type of object deserialized: "" + obj.GetType());
+        Console.WriteLine(""x = {0}, name = {1}"", obj.x, obj.name);
+    }
+}
+
+
+[Serializable]
+class Version1Type 
+{
+    public Int32 x;
+}
+
+
+[Serializable]
+class Version2Type : ISerializable 
+{
+    public Int32 x;
+    public String name;
+   
+    // The security attribute demands that code that calls
+    // this method have permission to perform serialization.
+    [SecurityPermissionAttribute(SecurityAction.Demand,SerializationFormatter=true)]
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) 
+    {
+        info.AddValue(""x"", x);
+        info.AddValue(""name"", name);
+    }
+
+    // The security attribute demands that code that calls  
+    // this method have permission to perform serialization.
+    [SecurityPermissionAttribute(SecurityAction.Demand,SerializationFormatter=true)]
+    private Version2Type(SerializationInfo info, StreamingContext context) 
+    {
+        x = info.GetInt32(""x"");
+        try 
+        {
+            name = info.GetString(""name"");
+        }
+        catch (SerializationException) 
+        {
+            // The ""name"" field was not serialized because Version1Type 
+            // did not contain this field.
+            // Set this field to a reasonable default value.
+            name = ""Reasonable default value"";
+        }
+    }
+}
+
+
+sealed class Version1ToVersion2DeserializationBinder : SerializationBinder 
+{
+    string[] typenames = new string[2];
+    Type pointlessRecursiveFunction(string assemblyName, string typeName, int offset=0) {
+        try {
+            if (typeName == typenames[offset]) {
+                return Type.GetType(String.Format(""{0}, {1}"", 
+                typenames[offset+1], assemblyName));
+            }
+        }
+        catch (IndexOutOfRangeException) {
+            return null;
+        }
+        return pointlessRecursiveFunction(typeName, assemblyName, offset+2);
+    }
+    
+    public override Type BindToType(string assemblyName, string typeName) 
+    {
+        String assemVer1 = Assembly.GetExecutingAssembly().FullName;
+        typenames[0]=""Version1Type"";
+        typenames[1] = ""Version2Type"";
+        return pointlessRecursiveFunction(assemVer1, typeName, 0);
+    }
+}
+            ", GetCSharpResultAt(148, 26, DoNotOverloadSerializationBinderWithoutThrowingAnException.DoNotOverloadSerializationBinderWithoutThrowingAnExceptionRule));
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new DoNotOverloadSerializationBinderWithoutThrowingAnException();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DoNotOverloadSerializationBinderWithoutThrowingAnException();
+        }
+    } //end class
+} //end namespace

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -19,6 +19,7 @@ namespace Analyzer.Utilities
         public const string SystemThreadingTasksGenericTask = "System.Threading.Tasks.Task`1";
         public const string SystemCollectionsICollection = "System.Collections.ICollection";
         public const string SystemRuntimeSerializationSerializationInfo = "System.Runtime.Serialization.SerializationInfo";
+        public const string SystemRuntimeSerializationSerializationBinder = "System.Runtime.Serialization.SerializationBinder";
         public const string SystemIEquatable1 = "System.IEquatable`1";
         public const string SystemWebUIWebControlsSqlDataSource = "System.Web.UI.WebControls.SqlDataSource";
         public const string SystemDataSqlClientSqlParameter = "System.Data.SqlClient.SqlParameter";


### PR DESCRIPTION
This includes two commits, affecting three files. An analyzer, DoNotOverloadSerializationBinderWithoutThrowingAnException, is added. Unit tests for this analyzer (total of four) are also included.