### PR TITLE
Make all the analyzer utility types and CFG related extension methods…

### DIFF
--- a/nuget/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/Microsoft.CodeAnalysis.FlowAnalysis.Utilities.Package.csproj
+++ b/nuget/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/Microsoft.CodeAnalysis.FlowAnalysis.Utilities.Package.csproj
@@ -16,6 +16,9 @@
     -->
     <PackageId>*$(MSBuildProjectFullPath)*</PackageId>
     <DevelopmentDependency>false</DevelopmentDependency>
+
+    <!-- Override the version prefix for this package to append a "revision" field to allow more frequent stable releases -->
+    <VersionPrefix>$(VersionPrefix).0</VersionPrefix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
@@ -1,18 +1,4 @@
-﻿Analyzer.Utilities.DisposeAnalysisHelper
-Analyzer.Utilities.DisposeAnalysisHelper.GetDisposableFields(Microsoft.CodeAnalysis.INamedTypeSymbol namedType) -> System.Collections.Immutable.ImmutableHashSet<Microsoft.CodeAnalysis.IFieldSymbol>
-Analyzer.Utilities.DisposeAnalysisHelper.HasAnyDisposableCreationDescendant(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation> operationBlocks, Microsoft.CodeAnalysis.IMethodSymbol containingMethod) -> bool
-Analyzer.Utilities.DisposeAnalysisHelper.IDisposable.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
-Analyzer.Utilities.DisposeAnalysisHelper.IsDisposableCreationOrDisposeOwnershipTransfer(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation location, Microsoft.CodeAnalysis.IMethodSymbol containingMethod) -> bool
-Analyzer.Utilities.DisposeAnalysisHelper.Task.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
-Analyzer.Utilities.DisposeAnalysisHelper.TryGetOrComputeResult(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation> operationBlocks, Microsoft.CodeAnalysis.IMethodSymbol containingMethod, Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions analyzerOptions, Microsoft.CodeAnalysis.DiagnosticDescriptor rule, bool trackInstanceFields, bool trackExceptionPaths, System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysisResult disposeAnalysisResult, out Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAnalysisResult pointsToAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisPredicate interproceduralAnalysisPredicateOpt = null, bool defaultDisposeOwnershipTransferAtConstructor = false) -> bool
-Analyzer.Utilities.DisposeAnalysisKind
-Analyzer.Utilities.DisposeAnalysisKind.AllPaths = 0 -> Analyzer.Utilities.DisposeAnalysisKind
-Analyzer.Utilities.DisposeAnalysisKind.AllPathsOnlyNotDisposed = 1 -> Analyzer.Utilities.DisposeAnalysisKind
-Analyzer.Utilities.DisposeAnalysisKind.NonExceptionPaths = 2 -> Analyzer.Utilities.DisposeAnalysisKind
-Analyzer.Utilities.DisposeAnalysisKind.NonExceptionPathsOnlyNotDisposed = 3 -> Analyzer.Utilities.DisposeAnalysisKind
-Analyzer.Utilities.DisposeAnalysisKindExtensions
-Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions
-Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo
+﻿Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo
 Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo.BranchValueOpt.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo.ControlFlowConditionKind.get -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowConditionKind
 Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo.Destination.get -> Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock
@@ -22,8 +8,6 @@ Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo.Kind.get -> Microsoft.CodeAna
 Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo.LeavingRegionFlowCaptures.get -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.FlowAnalysis.CaptureId>
 Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo.LeavingRegionLocals.get -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ILocalSymbol>
 Microsoft.CodeAnalysis.FlowAnalysis.BranchWithInfo.LeavingRegions.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegion>
-Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowBranchExtensions
-Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraphExtensions
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisData
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisData.AbstractAnalysisData() -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisData.Dispose() -> void
@@ -97,7 +81,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.SymbolOpt.get -> Mic
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.Type.get -> Microsoft.CodeAnalysis.ITypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.WithMergedInstanceLocation(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntityToMerge) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>
-Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AddTrackedEntities(Analyzer.Utilities.PooledObjects.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder) -> void
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AddTrackedEntities(System.Collections.Generic.HashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AnalysisEntityBasedPredicateAnalysisData() -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AnalysisEntityBasedPredicateAnalysisData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> data1, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> data2, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TValue> coreDataAnalysisDomain) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.AnalysisEntityBasedPredicateAnalysisData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> fromData) -> void
@@ -113,7 +97,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysi
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.TryGetValue(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity key, out TValue value) -> bool
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.this[Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity key].get -> TValue
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>
-Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AddTrackedEntities(Analyzer.Utilities.PooledObjects.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder, bool forInterproceduralAnalysis = false) -> void
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AddTrackedEntities(System.Collections.Generic.HashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder, bool forInterproceduralAnalysis = false) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AnalysisEntityDataFlowOperationVisitor(TAnalysisContext analysisContext) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyInterproceduralAnalysisResultHelper(System.Collections.Generic.IDictionary<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TAbstractAnalysisValue> resultToApply) -> void
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyMissingCurrentAnalysisDataForUnhandledExceptionData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TAbstractAnalysisValue> coreDataAtException, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TAbstractAnalysisValue> coreCurrentAnalysisData, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ThrownExceptionInfo throwBranchWithExceptionType) -> void
@@ -386,14 +370,11 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.Monitor.get -
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.SerializationInfo.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.Task.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.TryGetTypeByMetadataName(string fullTypeName, out Microsoft.CodeAnalysis.INamedTypeSymbol namedTypeSymbol) -> bool
-Analyzer.Utilities.PooledObjects.PooledHashSet<T>
-Analyzer.Utilities.PooledObjects.PooledHashSet<T>.Free() -> void
-Analyzer.Utilities.PooledObjects.PooledHashSet<T>.ToImmutableAndFree() -> System.Collections.Immutable.ImmutableHashSet<T>
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisDomain<TAnalysisData>.Clone(TAnalysisData value) -> TAnalysisData
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisDomain<TAnalysisData>.Compare(TAnalysisData oldValue, TAnalysisData newValue) -> int
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisDomain<TAnalysisData>.Equals(TAnalysisData value1, TAnalysisData value2) -> bool
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractAnalysisDomain<TAnalysisData>.Merge(TAnalysisData value1, TAnalysisData value2) -> TAnalysisData
-abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeHashCodePartsSpecific(Analyzer.Utilities.PooledObjects.ArrayBuilder<int> builder) -> void
+abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeHashCodePartsSpecific(System.Action<int> builder) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ForkForInterproceduralAnalysis(Microsoft.CodeAnalysis.IMethodSymbol invokedMethod, Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph invokedCfg, Microsoft.CodeAnalysis.IOperation operation, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAnalysisResult pointsToAnalysisResultOpt, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis.CopyBlockAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis.CopyAbstractValue> copyAnalysisResultOpt, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentBlockAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue> valueContentAnalysisResultOpt, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisData<TAnalysisData, TAnalysisContext, TAbstractAnalysisValue> interproceduralAnalysisData) -> TAnalysisContext
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDomain<T>.Bottom.get -> T
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDomain<T>.Compare(T oldValue, T newValue, bool assertMonotonicity) -> int
@@ -407,7 +388,7 @@ abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractValueDomain<T>.Unk
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.Clone() -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.Compare(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> other, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TValue> coreDataAnalysisDomain) -> int
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.WithMergedData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue> data, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, TValue> coreDataAnalysisDomain) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>
-abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AddTrackedEntities(TAnalysisData analysisData, Analyzer.Utilities.PooledObjects.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder, bool forInterproceduralAnalysis = false) -> void
+abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.AddTrackedEntities(TAnalysisData analysisData, System.Collections.Generic.HashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> builder, bool forInterproceduralAnalysis = false) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyInterproceduralAnalysisResultCore(TAnalysisData resultData) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.GetAbstractValue(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity) -> TAbstractAnalysisValue
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.GetTrimmedCurrentAnalysisData(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> withEntities) -> TAnalysisData
@@ -418,7 +399,7 @@ abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOper
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityMapAbstractDomain<TValue>.AssertValidEntryForMergedMap(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity, TValue value) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityMapAbstractDomain<TValue>.CanSkipNewEntry(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity, TValue value) -> bool
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityMapAbstractDomain<TValue>.GetDefaultValue(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity) -> TValue
-abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T>.ComputeHashCodeParts(Analyzer.Utilities.PooledObjects.ArrayBuilder<int> builder) -> void
+abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T>.ComputeHashCodeParts(System.Action<int> addPart) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysis<TAnalysisData, TAnalysisContext, TAnalysisResult, TBlockAnalysisResult, TAbstractAnalysisValue>.ToBlockResult(Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, TAnalysisData blockAnalysisData) -> TBlockAnalysisResult
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysis<TAnalysisData, TAnalysisContext, TAnalysisResult, TBlockAnalysisResult, TAbstractAnalysisValue>.ToResult(TAnalysisContext analysisContext, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<TBlockAnalysisResult, TAbstractAnalysisValue> dataFlowAnalysisResult) -> TAnalysisResult
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyMissingCurrentAnalysisDataForUnhandledExceptionData(TAnalysisData dataAtException, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ThrownExceptionInfo throwBranchWithExceptionType) -> void
@@ -536,7 +517,7 @@ override Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.Value
 override Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysisData.Clone() -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue>
 override Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysisData.Compare(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue> other, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue> coreDataAnalysisDomain) -> int
 override Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysisData.WithMergedData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue> data, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue> coreDataAnalysisDomain) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue>
-override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeHashCodeParts(Analyzer.Utilities.PooledObjects.ArrayBuilder<int> builder) -> void
+override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeHashCodeParts(System.Action<int> addPart) -> void
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyInterproceduralAnalysisResult(TAnalysisData resultData, bool isLambdaOrLocalFunction, bool hasParameterWithDelegateType, TAnalysisResult interproceduralResult) -> void
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ApplyPredicatedDataForEntity(TAnalysisData analysisData, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity predicatedEntity, bool trueData) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PredicateValueKind
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeAnalysisValueForEscapedRefOrOutArgument(Microsoft.CodeAnalysis.Operations.IArgumentOperation operation, TAbstractAnalysisValue defaultValue) -> TAbstractAnalysisValue
@@ -592,22 +573,6 @@ override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVi
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.VisitWhileLoop(Microsoft.CodeAnalysis.Operations.IWhileLoopOperation operation, object argument) -> TAbstractAnalysisValue
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<TKey, TValue>.Compare(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> oldValue, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> newValue) -> int
 override sealed Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.MapAbstractDomain<TKey, TValue>.Equals(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> value1, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> value2) -> bool
-static Analyzer.Utilities.DisposeAnalysisHelper.TryGetOrCreate(Microsoft.CodeAnalysis.Compilation compilation, out Analyzer.Utilities.DisposeAnalysisHelper disposeHelper) -> bool
-static Analyzer.Utilities.DisposeAnalysisKindExtensions.AreExceptionPathsAndMayBeNotDisposedViolationsEnabled(this Analyzer.Utilities.DisposeAnalysisKind disposeAnalysisKind) -> bool
-static Analyzer.Utilities.DisposeAnalysisKindExtensions.AreExceptionPathsEnabled(this Analyzer.Utilities.DisposeAnalysisKind disposeAnalysisKind) -> bool
-static Analyzer.Utilities.DisposeAnalysisKindExtensions.AreMayBeNotDisposedViolationsEnabled(this Analyzer.Utilities.DisposeAnalysisKind disposeAnalysisKind) -> bool
-static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.DescendantOperations(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.IOperation>
-static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.GetContainingRegionOfKind(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegionKind regionKind) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegion
-static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.IsContainedInRegionOfKind(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegionKind regionKind) -> bool
-static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.IsFirstBlockOfFinally(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, out Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegion finallyRegion) -> bool
-static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.IsFirstBlockOfRegionKind(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegionKind regionKind, out Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegion region) -> bool
-static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.IsLastBlockOfFinally(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, out Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegion finallyRegion) -> bool
-static Microsoft.CodeAnalysis.FlowAnalysis.BasicBlockExtensions.IsLastBlockOfRegionKind(this Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock basicBlock, Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegionKind regionKind, out Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowRegion region) -> bool
-static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowBranchExtensions.IsBackEdge(this Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowBranch controlFlowBranch) -> bool
-static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraphExtensions.DescendantOperations(this Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph cfg) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.IOperation>
-static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraphExtensions.DescendantOperations<T>(this Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph cfg, Microsoft.CodeAnalysis.OperationKind operationKind) -> System.Collections.Generic.IEnumerable<T>
-static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraphExtensions.GetEntry(this Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph cfg) -> Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock
-static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraphExtensions.GetExit(this Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph cfg) -> Microsoft.CodeAnalysis.FlowAnalysis.BasicBlock
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDomain<T>.FireNonMonotonicAssertIfNeeded(bool assertMonotonicity) -> void
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractIndex.Create(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractIndex
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractIndex.Create(Microsoft.CodeAnalysis.IOperation operation) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractIndex
@@ -623,7 +588,7 @@ static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.Create(Micros
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.Create(Microsoft.CodeAnalysis.ISymbol symbolOpt, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractIndex> indices, Microsoft.CodeAnalysis.ITypeSymbol type, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAbstractValue instanceLocation, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity parentOpt) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.Create(Microsoft.CodeAnalysis.Operations.IInstanceReferenceOperation instanceReferenceOperation, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAbstractValue instanceLocation) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity.CreateThisOrMeInstance(Microsoft.CodeAnalysis.INamedTypeSymbol typeSymbol, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAbstractValue instanceLocation) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity
-static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.GetChildAnalysisEntities(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity, Analyzer.Utilities.PooledObjects.PooledHashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> allEntities) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity>
+static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.GetChildAnalysisEntities(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity analysisEntity, System.Collections.Generic.HashSet<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity> allEntities) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity>
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.IsChildAnalysisEntity(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity entity, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity ancestorEntity) -> bool
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityDataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.IsChildAnalysisEntity(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntity entity, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAbstractValue instanceLocation) -> bool
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T>.operator !=(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T> value1, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T> value2) -> bool
@@ -656,8 +621,6 @@ static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.SetAbstractDomain<T>.Default
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysis.TryGetOrComputeResult(Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph cfg, Microsoft.CodeAnalysis.ISymbol owningSymbol, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider wellKnownTypeProvider, Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions analyzerOptions, Microsoft.CodeAnalysis.DiagnosticDescriptor rule, System.Threading.CancellationToken cancellationToken, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisKind interproceduralAnalysisKind = Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisKind.None, bool pessimisticAnalysis = true, bool performPointsToAnalysis = true) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentBlockAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue>
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAnalysis.TryGetOrComputeResult(Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph cfg, Microsoft.CodeAnalysis.ISymbol owningSymbol, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider wellKnownTypeProvider, Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions analyzerOptions, Microsoft.CodeAnalysis.DiagnosticDescriptor rule, System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis.CopyBlockAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis.CopyAbstractValue> copyAnalysisResultOpt, out Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis.PointsToAnalysisResult pointsToAnalysisResultOpt, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisKind interproceduralAnalysisKind = Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisKind.None, bool pessimisticAnalysis = true, bool performPointsToAnalysis = true, bool performCopyAnalysisIfNotUserConfigured = true, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.InterproceduralAnalysisPredicate interproceduralAnalysisPredicateOpt = null) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowAnalysisResult<Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentBlockAnalysisResult, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis.ValueContentAbstractValue>
 static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.GetOrCreate(Microsoft.CodeAnalysis.Compilation compilation) -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider
-static Analyzer.Utilities.PooledObjects.PooledHashSet<T>.CreatePool() -> Analyzer.Utilities.PooledObjects.ObjectPool<Analyzer.Utilities.PooledObjects.PooledHashSet<T>>
-static Analyzer.Utilities.PooledObjects.PooledHashSet<T>.GetInstance() -> Analyzer.Utilities.PooledObjects.PooledHashSet<T>
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation.NoLocation -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation.Null -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractLocation
 static readonly Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue.Invalid -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAbstractValue
@@ -726,65 +689,3 @@ virtual Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TA
 virtual Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.VisitUnaryOperatorCore(Microsoft.CodeAnalysis.Operations.IUnaryOperation operation, object argument) -> TAbstractAnalysisValue
 virtual Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PredicatedAnalysisData<TKey, TValue>.ApplyPredicatedData(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> coreAnalysisData, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> predicatedData) -> void
 virtual Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PredicatedAnalysisData<TKey, TValue>.RemoveEntryInPredicatedData(TKey key, Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DictionaryAnalysisData<TKey, TValue> predicatedData) -> void
-Analyzer.Utilities.DisposeMethodKind
-Analyzer.Utilities.DisposeMethodKind.Close = 5 -> Analyzer.Utilities.DisposeMethodKind
-Analyzer.Utilities.DisposeMethodKind.Dispose = 1 -> Analyzer.Utilities.DisposeMethodKind
-Analyzer.Utilities.DisposeMethodKind.DisposeAsync = 3 -> Analyzer.Utilities.DisposeMethodKind
-Analyzer.Utilities.DisposeMethodKind.DisposeBool = 2 -> Analyzer.Utilities.DisposeMethodKind
-Analyzer.Utilities.DisposeMethodKind.DisposeCoreAsync = 4 -> Analyzer.Utilities.DisposeMethodKind
-Analyzer.Utilities.DisposeMethodKind.None = 0 -> Analyzer.Utilities.DisposeMethodKind
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Add(T item) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddMany(T item, int count) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(Analyzer.Utilities.PooledObjects.ArrayBuilder<T> items) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(System.Collections.Immutable.ImmutableArray<T> items) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(T[] items, int length) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(T[] items, int start, int length) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange(params T[] items) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange<S>(System.Collections.Immutable.ImmutableArray<S> items) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.AddRange<U>(Analyzer.Utilities.PooledObjects.ArrayBuilder<U> items) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Any() -> bool
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ArrayBuilder() -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ArrayBuilder(int size) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Clear() -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Clip(int limit) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Contains(T item) -> bool
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.CopyTo(T[] array, int start) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Count.get -> int
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Count.set -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.EnsureCapacity(int capacity) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.FindIndex(System.Predicate<T> match) -> int
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.FindIndex(int startIndex, System.Predicate<T> match) -> int
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.FindIndex(int startIndex, int count, System.Predicate<T> match) -> int
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.First() -> T
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Free() -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.IndexOf(T item) -> int
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.IndexOf(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) -> int
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.IndexOf(T item, int startIndex, int count) -> int
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Insert(int index, T item) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Last() -> T
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.RemoveAt(int index) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.RemoveDuplicates() -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.RemoveLast() -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ReverseContents() -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.SelectDistinct<S>(System.Func<T, S> selector) -> System.Collections.Immutable.ImmutableArray<S>
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.SetItem(int index, T value) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Sort() -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Sort(System.Collections.Generic.IComparer<T> comparer) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Sort(System.Comparison<T> compare) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.Sort(int startIndex, System.Collections.Generic.IComparer<T> comparer) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToArray() -> T[]
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToArrayAndFree() -> T[]
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToDowncastedImmutable<U>() -> System.Collections.Immutable.ImmutableArray<U>
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToImmutable() -> System.Collections.Immutable.ImmutableArray<T>
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToImmutableAndFree() -> System.Collections.Immutable.ImmutableArray<T>
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ToImmutableOrNull() -> System.Collections.Immutable.ImmutableArray<T>
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.ZeroInit(int count) -> void
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.this[int index].get -> T
-Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.this[int index].set -> void
-Analyzer.Utilities.PooledObjects.ObjectPool<T>
-static Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.GetInstance() -> Analyzer.Utilities.PooledObjects.ArrayBuilder<T>
-static Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.GetInstance(int capacity) -> Analyzer.Utilities.PooledObjects.ArrayBuilder<T>
-static Analyzer.Utilities.PooledObjects.ArrayBuilder<T>.GetInstance(int capacity, T fillWithValue) -> Analyzer.Utilities.PooledObjects.ArrayBuilder<T>

--- a/src/Utilities/Compiler/DisposeMethodKind.cs
+++ b/src/Utilities/Compiler/DisposeMethodKind.cs
@@ -5,7 +5,7 @@ namespace Analyzer.Utilities
     /// <summary>
     /// Describes different kinds of Dispose-like methods.
     /// </summary>
-    public enum DisposeMethodKind
+    internal enum DisposeMethodKind
     {
         /// <summary>
         /// Not a dispose-like method.

--- a/src/Utilities/Compiler/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ImmutableArrayExtensions.cs
@@ -1,12 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Collections.Immutable
 {
     internal static class ImmutableArrayExtensions

--- a/src/Utilities/Compiler/PooledObjects/ArrayBuilder.Enumerator.cs
+++ b/src/Utilities/Compiler/PooledObjects/ArrayBuilder.Enumerator.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Analyzer.Utilities.PooledObjects
 {
-    public partial class ArrayBuilder<T>
+    internal partial class ArrayBuilder<T>
     {
         /// <summary>
         /// struct enumerator used in foreach.

--- a/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
+++ b/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
@@ -12,7 +12,7 @@ namespace Analyzer.Utilities.PooledObjects
 {
     [DebuggerDisplay("Count = {Count,nq}")]
     [DebuggerTypeProxy(typeof(ArrayBuilder<>.DebuggerProxy))]
-    public sealed partial class ArrayBuilder<T> : IReadOnlyCollection<T>, IReadOnlyList<T>
+    internal sealed partial class ArrayBuilder<T> : IReadOnlyCollection<T>, IReadOnlyList<T>
     {
         #region DebuggerProxy
 #pragma warning disable CA1812 // ArrayBuilder<T>.DebuggerProxy is an internal class that is apparently never instantiated - used in DebuggerTypeProxy attribute above.

--- a/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
+++ b/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
@@ -37,7 +37,7 @@ namespace Analyzer.Utilities.PooledObjects
     /// Rationale: 
     ///    If there is no intent for reusing the object, do not use pool - just use "new". 
     /// </summary>
-    public class ObjectPool<T> where T : class
+    internal class ObjectPool<T> where T : class
     {
         [DebuggerDisplay("{Value,nq}")]
 #pragma warning disable CA1815 // Override equals and operator equals on value types

--- a/src/Utilities/Compiler/PooledObjects/PooledHashSet.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledHashSet.cs
@@ -12,7 +12,7 @@ namespace Analyzer.Utilities.PooledObjects
 {
     // HashSet that can be recycled via an object pool
     // NOTE: these HashSets always have the default comparer.
-    public class PooledHashSet<T> : HashSet<T>
+    internal class PooledHashSet<T> : HashSet<T>
     {
         private readonly ObjectPool<PooledHashSet<T>> _pool;
 

--- a/src/Utilities/FlowAnalysis/Extensions/BasicBlockExtensions.cs
+++ b/src/Utilities/FlowAnalysis/Extensions/BasicBlockExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
 {
-    public static class BasicBlockExtensions
+    internal static class BasicBlockExtensions
     {
         internal static IEnumerable<(BasicBlock predecessorBlock, BranchWithInfo branchWithInfo)> GetPredecessorsWithBranches(this BasicBlock basicBlock, ControlFlowGraph cfg)
         {

--- a/src/Utilities/FlowAnalysis/Extensions/ControlFlowBranchExtensions.cs
+++ b/src/Utilities/FlowAnalysis/Extensions/ControlFlowBranchExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
 {
-    public static class ControlFlowBranchExtensions
+    internal static class ControlFlowBranchExtensions
     {
         public static bool IsBackEdge(this ControlFlowBranch controlFlowBranch)
             => controlFlowBranch != null &&

--- a/src/Utilities/FlowAnalysis/Extensions/ControlFlowGraphExtensions.cs
+++ b/src/Utilities/FlowAnalysis/Extensions/ControlFlowGraphExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
 {
-    public static class ControlFlowGraphExtensions
+    internal static class ControlFlowGraphExtensions
     {
         public static BasicBlock GetEntry(this ControlFlowGraph cfg) => cfg.Blocks.Single(b => b.Kind == BasicBlockKind.Entry);
         public static BasicBlock GetExit(this ControlFlowGraph cfg) => cfg.Blocks.Single(b => b.Kind == BasicBlockKind.Exit);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAbstractValue.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
-using Analyzer.Utilities.PooledObjects;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T> - CacheBasedEquatable handles equality
 
@@ -76,10 +76,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
         public ImmutableHashSet<AnalysisEntity> AnalysisEntities { get; }
         public CopyAbstractValueKind Kind { get; }
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(HashUtilities.Combine(AnalysisEntities));
-            builder.Add(Kind.GetHashCode());
+            addPart(HashUtilities.Combine(AnalysisEntities));
+            addPart(Kind.GetHashCode());
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                 copyAnalysisData.AssertValidCopyAnalysisData(GetDefaultCopyValue);
             }
 
-            protected override void AddTrackedEntities(CopyAnalysisData analysisData, PooledHashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
+            protected override void AddTrackedEntities(CopyAnalysisData analysisData, HashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
                 => analysisData.AddTrackedEntities(builder);
 
             protected override bool HasAbstractValue(AnalysisEntity analysisEntity) => CurrentAnalysisData.HasAbstractValue(analysisEntity);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
@@ -11,8 +10,8 @@ using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
 {
     using CopyAnalysisResult = DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue>;
-    using ValueContentAnalysisResult = DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>;
     using InterproceduralCopyAnalysisData = InterproceduralAnalysisData<CopyAnalysisData, CopyAnalysisContext, CopyAbstractValue>;
+    using ValueContentAnalysisResult = DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>;
 
     /// <summary>
     /// Analysis context for execution of <see cref="CopyAnalysis"/> on a control flow graph.
@@ -71,7 +70,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                 InterproceduralAnalysisPredicateOpt);
         }
 
-        protected override void ComputeHashCodePartsSpecific(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodePartsSpecific(Action<int> addPart)
         {
         }
     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAbstractValue.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities;
-using Analyzer.Utilities.PooledObjects;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T> - CacheBasedEquatable handles equality
 
@@ -75,10 +74,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
         public ImmutableHashSet<IOperation> DisposingOrEscapingOperations { get; }
         public DisposeAbstractValueKind Kind { get; }
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(HashUtilities.Combine(DisposingOrEscapingOperations));
-            builder.Add(Kind.GetHashCode());
+            addPart(HashUtilities.Combine(DisposingOrEscapingOperations));
+            addPart(Kind.GetHashCode());
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisContext.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
@@ -15,9 +14,9 @@ using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
 {
     using CopyAnalysisResult = DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue>;
-    using ValueContentAnalysisResult = DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>;
     using DisposeAnalysisData = DictionaryAnalysisData<AbstractLocation, DisposeAbstractValue>;
     using InterproceduralDisposeAnalysisData = InterproceduralAnalysisData<DictionaryAnalysisData<AbstractLocation, DisposeAbstractValue>, DisposeAnalysisContext, DisposeAbstractValue>;
+    using ValueContentAnalysisResult = DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>;
 
     /// <summary>
     /// Analysis context for execution of <see cref="DisposeAnalysis"/> on a control flow graph.
@@ -109,12 +108,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
         internal bool DisposeOwnershipTransferAtMethodCall { get; }
         internal bool TrackInstanceFields { get; }
 
-        protected override void ComputeHashCodePartsSpecific(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodePartsSpecific(Action<int> addPart)
         {
-            builder.Add(TrackInstanceFields.GetHashCode());
-            builder.Add(DisposeOwnershipTransferAtConstructor.GetHashCode());
-            builder.Add(DisposeOwnershipTransferAtMethodCall.GetHashCode());
-            builder.Add(HashUtilities.Combine(DisposeOwnershipTransferLikelyTypes));
+            addPart(TrackInstanceFields.GetHashCode());
+            addPart(DisposeOwnershipTransferAtConstructor.GetHashCode());
+            addPart(DisposeOwnershipTransferAtMethodCall.GetHashCode());
+            addPart(HashUtilities.Combine(DisposeOwnershipTransferLikelyTypes));
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisHelper.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysisHelper.cs
@@ -6,21 +6,20 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
-using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using System;
-using Analyzer.Utilities.PooledObjects;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Analyzer.Utilities
 {
     /// <summary>
     /// Helper for DisposeAnalysis.
     /// </summary>
-    public class DisposeAnalysisHelper
+    internal sealed class DisposeAnalysisHelper
     {
         private static readonly string[] s_disposeOwnershipTransferLikelyTypes = new string[]
             {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysisContext.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Analyzer.Utilities;
-using Analyzer.Utilities.Extensions;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
@@ -105,10 +101,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
         public bool IsNullCheckValidationMethod(IMethodSymbol method)
             => NullCheckValidationMethodNames.Contains(method);
 
-        protected override void ComputeHashCodePartsSpecific(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodePartsSpecific(Action<int> addPart)
         {
-            builder.Add(TrackHazardousParameterUsages.GetHashCode());
-            builder.Add(NullCheckValidationMethodNames.GetHashCode());
+            addPart(TrackHazardousParameterUsages.GetHashCode());
+            addPart(NullCheckValidationMethodNames.GetHashCode());
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAbstractValue.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Analyzer.Utilities;
-using Analyzer.Utilities.PooledObjects;
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -187,12 +187,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         public PointsToAbstractValueKind Kind { get; }
         public NullAbstractValue NullState { get; }
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(HashUtilities.Combine(Locations));
-            builder.Add(HashUtilities.Combine(LValueCapturedOperations));
-            builder.Add(Kind.GetHashCode());
-            builder.Add(NullState.GetHashCode());
+            addPart(HashUtilities.Combine(Locations));
+            addPart(HashUtilities.Combine(LValueCapturedOperations));
+            addPart(Kind.GetHashCode());
+            addPart(NullState.GetHashCode());
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 return result;
             }
 
-            protected override void AddTrackedEntities(PointsToAnalysisData analysisData, PooledHashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
+            protected override void AddTrackedEntities(PointsToAnalysisData analysisData, HashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
             {
                 if (!analysisData.HasAnyAbstractValue &&
                     (forInterproceduralAnalysis || !_defaultPointsToValueGenerator.HasAnyTrackedEntity))

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisContext.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Diagnostics;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
@@ -75,7 +74,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 InterproceduralAnalysisPredicateOpt);
         }
 
-        protected override void ComputeHashCodePartsSpecific(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodePartsSpecific(Action<int> addPart)
         {
         }
     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysisContext.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis;
@@ -160,12 +159,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
         public ImmutableDictionary<INamedTypeSymbol, string> HazardousUsageTypesToNames { get; }
 
 #pragma warning disable CA1307 // Specify StringComparison - string.GetHashCode(StringComparison) not available in all projects that reference this shared project
-        protected override void ComputeHashCodePartsSpecific(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodePartsSpecific(Action<int> addPart)
         {
-            builder.Add(TypeToTrackMetadataName.GetHashCode());
-            builder.Add(ConstructorMapper.GetHashCode());
-            builder.Add(PropertyMappers.GetHashCode());
-            builder.Add(HazardousUsageEvaluators.GetHashCode());
+            addPart(TypeToTrackMetadataName.GetHashCode());
+            addPart(ConstructorMapper.GetHashCode());
+            addPart(PropertyMappers.GetHashCode());
+            addPart(HazardousUsageEvaluators.GetHashCode());
         }
 #pragma warning restore CA1307 // Specify StringComparison
     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SymbolAccess.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SymbolAccess.cs
@@ -50,11 +50,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public ISymbol AccessingMethod { get; }
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(Location.GetHashCode());
-            builder.Add(Symbol.GetHashCode());
-            builder.Add(AccessingMethod.GetHashCode());
+            addPart(Location.GetHashCode());
+            addPart(Symbol.GetHashCode());
+            addPart(AccessingMethod.GetHashCode());
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAbstractValue.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -35,10 +36,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public ImmutableHashSet<SymbolAccess> SourceOrigins { get; }
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(HashUtilities.Combine(SourceOrigins));
-            builder.Add(Kind.GetHashCode());
+            addPart(HashUtilities.Combine(SourceOrigins));
+            addPart(Kind.GetHashCode());
         }
 
         /// <summary>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -46,7 +46,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 return builder.ToImmutableArray();
             }
 
-            protected override void AddTrackedEntities(TaintedDataAnalysisData analysisData, PooledHashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
+            protected override void AddTrackedEntities(TaintedDataAnalysisData analysisData, HashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
                 => analysisData.AddTrackedEntities(builder);
 
             protected override bool Equals(TaintedDataAnalysisData value1, TaintedDataAnalysisData value2)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisContext.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Diagnostics;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis;
@@ -15,8 +14,8 @@ using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {
-    using InterproceduralTaintedDataAnalysisData = InterproceduralAnalysisData<TaintedDataAnalysisData, TaintedDataAnalysisContext, TaintedDataAbstractValue>;
     using CopyAnalysisResult = DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue>;
+    using InterproceduralTaintedDataAnalysisData = InterproceduralAnalysisData<TaintedDataAnalysisData, TaintedDataAnalysisContext, TaintedDataAbstractValue>;
     using ValueContentAnalysisResult = DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>;
 
     internal sealed class TaintedDataAnalysisContext : AbstractDataFlowAnalysisContext<TaintedDataAnalysisData, TaintedDataAnalysisContext, TaintedDataAnalysisResult, TaintedDataAbstractValue>
@@ -143,11 +142,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public TaintedDataSymbolMap<SinkInfo> SinkInfos { get; }
 
-        protected override void ComputeHashCodePartsSpecific(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodePartsSpecific(Action<int> addPart)
         {
-            builder.Add(SourceInfos.GetHashCode());
-            builder.Add(SanitizerInfos.GetHashCode());
-            builder.Add(SinkInfos.GetHashCode());
+            addPart(SourceInfos.GetHashCode());
+            addPart(SanitizerInfos.GetHashCode());
+            addPart(SinkInfos.GetHashCode());
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAbstractValue.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
@@ -151,10 +150,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
         /// </summary>
         public ImmutableHashSet<object> LiteralValues { get; }
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(HashUtilities.Combine(LiteralValues));
-            builder.Add(NonLiteralState.GetHashCode());
+            addPart(HashUtilities.Combine(LiteralValues));
+            addPart(NonLiteralState.GetHashCode());
         }
 
         /// <summary>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.ValueContentDataFlowOperationVisitor.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -24,7 +22,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
             {
             }
 
-            protected override void AddTrackedEntities(ValueContentAnalysisData analysisData, PooledHashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
+            protected override void AddTrackedEntities(ValueContentAnalysisData analysisData, HashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis)
                 => analysisData.AddTrackedEntities(builder);
 
             protected override void ResetAbstractValue(AnalysisEntity analysisEntity)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisContext.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Diagnostics;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
@@ -11,9 +10,9 @@ using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
 {
+    using CopyAnalysisResult = DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue>;
     using InterproceduralValueContentAnalysisData = InterproceduralAnalysisData<ValueContentAnalysisData, ValueContentAnalysisContext, ValueContentAbstractValue>;
     using ValueContentAnalysisResult = DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>;
-    using CopyAnalysisResult = DataFlowAnalysisResult<CopyBlockAnalysisResult, CopyAbstractValue>;
 
     /// <summary>
     /// Analysis context for execution of <see cref="ValueContentAnalysis"/> on a control flow graph.
@@ -76,7 +75,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
                 InterproceduralAnalysisPredicateOpt);
         }
 
-        protected override void ComputeHashCodePartsSpecific(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodePartsSpecific(Action<int> addPart)
         {
         }
     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
@@ -4,7 +4,6 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
@@ -149,24 +148,24 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
         }
 
-        protected abstract void ComputeHashCodePartsSpecific(ArrayBuilder<int> builder);
+        protected abstract void ComputeHashCodePartsSpecific(Action<int> builder);
 
-        protected sealed override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected sealed override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(ValueDomain.GetHashCode());
-            builder.Add(OwningSymbol.GetHashCode());
-            builder.Add(ControlFlowGraph.OriginalOperation.GetHashCode());
-            builder.Add(AnalyzerOptions.GetHashCode());
-            builder.Add(InterproceduralAnalysisConfiguration.GetHashCode());
-            builder.Add(PessimisticAnalysis.GetHashCode());
-            builder.Add(PredicateAnalysis.GetHashCode());
-            builder.Add(ExceptionPathsAnalysis.GetHashCode());
-            builder.Add(CopyAnalysisResultOpt.GetHashCodeOrDefault());
-            builder.Add(PointsToAnalysisResultOpt.GetHashCodeOrDefault());
-            builder.Add(ValueContentAnalysisResultOpt.GetHashCodeOrDefault());
-            builder.Add(InterproceduralAnalysisDataOpt.GetHashCodeOrDefault());
-            builder.Add(InterproceduralAnalysisPredicateOpt.GetHashCodeOrDefault());
-            ComputeHashCodePartsSpecific(builder);
+            addPart(ValueDomain.GetHashCode());
+            addPart(OwningSymbol.GetHashCode());
+            addPart(ControlFlowGraph.OriginalOperation.GetHashCode());
+            addPart(AnalyzerOptions.GetHashCode());
+            addPart(InterproceduralAnalysisConfiguration.GetHashCode());
+            addPart(PessimisticAnalysis.GetHashCode());
+            addPart(PredicateAnalysis.GetHashCode());
+            addPart(ExceptionPathsAnalysis.GetHashCode());
+            addPart(CopyAnalysisResultOpt.GetHashCodeOrDefault());
+            addPart(PointsToAnalysisResultOpt.GetHashCodeOrDefault());
+            addPart(ValueContentAnalysisResultOpt.GetHashCodeOrDefault());
+            addPart(InterproceduralAnalysisDataOpt.GetHashCodeOrDefault());
+            addPart(InterproceduralAnalysisPredicateOpt.GetHashCodeOrDefault());
+            ComputeHashCodePartsSpecific(addPart);
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.ConstantValueIndex.cs
@@ -2,7 +2,7 @@
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T>
 
-using Analyzer.Utilities.PooledObjects;
+using System;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
@@ -18,10 +18,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             public int Index { get; }
 
 #pragma warning disable CA1307 // Specify StringComparison - string.GetHashCode(StringComparison) not available in all projects that reference this shared project
-            protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+            protected override void ComputeHashCodeParts(Action<int> addPart)
             {
-                builder.Add(Index.GetHashCode());
-                builder.Add(nameof(ConstantValueIndex).GetHashCode());
+                addPart(Index.GetHashCode());
+                addPart(nameof(ConstantValueIndex).GetHashCode());
             }
 #pragma warning restore CA1307 // Specify StringComparison
         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.OperationBasedIndex.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
-using Analyzer.Utilities.PooledObjects;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T> - CacheBasedEquatable handles equality
 
@@ -20,10 +20,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             public IOperation Operation { get; }
 
 #pragma warning disable CA1307 // Specify StringComparison - string.GetHashCode(StringComparison) not available in all projects that reference this shared project
-            protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+            protected override void ComputeHashCodeParts(Action<int> addPart)
             {
-                builder.Add(Operation.GetHashCode());
-                builder.Add(nameof(OperationBasedIndex).GetHashCode());
+                addPart(Operation.GetHashCode());
+                addPart(nameof(OperationBasedIndex).GetHashCode());
             }
 #pragma warning restore CA1307 // Specify StringComparison
         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.SymbolBasedIndex.cs
@@ -2,7 +2,7 @@
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T> - CacheBasedEquatable handles equality
 
-using Analyzer.Utilities.PooledObjects;
+using System;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
@@ -18,10 +18,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             public AnalysisEntity AnalysisEntity { get; }
 
 #pragma warning disable CA1307 // Specify StringComparison - string.GetHashCode(StringComparison) not available in all projects that reference this shared project
-            protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+            protected override void ComputeHashCodeParts(Action<int> addPart)
             {
-                builder.Add(AnalysisEntity.GetHashCode());
-                builder.Add(nameof(AnalysisEntityBasedIndex).GetHashCode());
+                addPart(AnalysisEntity.GetHashCode());
+                addPart(nameof(AnalysisEntityBasedIndex).GetHashCode());
             }
 #pragma warning restore CA1307 // Specify StringComparison
         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractLocation.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -93,16 +92,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public bool IsNoLocation => ReferenceEquals(this, NoLocation);
         public bool IsAnalysisEntityDefaultLocation => AnalysisEntityOpt != null;
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(CreationOpt.GetHashCodeOrDefault());
-            builder.Add(HashUtilities.Combine(CreationCallStack));
-            builder.Add(SymbolOpt.GetHashCodeOrDefault());
-            builder.Add(CaptureIdOpt.GetHashCodeOrDefault());
-            builder.Add(AnalysisEntityOpt.GetHashCodeOrDefault());
-            builder.Add(LocationTypeOpt.GetHashCodeOrDefault());
-            builder.Add(_isSpecialSingleton.GetHashCode());
-            builder.Add(IsNull.GetHashCode());
+            addPart(CreationOpt.GetHashCodeOrDefault());
+            addPart(HashUtilities.Combine(CreationCallStack));
+            addPart(SymbolOpt.GetHashCodeOrDefault());
+            addPart(CaptureIdOpt.GetHashCodeOrDefault());
+            addPart(AnalysisEntityOpt.GetHashCodeOrDefault());
+            addPart(LocationTypeOpt.GetHashCodeOrDefault());
+            addPart(_isSpecialSingleton.GetHashCode());
+            addPart(IsNull.GetHashCode());
         }
 
         /// <summary>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -235,27 +235,27 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         public int EqualsIgnoringInstanceLocationId => _ignoringLocationHashCode;
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(InstanceLocation.GetHashCode());
-            ComputeHashCodePartsIgnoringLocation(builder);
+            addPart(InstanceLocation.GetHashCode());
+            ComputeHashCodePartsIgnoringLocation(addPart);
         }
 
-        private void ComputeHashCodePartsIgnoringLocation(ArrayBuilder<int> builder)
+        private void ComputeHashCodePartsIgnoringLocation(Action<int> addPart)
         {
-            builder.Add(SymbolOpt.GetHashCodeOrDefault());
-            builder.Add(HashUtilities.Combine(Indices));
-            builder.Add(InstanceReferenceOperationSyntaxOpt.GetHashCodeOrDefault());
-            builder.Add(CaptureIdOpt.GetHashCodeOrDefault());
-            builder.Add(Type.GetHashCode());
-            builder.Add(ParentOpt.GetHashCodeOrDefault());
-            builder.Add(IsThisOrMeInstance.GetHashCode());
+            addPart(SymbolOpt.GetHashCodeOrDefault());
+            addPart(HashUtilities.Combine(Indices));
+            addPart(InstanceReferenceOperationSyntaxOpt.GetHashCodeOrDefault());
+            addPart(CaptureIdOpt.GetHashCodeOrDefault());
+            addPart(Type.GetHashCode());
+            addPart(ParentOpt.GetHashCodeOrDefault());
+            addPart(IsThisOrMeInstance.GetHashCode());
         }
 
         private ImmutableArray<int> ComputeIgnoringLocationHashCodeParts()
         {
             var builder = ArrayBuilder<int>.GetInstance(7);
-            ComputeHashCodePartsIgnoringLocation(builder);
+            ComputeHashCodePartsIgnoringLocation(builder.Add);
             return builder.ToImmutableAndFree();
         }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
@@ -157,7 +156,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             return result;
         }
 
-        public void AddTrackedEntities(PooledHashSet<AnalysisEntity> builder) => builder.UnionWith(CoreAnalysisData.Keys);
+        public void AddTrackedEntities(HashSet<AnalysisEntity> builder) => builder.UnionWith(CoreAnalysisData.Keys);
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -30,9 +30,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         {
         }
 
-        protected void AddTrackedEntities(PooledHashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis = false)
+        protected void AddTrackedEntities(HashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis = false)
             => AddTrackedEntities(CurrentAnalysisData, builder, forInterproceduralAnalysis);
-        protected abstract void AddTrackedEntities(TAnalysisData analysisData, PooledHashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis = false);
+        protected abstract void AddTrackedEntities(TAnalysisData analysisData, HashSet<AnalysisEntity> builder, bool forInterproceduralAnalysis = false);
         protected abstract void SetAbstractValue(AnalysisEntity analysisEntity, TAbstractAnalysisValue value);
         protected abstract void ResetAbstractValue(AnalysisEntity analysisEntity);
         protected abstract TAbstractAnalysisValue GetAbstractValue(AnalysisEntity analysisEntity);
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             return GetChildAnalysisEntities(analysisEntity.InstanceLocation, entity => IsChildAnalysisEntity(entity, analysisEntity));
         }
 
-        protected static IEnumerable<AnalysisEntity> GetChildAnalysisEntities(AnalysisEntity analysisEntity, PooledHashSet<AnalysisEntity> allEntities)
+        protected static IEnumerable<AnalysisEntity> GetChildAnalysisEntities(AnalysisEntity analysisEntity, HashSet<AnalysisEntity> allEntities)
         {
             foreach (var entity in allEntities)
             {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/ArgumentInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/ArgumentInfo.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
+using System;
 using Analyzer.Utilities;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 
 #pragma warning disable CA1067 // Override Object.Equals(object) when implementing IEquatable<T>
@@ -32,12 +31,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public PointsToAbstractValue InstanceLocation { get; }
         public TAbstractAnalysisValue Value { get; }
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(Operation.GetHashCode());
-            builder.Add(AnalysisEntityOpt.GetHashCodeOrDefault());
-            builder.Add(InstanceLocation.GetHashCode());
-            builder.Add(Value.GetHashCode());
+            addPart(Operation.GetHashCode());
+            addPart(AnalysisEntityOpt.GetHashCodeOrDefault());
+            addPart(InstanceLocation.GetHashCode());
+            addPart(Value.GetHashCode());
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/CacheBasedEquatable.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/CacheBasedEquatable.cs
@@ -45,11 +45,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         private ImmutableArray<int> ComputeHashCodeParts()
         {
             var builder = ArrayBuilder<int>.GetInstance();
-            ComputeHashCodeParts(builder);
+            ComputeHashCodeParts(builder.Add);
             return builder.ToImmutableAndFree();
         }
 
-        protected abstract void ComputeHashCodeParts(ArrayBuilder<int> builder);
+        protected abstract void ComputeHashCodeParts(Action<int> addPart);
 
         public sealed override int GetHashCode() => GetOrComputeHashCode();
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/InterproceduralAnalysisData.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 
@@ -78,30 +77,30 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public Func<IOperation, AnalysisEntity> GetAnalysisEntityForFlowCapture { get; }
         public Func<ISymbol, ImmutableStack<IOperation>> GetInterproceduralCallStackForOwningSymbol { get; }
 
-        protected override void ComputeHashCodeParts(ArrayBuilder<int> builder)
+        protected override void ComputeHashCodeParts(Action<int> addPart)
         {
-            builder.Add(InitialAnalysisData.GetHashCodeOrDefault());
-            AddHashCodeParts(InvocationInstanceOpt, builder);
-            AddHashCodeParts(ThisOrMeInstanceForCallerOpt, builder);
-            builder.Add(HashUtilities.Combine(ArgumentValuesMap));
-            builder.Add(HashUtilities.Combine(CapturedVariablesMap));
-            builder.Add(HashUtilities.Combine(AddressSharedEntities));
-            builder.Add(HashUtilities.Combine(CallStack));
-            builder.Add(HashUtilities.Combine(MethodsBeingAnalyzed));
+            addPart(InitialAnalysisData.GetHashCodeOrDefault());
+            AddHashCodeParts(InvocationInstanceOpt, addPart);
+            AddHashCodeParts(ThisOrMeInstanceForCallerOpt, addPart);
+            addPart(HashUtilities.Combine(ArgumentValuesMap));
+            addPart(HashUtilities.Combine(CapturedVariablesMap));
+            addPart(HashUtilities.Combine(AddressSharedEntities));
+            addPart(HashUtilities.Combine(CallStack));
+            addPart(HashUtilities.Combine(MethodsBeingAnalyzed));
         }
 
         private static void AddHashCodeParts(
             (AnalysisEntity InstanceOpt, PointsToAbstractValue PointsToValue)? instanceAndPointsToValueOpt,
-            ArrayBuilder<int> builder)
+            Action<int> addPart)
         {
             if (instanceAndPointsToValueOpt.HasValue)
             {
-                builder.Add(instanceAndPointsToValueOpt.Value.InstanceOpt.GetHashCodeOrDefault());
-                builder.Add(instanceAndPointsToValueOpt.Value.PointsToValue.GetHashCode());
+                addPart(instanceAndPointsToValueOpt.Value.InstanceOpt.GetHashCodeOrDefault());
+                addPart(instanceAndPointsToValueOpt.Value.PointsToValue.GetHashCode());
             }
             else
             {
-                builder.Add(0);
+                addPart(0);
             }
         }
     }

--- a/src/Utilities/FlowAnalysis/Options/DisposeAnalysisKind.cs
+++ b/src/Utilities/FlowAnalysis/Options/DisposeAnalysisKind.cs
@@ -7,7 +7,7 @@ namespace Analyzer.Utilities
     /// <summary>
     /// Describes a group of effective <see cref="SymbolVisibility"/> for symbols.
     /// </summary>
-    public enum DisposeAnalysisKind
+    internal enum DisposeAnalysisKind
     {
         // NOTE: Below fields names are used in the .editorconfig specification
         //       for DisposeAnalysisKind option. Hence the names should *not* be modified,
@@ -42,7 +42,7 @@ namespace Analyzer.Utilities
         NonExceptionPathsOnlyNotDisposed,
     }
 
-    public static class DisposeAnalysisKindExtensions
+    internal static class DisposeAnalysisKindExtensions
     {
         public static bool AreExceptionPathsAndMayBeNotDisposedViolationsEnabled(this DisposeAnalysisKind disposeAnalysisKind)
             => disposeAnalysisKind.AreExceptionPathsEnabled() && disposeAnalysisKind.AreMayBeNotDisposedViolationsEnabled();


### PR DESCRIPTION
… internal

Cleans up our public API surface and also avoids accidental usage of our pooled objects by FlowAnalysis utility clients (see https://github.com/dotnet/roslyn/pull/37640 which fixes a related RPS regression)