### PR TITLE
Fix CA2000 false positive for array initializers with multiple elements

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -2017,6 +2017,46 @@ Class Test
 End Class");
         }
 
+        [Fact, WorkItem(37528, "https://github.com/dotnet/roslyn/issues/37528")]
+        public void ArrayInitializer_MultipleElementsWithDisposableAssignment_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+
+    }
+}
+
+class Test
+{
+    void M1()
+    {
+        A[] a = new A[] { new A(), new A() };   // TODO: https://github.com/dotnet/roslyn-analyzers/issues/1577
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+
+    End Sub
+End Class
+
+Class Test
+    Sub M1()
+        Dim a As A() = New A() {New A(), New A()}    ' TODO: https://github.com/dotnet/roslyn-analyzers/issues/1577
+    End Sub
+End Class");
+        }
+
         [Fact]
         public void ArrayInitializer_ElementWithDisposableAssignment_ConstantIndex_NoDiagnostic()
         {
@@ -2055,6 +2095,50 @@ Class Test
     Sub M1()
         Dim a As A() = New A() {New A()}
         a(0).Dispose()
+    End Sub
+End Class");
+        }
+
+        [Fact, WorkItem(37528, "https://github.com/dotnet/roslyn/issues/37528")]
+        public void ArrayInitializer_MultipleElementsWithDisposableAssignment_ConstantIndices_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+
+    }
+}
+
+class Test
+{
+    void M1()
+    {
+        A[] a = new A[] { new A(), new A() };
+        a[0].Dispose();
+        a[1].Dispose();
+    }
+}
+");
+
+            VerifyBasic(@"
+Imports System
+
+Class A
+    Implements IDisposable
+    Public Sub Dispose() Implements IDisposable.Dispose
+
+    End Sub
+End Class
+
+Class Test
+    Sub M1()
+        Dim a As A() = New A() {New A(), New A()}
+        a(0).Dispose()
+        a(1).Dispose()
     End Sub
 End Class");
         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -693,7 +693,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             {
                 base.SetAbstractValueForArrayElementInitializer(arrayCreation, indices, elementType, initializer, value);
 
-                HandleEscapingOperation(arrayCreation, initializer);
+                // We use the array initializer as the escaping operation instead of arrayCreation
+                // to ensure we have a unique escaping operation key for each initializer.
+                HandleEscapingOperation(initializer, initializer);
             }
 
             #region Visitor methods


### PR DESCRIPTION
Escaping logic in PointsToAnalysis was not using unique escaping key for each array element initializer.

Fixes https://github.com/dotnet/roslyn/issues/37528