### PR TITLE
Do not cache interprocedural dataflow analysis results

### DIFF
--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -41,7 +41,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 throw new ArgumentNullException(nameof(analysisContext));
             }
 
-            if (!cacheResult)
+            // Don't add interprocedural analysis result to our static results cache.
+            if (!cacheResult || analysisContext.InterproceduralAnalysisDataOpt != null)
             {
                 return Run(analysisContext);
             }


### PR DESCRIPTION
Given our interprocedural analysis is context sensitive, it is highly unlikely that we will re-use the result after computing.
This brings down our flow analysis memory usage for some of the high memory usage repros to 15-20% of the original (down from 12-13 GB to close to 2 GB)