### PR TITLE
Reduce linq allocations for CA1708 (IdentifiersShouldDifferByMoreThan…

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
 
             using var overloadsToSkip = PooledHashSet<ISymbol>.GetInstance();
-            var membersByName = PooledDictionary<string, PooledHashSet<ISymbol>>.GetInstance(StringComparer.OrdinalIgnoreCase);
+            using var membersByName = PooledDictionary<string, PooledHashSet<ISymbol>>.GetInstance(StringComparer.OrdinalIgnoreCase);
             foreach (var member in members)
             {
                 // Ignore constructors, indexers, operators and destructors for name check

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using System.Threading;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
@@ -125,73 +126,105 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static void CheckTypeMembers(IEnumerable<ISymbol> members, Action<Diagnostic> addDiagnostic)
         {
-            // Remove constructors, indexers, operators and destructors for name check
-            IEnumerable<ISymbol> membersForNameCheck = members.Where(item => !item.IsConstructor() && !item.IsDestructor() && !item.IsIndexer() && !item.IsUserDefinedOperator());
-            if (membersForNameCheck.Any())
-            {
-                CheckMemberNames(membersForNameCheck, addDiagnostic);
-            }
-        }
-
-        private static void CheckParameterMembers(IEnumerable<ISymbol> members, Action<Diagnostic> addDiagnostic)
-        {
-            IEnumerable<ISymbol> violatingMembers = members
-                .Where(item => item.ContainingType.DelegateInvokeMethod == null && HasViolatingParameters(item));
-
-            IEnumerable<ISymbol> violatingDelegates = members.Select(item =>
-            {
-                if (item is INamedTypeSymbol typeSymbol &&
-    typeSymbol.DelegateInvokeMethod != null &&
-    HasViolatingParameters(typeSymbol.DelegateInvokeMethod))
-                {
-                    return item;
-                }
-                else
-                {
-                    return null;
-                }
-            }).WhereNotNull();
-
-            foreach (ISymbol symbol in violatingMembers.Concat(violatingDelegates))
-            {
-                addDiagnostic(symbol.CreateDiagnostic(Rule, Parameter, symbol.ToDisplayString()));
-            }
-        }
-
-        #region NameCheck Methods
-
-        private static bool HasViolatingParameters(ISymbol symbol)
-        {
-            ImmutableArray<IParameterSymbol> parameters = symbol.GetParameters();
-
-            // If there is only one parameter, then return an empty collection
-            if (!parameters.Skip(1).Any())
-            {
-                return false;
-            }
-
-            return parameters.GroupBy(item => item.Name, StringComparer.OrdinalIgnoreCase).Where((group) => group.HasMoreThan(1)).Any();
-        }
-
-        private static void CheckMemberNames(IEnumerable<ISymbol> members, Action<Diagnostic> addDiagnostic)
-        {
             // If there is only one member, then return
             if (!members.Skip(1).Any())
             {
                 return;
             }
 
-            IEnumerable<ISymbol> overloadedMembers = members.Where((item) => !item.IsType()).GroupBy((item) => item.Name).Where((group) => group.HasMoreThan(1)).SelectMany((group) => group.Skip(1));
-            IEnumerable<IGrouping<string, ISymbol>> memberList = members.Where((item) => !overloadedMembers.Contains(item)).GroupBy((item) => DiagnosticHelpers.GetMemberName(item), StringComparer.OrdinalIgnoreCase).Where((group) => group.HasMoreThan(1));
-
-            foreach (IGrouping<string, ISymbol> group in memberList)
+            using var overloadsToSkip = PooledHashSet<ISymbol>.GetInstance();
+            var membersByName = PooledDictionary<string, PooledHashSet<ISymbol>>.GetInstance(StringComparer.OrdinalIgnoreCase);
+            foreach (var member in members)
             {
-                ISymbol symbol = group.First().ContainingSymbol;
-                addDiagnostic(symbol.CreateDiagnostic(Rule, Member, GetSymbolDisplayString(group)));
+                // Ignore constructors, indexers, operators and destructors for name check
+                if (member.IsConstructor() ||
+                    member.IsDestructor() ||
+                    member.IsIndexer() ||
+                    member.IsUserDefinedOperator() ||
+                    overloadsToSkip.Contains(member))
+                {
+                    continue;
+                }
+
+                var name = DiagnosticHelpers.GetMemberName(member);
+                if (!membersByName.TryGetValue(name, out var membersWithName))
+                {
+                    membersWithName = PooledHashSet<ISymbol>.GetInstance();
+                    membersByName[name] = membersWithName;
+                }
+
+                membersWithName.Add(member);
+
+                if (member is IMethodSymbol method)
+                {
+                    foreach (var overload in method.GetOverloads())
+                    {
+                        overloadsToSkip.Add(overload);
+                    }
+                }
+            }
+
+            foreach (var (name, membersWithName) in membersByName)
+            {
+                if (membersWithName.Count > 1 &&
+                    !membersWithName.All(m => m.IsOverride))
+                {
+                    ISymbol symbol = membersWithName.First().ContainingSymbol;
+                    addDiagnostic(symbol.CreateDiagnostic(Rule, Member, GetSymbolDisplayString(membersWithName)));
+                }
+
+                membersWithName.Free();
             }
         }
 
-        private static void CheckTypeNames(IEnumerable<ITypeSymbol> types, Action<Diagnostic> addDiagnostic)
+        private static void CheckParameterMembers(IEnumerable<ISymbol> members, Action<Diagnostic> addDiagnostic)
+        {
+            foreach (var member in members)
+            {
+                if (IsViolatingMember(member) || IsViolatingDelegate(member))
+                {
+                    addDiagnostic(member.CreateDiagnostic(Rule, Parameter, member.ToDisplayString()));
+                }
+            }
+
+            return;
+
+            // Local functions
+            static bool IsViolatingMember(ISymbol member)
+                => member.ContainingType.DelegateInvokeMethod == null &&
+                   HasViolatingParameters(member);
+
+            static bool IsViolatingDelegate(ISymbol member)
+                => member is INamedTypeSymbol typeSymbol &&
+                   typeSymbol.DelegateInvokeMethod != null &&
+                   HasViolatingParameters(typeSymbol.DelegateInvokeMethod);
+        }
+
+        #region NameCheck Methods
+
+        private static bool HasViolatingParameters(ISymbol symbol)
+        {
+            var parameters = symbol.GetParameters();
+
+            // We only analyze symbols with more then one parameter.
+            if (parameters.Length <= 1)
+            {
+                return false;
+            }
+
+            using var uniqueNames = PooledHashSet<string>.GetInstance(StringComparer.OrdinalIgnoreCase);
+            foreach (var parameter in parameters)
+            {
+                if (!uniqueNames.Add(parameter.Name))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void CheckTypeNames(IEnumerable<INamedTypeSymbol> types, Action<Diagnostic> addDiagnostic)
         {
             // If there is only one type, then return
             if (!types.Skip(1).Any())
@@ -199,12 +232,27 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            IEnumerable<IGrouping<string, ITypeSymbol>> typeList = types.GroupBy((item) => DiagnosticHelpers.GetMemberName(item), StringComparer.OrdinalIgnoreCase)
-                .Where((group) => group.HasMoreThan(1));
-
-            foreach (IGrouping<string, ITypeSymbol> group in typeList)
+            using var typesByName = PooledDictionary<string, PooledHashSet<ISymbol>>.GetInstance(StringComparer.OrdinalIgnoreCase);
+            foreach (var type in types)
             {
-                addDiagnostic(Diagnostic.Create(Rule, Location.None, Type, GetSymbolDisplayString(group)));
+                var name = DiagnosticHelpers.GetMemberName(type);
+                if (!typesByName.TryGetValue(name, out var typesWithName))
+                {
+                    typesWithName = PooledHashSet<ISymbol>.GetInstance();
+                    typesByName[name] = typesWithName;
+                }
+
+                typesWithName.Add(type);
+            }
+
+            foreach (var (name, typesWithName) in typesByName)
+            {
+                if (typesWithName.Count > 1)
+                {
+                    addDiagnostic(Diagnostic.Create(Rule, Location.None, Type, GetSymbolDisplayString(typesWithName)));
+                }
+
+                typesWithName.Free();
             }
         }
 
@@ -216,11 +264,27 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            IEnumerable<IGrouping<string, INamespaceSymbol>> namespaceList = namespaces.GroupBy((item) => item.ToDisplayString(), StringComparer.OrdinalIgnoreCase).Where((group) => group.HasMoreThan(1));
-
-            foreach (IGrouping<string, INamespaceSymbol> group in namespaceList)
+            using var namespacesByName = PooledDictionary<string, PooledHashSet<ISymbol>>.GetInstance(StringComparer.OrdinalIgnoreCase);
+            foreach (var namespaceSym in namespaces)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Rule, Location.None, Namespace, GetSymbolDisplayString(group)));
+                var name = namespaceSym.ToDisplayString();
+                if (!namespacesByName.TryGetValue(name, out var namespacesWithName))
+                {
+                    namespacesWithName = PooledHashSet<ISymbol>.GetInstance();
+                    namespacesByName[name] = namespacesWithName;
+                }
+
+                namespacesWithName.Add(namespaceSym);
+            }
+
+            foreach (var (name, namespacesWithName) in namespacesByName)
+            {
+                if (namespacesWithName.Count > 1)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, Location.None, Namespace, GetSymbolDisplayString(namespacesWithName)));
+                }
+
+                namespacesWithName.Free();
             }
         }
 
@@ -228,7 +292,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         #region Helper Methods
 
-        private static string GetSymbolDisplayString(IGrouping<string, ISymbol> group)
+        private static string GetSymbolDisplayString(PooledHashSet<ISymbol> group)
         {
             return string.Join(", ", group.Select(s => s.ToDisplayString()).OrderBy(k => k, StringComparer.Ordinal));
         }

--- a/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
+++ b/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
@@ -12,7 +12,7 @@ namespace Analyzer.Utilities.PooledObjects
 {
     [DebuggerDisplay("Count = {Count,nq}")]
     [DebuggerTypeProxy(typeof(ArrayBuilder<>.DebuggerProxy))]
-    internal sealed partial class ArrayBuilder<T> : IReadOnlyCollection<T>, IReadOnlyList<T>
+    internal sealed partial class ArrayBuilder<T> : IReadOnlyCollection<T>, IReadOnlyList<T>, IDisposable
     {
         #region DebuggerProxy
 #pragma warning disable CA1812 // ArrayBuilder<T>.DebuggerProxy is an internal class that is apparently never instantiated - used in DebuggerTypeProxy attribute above.
@@ -297,6 +297,8 @@ namespace Analyzer.Utilities.PooledObjects
             this.Free();
             return result;
         }
+
+        public void Dispose() => Free();
 
         #region Poolable
 

--- a/src/Utilities/Compiler/PooledObjects/PooledDictionary.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledDictionary.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -10,14 +12,17 @@ namespace Analyzer.Utilities.PooledObjects
 {
     // Dictionary that can be recycled via an object pool
     // NOTE: these dictionaries always have the default comparer.
-    internal class PooledDictionary<K, V> : Dictionary<K, V>
+    internal sealed class PooledDictionary<K, V> : Dictionary<K, V>, IDisposable
     {
         private readonly ObjectPool<PooledDictionary<K, V>> _pool;
 
-        private PooledDictionary(ObjectPool<PooledDictionary<K, V>> pool)
+        private PooledDictionary(ObjectPool<PooledDictionary<K, V>> pool, IEqualityComparer<K> keyComparer)
+            : base(keyComparer)
         {
             _pool = pool;
         }
+
+        public void Dispose() => Free();
 
         public ImmutableDictionary<K, V> ToImmutableDictionaryAndFree()
         {
@@ -28,7 +33,7 @@ namespace Analyzer.Utilities.PooledObjects
             }
             else
             {
-                result = this.ToImmutableDictionary();
+                result = this.ToImmutableDictionary(Comparer);
                 this.Clear();
             }
 
@@ -44,25 +49,30 @@ namespace Analyzer.Utilities.PooledObjects
 
         // global pool
         private static readonly ObjectPool<PooledDictionary<K, V>> s_poolInstance = CreatePool();
+        private static readonly ConcurrentDictionary<IEqualityComparer<K>, ObjectPool<PooledDictionary<K, V>>> s_poolInstancesByComparer
+            = new ConcurrentDictionary<IEqualityComparer<K>, ObjectPool<PooledDictionary<K, V>>>();
 
         // if someone needs to create a pool;
-        public static ObjectPool<PooledDictionary<K, V>> CreatePool()
+        public static ObjectPool<PooledDictionary<K, V>> CreatePool(IEqualityComparer<K> keyComparer = null)
         {
             ObjectPool<PooledDictionary<K, V>> pool = null;
-            pool = new ObjectPool<PooledDictionary<K, V>>(() => new PooledDictionary<K, V>(pool), 128);
+            pool = new ObjectPool<PooledDictionary<K, V>>(() => new PooledDictionary<K, V>(pool, keyComparer), 128);
             return pool;
         }
 
-        public static PooledDictionary<K, V> GetInstance()
+        public static PooledDictionary<K, V> GetInstance(IEqualityComparer<K> keyComparer = null)
         {
-            var instance = s_poolInstance.Allocate();
+            var pool = keyComparer == null ?
+                s_poolInstance :
+                s_poolInstancesByComparer.GetOrAdd(keyComparer, c => CreatePool(c));
+            var instance = pool.Allocate();
             Debug.Assert(instance.Count == 0);
             return instance;
         }
 
-        public static PooledDictionary<K, V> GetInstance(IEnumerable<KeyValuePair<K, V>> initializer)
+        public static PooledDictionary<K, V> GetInstance(IEnumerable<KeyValuePair<K, V>> initializer, IEqualityComparer<K> keyComparer = null)
         {
-            var instance = GetInstance();
+            var instance = GetInstance(keyComparer);
             foreach (var kvp in initializer)
             {
                 instance.Add(kvp.Key, kvp.Value);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
@@ -16,7 +16,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
     internal sealed class DataFlowAnalysisResultBuilder<TAnalysisData> : IDisposable
         where TAnalysisData : AbstractAnalysisData
     {
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly PooledDictionary<BasicBlock, TAnalysisData> _info;
+#pragma warning restore
 
         public DataFlowAnalysisResultBuilder()
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
@@ -13,7 +13,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
     public sealed class DictionaryAnalysisData<TKey, TValue> : AbstractAnalysisData, IDictionary<TKey, TValue>
     {
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private PooledDictionary<TKey, TValue> _coreAnalysisData;
+#pragma warning restore
 
         public DictionaryAnalysisData()
         {


### PR DESCRIPTION
…CaseAnalyzer)

Brings the total compile + analysis time down from few minutes to less then 10 seconds for a provided repro.