### PR TITLE
Handle IOperation tree shape change for IThrowOperation

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     operationBlockContext.RegisterOperationAction(operationContext =>
                     {
                         // Get ThrowOperation's ExceptionType
-                        if (((IThrowOperation)operationContext.Operation).Exception?.Type is INamedTypeSymbol thrownExceptionType && thrownExceptionType.DerivesFrom(exceptionType))
+                        if (((IThrowOperation)operationContext.Operation).GetThrownExceptionType() is INamedTypeSymbol thrownExceptionType && thrownExceptionType.DerivesFrom(exceptionType))
                         {
                             // If no exceptions are allowed or if the thrown exceptions is not an allowed one..
                             if (methodCategory.AllowedExceptions.IsEmpty || !methodCategory.AllowedExceptions.Any(n => IsAssignableTo(thrownExceptionType, n, compilation)))

--- a/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
@@ -694,6 +694,20 @@ namespace Analyzer.Utilities.Extensions
 
             return operation;
         }
+
+        public static ITypeSymbol GetThrownExceptionType(this IThrowOperation operation)
+        {
+            var thrownObject = operation.Exception;
+
+            // Starting C# 8.0, C# compiler wraps the thrown operation within an implicit conversion to System.Exception type.
+            if (thrownObject is IConversionOperation conversion &&
+                conversion.IsImplicit)
+            {
+                thrownObject = conversion.Operand;
+            }
+
+            return thrownObject?.Type;
+        }
     }
 }
 

--- a/src/Utilities/Compiler/Extensions/OperationBlockAnalysisContextExtension.cs
+++ b/src/Utilities/Compiler/Extensions/OperationBlockAnalysisContextExtension.cs
@@ -60,10 +60,10 @@ namespace Analyzer.Utilities.Extensions
 
                     if (innerOperation.Kind == OperationKind.Throw &&
                         innerOperation is IThrowOperation throwOperation &&
-                        throwOperation.Exception is IObjectCreationOperation createdException)
+                        throwOperation.GetThrownExceptionType() is ITypeSymbol createdExceptionType)
                     {
-                        if (Equals(WellKnownTypes.NotImplementedException(context.Compilation), createdException.Type.OriginalDefinition)
-                            || Equals(WellKnownTypes.NotSupportedException(context.Compilation), createdException.Type.OriginalDefinition))
+                        if (Equals(WellKnownTypes.NotImplementedException(context.Compilation), createdExceptionType.OriginalDefinition)
+                            || Equals(WellKnownTypes.NotSupportedException(context.Compilation), createdExceptionType.OriginalDefinition))
                         {
                             return true;
                         }

--- a/src/Utilities/FlowAnalysis/Extensions/IOperationExtensions_FlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/Extensions/IOperationExtensions_FlowAnalysis.cs
@@ -39,16 +39,5 @@ namespace Analyzer.Utilities.Extensions
 
             return false;
         }
-
-        public static ITypeSymbol GetThrowExceptionType(this IOperation thrownOperation, BasicBlock currentBlock)
-        {
-            if (thrownOperation?.Type != null)
-            {
-                return thrownOperation.Type;
-            }
-
-            // rethrow or throw with no argument.
-            return currentBlock.GetEnclosingRegionExceptionType();
-        }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -571,7 +571,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 case ControlFlowBranchSemantics.Throw:
                 case ControlFlowBranchSemantics.Rethrow:
                     // Update the tracked merged analysis data at throw branches.
-                    if (branch.BranchValueOpt?.GetThrowExceptionType(CurrentBasicBlock) is INamedTypeSymbol exceptionType &&
+                    var thrownExceptionType = branch.BranchValueOpt?.Type ?? CurrentBasicBlock.GetEnclosingRegionExceptionType();
+                    if (thrownExceptionType is INamedTypeSymbol exceptionType &&
                         exceptionType.DerivesFrom(WellKnownTypeProvider.Exception, baseTypesOnly: true))
                     {
                         AnalysisDataForUnhandledThrowOperations ??= new Dictionary<ThrownExceptionInfo, TAnalysisData>();


### PR DESCRIPTION
Fixes #2761
IOperation tree for IThrowOperation now has an implicit IConversionOperation wrapping the underlying thrown object. Details at https://github.com/dotnet/roslyn/blame/a5418f7398495db4ea858f0c9efd9b13541ff478/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs#L395