### PR TITLE
Harden analyzers/fixers

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
             var typeIsSealed = ((INamedTypeSymbol)model.GetDeclaredSymbol(classDecl)).IsSealed;
 
             INamedTypeSymbol codeFixProviderSymbol = model.Compilation.GetTypeByMetadataName(FixerWithFixAllAnalyzer.CodeFixProviderMetadataName);
-            IMethodSymbol getFixAllProviderMethod = codeFixProviderSymbol.GetMembers(FixerWithFixAllAnalyzer.GetFixAllProviderMethodName).OfType<IMethodSymbol>().Single();
+            IMethodSymbol getFixAllProviderMethod = codeFixProviderSymbol.GetMembers(FixerWithFixAllAnalyzer.GetFixAllProviderMethodName).OfType<IMethodSymbol>().First();
             var returnStatement = generator.ReturnStatement(generator.MemberAccessExpression(
                 generator.IdentifierName("WellKnownFixAllProviders"), "BatchFixer"));
             var statements = new SyntaxNode[] { returnStatement };

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                 return;
             }
 
-            IMethodSymbol getFixAllProviderMethod = codeFixProviderSymbol.GetMembers(GetFixAllProviderMethodName).OfType<IMethodSymbol>().SingleOrDefault();
+            IMethodSymbol getFixAllProviderMethod = codeFixProviderSymbol.GetMembers(GetFixAllProviderMethodName).OfType<IMethodSymbol>().FirstOrDefault();
             if (getFixAllProviderMethod == null)
             {
                 return;
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                 return;
             }
 
-            IPropertySymbol equivalenceKeyProperty = codeActionSymbol.GetMembers(EquivalenceKeyPropertyName).OfType<IPropertySymbol>().SingleOrDefault();
+            IPropertySymbol equivalenceKeyProperty = codeActionSymbol.GetMembers(EquivalenceKeyPropertyName).OfType<IPropertySymbol>().FirstOrDefault();
             if (equivalenceKeyProperty == null)
             {
                 return;
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                     {
                         if (!type.Equals(_codeFixProviderSymbol))
                         {
-                            IMethodSymbol getFixAllProviderMethod = type.GetMembers(GetFixAllProviderMethodName).OfType<IMethodSymbol>().SingleOrDefault();
+                            IMethodSymbol getFixAllProviderMethod = type.GetMembers(GetFixAllProviderMethodName).OfType<IMethodSymbol>().FirstOrDefault();
                             if (getFixAllProviderMethod != null && getFixAllProviderMethod.IsOverride)
                             {
                                 return true;
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
 
                 static bool IsViolatingCodeActionCreateInvocation(IInvocationOperation invocation)
                 {
-                    IParameterSymbol param = invocation.TargetMethod.Parameters.SingleOrDefault(p => p.Name == EquivalenceKeyParameterName);
+                    IParameterSymbol param = invocation.TargetMethod.Parameters.FirstOrDefault(p => p.Name == EquivalenceKeyParameterName);
                     if (param == null)
                     {
                         return true;
@@ -364,7 +364,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                     return false;
                 }
 
-                IPropertySymbol equivalenceKeyProperty = namedType.GetMembers(EquivalenceKeyPropertyName).OfType<IPropertySymbol>().SingleOrDefault();
+                IPropertySymbol equivalenceKeyProperty = namedType.GetMembers(EquivalenceKeyPropertyName).OfType<IPropertySymbol>().FirstOrDefault();
                 return equivalenceKeyProperty != null && equivalenceKeyProperty.IsOverride;
             }
         }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
@@ -394,7 +394,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     }
                     else
                     {
-                        ITypeParameterSymbol typeParam = method.TypeParameters.SingleOrDefault(t => t.Name == TLanguageKindEnumName);
+                        ITypeParameterSymbol typeParam = method.TypeParameters.FirstOrDefault(t => t.Name == TLanguageKindEnumName);
                         if (typeParam != null)
                         {
                             int index = method.TypeParameters.IndexOf(typeParam);

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructors.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructors.Fixer.cs
@@ -26,14 +26,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             SyntaxNode node = root.FindNode(context.Span);
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
-
             string title = MicrosoftCodeQualityAnalyzersResources.AbstractTypesShouldNotHavePublicConstructorsCodeFix;
             context.RegisterCodeFix(new MyCodeAction(title,
                                         async ct => await ChangeAccessibilityCodeFix(context.Document, root, node, ct).ConfigureAwait(false),
                                         equivalenceKey: title),
-                                    diagnostic);
+                                    context.Diagnostics);
         }
 
         private static SyntaxNode GetDeclaration(ISymbol symbol)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DefineAccessorsForAttributeArguments.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/DefineAccessorsForAttributeArguments.Fixer.cs
@@ -24,47 +24,48 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             SyntaxNode node = root.FindNode(context.Span);
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
-            if (diagnostic.Properties.TryGetValue("case", out string fixCase))
+            foreach (var diagnostic in context.Diagnostics)
             {
-                string title;
-                switch (fixCase)
+                if (diagnostic.Properties.TryGetValue("case", out string fixCase))
                 {
-                    case DefineAccessorsForAttributeArgumentsAnalyzer.AddAccessorCase:
-                        SyntaxNode parameter = generator.GetDeclaration(node, DeclarationKind.Parameter);
-                        if (parameter != null)
-                        {
-                            title = MicrosoftCodeQualityAnalyzersResources.CreatePropertyAccessorForParameter;
+                    string title;
+                    switch (fixCase)
+                    {
+                        case DefineAccessorsForAttributeArgumentsAnalyzer.AddAccessorCase:
+                            SyntaxNode parameter = generator.GetDeclaration(node, DeclarationKind.Parameter);
+                            if (parameter != null)
+                            {
+                                title = MicrosoftCodeQualityAnalyzersResources.CreatePropertyAccessorForParameter;
+                                context.RegisterCodeFix(new MyCodeAction(title,
+                                                             async ct => await AddAccessor(context.Document, parameter, ct).ConfigureAwait(false),
+                                                             equivalenceKey: title),
+                                                        diagnostic);
+                            }
+                            return;
+
+                        case DefineAccessorsForAttributeArgumentsAnalyzer.MakePublicCase:
+                            SyntaxNode property = generator.GetDeclaration(node, DeclarationKind.Property);
+                            if (property != null)
+                            {
+                                title = MicrosoftCodeQualityAnalyzersResources.MakeGetterPublic;
+                                context.RegisterCodeFix(new MyCodeAction(title,
+                                                                 async ct => await MakePublic(context.Document, node, property, ct).ConfigureAwait(false),
+                                                                 equivalenceKey: title),
+                                                        diagnostic);
+                            }
+                            return;
+
+                        case DefineAccessorsForAttributeArgumentsAnalyzer.RemoveSetterCase:
+                            title = MicrosoftCodeQualityAnalyzersResources.MakeSetterNonPublic;
                             context.RegisterCodeFix(new MyCodeAction(title,
-                                                         async ct => await AddAccessor(context.Document, parameter, ct).ConfigureAwait(false),
+                                                         async ct => await RemoveSetter(context.Document, node, ct).ConfigureAwait(false),
                                                          equivalenceKey: title),
                                                     diagnostic);
-                        }
-                        return;
+                            return;
 
-                    case DefineAccessorsForAttributeArgumentsAnalyzer.MakePublicCase:
-                        SyntaxNode property = generator.GetDeclaration(node, DeclarationKind.Property);
-                        if (property != null)
-                        {
-                            title = MicrosoftCodeQualityAnalyzersResources.MakeGetterPublic;
-                            context.RegisterCodeFix(new MyCodeAction(title,
-                                                             async ct => await MakePublic(context.Document, node, property, ct).ConfigureAwait(false),
-                                                             equivalenceKey: title),
-                                                    diagnostic);
-                        }
-                        return;
-
-                    case DefineAccessorsForAttributeArgumentsAnalyzer.RemoveSetterCase:
-                        title = MicrosoftCodeQualityAnalyzersResources.MakeSetterNonPublic;
-                        context.RegisterCodeFix(new MyCodeAction(title,
-                                                     async ct => await RemoveSetter(context.Document, node, ct).ConfigureAwait(false),
-                                                     equivalenceKey: title),
-                                                diagnostic);
-                        return;
-
-                    default:
-                        return;
+                        default:
+                            return;
+                    }
                 }
             }
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumStorageShouldBeInt32.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumStorageShouldBeInt32.Fixer.cs
@@ -34,13 +34,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             // Get syntax root node
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            // No multiple overlapping diagnostics of this id. So get the only diagnostic.
-            var diagnostic = context.Diagnostics.Single();
-
-            // Register fixer
-            context.RegisterCodeFix(new MyCodeAction(title,
-                     c => ChangeEnumTypeToInt32Async(context.Document, diagnostic, root, c),
-                     equivalenceKey: title), context.Diagnostics.First());
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                // Register fixer
+                context.RegisterCodeFix(new MyCodeAction(title,
+                         c => ChangeEnumTypeToInt32Async(context.Document, diagnostic, root, c),
+                         equivalenceKey: title), diagnostic);
+            }
         }
 
         private async Task<Document> ChangeEnumTypeToInt32Async(Document document, Diagnostic diagnostic, SyntaxNode root, CancellationToken cancellationToken)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumWithFlagsAttribute.Fixer.cs
@@ -35,15 +35,16 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
-            string fixTitle = diagnostic.Id == EnumWithFlagsAttributeAnalyzer.RuleIdMarkEnumsWithFlags ?
-                                                    MicrosoftCodeQualityAnalyzersResources.MarkEnumsWithFlagsCodeFix :
-                                                    MicrosoftCodeQualityAnalyzersResources.DoNotMarkEnumsWithFlagsCodeFix;
-            context.RegisterCodeFix(new MyCodeAction(fixTitle,
-                                         async ct => await AddOrRemoveFlagsAttribute(context.Document, context.Span, diagnostic.Id, flagsAttributeType, ct).ConfigureAwait(false),
-                                         equivalenceKey: fixTitle),
-                        diagnostic);
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                string fixTitle = diagnostic.Id == EnumWithFlagsAttributeAnalyzer.RuleIdMarkEnumsWithFlags ?
+                                                        MicrosoftCodeQualityAnalyzersResources.MarkEnumsWithFlagsCodeFix :
+                                                        MicrosoftCodeQualityAnalyzersResources.DoNotMarkEnumsWithFlagsCodeFix;
+                context.RegisterCodeFix(new MyCodeAction(fixTitle,
+                                             async ct => await AddOrRemoveFlagsAttribute(context.Document, context.Span, diagnostic.Id, flagsAttributeType, ct).ConfigureAwait(false),
+                                             equivalenceKey: fixTitle),
+                                        diagnostic);
+            }
         }
 
         private static async Task<Document> AddOrRemoveFlagsAttribute(Document document, TextSpan span, string diagnosticId, INamedTypeSymbol flagsAttributeType, CancellationToken cancellationToken)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHaveZeroValue.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHaveZeroValue.Fixer.cs
@@ -32,41 +32,42 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
-            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            SyntaxNode node = root.FindNode(context.Span);
-
-            ISymbol declaredSymbol = model.GetDeclaredSymbol(node, context.CancellationToken);
-            Debug.Assert(declaredSymbol != null);
-            string title;
-
-            foreach (string customTag in diagnostic.Descriptor.CustomTags)
+            foreach (var diagnostic in context.Diagnostics)
             {
-                switch (customTag)
-                {
-                    case EnumsShouldHaveZeroValueAnalyzer.RuleRenameCustomTag:
-                        title = MicrosoftCodeQualityAnalyzersResources.EnumsShouldZeroValueFlagsRenameCodeFix;
-                        context.RegisterCodeFix(new MyCodeAction(title,
-                                                    async ct => await GetUpdatedDocumentForRuleNameRenameAsync(context.Document, (IFieldSymbol)declaredSymbol, context.CancellationToken).ConfigureAwait(false),
-                                                    equivalenceKey: title),
-                                                diagnostic);
-                        return;
-                    case EnumsShouldHaveZeroValueAnalyzer.RuleMultipleZeroCustomTag:
-                        title = MicrosoftCodeQualityAnalyzersResources.EnumsShouldZeroValueFlagsMultipleZeroCodeFix;
-                        context.RegisterCodeFix(new MyCodeAction(title,
-                                                    async ct => await ApplyRuleNameMultipleZeroAsync(context.Document, (INamedTypeSymbol)declaredSymbol, context.CancellationToken).ConfigureAwait(false),
-                                                    equivalenceKey: title),
-                                                diagnostic);
-                        return;
+                SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+                SyntaxNode node = root.FindNode(context.Span);
 
-                    case EnumsShouldHaveZeroValueAnalyzer.RuleNoZeroCustomTag:
-                        title = MicrosoftCodeQualityAnalyzersResources.EnumsShouldZeroValueNotFlagsNoZeroValueCodeFix;
-                        context.RegisterCodeFix(new MyCodeAction(title,
-                                                    async ct => await ApplyRuleNameNoZeroValueAsync(context.Document, (INamedTypeSymbol)declaredSymbol, context.CancellationToken).ConfigureAwait(false),
-                                                    equivalenceKey: title),
-                                                diagnostic);
-                        return;
+                ISymbol declaredSymbol = model.GetDeclaredSymbol(node, context.CancellationToken);
+                Debug.Assert(declaredSymbol != null);
+                string title;
+
+                foreach (string customTag in diagnostic.Descriptor.CustomTags)
+                {
+                    switch (customTag)
+                    {
+                        case EnumsShouldHaveZeroValueAnalyzer.RuleRenameCustomTag:
+                            title = MicrosoftCodeQualityAnalyzersResources.EnumsShouldZeroValueFlagsRenameCodeFix;
+                            context.RegisterCodeFix(new MyCodeAction(title,
+                                                        async ct => await GetUpdatedDocumentForRuleNameRenameAsync(context.Document, (IFieldSymbol)declaredSymbol, context.CancellationToken).ConfigureAwait(false),
+                                                        equivalenceKey: title),
+                                                    diagnostic);
+                            return;
+                        case EnumsShouldHaveZeroValueAnalyzer.RuleMultipleZeroCustomTag:
+                            title = MicrosoftCodeQualityAnalyzersResources.EnumsShouldZeroValueFlagsMultipleZeroCodeFix;
+                            context.RegisterCodeFix(new MyCodeAction(title,
+                                                        async ct => await ApplyRuleNameMultipleZeroAsync(context.Document, (INamedTypeSymbol)declaredSymbol, context.CancellationToken).ConfigureAwait(false),
+                                                        equivalenceKey: title),
+                                                    diagnostic);
+                            return;
+
+                        case EnumsShouldHaveZeroValueAnalyzer.RuleNoZeroCustomTag:
+                            title = MicrosoftCodeQualityAnalyzersResources.EnumsShouldZeroValueNotFlagsNoZeroValueCodeFix;
+                            context.RegisterCodeFix(new MyCodeAction(title,
+                                                        async ct => await ApplyRuleNameNoZeroValueAsync(context.Document, (INamedTypeSymbol)declaredSymbol, context.CancellationToken).ConfigureAwait(false),
+                                                        equivalenceKey: title),
+                                                    diagnostic);
+                            return;
+                    }
                 }
             }
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
@@ -53,9 +53,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
-
             if (type.TypeKind == TypeKind.Struct && !TypeImplementsEquatable(type, equatableType))
             {
                 string title = MicrosoftCodeQualityAnalyzersResources.ImplementEquatable;
@@ -64,7 +61,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     async ct =>
                         await ImplementEquatableInStructAsync(context.Document, declaration, type, model.Compilation,
                             equatableType, ct).ConfigureAwait(false),
-                    equivalenceKey: title), diagnostic);
+                    equivalenceKey: title), context.Diagnostics);
             }
 
             if (!type.OverridesEquals())
@@ -75,7 +72,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     async ct =>
                         await OverrideObjectEqualsAsync(context.Document, declaration, type, equatableType,
                             ct).ConfigureAwait(false),
-                    equivalenceKey: title), diagnostic);
+                    equivalenceKey: title), context.Diagnostics);
             }
         }
 
@@ -156,7 +153,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static bool HasExplicitEqualsImplementation(INamedTypeSymbol typeSymbol, INamedTypeSymbol equatableType)
         {
             INamedTypeSymbol constructedType = equatableType.Construct(typeSymbol);
-            IMethodSymbol constructedEqualsMethod = constructedType.GetMembers().OfType<IMethodSymbol>().Single();
+            IMethodSymbol constructedEqualsMethod = constructedType.GetMembers().OfType<IMethodSymbol>().FirstOrDefault();
 
             foreach (IMethodSymbol method in typeSymbol.GetMembers().OfType<IMethodSymbol>())
             {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ExceptionsShouldBePublic.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ExceptionsShouldBePublic.Fixer.cs
@@ -31,8 +31,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             SyntaxNode node = root.FindNode(context.Span);
 
-            Diagnostic diagnostic = context.Diagnostics.Single();
-
             // create one equivalence key value for all actions produced by this fixer 
             // i.e. Fix All fixes every occurrence of this diagnostic
             string equivalenceKey = nameof(ExceptionsShouldBePublicFixer);
@@ -42,7 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 c => MakePublic(context.Document, node, context.CancellationToken),
                 equivalenceKey);
 
-            context.RegisterCodeFix(action, diagnostic);
+            context.RegisterCodeFix(action, context.Diagnostics);
         }
 
         private static async Task<Document> MakePublic(Document document, SyntaxNode classDecl, CancellationToken cancellationToken)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         return;
                     }
 
-                    if (!(disposableType.GetMembers(DisposeMethodName).Single() is IMethodSymbol disposeInterfaceMethod))
+                    if (!(disposableType.GetMembers(DisposeMethodName).FirstOrDefault() is IMethodSymbol disposeInterfaceMethod))
                     {
                         return;
                     }
@@ -146,7 +146,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         return;
                     }
 
-                    if (!(garbageCollectorType.GetMembers(SuppressFinalizeMethodName).Single() is IMethodSymbol suppressFinalizeMethod))
+                    if (!(garbageCollectorType.GetMembers(SuppressFinalizeMethodName).FirstOrDefault() is IMethodSymbol suppressFinalizeMethod))
                     {
                         return;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternates.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     // don't report a diagnostic on the `op_False` method because then the user would see two diagnostics for what is really one error
                     // special-case looking for `IsTrue` instance property
                     // named properties can't be overloaded so there will only ever be 0 or 1
-                    IPropertySymbol property = typeSymbol.GetMembers(IsTrueText).OfType<IPropertySymbol>().SingleOrDefault();
+                    IPropertySymbol property = typeSymbol.GetMembers(IsTrueText).OfType<IPropertySymbol>().FirstOrDefault();
                     if (property == null || property.Type.SpecialType != SpecialType.System_Boolean)
                     {
                         symbolContext.ReportDiagnostic(CreateDiagnostic(PropertyRule, GetSymbolLocation(methodSymbol), AddAlternateText, IsTrueText, operatorName));

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
@@ -40,13 +40,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftCodeQualityAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEqualsTitle;
             context.RegisterCodeFix(
                 new MyCodeAction(title,
                     async ct => await ImplementOperatorEquals(context.Document, declaration, typeSymbol, ct).ConfigureAwait(false),
-                    equivalenceKey: title), diagnostic);
+                    equivalenceKey: title), context.Diagnostics);
         }
 
         private static async Task<Document> ImplementOperatorEquals(Document document, SyntaxNode declaration, INamedTypeSymbol typeSymbol, CancellationToken cancellationToken)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEquals.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEquals.Fixer.cs
@@ -43,15 +43,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             // CONSIDER: Do we need to confirm that System.Object.Equals isn't shadowed in a base type?
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftCodeQualityAnalyzersResources.OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle;
             context.RegisterCodeFix(
                 new MyCodeAction(
                     title,
                     cancellationToken => OverrideObjectEquals(context.Document, typeDeclaration, typeSymbol, cancellationToken),
                     equivalenceKey: title),
-                diagnostic);
+                context.Diagnostics);
         }
 
         private static async Task<Document> OverrideObjectEquals(Document document, SyntaxNode typeDeclaration, INamedTypeSymbol typeSymbol, CancellationToken cancellationToken)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideGetHashCodeOnOverridingEquals.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideGetHashCodeOnOverridingEquals.Fixer.cs
@@ -35,15 +35,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             // CONSIDER: Do we need to confirm that System.Object.GetHashCode isn't shadowed in a base type?
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftCodeQualityAnalyzersResources.OverrideGetHashCodeOnOverridingEqualsCodeActionTitle;
             context.RegisterCodeFix(
                 new MyCodeAction(
                     title,
                     cancellationToken => OverrideObjectGetHashCode(context.Document, typeDeclaration, cancellationToken),
                     equivalenceKey: title),
-                diagnostic);
+                context.Diagnostics);
         }
 
         private static async Task<Document> OverrideObjectGetHashCode(Document document, SyntaxNode typeDeclaration, CancellationToken cancellationToken)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideMethodsOnComparableTypes.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/OverrideMethodsOnComparableTypes.Fixer.cs
@@ -39,13 +39,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftCodeQualityAnalyzersResources.ImplementComparable;
             context.RegisterCodeFix(
                 new MyCodeAction(title,
                     async ct => await ImplementComparableAsync(context.Document, declaration, typeSymbol, ct).ConfigureAwait(false),
-                    equivalenceKey: title), diagnostic);
+                    equivalenceKey: title),
+                context.Diagnostics);
         }
 
         private static async Task<Document> ImplementComparableAsync(Document document, SyntaxNode declaration, INamedTypeSymbol typeSymbol, CancellationToken cancellationToken)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.Fixer.cs
@@ -34,13 +34,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableInterface;
             context.RegisterCodeFix(new MyCodeAction(title,
                                                      async ct => await ImplementIDisposable(context.Document, declaration, ct).ConfigureAwait(false),
                                                      equivalenceKey: title),
-                                    diagnostic);
+                                    context.Diagnostics);
         }
 
         private static async Task<Document> ImplementIDisposable(Document document, SyntaxNode declaration, CancellationToken cancellationToken)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUnusedPrivateFields.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/AvoidUnusedPrivateFields.Fixer.cs
@@ -37,15 +37,13 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id. 
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftCodeQualityAnalyzersResources.AvoidUnusedPrivateFieldsTitle;
             context.RegisterCodeFix(
                 new MyCodeAction(
                     title,
                     async ct => await RemoveField(context.Document, node, ct).ConfigureAwait(false),
                     equivalenceKey: title),
-                diagnostic);
+                context.Diagnostics);
 
             return;
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/Maintainability/ReviewUnusedParameters.Fixer.cs
@@ -30,15 +30,15 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // Fixer not yet implemented.
-            Diagnostic diagnostic = context.Diagnostics.Single();
-
-            context.RegisterCodeFix(
-                new MyCodeAction(
-                    MicrosoftCodeQualityAnalyzersResources.RemoveUnusedParameterMessage,
-                    async ct => await RemoveNodes(context.Document, diagnostic, ct).ConfigureAwait(false),
-                    equivalenceKey: MicrosoftCodeQualityAnalyzersResources.RemoveUnusedParameterMessage),
-                diagnostic);
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                context.RegisterCodeFix(
+                    new MyCodeAction(
+                        MicrosoftCodeQualityAnalyzersResources.RemoveUnusedParameterMessage,
+                        async ct => await RemoveNodes(context.Document, diagnostic, ct).ConfigureAwait(false),
+                        equivalenceKey: MicrosoftCodeQualityAnalyzersResources.RemoveUnusedParameterMessage),
+                    diagnostic);
+            }
 
             return Task.CompletedTask;
         }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AbstractRemoveEmptyFinalizers.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/AbstractRemoveEmptyFinalizers.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                     return;
                 }
 
-                var methodBody = methodSymbol.DeclaringSyntaxReferences.Single().GetSyntax();
+                var methodBody = methodSymbol.DeclaringSyntaxReferences.First().GetSyntax();
 
                 if (IsEmptyFinalizer(methodBody, codeBlockContext))
                 {

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/RemoveEmptyFinalizers.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/RemoveEmptyFinalizers.Fixer.cs
@@ -31,13 +31,11 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftCodeQualityAnalyzersResources.RemoveEmptyFinalizers;
             context.RegisterCodeFix(new MyCodeAction(title,
                              async ct => await RemoveFinalizer(context.Document, node, ct).ConfigureAwait(false),
                              equivalenceKey: title),
-                        diagnostic);
+                        context.Diagnostics);
             return;
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/UseLiteralsWhereAppropriate.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/UseLiteralsWhereAppropriate.Fixer.cs
@@ -38,15 +38,13 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftCodeQualityAnalyzersResources.UseLiteralsWhereAppropriateCodeActionTitle;
             context.RegisterCodeFix(
                 new MyCodeAction(
                     title,
                     cancellationToken => ToConstantDeclarationAsync(context.Document, fieldFeclaration, cancellationToken),
                     equivalenceKey: title),
-                diagnostic);
+                context.Diagnostics);
         }
 
         private async Task<Document> ToConstantDeclarationAsync(Document document, SyntaxNode fieldDeclaration, CancellationToken cancellationToken)

--- a/src/Microsoft.NetCore.Analyzers/Core/Data/ReviewSqlQueriesForSecurityVulnerabilities.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Data/ReviewSqlQueriesForSecurityVulnerabilities.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
+using System.Linq;
 
 namespace Microsoft.NetCore.Analyzers.Data
 {
@@ -43,7 +44,7 @@ namespace Microsoft.NetCore.Analyzers.Data
             {
                 INamedTypeSymbol iDbCommandType = WellKnownTypes.IDbCommand(compilationContext.Compilation);
                 INamedTypeSymbol iDataAdapterType = WellKnownTypes.IDataAdapter(compilationContext.Compilation);
-                IPropertySymbol commandTextProperty = iDbCommandType?.GetProperty("CommandText");
+                IPropertySymbol commandTextProperty = iDbCommandType?.GetMembers("CommandText").OfType<IPropertySymbol>().FirstOrDefault();
 
                 if (iDbCommandType == null ||
                     iDataAdapterType == null ||

--- a/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
@@ -58,9 +58,9 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
                 var immutableArraySymbol = compilation.GetTypeByMetadataName(ImmutableArrayMetadataName);
                 if (immutableArraySymbol is null)
                 {
-                    var systemNamespace = compilation.GlobalNamespace.GetMembers(nameof(System)).OfType<INamespaceSymbol>().SingleOrDefault();
-                    var systemCollectionsNamespace = systemNamespace?.GetMembers(nameof(System.Collections)).OfType<INamespaceSymbol>().SingleOrDefault();
-                    var systemCollectionsImmutableNamespace = systemCollectionsNamespace?.GetMembers(nameof(System.Collections.Immutable)).OfType<INamespaceSymbol>().SingleOrDefault();
+                    var systemNamespace = compilation.GlobalNamespace.GetMembers(nameof(System)).OfType<INamespaceSymbol>().FirstOrDefault();
+                    var systemCollectionsNamespace = systemNamespace?.GetMembers(nameof(System.Collections)).OfType<INamespaceSymbol>().FirstOrDefault();
+                    var systemCollectionsImmutableNamespace = systemCollectionsNamespace?.GetMembers(nameof(System.Collections.Immutable)).OfType<INamespaceSymbol>().FirstOrDefault();
                     if (systemCollectionsImmutableNamespace is null)
                     {
                         return;

--- a/src/Microsoft.NetCore.Analyzers/Core/InteropServices/SpecifyMarshalingForPInvokeStringArguments.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/InteropServices/SpecifyMarshalingForPInvokeStringArguments.Fixer.cs
@@ -40,8 +40,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return;
             }
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftNetCoreAnalyzersResources.SpecifyMarshalingForPInvokeStringArgumentsTitle;
 
             if (IsAttribute(node))
@@ -49,14 +47,14 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 context.RegisterCodeFix(new MyCodeAction(title,
                                                          async ct => await FixAttributeArguments(context.Document, node, charSetType, dllImportType, marshalAsType, unmanagedType, ct).ConfigureAwait(false),
                                                          equivalenceKey: title),
-                                        diagnostic);
+                                        context.Diagnostics);
             }
             else if (IsDeclareStatement(node))
             {
                 context.RegisterCodeFix(new MyCodeAction(title,
                                                          async ct => await FixDeclareStatement(context.Document, node, ct).ConfigureAwait(false),
                                                          equivalenceKey: title),
-                                        diagnostic);
+                                        context.Diagnostics);
             }
         }
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidUnsealedAttributes.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/AvoidUnsealedAttributes.Fixer.cs
@@ -30,14 +30,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             if (declaration != null)
             {
-                // We cannot have multiple overlapping diagnostics of this id.
-                Diagnostic diagnostic = context.Diagnostics.Single();
-
                 string title = MicrosoftNetCoreAnalyzersResources.AvoidUnsealedAttributesMessage;
                 context.RegisterCodeFix(new MyCodeAction(title,
                     async ct => await MakeSealed(editor, declaration).ConfigureAwait(false),
                     equivalenceKey: title),
-                    diagnostic);
+                    context.Diagnostics);
             }
         }
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/CallGCSuppressFinalizeCorrectly.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/CallGCSuppressFinalizeCorrectly.cs
@@ -77,7 +77,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                         .GetTypeByMetadataName("System.GC")
                                                         ?.GetMembers("SuppressFinalize")
                                                         .OfType<IMethodSymbol>()
-                                                        .SingleOrDefault();
+                                                        .FirstOrDefault();
 
                 if (gcSuppressFinalizeMethodSymbol == null)
                 {

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/ImplementSerializationConstructors.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/ImplementSerializationConstructors.Fixer.cs
@@ -41,8 +41,6 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return;
             }
 
-            Diagnostic diagnostic = context.Diagnostics.Single();
-
             // There was no constructor and so the diagnostic was on the type. Generate a serialization ctor.
             string title = MicrosoftNetCoreAnalyzersResources.ImplementSerializationConstructorsCodeActionTitle;
             if (symbol.Kind == SymbolKind.NamedType)
@@ -50,7 +48,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 context.RegisterCodeFix(new MyCodeAction(title,
                      async ct => await GenerateConstructor(context.Document, node, symbol, notImplementedExceptionType, ct).ConfigureAwait(false),
                      equivalenceKey: title),
-                diagnostic);
+                context.Diagnostics);
             }
             // There is a serialization constructor but with incorrect accessibility. Set that right.
             else if (symbol.Kind == SymbolKind.Method)
@@ -58,7 +56,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 context.RegisterCodeFix(new MyCodeAction(title,
                      async ct => await SetAccessibility(context.Document, symbol, ct).ConfigureAwait(false),
                      equivalenceKey: title),
-                diagnostic);
+                context.Diagnostics);
             }
         }
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/MarkAllNonSerializableFields.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/MarkAllNonSerializableFields.Fixer.cs
@@ -31,13 +31,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return;
             }
 
-            Diagnostic diagnostic = context.Diagnostics.Single();
-
             // Fix 1: Add a NonSerialized attribute to the field
             context.RegisterCodeFix(new MyCodeAction(MicrosoftNetCoreAnalyzersResources.AddNonSerializedAttributeCodeActionTitle,
                                         async ct => await AddNonSerializedAttribute(context.Document, fieldNode, ct).ConfigureAwait(false),
                                         equivalenceKey: MicrosoftNetCoreAnalyzersResources.AddNonSerializedAttributeCodeActionTitle),
-                                    diagnostic);
+                                    context.Diagnostics);
 
 
             // Fix 2: If the type of the field is defined in source, then add the serializable attribute to the type.
@@ -49,7 +47,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 context.RegisterCodeFix(new MyCodeAction(MicrosoftNetCoreAnalyzersResources.AddSerializableAttributeCodeActionTitle,
                             async ct => await AddSerializableAttributeToType(context.Document, type, ct).ConfigureAwait(false),
                             equivalenceKey: MicrosoftNetCoreAnalyzersResources.AddSerializableAttributeCodeActionTitle),
-                        diagnostic);
+                        context.Diagnostics);
             }
         }
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/MarkISerializableTypesWithSerializable.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/MarkISerializableTypesWithSerializable.Fixer.cs
@@ -32,12 +32,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return;
             }
 
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftNetCoreAnalyzersResources.AddSerializableAttributeCodeActionTitle;
             context.RegisterCodeFix(new MyCodeAction(title,
                                         async ct => await AddSerializableAttribute(context.Document, node, ct).ConfigureAwait(false),
                                         equivalenceKey: title),
-                                    diagnostic);
+                                    context.Diagnostics);
         }
 
         private static async Task<Document> AddSerializableAttribute(Document document, SyntaxNode node, CancellationToken cancellationToken)

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SerializationRulesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SerializationRulesDiagnosticAnalyzer.cs
@@ -180,7 +180,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         // Look for a serialization constructor.
                         // A serialization constructor takes two params of type SerializationInfo and StreamingContext.
                         IMethodSymbol serializationCtor = namedTypeSymbol.Constructors
-                            .SingleOrDefault(
+                            .FirstOrDefault(
                                 c => c.Parameters.Length == 2 &&
                                      c.Parameters[0].Type.Equals(_serializationInfoTypeSymbol) &&
                                      c.Parameters[1].Type.Equals(_streamingContextTypeSymbol));

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
@@ -86,39 +86,39 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 var stringType = csaContext.Compilation.GetSpecialType(SpecialType.System_String);
                 var stringFormatMembers = stringType?.GetMembers("Format").OfType<IMethodSymbol>();
 
-                var stringFormatMemberWithStringAndObjectParameter = stringFormatMembers.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringFormatMemberWithStringAndObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
                                                                          GetParameterInfo(stringType),
                                                                          GetParameterInfo(objectType));
-                var stringFormatMemberWithStringObjectAndObjectParameter = stringFormatMembers.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringFormatMemberWithStringObjectAndObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
                                                                                GetParameterInfo(stringType),
                                                                                GetParameterInfo(objectType),
                                                                                GetParameterInfo(objectType));
-                var stringFormatMemberWithStringObjectObjectAndObjectParameter = stringFormatMembers.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringFormatMemberWithStringObjectObjectAndObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
                                                                                      GetParameterInfo(stringType),
                                                                                      GetParameterInfo(objectType),
                                                                                      GetParameterInfo(objectType),
                                                                                      GetParameterInfo(objectType));
-                var stringFormatMemberWithStringAndParamsObjectParameter = stringFormatMembers.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringFormatMemberWithStringAndParamsObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
                                                                                GetParameterInfo(stringType),
                                                                                GetParameterInfo(objectType, isArray: true, arrayRank: 1, isParams: true));
-                var stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter = stringFormatMembers.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
                                                                                               GetParameterInfo(iformatProviderType),
                                                                                               GetParameterInfo(stringType),
                                                                                               GetParameterInfo(objectType, isArray: true, arrayRank: 1, isParams: true));
 
-                var currentCultureProperty = cultureInfoType?.GetMembers("CurrentCulture").OfType<IPropertySymbol>().SingleOrDefault();
-                var invariantCultureProperty = cultureInfoType?.GetMembers("InvariantCulture").OfType<IPropertySymbol>().SingleOrDefault();
-                var currentUICultureProperty = cultureInfoType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().SingleOrDefault();
-                var installedUICultureProperty = cultureInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().SingleOrDefault();
+                var currentCultureProperty = cultureInfoType?.GetMembers("CurrentCulture").OfType<IPropertySymbol>().FirstOrDefault();
+                var invariantCultureProperty = cultureInfoType?.GetMembers("InvariantCulture").OfType<IPropertySymbol>().FirstOrDefault();
+                var currentUICultureProperty = cultureInfoType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
+                var installedUICultureProperty = cultureInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
 
                 var threadType = csaContext.Compilation.GetTypeByMetadataName("System.Threading.Thread");
-                var currentThreadCurrentUICultureProperty = threadType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().SingleOrDefault();
+                var currentThreadCurrentUICultureProperty = threadType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
 
                 var activatorType = csaContext.Compilation.GetTypeByMetadataName("System.Activator");
                 var resourceManagerType = csaContext.Compilation.GetTypeByMetadataName("System.Resources.ResourceManager");
 
                 var computerInfoType = csaContext.Compilation.GetTypeByMetadataName("Microsoft.VisualBasic.Devices.ComputerInfo");
-                var installedUICulturePropertyOfComputerInfoType = computerInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().SingleOrDefault();
+                var installedUICulturePropertyOfComputerInfoType = computerInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
 
                 var obsoleteAttributeType = WellKnownTypes.ObsoleteAttribute(csaContext.Compilation);
                 #endregion

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyStringComparison.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyStringComparison.cs
@@ -55,28 +55,28 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 var booleanType = csaContext.Compilation.GetSpecialType(SpecialType.System_Boolean);
                 var integerType = csaContext.Compilation.GetSpecialType(SpecialType.System_Int32);
                 var stringCompareToNamedMethods = stringType.GetMembers("CompareTo").OfType<IMethodSymbol>();
-                var stringCompareToParameterString = stringCompareToNamedMethods.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringCompareToParameterString = stringCompareToNamedMethods.GetFirstOrDefaultMemberWithParameterInfos(
                                                          GetParameterInfo(stringType));
-                var stringCompareToParameterObject = stringCompareToNamedMethods.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringCompareToParameterObject = stringCompareToNamedMethods.GetFirstOrDefaultMemberWithParameterInfos(
                                                          GetParameterInfo(objectType));
 
                 var stringCompareNamedMethods = stringType.GetMembers("Compare").OfType<IMethodSymbol>();
-                var stringCompareParameterStringStringBool = stringCompareNamedMethods.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringCompareParameterStringStringBool = stringCompareNamedMethods.GetFirstOrDefaultMemberWithParameterInfos(
                                                                  GetParameterInfo(stringType),
                                                                  GetParameterInfo(stringType),
                                                                  GetParameterInfo(booleanType));
-                var stringCompareParameterStringStringStringComparison = stringCompareNamedMethods.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringCompareParameterStringStringStringComparison = stringCompareNamedMethods.GetFirstOrDefaultMemberWithParameterInfos(
                                                                              GetParameterInfo(stringType),
                                                                              GetParameterInfo(stringType),
                                                                              GetParameterInfo(stringComparisonType));
-                var stringCompareParameterStringIntStringIntIntBool = stringCompareNamedMethods.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringCompareParameterStringIntStringIntIntBool = stringCompareNamedMethods.GetFirstOrDefaultMemberWithParameterInfos(
                                                                           GetParameterInfo(stringType),
                                                                           GetParameterInfo(integerType),
                                                                           GetParameterInfo(stringType),
                                                                           GetParameterInfo(integerType),
                                                                           GetParameterInfo(integerType),
                                                                           GetParameterInfo(booleanType));
-                var stringCompareParameterStringIntStringIntIntComparison = stringCompareNamedMethods.GetSingleOrDefaultMemberWithParameterInfos(
+                var stringCompareParameterStringIntStringIntIntComparison = stringCompareNamedMethods.GetFirstOrDefaultMemberWithParameterInfos(
                                                                                 GetParameterInfo(stringType),
                                                                                 GetParameterInfo(integerType),
                                                                                 GetParameterInfo(stringType),

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/TestForNaNCorrectly.Fixer.cs
@@ -50,14 +50,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             if (resolution != null)
             {
-                // We cannot have multiple overlapping diagnostics of this id.
-                Diagnostic diagnostic = context.Diagnostics.Single();
-
                 var action = CodeAction.Create(MicrosoftNetCoreAnalyzersResources.TestForNaNCorrectlyMessage,
                     async ct => await ConvertToMethodInvocation(context, resolution).ConfigureAwait(false),
                     equivalenceKey: MicrosoftNetCoreAnalyzersResources.TestForNaNCorrectlyMessage);
 
-                context.RegisterCodeFix(action, diagnostic);
+                context.RegisterCodeFix(action, context.Diagnostics);
             }
         }
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/UseOrdinalStringComparison.Fixer.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/UseOrdinalStringComparison.Fixer.cs
@@ -23,8 +23,6 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             SyntaxNode node = root.FindNode(context.Span);
 
-            // We cannot have multiple overlapping diagnostics of this id.
-            Diagnostic diagnostic = context.Diagnostics.Single();
             string title = MicrosoftNetCoreAnalyzersResources.UseOrdinalStringComparisonTitle;
 
             if (IsInArgumentContext(node))
@@ -34,7 +32,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 context.RegisterCodeFix(new MyCodeAction(title,
                                                          async ct => await FixArgument(context.Document, syntaxGenerator, root, node).ConfigureAwait(false),
                                                          equivalenceKey: title),
-                                                    diagnostic);
+                                        context.Diagnostics);
             }
             else if (IsInIdentifierNameContext(node))
             {
@@ -43,7 +41,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 context.RegisterCodeFix(new MyCodeAction(title,
                                                          async ct => await FixIdentifierName(context.Document, syntaxGenerator, root, node, context.CancellationToken).ConfigureAwait(false),
                                                          equivalenceKey: title),
-                                                    diagnostic);
+                                        context.Diagnostics);
             }
         }
 

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpSpecializedEnumerableCreationAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpSpecializedEnumerableCreationAnalyzer.cs
@@ -82,7 +82,7 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
                     // Check for explicit specification of empty or singleton array
 
                     if (arrayType.RankSpecifiers[0].ChildNodes()
-                        .SingleOrDefault(n => n.Kind() == SyntaxKind.NumericLiteralExpression) is LiteralExpressionSyntax literalRankSpecifier)
+                        .FirstOrDefault(n => n.Kind() == SyntaxKind.NumericLiteralExpression) is LiteralExpressionSyntax literalRankSpecifier)
                     {
                         Debug.Assert(literalRankSpecifier.Token.Value != null);
                         AnalyzeArrayLength((int)literalRankSpecifier.Token.Value, arrayCreationExpression, addDiagnostic);

--- a/src/Roslyn.Diagnostics.Analyzers/VisualBasic/BasicSpecializedEnumerableCreationAnalyzer.vb
+++ b/src/Roslyn.Diagnostics.Analyzers/VisualBasic/BasicSpecializedEnumerableCreationAnalyzer.vb
@@ -82,7 +82,7 @@ Namespace Roslyn.Diagnostics.VisualBasic.Analyzers
 
                     ' Check for explicit specification of empty or singleton array
                     Dim literalRankSpecifier = DirectCast(arrayCreationExpression.RankSpecifiers(0).ChildNodes() _
-                        .SingleOrDefault(Function(n) n.Kind() = SyntaxKind.NumericLiteralExpression),
+                        .FirstOrDefault(Function(n) n.Kind() = SyntaxKind.NumericLiteralExpression),
                         LiteralExpressionSyntax)
 
                     If literalRankSpecifier IsNot Nothing Then

--- a/src/Utilities/Compiler/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
@@ -100,10 +100,10 @@ namespace Analyzer.Utilities.Extensions
         /// <param name="members"></param>
         /// <param name="expectedParameterTypesInOrder"></param>
         /// <returns></returns>
-        public static IMethodSymbol GetSingleOrDefaultMemberWithParameterInfos(this IEnumerable<IMethodSymbol> members, params ParameterInfo[] expectedParameterTypesInOrder)
+        public static IMethodSymbol GetFirstOrDefaultMemberWithParameterInfos(this IEnumerable<IMethodSymbol> members, params ParameterInfo[] expectedParameterTypesInOrder)
         {
             var expectedParameterCount = expectedParameterTypesInOrder.Count();
-            return members?.SingleOrDefault(member =>
+            return members?.FirstOrDefault(member =>
             {
                 if (member.Parameters.Count() != expectedParameterCount)
                 {

--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -150,7 +150,7 @@ namespace Analyzer.Utilities.Extensions
         {
             INamedTypeSymbol constructedInterface = typeArgument != null ? interfaceType?.Construct(typeArgument) : interfaceType;
 
-            return constructedInterface?.GetMembers(interfaceMethodName).Single() is IMethodSymbol interfaceMethod && method.Equals(method.ContainingType.FindImplementationForInterfaceMember(interfaceMethod));
+            return constructedInterface?.GetMembers(interfaceMethodName).FirstOrDefault() is IMethodSymbol interfaceMethod && method.Equals(method.ContainingType.FindImplementationForInterfaceMember(interfaceMethod));
         }
 
         /// <summary>

--- a/src/Utilities/Compiler/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/INamedTypeSymbolExtensions.cs
@@ -279,20 +279,5 @@ namespace Analyzer.Utilities.Extensions
             // from being considered a static holder class.
             return !member.IsStatic && !member.IsDefaultConstructor();
         }
-
-        public static IPropertySymbol GetProperty(this INamedTypeSymbol namedType, string propertyName)
-        {
-            if (namedType == null)
-            {
-                throw new ArgumentNullException(nameof(namedType));
-            }
-
-            if (propertyName == null)
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
-
-            return (IPropertySymbol)namedType.GetMembers(propertyName).Single();
-        }
     }
 }


### PR DESCRIPTION
1. Avoid use of `Single` and `SingleOrDefault` to fetch well-known type member symbols as there can often be multiple ones in code with errors.
2. Avoid use of `Single` on `CodeFixContext.Diagnostics` as there can be multiple overlapping diagnostics in various erroneous conditions. It is always recommended to either iterate all diagnostics in the context or register a single fix with all context diagnostics.

Fixes #2783
Fixes #2784