### PR TITLE
Do not generate AnalysisEntity for invocations

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
@@ -2558,5 +2558,32 @@ public static class C
 }
 ");
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
+        [Fact, WorkItem(2246, "https://github.com/dotnet/roslyn-analyzers/issues/2246")]
+        public void NestedPredicateAnalysisWithDifferentStrings()
+        {
+            VerifyCSharp(@"
+using System;
+
+public static class C
+{
+    private static bool Test(string A, string B, string C, string D)
+    {
+        bool result = false;
+
+        if (string.Compare(A, B, StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            if (string.Compare(C, D, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                result = true;
+            }
+        }
+
+        return result;
+    }
+}
+");
+        }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -9984,7 +9984,9 @@ class A : IDisposable
     {
     }
 }
-");
+",
+            // Test0.cs(20,17): warning CA2000: Call System.IDisposable.Dispose on object created by 'Create()' before all references to it are out of scope.
+            GetCSharpResultAt(20, 17, "Create()"));
         }
 
         [Fact]
@@ -10024,7 +10026,9 @@ class A : IDisposable
     {
     }
 }
-");
+",
+            // Test0.cs(22,17): warning CA2000: Call System.IDisposable.Dispose on object created by 'Create()' before all references to it are out of scope.
+            GetCSharpResultAt(22, 17, "Create()"));
         }
 
         [Fact]
@@ -10058,7 +10062,9 @@ class A : IDisposable
     {
     }
 }
-");
+",
+            // Test0.cs(21,17): warning CA2000: Call System.IDisposable.Dispose on object created by 'new A()' before all references to it are out of scope.
+            GetCSharpResultAt(21, 17, "new A()"));
         }
 
         [Fact]
@@ -11028,6 +11034,48 @@ Class Test
         a.Dispose()
     End Sub
 End Class", GetEditorConfigAdditionalFile(editorConfigText), expected);
+        }
+
+        [Fact]
+        [WorkItem(2746, "https://github.com/dotnet/roslyn-analyzers/issues/2746#issuecomment-518959894")]
+        public void DisposableObject_ReturnOperationWithInvocation_NotDisposed_Diagnostic()
+        {
+            VerifyCSharp(@"
+using System;
+
+public interface IMyDisposable : IDisposable
+{
+    bool IsItFalse();
+}
+
+public class MyDisposable : IMyDisposable
+{
+    public void Dispose()
+    {
+        return;
+    }
+
+    public bool IsItFalse()
+    {
+        return false;
+    }
+}
+
+public class Consumer
+{
+    public IMyDisposable CreateMyDisposable()
+    {
+        return new MyDisposable();
+    }
+
+    public bool Foo()
+    {
+        var myDisposable = CreateMyDisposable();
+        return myDisposable.IsItFalse();
+    }
+}",
+            // Test0.cs(31,28): warning CA2000: Call System.IDisposable.Dispose on object created by 'CreateMyDisposable()' before all references to it are out of scope.
+            GetCSharpResultAt(31, 28, "CreateMyDisposable()"));
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -188,11 +188,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     }
                     break;
 
-                case IInvocationOperation invocation:
-                    symbolOpt = invocation.TargetMethod;
-                    instanceOpt = invocation.Instance;
-                    break;
-
                 case IConversionOperation conversion:
                     return TryCreate(conversion.Operand, out analysisEntity);
 


### PR DESCRIPTION
We generate PointsToValue for the object returned by invocations, but were incorrectly generating an analysis entity for invocations.

Fixes a bunch of false positives from value content analysis and also false negatives from return operations that have an invocation.

Fixes #2246
Addresses https://github.com/dotnet/roslyn-analyzers/issues/2746#issuecomment-518959894