### PR TITLE
Fix the license tag generation in our NuGet packages.

### DIFF
--- a/eng/GenerateAnalyzerNuspec.csx
+++ b/eng/GenerateAnalyzerNuspec.csx
@@ -38,6 +38,7 @@ foreach (string entry in metadataList)
         case "repositoryType": repositoryType = value; continue;
         case "repositoryUrl": repositoryUrl = value; continue;
         case "repositoryCommit": repositoryCommit = value; continue;
+		case "license": result.AppendLine($"    <license type=\"expression\">{value}</license>"); continue;
     }
     
     if (value != "")

--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -17,6 +17,7 @@
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <PackageLicenseExpression Condition="'$(PackageLicenseExpression)' == ''">Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <Target Name="GenerateAnalyzerRulesets"
@@ -73,7 +74,7 @@
       <_NuspecMetadata Include="requireLicenseAcceptance=$(PackageRequireLicenseAcceptance)" />
       <_NuspecMetadata Include="description=$(Description)" />
       <_NuspecMetadata Include="copyright=$(Copyright)" />
-      <_NuspecMetadata Include="licenseUrl=$(PackageLicenseUrl)" />
+      <_NuspecMetadata Include="license=$(PackageLicenseExpression)" />
       <_NuspecMetadata Include="projectUrl=$(PackageProjectUrl)" />
       <_NuspecMetadata Include="iconUrl=$(PackageIconUrl)" />
       <_NuspecMetadata Include="releaseNotes=$(PackageReleaseNotes)" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.1.401",
+    "dotnet": "2.1.503",
     "vswhere": "2.2.7"
   },
   "msbuild-sdks": {

--- a/nuget/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.Package.csproj
+++ b/nuget/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.Package.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecPackageId>Microsoft.CodeAnalysis.Analyzers</NuspecPackageId>
-    <Description>Guidelines for using .NET Compiler Platform ("Roslyn") APIs.</Description>
+    <Description>Analyzers for consumers of "Microsoft.CodeAnalysis" NuGet package, i.e. extensions and applications built on top of .NET Compiler Platform ("Roslyn"). This package is included as a development dependency of "Microsoft.CodeAnalysis" NuGet package and does not need to be installed separately if you are referencing "Microsoft.CodeAnalysis" NuGet package.</Description>
     <Summary>Analyzers for .NET Compiler Platform ("Roslyn")</Summary>
     <ReleaseNotes>Diagnostic analyzers for the Microsoft .NET Compiler Platform (Roslyn)</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>

--- a/nuget/Microsoft.CodeAnalysis.FxCopAnalyzers/Microsoft.CodeAnalysis.FxCopAnalyzers.Package.csproj
+++ b/nuget/Microsoft.CodeAnalysis.FxCopAnalyzers/Microsoft.CodeAnalysis.FxCopAnalyzers.Package.csproj
@@ -6,7 +6,7 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecPackageId>Microsoft.CodeAnalysis.FxCopAnalyzers</NuspecPackageId>
-    <Description>Microsoft FxCop rules implemented as analyzers using the .NET Compiler Platform ("Roslyn").</Description>
+    <Description>Microsoft recommended code quality rules and .NET API usage rules, including the most important "FxCop" rules, implemented as analyzers using the .NET Compiler Platform ("Roslyn"). These analyzers check your code for security, performance, and design issues, among others. The documentation for FxCop analyzers can be found at https://docs.microsoft.com/visualstudio/code-quality/install-fxcop-analyzers</Description>
     <Summary>Microsoft FxCop Analyzers</Summary>
     <ReleaseNotes>Microsoft FxCop rules implemented as analyzers using the .NET Compiler Platform ("Roslyn").</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>

--- a/nuget/Microsoft.CodeQuality.Analyzers/Microsoft.CodeQuality.Analyzers.Package.csproj
+++ b/nuget/Microsoft.CodeQuality.Analyzers/Microsoft.CodeQuality.Analyzers.Package.csproj
@@ -6,7 +6,7 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecPackageId>Microsoft.CodeQuality.Analyzers</NuspecPackageId>
-    <Description>CodeQuality Analyzers</Description>
+    <Description>Microsoft recommended code quality rules implemented as analyzers using the .NET Compiler Platform ("Roslyn"). This package is included as a part of "Microsoft.CodeAnalysis.FxCopAnalyzers" NuGet package and does not need to be installed separately.</Description>
     <Summary>Microsoft.CodeQuality Analyzers</Summary>
     <ReleaseNotes>Diagnostic analyzers for the Microsoft .NET Compiler Platform (Roslyn)</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>

--- a/nuget/Microsoft.NetCore.Analyzers/Microsoft.NetCore.Analyzers.Package.csproj
+++ b/nuget/Microsoft.NetCore.Analyzers/Microsoft.NetCore.Analyzers.Package.csproj
@@ -6,7 +6,7 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecPackageId>Microsoft.NetCore.Analyzers</NuspecPackageId>
-    <Description>Analyzers for .NetCore APIs</Description>
+    <Description>Microsoft recommended .NetCore API usage rules implemented as analyzers using the .NET Compiler Platform ("Roslyn"). This package is included as a part of "Microsoft.CodeAnalysis.FxCopAnalyzers" NuGet package and does not need to be installed separately.</Description>
     <Summary>Microsoft .NetCore API Analyzers</Summary>
     <ReleaseNotes>Microsoft .NetCore API Analyzers</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>

--- a/nuget/Microsoft.NetFramework.Analyzers/Microsoft.NetFramework.Analyzers.Package.csproj
+++ b/nuget/Microsoft.NetFramework.Analyzers/Microsoft.NetFramework.Analyzers.Package.csproj
@@ -6,7 +6,7 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecPackageId>Microsoft.NetFramework.Analyzers</NuspecPackageId>
-    <Description>Analyzers for APIs specific to the full .NetFramework which are not present in .NetCore.</Description>
+    <Description>Microsoft recommended API usage rules for APIs specific to the full .NetFramework which are not present in .NetCore, implemented as analyzers using the .NET Compiler Platform ("Roslyn"). This package is included as a part of "Microsoft.CodeAnalysis.FxCopAnalyzers" NuGet package and does not need to be installed separately.</Description>
     <Summary>Microsoft.NetFramework.Analyzers</Summary>
     <ReleaseNotes>Microsoft.NetFramework.Analyzers</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>

--- a/nuget/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.Package.csproj
+++ b/nuget/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.Package.csproj
@@ -6,7 +6,7 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecPackageId>Roslyn.Diagnostics.Analyzers</NuspecPackageId>
-    <Description>Roslyn.Diagnostics Analyzers</Description>
+    <Description>Private analyzers specific to Roslyn repo. These analyzers are not intended for public consumptions outside of the Roslyn repo.</Description>
     <Summary>Roslyn.Diagnostics Analyzers</Summary>
     <ReleaseNotes>Roslyn.Diagnostics Analyzers</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>


### PR DESCRIPTION
Fixes #2220

Also update the Description field for our important analyzer NuGet packages to be more informative.
Fixes #2024