### PR TITLE
Fix a false positive from CA1721 (PropertyNamesShouldNotMatchGetMethods)

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
@@ -88,6 +88,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         continue;
                     }
 
+                    // Ignore members whose IsStatic does not match with the symbol's IsStatic
+                    if (symbol.IsStatic != member.IsStatic)
+                    {
+                        continue;
+                    }
+
                     // If the declared type is a property, was a matching method found?
                     if (symbol.Kind == SymbolKind.Property && member.Kind == SymbolKind.Method)
                     {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
@@ -341,6 +341,41 @@ Class C
 End Class");
         }
 
+        [Fact, WorkItem(2085, "https://github.com/dotnet/roslyn-analyzers/issues/2085")]
+        public void CA1721_StaticAndInstanceMismatchNoDiagnostic()
+        {
+            VerifyCSharp(@"
+public class C1
+{
+    public int Value { get; }
+    public static int GetValue(int i) => i;
+}
+
+public class C2
+{
+    public static int Value { get; }
+    public int GetValue(int i) => i;
+}
+");
+
+            VerifyBasic(@"
+Public Class C1
+    Public ReadOnly Property Value As Integer
+
+    Public Shared Function GetValue(i As Integer) As Integer
+        Return i
+    End Function
+End Class
+
+Public Class C2
+    Public Shared ReadOnly Property Value As Integer
+
+    Public Function GetValue(i As Integer) As Integer
+        Return i
+    End Function
+End Class");
+        }
+
         #region Helpers
 
         private static DiagnosticResult GetCA1721CSharpResultAt(int line, int column, string identifierName, string otherIdentifierName)


### PR DESCRIPTION
Do not flag property/method pairs whose `IsStatic` value differs. There are few real world code bases (including Roslyn) where such an API pair is completely reasonable.

Fixes #2085