### PR TITLE
Fix an indeterministic test failure

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotHardCodeEncryptionKeyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotHardCodeEncryptionKeyTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
@@ -272,7 +273,9 @@ class TestClass
         [Fact]
         public void Test_PassTaintedSourceInfoAsParameter_SinkProperties_Interprocedual_Diagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            Parallel.For(1, 100, _ =>
+            {
+                VerifyCSharpWithDependencies(@"
 using System;
 using System.Security.Cryptography;
 
@@ -290,7 +293,8 @@ class TestClass
         rijn.Key = rgbKey;
     }
 }",
-            GetCSharpResultAt(16, 9, 9, 22, "byte[] SymmetricAlgorithm.Key", "void TestClass.CreateEncryptor(byte[] rgbKey)", "byte[] Convert.FromBase64String(string s)", "void TestClass.TestMethod()"));
+                GetCSharpResultAt(16, 9, 9, 22, "byte[] SymmetricAlgorithm.Key", "void TestClass.CreateEncryptor(byte[] rgbKey)", "byte[] Convert.FromBase64String(string s)", "void TestClass.TestMethod()"));
+            });
         }
 
         [Fact]

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
@@ -49,6 +49,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Debug.Assert(Equals(owningSymbol.OriginalDefinition, owningSymbol));
             Debug.Assert(wellKnownTypeProvider != null);
             Debug.Assert(tryGetOrComputeAnalysisResult != null);
+            Debug.Assert(pointsToAnalysisResultOpt == null ||
+                pointsToAnalysisResultOpt.ControlFlowGraph == controlFlowGraph);
+            Debug.Assert(copyAnalysisResultOpt == null ||
+                copyAnalysisResultOpt.ControlFlowGraph == controlFlowGraph);
+            Debug.Assert(valueContentAnalysisResultOpt == null ||
+                valueContentAnalysisResultOpt.ControlFlowGraph == controlFlowGraph);
 
             ValueDomain = valueDomain;
             WellKnownTypeProvider = wellKnownTypeProvider;
@@ -154,7 +160,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         {
             addPart(ValueDomain.GetHashCode());
             addPart(OwningSymbol.GetHashCode());
-            addPart(ControlFlowGraph.OriginalOperation.GetHashCode());
+            addPart(ControlFlowGraph.GetHashCode());
             addPart(AnalyzerOptions.GetHashCode());
             addPart(InterproceduralAnalysisConfiguration.GetHashCode());
             addPart(PessimisticAnalysis.GetHashCode());


### PR DESCRIPTION
AbstractDataFlowAnalysisContext hash code computation did not account for the whole CFG, just the original operation of the CFG. This bug was masked by our prior CWT based caching/leak that ensured that the static cache on IOperationExtensions from IOperation to CFG always returned the same CFG. With the new BoundedCache approach, it is more likely for the cache entries to get evicted under high memory pressure and multiple simultaneous compilations, which makes this failure lot more prominent, even though non-deterministic.

Unit test `Test_PassTaintedSourceInfoAsParameter_SinkProperties_Interprocedual_Diagnostic` fails intermittently prior to this fix. I updated the test to execute multiple instances in parallel and it fails consistently prior to the fix. It passed consistently multiple times after this fix.