### PR TITLE
Remove rule condition based on user region

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
@@ -93,13 +92,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            if (!CultureInfo.CurrentCulture.Name.Equals("en", StringComparison.Ordinal) &&
-                !CultureInfo.CurrentCulture.Parent.Name.Equals("en", StringComparison.Ordinal))
-            {
-                // FxCop compat: Skip for non-English cultures.
-                return;
-            }
-
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Globalization;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -522,6 +523,45 @@ End Class
                             M3 = 2
                         End Enum
                         End Class");
+        }
+
+        [Theory, WorkItem(2229, "https://github.com/dotnet/roslyn-analyzers/issues/2229")]
+        [InlineData("en-US")]
+        [InlineData("es-ES")]
+        [InlineData("pl-PL")]
+        [InlineData("fi-FI")]
+        [InlineData("de-DE")]
+        public void CA1714_CA1717__Test_EnumWithNoFlags_PluralName_MultipleCultures(string culture)
+        {
+            var currentCulture = CultureInfo.DefaultThreadCurrentCulture;
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.GetCultureInfo(culture);
+
+            VerifyCSharp(@" 
+                            public class A 
+                            { 
+                               public enum Days 
+                                {
+                                    sunday = 0,
+                                    Monday = 1,
+                                    Tuesday = 2
+                                       
+                                };
+                            }",
+                            GetCSharpNoPluralResultAt(4, 44));
+
+            VerifyBasic(@"
+                        Public Class A
+	                        Public Enum Days
+		                           Sunday = 0
+		                           Monday = 1
+		                           Tuesday = 2
+
+	                        End Enum
+                        End Class
+                        ",
+                        GetBasicNoPluralResultAt(3, 38));
+
+            CultureInfo.DefaultThreadCurrentCulture = currentCulture;
         }
 
         private static DiagnosticResult GetCSharpPluralResultAt(int line, int column)


### PR DESCRIPTION
As commented by @hubuk in https://github.com/dotnet/roslyn-analyzers/issues/2229 having a rule that only applies on some regions causes a false impression that code is OK when it isn't and it is really hard to diagnose, apart that there is no documentation about it.

When having a distributed development team between different regions in the world there is no any reason to have different compiling rules. The same behavior should exist in every PC compiling the code.