### PR TITLE
Fix couple of CA2000 false positives

### DIFF
--- a/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.FlowAnalysis.Utilities/PublicAPI.Unshipped.txt
@@ -367,6 +367,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.GenericIEquat
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.GenericTask.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.IDisposable.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.Monitor.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.Interlocked.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.SerializationInfo.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.Task.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.WellKnownTypeProvider.TryGetTypeByMetadataName(string fullTypeName, out Microsoft.CodeAnalysis.INamedTypeSymbol namedTypeSymbol) -> bool

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -11077,5 +11077,79 @@ public class Consumer
             // Test0.cs(31,28): warning CA2000: Call System.IDisposable.Dispose on object created by 'CreateMyDisposable()' before all references to it are out of scope.
             GetCSharpResultAt(31, 28, "CreateMyDisposable()"));
         }
+
+        [Fact]
+        [WorkItem(2746, "https://github.com/dotnet/roslyn-analyzers/issues/2746")]
+        public void DisposableObject_FieldAsOutArgument_NotDisposed_NoDiagnostic()
+        {
+            var editorConfigFile = GetEditorConfigFileToDisableInterproceduralAnalysis(DisposeAnalysisKind.AllPaths);
+
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+
+class B : IDisposable
+{
+    private A _a;
+    public bool Flag;
+    public void M()
+    {
+        TryCreate(out _a);
+    }
+
+    private void TryCreate(out A a)
+    {
+        a = Flag ? new A() : null;
+    }
+
+    public void Dispose()
+    {
+        _a?.Dispose();
+    }
+}", editorConfigFile);
+        }
+
+        [Fact]
+        [WorkItem(2746, "https://github.com/dotnet/roslyn-analyzers/issues/2746")]
+        public void DisposableObject_FieldAsRefArgument_NotDisposed_NoDiagnostic()
+        {
+            var editorConfigFile = GetEditorConfigFileToDisableInterproceduralAnalysis(DisposeAnalysisKind.AllPaths);
+
+            VerifyCSharp(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+
+class B : IDisposable
+{
+    private A _a;
+    public bool Flag;
+    public void M()
+    {
+        TryCreate(ref _a);
+    }
+
+    private void TryCreate(ref A a)
+    {
+        a = Flag ? new A() : null;
+    }
+
+    public void Dispose()
+    {
+        _a?.Dispose();
+    }
+}", editorConfigFile);
+        }
     }
 }

--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using System.Diagnostics;
 
 #if HAS_IOPERATION
 using System.Collections.Concurrent;
@@ -515,6 +516,33 @@ namespace Analyzer.Utilities.Extensions
                    method.ReturnsVoid &&
                    method.Parameters.Length >= 1 &&
                    method.Parameters[0].Type.SpecialType == SpecialType.System_Object;
+        }
+
+
+        public static bool IsInterlockedExchangeMethod(this IMethodSymbol method, INamedTypeSymbol systemThreadingInterlocked)
+        {
+            Debug.Assert(method.ContainingType.OriginalDefinition.Equals(systemThreadingInterlocked));
+
+            // "System.Threading.Interlocked.Exchange(ref T, T)"
+            return method.Name == "Exchange" &&
+                   method.Parameters.Length == 2 &&
+                   method.Parameters[0].RefKind == RefKind.Ref &&
+                   method.Parameters[1].RefKind != RefKind.Ref &&
+                   method.Parameters[0].Type.Equals(method.Parameters[1].Type);
+        }
+
+        public static bool IsInterlockedCompareExchangeMethod(this IMethodSymbol method, INamedTypeSymbol systemThreadingInterlocked)
+        {
+            Debug.Assert(method.ContainingType.OriginalDefinition.Equals(systemThreadingInterlocked));
+
+            // "System.Threading.Interlocked.CompareExchange(ref T, T, T)"
+            return method.Name == "CompareExchange" &&
+                   method.Parameters.Length == 3 &&
+                   method.Parameters[0].RefKind == RefKind.Ref &&
+                   method.Parameters[1].RefKind != RefKind.Ref &&
+                   method.Parameters[2].RefKind != RefKind.Ref &&
+                   method.Parameters[0].Type.Equals(method.Parameters[1].Type) &&
+                   method.Parameters[1].Type.Equals(method.Parameters[2].Type);
         }
 
         public static bool HasParameterWithDelegateType(this IMethodSymbol methodSymbol)

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -346,5 +346,6 @@ namespace Analyzer.Utilities
         public const string SystemRandom = "System.Random";
         public const string SystemSecurityAuthenticationSslProtocols = "System.Security.Authentication.SslProtocols";
         public const string MicrosoftAspNetCoreRazorHostingRazorCompiledItemAttribute = "Microsoft.AspNetCore.Razor.Hosting.RazorCompiledItemAttribute";
+        public const string SystemThreadingInterlocked = "System.Threading.Interlocked";
     }
 }

--- a/src/Utilities/Compiler/WellKnownTypeProvider.cs
+++ b/src/Utilities/Compiler/WellKnownTypeProvider.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Contract = GetTypeByMetadataName(WellKnownTypeNames.SystemDiagnosticContractsContract);
             IDisposable = GetTypeByMetadataName(WellKnownTypeNames.SystemIDisposable);
             Monitor = GetTypeByMetadataName(WellKnownTypeNames.SystemThreadingMonitor);
+            Interlocked = GetTypeByMetadataName(WellKnownTypeNames.SystemThreadingInterlocked);
             Task = GetTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask);
             GenericTask = GetTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksGenericTask);
             CollectionTypes = GetWellKnownCollectionTypes();
@@ -72,6 +73,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         /// <see cref="INamedTypeSymbol"/> for <see cref="System.Threading.Monitor"/>
         /// </summary>
         public INamedTypeSymbol Monitor { get; }
+
+        /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for <see cref="System.Threading.Interlocked"/>
+        /// </summary>
+        public INamedTypeSymbol Interlocked { get; }
 
         /// <summary>
         /// <see cref="INamedTypeSymbol"/> for 'System.Runtime.Serialization.SerializationInfo' type />

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -338,6 +338,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
                     {
                         var pointsToValue = GetPointsToAbstractValue(operation.Value);
                         HandlePossibleEscapingOperation(operation, pointsToValue.Locations);
+                        return;
                     }
                     else if (FlowBranchConditionKind == ControlFlowConditionKind.WhenFalse &&
                         operation.Parameter.RefKind == RefKind.Out &&
@@ -362,9 +363,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
                         //      obj.Dispose();
 
                         HandlePossibleInvalidatingOperation(operation);
+                        return;
                     }
                 }
-                else if (operation.Parameter.RefKind == RefKind.Out || operation.Parameter.RefKind == RefKind.Ref)
+
+                // Ref or out argument values from callee might be escaped by assigning to field.
+                if (operation.Parameter.RefKind == RefKind.Out || operation.Parameter.RefKind == RefKind.Ref)
                 {
                     HandlePossibleEscapingOperation(operation, GetEscapedLocations(operation));
                 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -328,10 +328,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                         }
                     }
                 }
-                else if (operation.Parameter.RefKind == RefKind.Ref)
+                else if (operation.Parameter.RefKind == RefKind.Ref || operation.Parameter.RefKind == RefKind.Out)
                 {
-                    // By-ref argument is considered escaped in non-interprocedural analysis case.
-                    HandleEscapingOperation(operation, operation.Value);
+                    if (operation.Parameter.RefKind == RefKind.Ref)
+                    {
+                        // Input by-ref argument passed to invoked method is considered escaped in non-interprocedural analysis case.
+                        HandleEscapingOperation(operation, operation.Value);
+                    }
+
+                    // Output by-ref or out argument might be escaped if assigned to a field.
+                    HandlePossibleEscapingForAssignment(target: operation.Value, value: operation, operation: operation);
                 }
             }
 


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn-analyzers/commit/a36d5ac16ff4e9a0ae295e1767a864378fea79cd: Fix CA2000 false positive from assigning to a field via an out argument. Fixes #2746
2. https://github.com/dotnet/roslyn-analyzers/commit/40e5146ec45013c2dc169730392edf0d9532c332: Handle Interlocked.Exchange and Interlocked.CompareExchange operations. Fixes #2681