### PR TITLE
Embed analyzer configuration file in the analyzer NuGet packages

### DIFF
--- a/eng/GenerateAnalyzerNuspec.csx
+++ b/eng/GenerateAnalyzerNuspec.csx
@@ -16,6 +16,8 @@ var analyzerDocumentationFileDir = Args[14];
 var analyzerDocumentationFileName = Args[15];
 var analyzerSarifFileDir = Args[16];
 var analyzerSarifFileName = Args[17];
+var analyzerConfigurationFileDir = Args[18];
+var analyzerConfigurationFileName = Args[19];
 
 var result = new StringBuilder();
 
@@ -197,6 +199,15 @@ if (analyzerDocumentationFileDir.Length > 0 && Directory.Exists(analyzerDocument
 if (analyzerSarifFileDir.Length > 0 && Directory.Exists(analyzerSarifFileDir) && analyzerSarifFileName.Length > 0)
 {
     var fileWithPath = Path.Combine(analyzerSarifFileDir, analyzerSarifFileName);
+    if (File.Exists(fileWithPath))
+    {
+        result.AppendLine(FileElement(fileWithPath, "documentation"));
+    }
+}
+
+if (analyzerConfigurationFileDir.Length > 0 && Directory.Exists(analyzerConfigurationFileDir) && analyzerConfigurationFileName.Length > 0)
+{
+    var fileWithPath = Path.Combine(analyzerConfigurationFileDir, analyzerConfigurationFileName);
     if (File.Exists(fileWithPath))
     {
         result.AppendLine(FileElement(fileWithPath, "documentation"));

--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -31,6 +31,7 @@
       <DevelopmentDependency Condition="'@(AnalyzerNupkgAssembly)' != '' or '@(AnalyzerNupkgDependency)' != ''">true</DevelopmentDependency>
       <GenerateAnalyzerMdFile Condition="'$(GenerateAnalyzerMdFile)' == ''">true</GenerateAnalyzerMdFile>
       <GenerateAnalyzerSarifFile Condition="'$(GenerateAnalyzerSarifFile)' == ''">true</GenerateAnalyzerSarifFile>
+      <GenerateAnalyzerConfigurationFile Condition="'$(GenerateAnalyzerConfigurationFile)' == ''">true</GenerateAnalyzerConfigurationFile>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(GeneratePackagePropsFile)' == 'true'">
@@ -49,6 +50,11 @@
     <PropertyGroup Condition="'$(GenerateAnalyzerSarifFile)' == 'true'">
       <AnalyzerSarifFileDir Condition="'$(AnalyzerSarifFileDir)' == ''">$(RepoRoot)src\$(NuspecPackageId)</AnalyzerSarifFileDir>
       <AnalyzerSarifFileName>$(NuspecPackageId).sarif</AnalyzerSarifFileName>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="'$(GenerateAnalyzerConfigurationFile)' == 'true'">
+      <AnalyzerConfigurationFileDir>$(RepoRoot)docs</AnalyzerConfigurationFileDir>
+      <AnalyzerConfigurationFileName>Analyzer Configuration.md</AnalyzerConfigurationFileName>
     </PropertyGroup>
     
     <MSBuild Projects="$(RepoRoot)src\GenerateAnalyzerRulesets\GenerateAnalyzerRulesets.csproj" Targets="Build">
@@ -93,6 +99,6 @@
       <_CscToolPath Condition="!HasTrailingSlash('$(_CscToolPath)')">$(_CscToolPath)\</_CscToolPath>
     </PropertyGroup>
 
-    <Exec Command='"$(_CscToolPath)csi.exe" "$(RepoRoot)eng\GenerateAnalyzerNuspec.csx" "$(NuspecFile)" "$(AssetsDir)\" "$(MSBuildProjectDirectory)" "$(Configuration)" "$(TargetFramework)" "@(_NuspecMetadata)" "@(AnalyzerNupkgFile)" "@(AnalyzerNupkgFolder)" "@(AnalyzerNupkgAssembly)" "@(AnalyzerNupkgDependency)" "@(AnalyzerNupkgLibrary)" "$(_GeneratedRulesetsDir)" "@(AnalyzerLegacyRuleset)" "$(ArtifactsBinDir)\" "$(AnalyzerDocumentationFileDir)" "$(AnalyzerDocumentationFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerSarifFileName)"' />
+    <Exec Command='"$(_CscToolPath)csi.exe" "$(RepoRoot)eng\GenerateAnalyzerNuspec.csx" "$(NuspecFile)" "$(AssetsDir)\" "$(MSBuildProjectDirectory)" "$(Configuration)" "$(TargetFramework)" "@(_NuspecMetadata)" "@(AnalyzerNupkgFile)" "@(AnalyzerNupkgFolder)" "@(AnalyzerNupkgAssembly)" "@(AnalyzerNupkgDependency)" "@(AnalyzerNupkgLibrary)" "$(_GeneratedRulesetsDir)" "@(AnalyzerLegacyRuleset)" "$(ArtifactsBinDir)\" "$(AnalyzerDocumentationFileDir)" "$(AnalyzerDocumentationFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerSarifFileName)" "$(AnalyzerConfigurationFileDir)" "$(AnalyzerConfigurationFileName)"' />
   </Target>
 </Project>


### PR DESCRIPTION
Given the number of new configuration options being requested and added, this would help easy mapping of configuration options available in each package.

![image](https://user-images.githubusercontent.com/10605811/64385092-0898b300-cfeb-11e9-8de7-9f1b1ea35840.png)

I will file a follow-up docs bug to update https://docs.microsoft.com/en-us/visualstudio/code-quality/fxcop-analyzer-options?view=vs-2019 to mention this.