### PR TITLE
Fixing an InvalidCastException

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureSettingsForJsonNetTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureSettingsForJsonNetTests.cs
@@ -369,6 +369,55 @@ End Class
         }
 
         [Fact]
+        public void Field_Interprocedural_NoDiagnostic()
+        {
+            this.VerifyCSharpWithJsonNet(@"
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+class Blah
+{
+    public class BookRecordSerializationBinder : ISerializationBinder
+    {
+        // To maintain backwards compatibility with serialized data before using an ISerializationBinder.
+        private static readonly DefaultSerializationBinder Binder = new DefaultSerializationBinder();
+
+        public BookRecordSerializationBinder()
+        {
+        }
+
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            Binder.BindToName(serializedType, out assemblyName, out typeName);
+        }
+
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            // If the type isn't expected, then stop deserialization.
+            if (typeName != ""BookRecord"" && typeName != ""AisleLocation"" && typeName != ""WarehouseLocation"")
+            {
+                return null;
+            }
+
+            return Binder.BindToType(assemblyName, typeName);
+        }
+    }
+
+    private static ISerializationBinder GetSerializationBinder()
+    {
+        return new BookRecordSerializationBinder();
+    }
+
+    protected static readonly JsonSerializerSettings Settings = new JsonSerializerSettings()
+    {
+        SerializationBinder = GetSerializationBinder(),
+    };
+}
+");
+        }
+
+        [Fact]
         public void Secure_SometimesInitialization_NoDiagnostic()
         {
             this.VerifyCSharpWithJsonNet(@"

--- a/src/Test.Utilities/DiagnosticExtensions.cs
+++ b/src/Test.Utilities/DiagnosticExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -11,9 +12,6 @@ namespace Test.Utilities
 {
     public static class DiagnosticExtensions
     {
-        private static void OnAnalyzerException(Exception exception, DiagnosticAnalyzer analyzer, Diagnostic diagnostic)
-            => Environment.FailFast(exception.ToString(), exception);
-
         public static ImmutableArray<Diagnostic> GetAnalyzerDiagnostics<TCompilation>(
             this TCompilation c,
             DiagnosticAnalyzer[] analyzers,
@@ -21,8 +19,7 @@ namespace Test.Utilities
             AnalyzerOptions options = null)
             where TCompilation : Compilation
         {
-            var compilationWithAnalyzerOptions = new CompilationWithAnalyzersOptions(options, OnAnalyzerException, concurrentAnalysis: c.Options.ConcurrentBuild, logAnalyzerExecutionTime: false);
-            var compilationWithAnalyzers = c.WithAnalyzers(analyzers.ToImmutableArray(), compilationWithAnalyzerOptions);
+            var compilationWithAnalyzers = c.WithAnalyzers(analyzers.ToImmutableArray(), options, CancellationToken.None);
             var diagnostics = c.GetDiagnostics();
             if (validationMode != TestValidationMode.AllowCompileErrors)
             {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -1969,7 +1969,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
 
             // Check if we are already at the maximum allowed interprocedural call chain length.
-            int currentMethodCallCount = currentMethodsBeingAnalyzed.Where(m => !((IMethodSymbol)m.OwningSymbol).IsLambdaOrLocalFunctionOrDelegate()).Count();
+            int currentMethodCallCount = currentMethodsBeingAnalyzed.Where(m => !(m.OwningSymbol is IMethodSymbol ms && ms.IsLambdaOrLocalFunctionOrDelegate())).Count();
             int currentLambdaOrLocalFunctionCallCount = currentMethodsBeingAnalyzed.Count - currentMethodCallCount;
 
             if (currentMethodCallCount >= MaxInterproceduralMethodCallChain ||


### PR DESCRIPTION
error AD0001: Analyzer 'Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureSettingsForJsonNet' threw an exception of type 'System.InvalidCastException' with message 'Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberFieldSymbolFromDeclarator' to type 'Microsoft.CodeAnalysis.IMethodSymbol'.'.