### PR TITLE
ReleaseNoteUtil: Ignore CodeFixProviders with no-op RegisterCodeFixesAsync() methods

### DIFF
--- a/src/ReleaseNotesUtil/Program.cs
+++ b/src/ReleaseNotesUtil/Program.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Json;
@@ -51,6 +52,7 @@ namespace ReleaseNotesUtil
             IEnumerable<string> dllPaths = GetFxCopAnalyzerBinaries(nugetInstalledPackagesPath, version);
             RuleFileContent ruleFileContent = new RuleFileContent();
             ruleFileContent.Rules = GetRules(dllPaths);
+            ruleFileContent.Rules.Sort(CategoryThenIdComparer.Instance);
             WriteRuleFileContent(ruleFileContent, outputPath);
         }
 

--- a/src/ReleaseNotesUtil/Program.cs
+++ b/src/ReleaseNotesUtil/Program.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Json;


### PR DESCRIPTION
In another PR, we can consolidate FixerExtensions.cs implementations, and make sure GenerateAnalyzerRulesets works (I seem to be getting different results between ReleaseNotesUtil and GenerateAnalyzerRulesets even before this change).