### PR TITLE
Add assert for required parameter 'valueDomain'

### DIFF
--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractDataFlowAnalysisContext.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             InterproceduralAnalysisData<TAnalysisData, TAnalysisContext, TAbstractAnalysisValue> interproceduralAnalysisDataOpt,
             InterproceduralAnalysisPredicate interproceduralAnalysisPredicateOpt)
         {
+            Debug.Assert(valueDomain != null, "valueDomain must not be null for use in ComputeHashCodeParts");
             Debug.Assert(controlFlowGraph != null);
             Debug.Assert(owningSymbol != null);
             Debug.Assert(owningSymbol.Kind == SymbolKind.Method ||


### PR DESCRIPTION
The parameter 'valueDomain' is optional in the constructor of `AbstractDataFlowAnalysisContext` and must not be null in `ComputeHashCodeParts` which looks like a NR exception waiting to happen.