### PR TITLE
Fixing tainted data analyzers performance regression

### DIFF
--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -74,7 +74,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                                 (methodName, argumets) => methodName == o,
                                 ImmutableHashSet<(PointsToCheck, string)>.Empty.Add(
                                     (
-                                        pointsTos => true,
+                                        SourceInfo.AlwaysTruePointsToCheck,
                                         TaintedTargetValue.Return
                                     ))
                             ))
@@ -149,13 +149,13 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// Add SourceInfos which needs PointsToAnalysis checks or ValueContentAnalysis checks and each check taints return value by default.
         /// </summary>
         public static void AddSourceInfo(
-        this PooledHashSet<SourceInfo> builder,
-        string fullTypeName,
-        bool isInterface,
-        string[] taintedProperties,
-        IEnumerable<(MethodMatcher methodMatcher, PointsToCheck[] pointsToChecks)> taintedMethodsNeedsPointsToAnalysis,
-        IEnumerable<(MethodMatcher methodMatcher, ValueContentCheck[] valueContentChecks)> taintedMethodsNeedsValueContentAnalysis,
-        bool taintConstantArray = false)
+            this PooledHashSet<SourceInfo> builder,
+            string fullTypeName,
+            bool isInterface,
+            string[] taintedProperties,
+            IEnumerable<(MethodMatcher methodMatcher, PointsToCheck[] pointsToChecks)> taintedMethodsNeedsPointsToAnalysis,
+            IEnumerable<(MethodMatcher methodMatcher, ValueContentCheck[] valueContentChecks)> taintedMethodsNeedsValueContentAnalysis,
+            bool taintConstantArray = false)
         {
             SourceInfo metadata = new SourceInfo(
                 fullTypeName,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
@@ -17,6 +17,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
     /// </summary>
     internal class SourceInfo : ITaintedDataInfo, IEquatable<SourceInfo>
     {
+        // TODO: This is just a quick fix for a performance regression.  Perhaps we should have a dedicated collection
+        // of methods which are always tainted.
+        public static readonly PointsToCheck AlwaysTruePointsToCheck = (ImmutableArray<PointsToAbstractValue> pointsTos) => true;
+
         /// <summary>
         /// Constructs.
         /// </summary>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
@@ -73,6 +73,73 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         }
 
         /// <summary>
+        /// Faster IsSourceMethod(), before using PointsToAnalysis or ValueContentAnalysis.
+        /// </summary>
+        /// <param name="sourceSymbolMap">SourceInfos.</param>
+        /// <param name="method">Invoked ethod to be evaluated.</param>
+        /// <param name="arguments">Arguments of the method.</param>
+        /// <param name="isSourceMethod">Indicates that the invoked method is definitely a tainted data source.</param>
+        /// <param name="requiresPointsTo">Indicates that the invoked method requires PointsToAnalysis for further
+        /// evaluation.</param>
+        /// <param name="requiresValueContent">Indicates that the invoked method requires ValueContentAnalysis for further
+        /// evaluation.</param>
+        /// <returns>True if the invoked method is potentially a tainted data source.</returns>
+        public static bool IsSourceMethodFast(
+            this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap,
+            IMethodSymbol method,
+            ImmutableArray<IArgumentOperation> arguments,
+            out bool isSourceMethod,
+            out bool requiresPointsTo,
+            out bool requiresValueContent)
+        {
+            isSourceMethod = false;
+            requiresPointsTo = false;
+            requiresValueContent = false;
+
+            foreach (SourceInfo sourceInfo in sourceSymbolMap.GetInfosForType(method.ContainingType))
+            {
+                if (!(requiresPointsTo && isSourceMethod))
+                {
+                    foreach ((MethodMatcher methodMatcher, ImmutableHashSet<(PointsToCheck pointsToCheck, string)> pointsToTaintedTargets) in sourceInfo.TaintedMethodsNeedsPointsToAnalysis)
+                    {
+                        if (methodMatcher(method.Name, arguments))
+                        {
+                            foreach ((PointsToCheck pointsToCheck, string) p in pointsToTaintedTargets)
+                            {
+                                if (p.pointsToCheck == SourceInfo.AlwaysTruePointsToCheck)
+                                {
+                                    isSourceMethod = true;
+                                }
+                                else
+                                {
+                                    requiresPointsTo = true;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (!requiresValueContent)
+                {
+                    foreach ((MethodMatcher methodMatcher, ImmutableHashSet<(ValueContentCheck valueContentCheck, string)> valueContentTaintedTargets) in sourceInfo.TaintedMethodsNeedsValueContentAnalysis)
+                    {
+                        if (methodMatcher(method.Name, arguments))
+                        {
+                            requiresValueContent = true;
+                        }
+                    }
+                }
+
+                if (requiresPointsTo && requiresValueContent && isSourceMethod)
+                {
+                    break;
+                }
+            }
+
+            return isSourceMethod || requiresPointsTo || requiresValueContent;
+        }
+
+        /// <summary>
         /// Determines if the given property is a tainted data source.
         /// </summary>
         /// <param name="sourceSymbolMap"></param>


### PR DESCRIPTION
Avoiding using PointsToAnalysis and ValueContentAnalysis unnecessarily when evaluating whether to do TaintedDataAnalysis.