### PR TITLE
Improve CA2200 Rethrow analyzer to allow reassigned exception

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpRethrowToPreserveStackDetails.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/QualityGuidelines/CSharpRethrowToPreserveStackDetails.cs
@@ -38,7 +38,9 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines
                                 catchClause.Declaration != null &&
                                 catchClause.Declaration.Identifier.RawKind != 0)
                             {
-                                if (!(context.SemanticModel.GetSymbolInfo(expr).Symbol is ILocalSymbol local) || local.Locations.Length == 0)
+                                if (!(context.SemanticModel.GetSymbolInfo(expr).Symbol is ILocalSymbol local)
+                                    || local.Locations.Length == 0
+                                    || context.SemanticModel.AnalyzeDataFlow(catchClause.Block).WrittenInside.Contains(local))
                                 {
                                     return;
                                 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -142,6 +142,49 @@ End Class
         }
 
         [Fact]
+        public void CA2200_NoDiagnosticsForThrowCaughtReassignedException()
+        {
+            VerifyCSharp(@"
+using System;
+
+class Program
+{
+    void CatchAndRethrowExplicitlyReassigned()
+    {
+        try
+        {
+            ThrowException();
+        }
+        catch (SystemException e)
+        { 
+            e = new ArithmeticException();
+            throw e;
+        }
+    }
+
+    void ThrowException()
+    {
+        throw new SystemException();
+    }
+}
+");
+            VerifyBasic(@"
+Imports System
+Class Program
+    Sub CatchAndRethrowExplicitly()
+
+        Try
+            Throw New Exception()
+        Catch e As Exception
+            e = New ArithmeticException()
+            Throw e
+        End Try
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
         public void CA2200_NoDiagnosticsForThrowCaughtExceptionInAnotherScope()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -185,6 +185,47 @@ End Class
         }
 
         [Fact]
+        public void CA2200_NoDiagnosticsForEmptyBlock()
+        {
+            VerifyCSharp(@"
+using System;
+
+class Program
+{
+    void CatchAndRethrowExplicitlyReassigned()
+    {
+        try
+        {
+            ThrowException();
+        }
+        catch (SystemException e)
+        { 
+
+        }
+    }
+
+    void ThrowException()
+    {
+        throw new SystemException();
+    }
+}
+");
+            VerifyBasic(@"
+Imports System
+Class Program
+    Sub CatchAndRethrowExplicitly()
+
+        Try
+            Throw New Exception()
+        Catch e As Exception
+
+        End Try
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
         public void CA2200_NoDiagnosticsForThrowCaughtExceptionInAnotherScope()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRethrowToPreserveStackDetails.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRethrowToPreserveStackDetails.vb
@@ -55,10 +55,12 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines
 
         Private Shared Function IsCaughtLocalThrown(semanticModel As SemanticModel, catchStatement As CatchStatementSyntax, throwExpression As ExpressionSyntax) As Boolean
             Dim local = TryCast(semanticModel.GetSymbolInfo(throwExpression).Symbol, ILocalSymbol)
-            Dim catchBlock = TryCast(catchStatement.Parent, CatchBlockSyntax)
+            Dim catchBlock = DirectCast(catchStatement.Parent, CatchBlockSyntax)
             If local Is Nothing _
                     OrElse local.Locations.Length = 0 _
-                    OrElse semanticModel.AnalyzeDataFlow(catchBlock?.Statements.First, catchBlock?.Statements.Last).WrittenInside.Contains(local) Then
+                    OrElse catchBlock Is Nothing _
+                    OrElse catchBlock.Statements.Count = 0 _
+                    OrElse semanticModel.AnalyzeDataFlow(catchBlock.Statements.First, catchBlock.Statements.Last).WrittenInside.Contains(local) Then
                 Return False
             End If
 

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRethrowToPreserveStackDetails.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/QualityGuidelines/BasicRethrowToPreserveStackDetails.vb
@@ -55,7 +55,10 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines
 
         Private Shared Function IsCaughtLocalThrown(semanticModel As SemanticModel, catchStatement As CatchStatementSyntax, throwExpression As ExpressionSyntax) As Boolean
             Dim local = TryCast(semanticModel.GetSymbolInfo(throwExpression).Symbol, ILocalSymbol)
-            If local Is Nothing OrElse local.Locations.Length = 0 Then
+            Dim catchBlock = TryCast(catchStatement.Parent, CatchBlockSyntax)
+            If local Is Nothing _
+                    OrElse local.Locations.Length = 0 _
+                    OrElse semanticModel.AnalyzeDataFlow(catchBlock?.Statements.First, catchBlock?.Statements.Last).WrittenInside.Contains(local) Then
                 Return False
             End If
 


### PR DESCRIPTION
If the caught exception is reassigned (new or set to another reference), it's then not actually "rethrowing the caught exception" such that it should not be reported as a diagnostic.
For example, this should be allowed:
```
            try
            {
                //.....
            }
            catch(Exception ex)
            {
                //.....
                ex = new SomeCustomException("some msg");
                throw ex;
            }
```