### PR TITLE
Add workaround for no location diagnostics

### DIFF
--- a/src/Microsoft.CodeAnalysis.VersionCheckAnalyzer/Microsoft.CodeAnalysis.VersionCheckAnalyzer.csproj
+++ b/src/Microsoft.CodeAnalysis.VersionCheckAnalyzer/Microsoft.CodeAnalysis.VersionCheckAnalyzer.csproj
@@ -21,6 +21,8 @@
   <ItemGroup>
     <Compile Include="..\Utilities\Compiler\DiagnosticCategory.cs" Link="DiagnosticCategory.cs" />
     <Compile Include="..\Utilities\Compiler\DiagnosticHelpers.cs" Link="DiagnosticHelpers.cs" />
+    <Compile Include="..\Utilities\Compiler\Extensions\DiagnosticExtensions.cs" Link="DiagnosticExtensions.cs" />
+    <Compile Include="..\Utilities\Compiler\Extensions\ReportDiagnosticExtensions.cs" Link="ReportDiagnosticExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisVersion)" />

--- a/src/Microsoft.CodeAnalysis.VersionCheckAnalyzer/VersionCheckAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.VersionCheckAnalyzer/VersionCheckAnalyzer.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Reflection;
 using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -58,8 +59,7 @@ namespace Microsoft.CodeAnalysis.VersionCheckAnalyzer
                         // Version mismatch between the analyzer package '{0}' and Microsoft.CodeAnalysis '{1}'. Certain analyzers in this package will not run until the version mismatch is fixed.
                         var arg1 = RequiredMicrosoftCodeAnalysisVersion;
                         var arg2 = s_MicrosoftCodeAnalysisVersion;
-                        var diagnostic = Diagnostic.Create(Rule, Location.None, arg1, arg2);
-                        compilationContext.ReportDiagnostic(diagnostic);
+                        compilationContext.ReportNoLocationDiagnostic(Rule, arg1, arg2);
                     }
                 });
             });

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     Equals(item.ContainingAssembly, context.Compilation.Assembly) &&
                     MatchesConfiguredVisibility(item, context.Options, context.CancellationToken));
 
-            CheckTypeNames(globalTypes, context.ReportDiagnostic);
+            CheckTypeNames(globalTypes, context);
             CheckNamespaceMembers(globalNamespaces, context);
         }
 
@@ -97,7 +97,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                 if (typeMembers.Any())
                 {
-                    CheckTypeNames(typeMembers, context.ReportDiagnostic);
+                    CheckTypeNames(typeMembers, context);
                 }
                 else
                 {
@@ -224,7 +224,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             return false;
         }
 
-        private static void CheckTypeNames(IEnumerable<INamedTypeSymbol> types, Action<Diagnostic> addDiagnostic)
+        private static void CheckTypeNames(IEnumerable<INamedTypeSymbol> types, CompilationAnalysisContext context)
         {
             // If there is only one type, then return
             if (!types.Skip(1).Any())
@@ -249,7 +249,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 if (typesWithName.Count > 1)
                 {
-                    addDiagnostic(Diagnostic.Create(Rule, Location.None, Type, GetSymbolDisplayString(typesWithName)));
+                    context.ReportNoLocationDiagnostic(Rule, Type, GetSymbolDisplayString(typesWithName));
                 }
 
                 typesWithName.Free();
@@ -281,7 +281,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 if (namespacesWithName.Count > 1)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Rule, Location.None, Namespace, GetSymbolDisplayString(namespacesWithName)));
+                    context.ReportNoLocationDiagnostic(Rule, Namespace, GetSymbolDisplayString(namespacesWithName));
                 }
 
                 namespacesWithName.Free();

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithAttributesDiagnosticAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithAttributesDiagnosticAnalyzer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -85,12 +86,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             if (!assemblyVersionAttributeFound && assemblyVersionAttributeSymbol != null)
             {
-                context.ReportDiagnostic(Diagnostic.Create(CA1016Rule, Location.None));
+                context.ReportNoLocationDiagnostic(CA1016Rule);
             }
 
             if (!assemblyComplianceAttributeFound && assemblyComplianceAttributeSymbol != null)
             {
-                context.ReportDiagnostic(Diagnostic.Create(CA1014Rule, Location.None));
+                context.ReportNoLocationDiagnostic(CA1014Rule);
             }
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithComVisible.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/MarkAssembliesWithComVisible.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -68,13 +69,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         attributeInstance.ConstructorArguments[0].Value.Equals(true))
                     {
                         // Has the attribute, with the value 'true'.
-                        context.ReportDiagnostic(Diagnostic.Create(RuleA, Location.None, context.Compilation.Assembly.Name));
+                        context.ReportNoLocationDiagnostic(RuleA, context.Compilation.Assembly.Name);
                     }
                 }
                 else
                 {
                     // No ComVisible attribute at all.
-                    context.ReportDiagnostic(Diagnostic.Create(RuleB, Location.None, context.Compilation.Assembly.Name));
+                    context.ReportNoLocationDiagnostic(RuleB, context.Compilation.Assembly.Name);
                 }
             }
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
@@ -79,7 +79,7 @@ namespace Microsoft.NetCore.Analyzers.Resources
                     }
 
                     // attribute just don't exist
-                    ce.ReportDiagnostic(Diagnostic.Create(Rule, Location.None));
+                    ce.ReportNoLocationDiagnostic(Rule);
                 });
             });
         }

--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -35,6 +35,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)BoundedCacheWithFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DoNotCatchGeneralUnlessRethrown.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CompilationExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\ReportDiagnosticExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ImmutableArrayExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\KeyValuePairExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\MethodKindEx.cs" />

--- a/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
@@ -225,13 +225,20 @@ namespace Analyzer.Utilities.Extensions
                     var options = (ImmutableDictionary<string, ReportDiagnostic>)s_syntaxTreeDiagnosticOptionsProperty.GetValue(tree);
                     if (options.TryGetValue(rule.Id, out var configuredValue))
                     {
+                        if (configuredValue == ReportDiagnostic.Suppress)
+                        {
+                            // Any suppression entry always wins.
+                            return null;
+                        }
+
                         if (overriddenSeverity == null)
                         {
                             overriddenSeverity = configuredValue;
                         }
-                        else if (overriddenSeverity != configuredValue)
+                        else if (overriddenSeverity.Value.IsLessSevereThen(configuredValue))
                         {
-                            return rule.DefaultSeverity;
+                            // Choose the most severe value for conflicts.
+                            overriddenSeverity = configuredValue;
                         }
                     }
                 }

--- a/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
@@ -240,7 +240,7 @@ namespace Analyzer.Utilities.Extensions
                         {
                             overriddenSeverity = configuredValue;
                         }
-                        else if (overriddenSeverity.Value.IsLessSevereThen(configuredValue))
+                        else if (overriddenSeverity.Value.IsLessSevereThan(configuredValue))
                         {
                             // Choose the most severe value for conflicts.
                             overriddenSeverity = configuredValue;

--- a/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
@@ -174,7 +174,6 @@ namespace Analyzer.Utilities.Extensions
                      messageArgs: args);
         }
 
-#if HAS_IOPERATION
         /// <summary>
         /// TODO: Revert this reflection based workaround once we move to Microsoft.CodeAnalysis version 3.0
         /// </summary>
@@ -208,7 +207,13 @@ namespace Analyzer.Utilities.Extensions
                 return;
             }
 
-            var diagnostic = Diagnostic.Create(rule, Location.None, effectiveSeverity.Value, additionalLocations: null, properties, args);
+            if (effectiveSeverity.Value != rule.DefaultSeverity)
+            {
+                rule = new DiagnosticDescriptor(rule.Id, rule.Title, rule.MessageFormat, rule.Category,
+                    effectiveSeverity.Value, rule.IsEnabledByDefault, rule.Description, rule.HelpLinkUri, rule.CustomTags.ToArray());
+            }
+
+            var diagnostic = Diagnostic.Create(rule, Location.None, properties, args);
             addDiagnostic(diagnostic);
             return;
 
@@ -246,6 +251,5 @@ namespace Analyzer.Utilities.Extensions
                 return overriddenSeverity.HasValue ? overriddenSeverity.Value.ToDiagnosticSeverity() : rule.DefaultSeverity;
             }
         }
-#endif
     }
 }

--- a/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license 
+
+using System;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class ReportDiagnosticExtensions
+    {
+        public static DiagnosticSeverity? ToDiagnosticSeverity(this ReportDiagnostic reportDiagnostic)
+        {
+            switch (reportDiagnostic)
+            {
+                case ReportDiagnostic.Error:
+                    return DiagnosticSeverity.Error;
+
+                case ReportDiagnostic.Warn:
+                    return DiagnosticSeverity.Warning;
+
+                case ReportDiagnostic.Info:
+                    return DiagnosticSeverity.Info;
+
+                case ReportDiagnostic.Hidden:
+                    return DiagnosticSeverity.Hidden;
+
+                case ReportDiagnostic.Suppress:
+                case ReportDiagnostic.Default:
+                    return null;
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static bool IsLessSevereThen(this ReportDiagnostic current, ReportDiagnostic other)
+        public static bool IsLessSevereThan(this ReportDiagnostic current, ReportDiagnostic other)
         {
             switch (current)
             {

--- a/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
@@ -30,5 +30,53 @@ namespace Microsoft.CodeAnalysis
                     throw new NotImplementedException();
             }
         }
+
+        public static bool IsLessSevereThen(this ReportDiagnostic current, ReportDiagnostic other)
+        {
+            switch (current)
+            {
+                case ReportDiagnostic.Error:
+                    return false;
+
+                case ReportDiagnostic.Warn:
+                    switch (other)
+                    {
+                        case ReportDiagnostic.Error:
+                            return true;
+
+                        default:
+                            return false;
+                    }
+
+                case ReportDiagnostic.Info:
+                    switch (other)
+                    {
+                        case ReportDiagnostic.Error:
+                        case ReportDiagnostic.Warn:
+                            return true;
+
+                        default:
+                            return false;
+                    }
+
+                case ReportDiagnostic.Hidden:
+                    switch (other)
+                    {
+                        case ReportDiagnostic.Error:
+                        case ReportDiagnostic.Warn:
+                        case ReportDiagnostic.Info:
+                            return true;
+
+                        default:
+                            return false;
+                    }
+
+                case ReportDiagnostic.Suppress:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
First item listed in https://github.com/dotnet/roslyn/issues/38042: `Diagnostics with Location.None cannot be configured with .editorconfig` leads to the Location.None diagnostics being non-configurable in editorconfig. This is also currently blocking https://github.com/dotnet/roslyn/pull/37795, as FxCop analyzers is the primary analyzer package with Location.None diagnostics.
This change should be able to unblock https://github.com/dotnet/roslyn/pull/37795.