### PR TITLE
Update CA2002 to detect usage of lock (this) and SyncLock Me

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -11,14 +12,14 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 {
     /// <summary>
     /// CA2002: Do not lock on objects with weak identities
-    /// 
+    ///
     /// Cause:
     /// A thread that attempts to acquire a lock on an object that has a weak identity could cause hangs.
-    /// 
+    ///
     /// Description:
-    /// An object is said to have a weak identity when it can be directly accessed across application domain boundaries. 
-    /// A thread that tries to acquire a lock on an object that has a weak identity can be blocked by a second thread in 
-    /// a different application domain that has a lock on the same object. 
+    /// An object is said to have a weak identity when it can be directly accessed across application domain boundaries.
+    /// A thread that tries to acquire a lock on an object that has a weak identity can be blocked by a second thread in
+    /// a different application domain that has a lock on the same object.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class DoNotLockOnObjectsWithWeakIdentityAnalyzer : DiagnosticAnalyzer
@@ -51,10 +52,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 compilationStartContext.RegisterOperationAction(context =>
                 {
                     var lockStatement = (ILockOperation)context.Operation;
-                    ITypeSymbol type = lockStatement.LockedValue?.Type;
-                    if (type != null && TypeHasWeakIdentity(type, compilation))
+
+                    if (lockStatement.LockedValue.Kind == OperationKind.InstanceReference)
                     {
-                        context.ReportDiagnostic(lockStatement.LockedValue.Syntax.CreateDiagnostic(Rule, type.ToDisplayString()));
+                        context.ReportDiagnostic(lockStatement.LockedValue.Syntax.CreateDiagnostic(Rule, lockStatement.LockedValue.Syntax.ToString()));
+                    }
+                    else
+                    {
+                        ITypeSymbol type = lockStatement.LockedValue?.Type;
+                        if (type != null && TypeHasWeakIdentity(type, compilation))
+                        {
+                            context.ReportDiagnostic(lockStatement.LockedValue.Syntax.CreateDiagnostic(Rule, type.ToDisplayString()));
+                        }
                     }
                 },
                 OperationKind.Lock);

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
@@ -52,7 +52,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 {
                     var lockStatement = (ILockOperation)context.Operation;
 
-                    if (lockStatement.LockedValue.Kind == OperationKind.InstanceReference)
+                    if (lockStatement.LockedValue is IInstanceReferenceOperation instanceReference &&
+                        instanceReference.ReferenceKind == InstanceReferenceKind.ContainingTypeInstance)
                     {
                         context.ReportDiagnostic(lockStatement.LockedValue.Syntax.CreateDiagnostic(Rule, lockStatement.LockedValue.Syntax.ToString()));
                     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotLockOnObjectsWithWeakIdentityTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotLockOnObjectsWithWeakIdentityTests.cs
@@ -84,6 +84,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
                     System.Reflection.MemberInfo[] values1 = null;
                     lock (values1) { }
+
+                    lock (this) { }
                 }
             }
             ",
@@ -97,7 +99,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             GetCA2002CSharpResultAt(23, 27, "System.Reflection.MemberInfo"),
             GetCA2002CSharpResultAt(26, 27, "System.Reflection.ConstructorInfo"),
             GetCA2002CSharpResultAt(29, 27, "System.Reflection.ParameterInfo"),
-            GetCA2002CSharpResultAt(32, 27, "int[]"));
+            GetCA2002CSharpResultAt(32, 27, "int[]"),
+            GetCA2002CSharpResultAt(37, 27, "this"));
 
             VerifyBasic(@"
             Imports System
@@ -144,6 +147,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     Dim values1 As System.Reflection.MemberInfo() = Nothing
                     SyncLock values1
                     End SyncLock
+
+                    SyncLock Me
+                    End SyncLock
                 End Sub
             End Class",
             GetCA2002BasicResultAt(6, 30, "String"),
@@ -156,7 +162,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             GetCA2002BasicResultAt(28, 30, "System.Reflection.MemberInfo"),
             GetCA2002BasicResultAt(32, 30, "System.Reflection.ConstructorInfo"),
             GetCA2002BasicResultAt(36, 30, "System.Reflection.ParameterInfo"),
-            GetCA2002BasicResultAt(40, 30, "Integer()"));
+            GetCA2002BasicResultAt(40, 30, "Integer()"),
+            GetCA2002BasicResultAt(47, 30, "Me"));
         }
 
         [Fact]


### PR DESCRIPTION
I have updated the `DoNotLockOnObjectsWithWeakIdentity` to also report when locking on `this` or `Me`.

Fix #294 