### PR TITLE
Update CA1001 to stop reporting on types implementing IAsyncDisposable

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/CSharp/ApiDesignGuidelines/CSharpTypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/CSharp/ApiDesignGuidelines/CSharpTypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -7,21 +7,22 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Analyzer.Utilities;
 
 namespace Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer : TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer<TypeDeclarationSyntax>
     {
-        protected override DisposableFieldAnalyzer GetAnalyzer(INamedTypeSymbol disposableTypeSymbol)
+        protected override DisposableFieldAnalyzer GetAnalyzer(WellKnownTypeProvider wellKnownTypeProvider)
         {
-            return new CSharpDisposableFieldAnalyzer(disposableTypeSymbol);
+            return new CSharpDisposableFieldAnalyzer(wellKnownTypeProvider);
         }
 
         private class CSharpDisposableFieldAnalyzer : DisposableFieldAnalyzer
         {
-            public CSharpDisposableFieldAnalyzer(INamedTypeSymbol disposableTypeSymbol)
-                : base(disposableTypeSymbol)
+            public CSharpDisposableFieldAnalyzer(WellKnownTypeProvider wellKnownTypeProvider)
+                : base(wellKnownTypeProvider)
             { }
 
             protected override bool IsDisposableFieldCreation(SyntaxNode node, SemanticModel model, HashSet<ISymbol> disposableFields, CancellationToken cancellationToken)

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -68,10 +68,15 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             public void AnalyzeSymbol(SymbolAnalysisContext symbolContext)
             {
                 INamedTypeSymbol namedType = (INamedTypeSymbol)symbolContext.Symbol;
-                if (namedType.AllInterfaces.Contains(_disposableTypeSymbol) ||
-                    (_asyncDisposableTypeSymbol != null && namedType.AllInterfaces.Contains(_asyncDisposableTypeSymbol)))
+
+                for (int i = 0; i < namedType.AllInterfaces.Length; i++)
                 {
-                    return;
+                    var currentInterface = namedType.AllInterfaces[i];
+                    if (currentInterface != null &&
+                        (currentInterface.Equals(_disposableTypeSymbol) || currentInterface.Equals(_asyncDisposableTypeSymbol)))
+                    {
+                        return;
+                    }
                 }
 
                 IEnumerable<IFieldSymbol> disposableFields = from member in namedType.GetMembers()

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -41,58 +41,64 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             analysisContext.RegisterCompilationStartAction(compilationContext =>
             {
-                if (!compilationContext.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIDisposable, out var disposableType))
+                var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(compilationContext.Compilation);
+                if (!wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIDisposable, out _))
                 {
                     return;
                 }
 
-                DisposableFieldAnalyzer analyzer = GetAnalyzer(disposableType);
+                DisposableFieldAnalyzer analyzer = GetAnalyzer(wellKnownTypeProvider);
                 compilationContext.RegisterSymbolAction(analyzer.AnalyzeSymbol, SymbolKind.NamedType);
             });
         }
 
-        protected abstract DisposableFieldAnalyzer GetAnalyzer(INamedTypeSymbol disposableType);
+        protected abstract DisposableFieldAnalyzer GetAnalyzer(WellKnownTypeProvider wellKnownTypeProvider);
 
         protected abstract class DisposableFieldAnalyzer
         {
             private readonly INamedTypeSymbol _disposableTypeSymbol;
+            private readonly INamedTypeSymbol _asyncDisposableTypeSymbol;
 
-            public DisposableFieldAnalyzer(INamedTypeSymbol disposableTypeSymbol)
+            public DisposableFieldAnalyzer(WellKnownTypeProvider wellKnownTypeProvider)
             {
-                _disposableTypeSymbol = disposableTypeSymbol;
+                _disposableTypeSymbol = wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIDisposable);
+                _asyncDisposableTypeSymbol = wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIAsyncDisposable);
             }
 
             public void AnalyzeSymbol(SymbolAnalysisContext symbolContext)
             {
                 INamedTypeSymbol namedType = (INamedTypeSymbol)symbolContext.Symbol;
-                if (!namedType.AllInterfaces.Contains(_disposableTypeSymbol))
+                if (namedType.AllInterfaces.Contains(_disposableTypeSymbol) ||
+                    (_asyncDisposableTypeSymbol != null && namedType.AllInterfaces.Contains(_asyncDisposableTypeSymbol)))
                 {
-                    IEnumerable<IFieldSymbol> disposableFields = from member in namedType.GetMembers()
-                                                                 where member.Kind == SymbolKind.Field && !member.IsStatic
-                                                                 let field = member as IFieldSymbol
-                                                                 where field.Type != null && field.Type.IsDisposable(_disposableTypeSymbol)
-                                                                 select field;
+                    return;
+                }
 
-                    if (disposableFields.Any())
+                IEnumerable<IFieldSymbol> disposableFields = from member in namedType.GetMembers()
+                                                             where member.Kind == SymbolKind.Field && !member.IsStatic
+                                                             let field = member as IFieldSymbol
+                                                             where field.Type != null && field.Type.IsDisposable(_disposableTypeSymbol)
+                                                             select field;
+
+                if (disposableFields.Any())
+                {
+                    var disposableFieldsHashSet = new HashSet<ISymbol>(disposableFields);
+                    IEnumerable<TTypeDeclarationSyntax> classDecls = GetClassDeclarationNodes(namedType, symbolContext.CancellationToken);
+                    foreach (TTypeDeclarationSyntax classDecl in classDecls)
                     {
-                        var disposableFieldsHashSet = new HashSet<ISymbol>(disposableFields);
-                        IEnumerable<TTypeDeclarationSyntax> classDecls = GetClassDeclarationNodes(namedType, symbolContext.CancellationToken);
-                        foreach (TTypeDeclarationSyntax classDecl in classDecls)
+                        SemanticModel model = symbolContext.Compilation.GetSemanticModel(classDecl.SyntaxTree);
+                        IEnumerable<SyntaxNode> syntaxNodes = classDecl.DescendantNodes(n => !(n is TTypeDeclarationSyntax) || ReferenceEquals(n, classDecl))
+                            .Where(n => IsDisposableFieldCreation(n,
+                                                                model,
+                                                                disposableFieldsHashSet,
+                                                                symbolContext.CancellationToken));
+                        if (syntaxNodes.Any())
                         {
-                            SemanticModel model = symbolContext.Compilation.GetSemanticModel(classDecl.SyntaxTree);
-                            IEnumerable<SyntaxNode> syntaxNodes = classDecl.DescendantNodes(n => !(n is TTypeDeclarationSyntax) || ReferenceEquals(n, classDecl))
-                                .Where(n => IsDisposableFieldCreation(n,
-                                                                    model,
-                                                                    disposableFieldsHashSet,
-                                                                    symbolContext.CancellationToken));
-                            if (syntaxNodes.Any())
-                            {
-                                // Type '{0}' owns disposable field(s) '{1}' but is not disposable
-                                var arg1 = namedType.Name;
-                                var arg2 = string.Join(", ", disposableFieldsHashSet.Select(f => f.Name).Order());
-                                symbolContext.ReportDiagnostic(namedType.CreateDiagnostic(Rule, arg1, arg2));
-                                return;
-                            }
+                            // Type '{0}' owns disposable field(s) '{1}' but is not disposable
+                            var arg1 = namedType.Name;
+                            var arg2 = string.Join(", ", disposableFieldsHashSet.Select(f => f.Name).Order());
+                            symbolContext.ReportDiagnostic(namedType.CreateDiagnostic(Rule, arg1, arg2));
+                            return;
                         }
                     }
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -221,9 +221,7 @@ namespace ClassLibrary1
         public void CA1001CSharpTestWithIAsyncDisposable()
         {
             VerifyCSharp(@"
-using System;
-
-namespace ClassLibrary1
+namespace System
 {
     public class ValueTask {}
 
@@ -232,14 +230,20 @@ namespace ClassLibrary1
         ValueTask DisposeAsync();
     }
 
-    public class Stream : IAsyncDisposable
+    public sealed class Stream : System.IDisposable, IAsyncDisposable
     {
         public ValueTask DisposeAsync() => new ValueTask();
+        public void Dispose() {}
     }
+}
+
+namespace ClassLibrary1
+{
+    using System;
 
     public class Class1 : IAsyncDisposable
     {
-        private Stream _disposableMember;
+        private readonly Stream _disposableMember = new Stream();
 
         public ValueTask DisposeAsync() => _disposableMember.DisposeAsync();
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines;
@@ -96,7 +98,7 @@ using System.IO;
     {
         public void Create()
         {
-            var obj = new NoDisposeClass() { newFile = new FileStream(""data.txt"", FileMode.Append) }; 
+            var obj = new NoDisposeClass() { newFile = new FileStream(""data.txt"", FileMode.Append) };
         }
     }
 ");
@@ -153,7 +155,7 @@ public class NoDisposeClass
         newFile = new FileStream(""data.txt"", FileMode.Append);
     }
 }
-   
+
 [|public class Foo
 {
 }
@@ -213,6 +215,26 @@ namespace ClassLibrary1
 }
 ",
             GetCA1001CSharpResultAt(7, 18, "Class1", "_disp1"));
+        }
+
+        [Fact, WorkItem(1562, "https://github.com/dotnet/roslyn-analyzers/issues/1562")]
+        public void CA1001CSharpTestWithIAsyncDisposable()
+        {
+            VerifyCSharp(@"
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ClassLibrary1
+{
+    public class Class1 : IAsyncDisposable
+    {
+        private Stream _disposableMember;
+
+        public ValueTask DisposeAsync() => _disposableMember.DisposeAsync();
+    }
+}
+", parseOptions: new CSharpParseOptions(LanguageVersion.Preview));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -222,11 +222,21 @@ namespace ClassLibrary1
         {
             VerifyCSharp(@"
 using System;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace ClassLibrary1
 {
+    public class ValueTask {}
+
+    public interface IAsyncDisposable
+    {
+        ValueTask DisposeAsync();
+    }
+
+    public class Stream : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => new ValueTask();
+    }
+
     public class Class1 : IAsyncDisposable
     {
         private Stream _disposableMember;
@@ -234,7 +244,7 @@ namespace ClassLibrary1
         public ValueTask DisposeAsync() => _disposableMember.DisposeAsync();
     }
 }
-", parseOptions: new CSharpParseOptions(LanguageVersion.Preview));
+");
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/VisualBasic/ApiDesignGuidelines/BasicTypesThatOwnDisposableFieldsShouldBeDisposable.vb
+++ b/src/Microsoft.CodeQuality.Analyzers/VisualBasic/ApiDesignGuidelines/BasicTypesThatOwnDisposableFieldsShouldBeDisposable.vb
@@ -6,19 +6,20 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Analyzer.Utilities
 
 Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public NotInheritable Class BasicTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer
         Inherits TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer(Of TypeBlockSyntax)
-        Protected Overrides Function GetAnalyzer(disposableTypeSymbol As INamedTypeSymbol) As DisposableFieldAnalyzer
-            Return New BasicDisposableFieldAnalyzer(disposableTypeSymbol)
+        Protected Overrides Function GetAnalyzer(wellKnownTypeProvider As WellKnownTypeProvider) As DisposableFieldAnalyzer
+            Return New BasicDisposableFieldAnalyzer(wellKnownTypeProvider)
         End Function
 
         Private Class BasicDisposableFieldAnalyzer
             Inherits DisposableFieldAnalyzer
-            Public Sub New(disposableTypeSymbol As INamedTypeSymbol)
-                MyBase.New(disposableTypeSymbol)
+            Public Sub New(wellKnownTypeProvider As WellKnownTypeProvider)
+                MyBase.New(wellKnownTypeProvider)
             End Sub
 
             Protected Overrides Function IsDisposableFieldCreation(node As SyntaxNode, model As SemanticModel, disposableFields As HashSet(Of ISymbol), cancellationToken As CancellationToken) As Boolean

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -446,5 +446,6 @@ namespace Analyzer.Utilities
         public const string SystemRuntimeInteropServicesComSourceInterfacesAttribute = "System.Runtime.InteropServices.ComSourceInterfacesAttribute";
         public const string MicrosoftCodeAnalysisDiagnosticsGeneratedCodeAnalysisFlags = "Microsoft.CodeAnalysis.Diagnostics.GeneratedCodeAnalysisFlags";
         public const string MicrosoftCodeAnalysisCSharpCSharpCompilation = "Microsoft.CodeAnalysis.CSharp.CSharpCompilation";
+        public const string SystemIAsyncDisposable = "System.IAsyncDisposable";
     }
 }


### PR DESCRIPTION
Fix #2325 

Note that the documentation will need to be updated.

I will need some help with the unit test, I don't know how to prevent the error about the unknown type `IAsyncDisposable`. Note that I have tried to use parse options with C#8 and Preview but both are failing.