### PR TITLE
Fix CA1721 - Do not report on overriden members

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
@@ -94,7 +94,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         continue;
                     }
 
-                    // Ignore declared type that overrides a base member
+                    // We only want to report an issue when the user is free to update the member.
+                    // So if the method or/and the property is an override and base clase defines both members we bail out
+                    // but if base defines only one of the member and derived defines the other we still want to raise an issue
                     if (symbol.IsOverride)
                     {
                         continue;

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             analysisContext.EnableConcurrentExecution();
             analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            // Analyze properties, methods 
+            // Analyze properties, methods
             analysisContext.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Method);
         }
 
@@ -90,6 +90,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                     // Ignore members whose IsStatic does not match with the symbol's IsStatic
                     if (symbol.IsStatic != member.IsStatic)
+                    {
+                        continue;
+                    }
+
+                    // Ignore declared type that overrides a base member
+                    if (symbol.IsOverride)
                     {
                         continue;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethods.cs
@@ -81,6 +81,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 var exposedMembers = type.GetMembers(identifier).Where(member => configuredVisibilities.Contains(member.GetResultantVisibility()));
                 foreach (var member in exposedMembers)
                 {
+                    // We only want to report an issue when the user is free to update the member.
+                    // So we can bail out when the property or method (symbol) is override and the other member (member)
+                    // is not local (i.e. symbol and member are declared
+                    if (symbol.IsOverride && member.ContainingType.Equals(type))
+                    {
+                        continue;
+                    }
+
                     // Ignore Object.GetType, as it's commonly seen and Type is a commonly-used property name.
                     if (member.ContainingType.SpecialType == SpecialType.System_Object &&
                         member.Name == nameof(GetType))
@@ -90,14 +98,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                     // Ignore members whose IsStatic does not match with the symbol's IsStatic
                     if (symbol.IsStatic != member.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    // We only want to report an issue when the user is free to update the member.
-                    // So if the method or/and the property is an override and base clase defines both members we bail out
-                    // but if base defines only one of the member and derived defines the other we still want to raise an issue
-                    if (symbol.IsOverride)
                     {
                         continue;
                     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
@@ -517,8 +517,82 @@ Public Class C2
 End Class
 
 ",
-        GetCA1721BasicResultAt(line: 15, column: 21, identifierName: "Value", otherIdentifierName: "GetValue"),
-        GetCA1721BasicResultAt(line: 29, column: 30, identifierName: "Value", otherIdentifierName: "GetValue"));
+            GetCA1721BasicResultAt(line: 15, column: 21, identifierName: "Value", otherIdentifierName: "GetValue"),
+            GetCA1721BasicResultAt(line: 29, column: 30, identifierName: "Value", otherIdentifierName: "GetValue"));
+        }
+
+        [Fact, WorkItem(2914, "https://github.com/dotnet/roslyn-analyzers/issues/2914")]
+        public void CA1721_OverrideMultiLevelDiagnostic()
+        {
+            VerifyCSharp(@"
+public class MyBaseClass
+{
+    public virtual int GetValue(int i) => i;
+    public virtual int Foo { get; }
+}
+
+public class MyClass : MyBaseClass
+{
+    public virtual int Value { get; }
+    public virtual int GetFoo(int i) => i;
+}
+
+public class MySubClass : MyClass
+{
+    public override int GetValue(int i) => 2;
+    public override int Value => 2;
+    public override int GetFoo(int i) => 2;
+    public override int Foo => 2;
+}
+",
+            GetCA1721CSharpResultAt(line: 10, column: 24, identifierName: "Value", otherIdentifierName: "GetValue"),
+            GetCA1721CSharpResultAt(line: 11, column: 24, identifierName: "Foo", otherIdentifierName: "GetFoo"));
+
+            VerifyBasic(@"
+Public Class MyBaseClass
+    Public Overridable Function GetValue(ByVal i As Integer) As Integer
+        Return i
+    End Function
+
+    Public Overridable ReadOnly Property Foo As Integer
+End Class
+
+Public Class [MyClass]
+    Inherits MyBaseClass
+
+    Public Overridable ReadOnly Property Value As Integer
+
+    Public Overridable Function GetFoo(ByVal i As Integer) As Integer
+        Return i
+    End Function
+End Class
+
+Public Class MySubClass
+    Inherits [MyClass]
+
+    Public Overrides Function GetValue(ByVal i As Integer) As Integer
+        Return 2
+    End Function
+
+    Public Overrides ReadOnly Property Value As Integer
+        Get
+            Return 2
+        End Get
+    End Property
+
+    Public Overrides Function GetFoo(ByVal i As Integer) As Integer
+        Return 2
+    End Function
+
+    Public Overrides ReadOnly Property Foo As Integer
+        Get
+            Return 2
+        End Get
+    End Property
+End Class
+",
+            GetCA1721BasicResultAt(line: 13, column: 42, identifierName: "Value", otherIdentifierName: "GetValue"),
+            GetCA1721BasicResultAt(line: 15, column: 33, identifierName: "Foo", otherIdentifierName: "GetFoo"));
         }
 
         #region Helpers


### PR DESCRIPTION
When a base class with virtual members is not complying with the rule (i.e. has a property and a get method with the same name) and your derived class override one or two of the member you will get the issue raised upon your override. Sadly there is nothing much you can do if you don't own the base class so the analyzer should not raise an issue here.

I have tried to add test for C# and VB.NET for all the cases I could think of.

Fix #2914 