### PR TITLE
CA1305: Do not raise for bool.ToString() and char.ToString()

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
@@ -83,6 +83,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 }
 
                 var objectType = csaContext.Compilation.GetSpecialType(SpecialType.System_Object);
+                var charType = csaContext.Compilation.GetSpecialType(SpecialType.System_Char);
+                var boolType = csaContext.Compilation.GetSpecialType(SpecialType.System_Boolean);
                 var stringType = csaContext.Compilation.GetSpecialType(SpecialType.System_String);
                 var stringFormatMembers = stringType?.GetMembers("Format").OfType<IMethodSymbol>();
 
@@ -132,7 +134,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     if (targetMethod.IsGenericMethod || targetMethod.ContainingType == null || targetMethod.ContainingType.IsErrorType() ||
                         (targetMethod.ContainingType != null &&
                          (activatorType != null && activatorType.Equals(targetMethod.ContainingType)) ||
-                         (resourceManagerType != null && resourceManagerType.Equals(targetMethod.ContainingType))))
+                         (resourceManagerType != null && resourceManagerType.Equals(targetMethod.ContainingType)) ||
+                         (charType != null && charType.Equals(targetMethod.ContainingType)) ||
+                         (boolType != null && boolType.Equals(targetMethod.ContainingType))))
                     {
                         return;
                     }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
@@ -131,12 +131,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     var targetMethod = invocationExpression.TargetMethod;
 
                     #region "Exceptions"
+                    const string ToStringMethodName = "ToString";
                     if (targetMethod.IsGenericMethod || targetMethod.ContainingType == null || targetMethod.ContainingType.IsErrorType() ||
                         (targetMethod.ContainingType != null &&
                          (activatorType != null && activatorType.Equals(targetMethod.ContainingType)) ||
                          (resourceManagerType != null && resourceManagerType.Equals(targetMethod.ContainingType)) ||
-                         (charType != null && charType.Equals(targetMethod.ContainingType)) ||
-                         (boolType != null && boolType.Equals(targetMethod.ContainingType))))
+                         (targetMethod.Name == ToStringMethodName &&
+                            (stringType != null && stringType.Equals(targetMethod.ContainingType)) ||
+                            (charType != null && charType.Equals(targetMethod.ContainingType)) ||
+                            (boolType != null && boolType.Equals(targetMethod.ContainingType)))))
                     {
                         return;
                     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
@@ -904,6 +904,7 @@ End Class
         }
 
         [Fact]
+        [WorkItem(2394, "https://github.com/dotnet/roslyn-analyzers/issues/2394")]
         public void CA1305_StringToString_NoDiagnostics()
         {
             VerifyCSharp(@"

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
@@ -859,6 +859,50 @@ Public NotInheritable Class IFormatProviderStringTest
 End Class");
         }
 
+        [Fact]
+        [WorkItem(2394, "https://github.com/dotnet/roslyn-analyzers/issues/2394")]
+        public void CA1305_BoolToString_NoDiagnostics()
+        {
+            VerifyCSharp(@"
+public class Foo
+{
+    public string Bar(bool b1, System.Boolean b2)
+    {
+        return b1.ToString() + b2.ToString();
+    }
+}");
+
+            VerifyBasic(@"
+Public Class Foo
+    Public Function Bar(ByVal b As Boolean) As String
+        Return b.ToString()
+    End Function
+End Class
+");
+        }
+
+        [Fact]
+        [WorkItem(2394, "https://github.com/dotnet/roslyn-analyzers/issues/2394")]
+        public void CA1305_CharToString_NoDiagnostics()
+        {
+            VerifyCSharp(@"
+public class Foo
+{
+    public string Bar(char c1, System.Char c2)
+    {
+        return c1.ToString() + c2.ToString();
+    }
+}");
+
+            VerifyBasic(@"
+Public Class Foo
+    Public Function Bar(ByVal c As Char) As String
+        Return c.ToString()
+    End Function
+End Class
+");
+        }
+
         private DiagnosticResult GetIFormatProviderAlternateStringRuleCSharpResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
             return GetCSharpResultAt(line, column, SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateStringRule, arg1, arg2, arg3);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
@@ -903,6 +903,27 @@ End Class
 ");
         }
 
+        [Fact]
+        public void CA1305_StringToString_NoDiagnostics()
+        {
+            VerifyCSharp(@"
+public class Foo
+{
+    public string Bar(string s1, System.String s2)
+    {
+        return s1.ToString() + s2.ToString();
+    }
+}");
+
+            VerifyBasic(@"
+Public Class Foo
+    Public Function Bar(ByVal s As String) As String
+        Return s.ToString()
+    End Function
+End Class
+");
+        }
+
         private DiagnosticResult GetIFormatProviderAlternateStringRuleCSharpResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
             return GetCSharpResultAt(line, column, SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateStringRule, arg1, arg2, arg3);


### PR DESCRIPTION
Add `bool` and `char` to the exclusion list as the `IFormatProvider` parameter is ignored.

Fix #2394 