### PR TITLE
Update CA1822 code fix to preserve modifiers

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.Fixer.cs
@@ -59,7 +59,8 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
             // Update definition to add static modifier.
             var syntaxGenerator = SyntaxGenerator.GetGenerator(document);
-            var madeStatic = syntaxGenerator.WithModifiers(node, DeclarationModifiers.Static).WithAdditionalAnnotations(s_annotationForFixedDeclaration);
+            var oldModifiersAndStatic = syntaxGenerator.GetModifiers(node).WithIsStatic(true);
+            var madeStatic = syntaxGenerator.WithModifiers(node, oldModifiersAndStatic).WithAdditionalAnnotations(s_annotationForFixedDeclaration);
             document = document.WithSyntaxRoot(root.ReplaceNode(node, madeStatic));
             var solution = document.Project.Solution;
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.Fixer.cs
@@ -1371,28 +1371,5 @@ Public Class C
     End Function
 End Class");
         }
-
-        [Fact, WorkItem(2888, "https://github.com/dotnet/roslyn-analyzers/issues/2888")]
-        public async Task CA1822_CSharp_UnsafeModifier()
-        {
-            await VerifyCS.VerifyCodeFixAsync(@"
-public class C
-{
-    public unsafe void [|M1|]()
-    {
-        int var = 20;
-        int* p = &var;
-    }
-}",
-@"
-public class C
-{
-    public static unsafe void M1()
-    {
-        int var = 20;
-        int* p = &var;
-    }
-}");
-        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.Fixer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.Fixer.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
+using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.QualityGuidelines.MarkMembersAsStaticAnalyzer,
@@ -1324,6 +1325,74 @@ Public Class C
         Return fieldC
     End Function
 End Class");
+        }
+
+        [Fact, WorkItem(2888, "https://github.com/dotnet/roslyn-analyzers/issues/2888")]
+        public async Task CA1822_CSharp_AsyncModifier()
+        {
+            await VerifyCS.VerifyCodeFixAsync(@"
+using System.Threading.Tasks;
+
+public class C
+{
+    public async Task<int> [|M1|]()
+    {
+        await Task.Delay(20).ConfigureAwait(false);
+        return 20;
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+public class C
+{
+    public static async Task<int> M1()
+    {
+        await Task.Delay(20).ConfigureAwait(false);
+        return 20;
+    }
+}");
+            await VerifyVB.VerifyCodeFixAsync(@"
+Imports System.Threading.Tasks
+
+Public Class C
+    Public Async Function [|M1|]() As Task(Of Integer)
+        Await Task.Delay(20).ConfigureAwait(False)
+        Return 20
+    End Function
+End Class",
+@"
+Imports System.Threading.Tasks
+
+Public Class C
+    Public Shared Async Function M1() As Task(Of Integer)
+        Await Task.Delay(20).ConfigureAwait(False)
+        Return 20
+    End Function
+End Class");
+        }
+
+        [Fact, WorkItem(2888, "https://github.com/dotnet/roslyn-analyzers/issues/2888")]
+        public async Task CA1822_CSharp_UnsafeModifier()
+        {
+            await VerifyCS.VerifyCodeFixAsync(@"
+public class C
+{
+    public unsafe void [|M1|]()
+    {
+        int var = 20;
+        int* p = &var;
+    }
+}",
+@"
+public class C
+{
+    public static unsafe void M1()
+    {
+        int var = 20;
+        int* p = &var;
+    }
+}");
         }
     }
 }


### PR DESCRIPTION
This PR was made to fix issue #2888, `async` modifier is lost during refactoring, but turned out as a more global problem where previous modifiers are always lost.

Fix #2888 