### PR TITLE
Ban Compilation.GetTypeByMetadataName

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,6 +21,7 @@
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>3.0.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftNetCompilersVersion>3.3.1-beta3-final</MicrosoftNetCompilersVersion>
+    <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>2.9.6</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyersVersion>2.9.5</MicrosoftCodeAnalysisFXCopAnalyersVersion>
     <MicrosoftCodeAnalysisAnalyersVersion>3.0.0-beta2.19218.3+e96bad97</MicrosoftCodeAnalysisAnalyersVersion>
     <CodeStyleAnalyersVersion>3.3.0-beta2-19376-02</CodeStyleAnalyersVersion>

--- a/src/BannedSymbols.txt
+++ b/src/BannedSymbols.txt
@@ -1,0 +1,1 @@
+M:Microsoft.CodeAnalysis.Compilation.GetTypeByMetadataName(System.String); Use WellKnownTypeProvider instead

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(MicrosoftCodeAnalysisBannedApiAnalyzersVersion)" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" Condition="'$(BannedSymbolsOptOut)' != 'true'" />
   </ItemGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -20,6 +20,11 @@
     <UpToDateCheckInput Include="$(MSBuildThisFileDirectory)..\eng\Analyzers_ShippingRules.ruleset" Condition="'$(CodeAnalysisRuleSet)' == '$(MSBuildThisFileDirectory)..\build\Analyzers_NonShippingRules.ruleset'" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.6" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" Condition="'$(BannedSymbolsOptOut)' != 'true'" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- Workaround for https://github.com/dotnet/roslyn/issues/25041 -->
     <MSBuildAllProjects Condition="'$(CodeAnalysisRuleSet)' == '$(MSBuildThisFileDirectory)..\eng\Analyzers_NonShippingRules.ruleset'">$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\build\Analyzers_ShippingRules.ruleset</MSBuildAllProjects>

--- a/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
+++ b/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
@@ -7,6 +7,8 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -1183,7 +1185,7 @@ namespace MetaCompilation.Analyzers
 
             SemanticModel semanticModel = await document.GetSemanticModelAsync().ConfigureAwait(false);
 
-            INamedTypeSymbol notImplementedException = semanticModel.Compilation.GetTypeByMetadataName("System.NotImplementedException");
+            INamedTypeSymbol notImplementedException = semanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException);
             SyntaxList<StatementSyntax> statements = new SyntaxList<StatementSyntax>();
             string name = "context";
             SyntaxNode initializeDeclaration = CodeFixHelper.BuildInitialize(generator, notImplementedException, statements, name);
@@ -1553,7 +1555,7 @@ namespace MetaCompilation.Analyzers
 
             SemanticModel semanticModel = await document.GetSemanticModelAsync().ConfigureAwait(false);
 
-            INamedTypeSymbol notImplementedException = semanticModel.Compilation.GetTypeByMetadataName("System.NotImplementedException");
+            INamedTypeSymbol notImplementedException = semanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException);
             SyntaxNode[] throwStatement = new[] { generator.ThrowStatement(generator.ObjectCreationExpression(notImplementedException)) };
             SyntaxNode type = generator.GetType(declaration);
             PropertyDeclarationSyntax newPropertyDeclaration = generator.PropertyDeclaration("SupportedDiagnostics", type, Accessibility.Public, DeclarationModifiers.Override, throwStatement) as PropertyDeclarationSyntax;
@@ -1726,7 +1728,7 @@ namespace MetaCompilation.Analyzers
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
 
             SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            INamedTypeSymbol notImplementedException = semanticModel.Compilation.GetTypeByMetadataName("System.NotImplementedException");
+            INamedTypeSymbol notImplementedException = semanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException);
             PropertyDeclarationSyntax propertyDeclaration = CodeFixHelper.CreateSupportedDiagnostics(generator, notImplementedException);
 
             var newNodes = new SyntaxList<SyntaxNode>();
@@ -2379,7 +2381,7 @@ namespace MetaCompilation.Analyzers
                 TypeSyntax type = SyntaxFactory.ParseTypeName("SyntaxNodeAnalysisContext");
                 SyntaxNode[] parameters = new[] { generator.ParameterDeclaration("context", type) };
                 SyntaxList<SyntaxNode> statements = new SyntaxList<SyntaxNode>();
-                INamedTypeSymbol notImplementedException = semanticModel.Compilation.GetTypeByMetadataName("System.NotImplementedException");
+                INamedTypeSymbol notImplementedException = semanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException);
                 statements = statements.Add(generator.ThrowStatement(generator.ObjectCreationExpression(notImplementedException)));
 
                 SyntaxNode newMethodDeclaration = generator.MethodDeclaration(methodName, parameters: parameters, accessibility: Accessibility.Private, statements: statements);

--- a/src/MetaCompilation.Analyzers/Core/DiagnosticAnalyzer.cs
+++ b/src/MetaCompilation.Analyzers/Core/DiagnosticAnalyzer.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -2607,7 +2608,7 @@ namespace MetaCompilation.Analyzers
                         ReportDiagnostic(context, IncorrectAnalysisReturnTypeRule, analysisMethodSyntax.Identifier.GetLocation(), analysisMethodSyntax.Identifier.ValueText);
                         return false;
                     }
-                    else if (analysisMethod.Parameters.Length != 1 || !Equals(analysisMethod.Parameters.First().Type, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext")))
+                    else if (analysisMethod.Parameters.Length != 1 || !Equals(analysisMethod.Parameters.First().Type, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext")))
                     {
                         ReportDiagnostic(context, IncorrectAnalysisParameterRule, analysisMethodSyntax.ParameterList.GetLocation(), analysisMethodSyntax.Identifier.ValueText);
                         return false;
@@ -2766,7 +2767,7 @@ namespace MetaCompilation.Analyzers
             private BlockSyntax InitializeOverview(CompilationAnalysisContext context)
             {
                 ImmutableArray<IParameterSymbol> parameters = _initializeSymbol.Parameters;
-                if (parameters.Length != 1 || !Equals(parameters[0].Type, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.AnalysisContext"))
+                if (parameters.Length != 1 || !Equals(parameters[0].Type, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.AnalysisContext"))
                     || _initializeSymbol.DeclaredAccessibility != Accessibility.Public || !_initializeSymbol.IsOverride || !_initializeSymbol.ReturnsVoid)
                 {
                     ReportDiagnostic(context, IncorrectInitSigRule, _initializeSymbol.Locations[0], _initializeSymbol.Name);
@@ -2866,9 +2867,9 @@ namespace MetaCompilation.Analyzers
                     return;
                 }
 
-                if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
+                if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
                 {
-                    if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider")))
+                    if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider")))
                     {
                         return;
                     }
@@ -2918,9 +2919,9 @@ namespace MetaCompilation.Analyzers
                     return;
                 }
 
-                if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
+                if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
                 {
-                    if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider")))
+                    if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider")))
                     {
                         return;
                     }
@@ -2967,7 +2968,7 @@ namespace MetaCompilation.Analyzers
                     return;
                 }
 
-                if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
+                if (!Equals(sym.ContainingType.BaseType, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
                 {
                     return;
                 }
@@ -2995,7 +2996,7 @@ namespace MetaCompilation.Analyzers
                     return;
                 }
 
-                if (!Equals(sym.BaseType, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
+                if (!Equals(sym.BaseType, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
                 {
                     if (sym.ContainingType == null)
                     {
@@ -3007,7 +3008,7 @@ namespace MetaCompilation.Analyzers
                         return;
                     }
 
-                    if (Equals(sym.ContainingType.BaseType, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
+                    if (Equals(sym.ContainingType.BaseType, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
                     {
                         if (_otherAnalyzerClassSymbols.Contains(sym))
                         {
@@ -3021,7 +3022,7 @@ namespace MetaCompilation.Analyzers
                     }
                 }
 
-                if (Equals(sym.BaseType, context.Compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
+                if (Equals(sym.BaseType, context.Compilation.GetOrCreateTypeByMetadataName("Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer")))
                 {
                     _analyzerClassSymbol = sym;
                 }

--- a/src/MetaCompilation.Analyzers/Core/MetaCompilation.Analyzers.csproj
+++ b/src/MetaCompilation.Analyzers/Core/MetaCompilation.Analyzers.csproj
@@ -12,4 +12,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
+  <Import Project="..\..\Utilities\Compiler\Analyzer.Utilities.projitems" Label="Shared" />
 </Project>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/RestrictedInternalsVisibleToAnalyzer.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
         private static ImmutableDictionary<IAssemblySymbol, ImmutableSortedSet<string>> GetRestrictedInternalsVisibleToMap(Compilation compilation)
         {
-            var restrictedInternalsVisibleToAttribute = compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesRestrictedInternalsVisibleToAttribute);
+            var restrictedInternalsVisibleToAttribute = compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesRestrictedInternalsVisibleToAttribute);
             if (restrictedInternalsVisibleToAttribute == null)
             {
                 return ImmutableDictionary<IAssemblySymbol, ImmutableSortedSet<string>>.Empty;

--- a/src/PerformanceSensitiveAnalyzers/Core/AbstractAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/Core/AbstractAllocationAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers
@@ -26,7 +27,7 @@ namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var compilation = compilationStartContext.Compilation;
-                var attributeSymbol = compilation.GetTypeByMetadataName(AllocationRules.PerformanceSensitiveAttributeName);
+                var attributeSymbol = compilation.GetOrCreateTypeByMetadataName(AllocationRules.PerformanceSensitiveAttributeName);
 
                 // Bail if PerformanceSensitiveAttribute is not delcared in the compilation.
                 if (attributeSymbol == null)

--- a/src/PerformanceSensitiveAnalyzers/Core/AbstractAllocationAnalyzer`1.cs
+++ b/src/PerformanceSensitiveAnalyzers/Core/AbstractAllocationAnalyzer`1.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var compilation = compilationStartContext.Compilation;
-                var attributeSymbol = compilation.GetTypeByMetadataName(AllocationRules.PerformanceSensitiveAttributeName);
+                var attributeSymbol = compilation.GetOrCreateTypeByMetadataName(AllocationRules.PerformanceSensitiveAttributeName);
 
                 // Bail if PerformanceSensitiveAttribute is not delcared in the compilation.
                 if (attributeSymbol == null)

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -493,7 +493,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
             private void ProcessTypeForwardedAttributes(Compilation compilation, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
             {
-                var typeForwardedToAttribute = compilation.GetTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesTypeForwardedToAttribute);
+                var typeForwardedToAttribute = compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesTypeForwardedToAttribute);
 
                 if (typeForwardedToAttribute != null)
                 {

--- a/src/Utilities/Compiler/WellKnownTypeProvider.cs
+++ b/src/Utilities/Compiler/WellKnownTypeProvider.cs
@@ -51,8 +51,14 @@ namespace Analyzer.Utilities
                 fullyQualifiedMetadataName =>
                 {
                     // Caching null results in our cache is intended.
-                    var type = Compilation.GetTypeByMetadataName(fullyQualifiedMetadataName)
-                        ?? Compilation.Assembly.GetTypeByMetadataName(fullyQualifiedMetadataName);
+
+#pragma warning disable RS0030 // Do not used banned APIs
+                    // Use of Compilation.GetTypeByMetadataName is allowed here (this is our wrapper for it which
+                    // includes fallback handling for cases where GetTypeByMetadataName returns null).
+                    var type = Compilation.GetTypeByMetadataName(fullyQualifiedMetadataName);
+#pragma warning restore RS0030 // Do not used banned APIs
+
+                    type ??= Compilation.Assembly.GetTypeByMetadataName(fullyQualifiedMetadataName);
                     if (type is null)
                     {
                         foreach (var module in Compilation.Assembly.Modules)


### PR DESCRIPTION
Fixes #2953

This is using the analyzer via NuGet. 