### PR TITLE
New analyzer: Do not call BeginInvoke on a delegate for .NET Core #2807

### DIFF
--- a/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/Microsoft.NetCore.Analyzers/Core/MicrosoftNetCoreAnalyzersResources.resx
@@ -1212,4 +1212,13 @@
   <data name="DoNotUseCreateEncryptorWithNonDefaultIVDescription" xml:space="preserve">
     <value>Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks.</value>
   </data>
+  <data name="DoNotCallBeginInvokeOnDelegateDescription" xml:space="preserve">
+    <value>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</value>
+  </data>
+  <data name="DoNotCallBeginInvokeOnDelegateMessage" xml:space="preserve">
+    <value>Do not call BeginInvoke on a delegate in .NET Core.</value>
+  </data>
+  <data name="DoNotCallBeginInvokeOnDelegateTitle" xml:space="preserve">
+    <value>Do not call BeginInvoke on a delegate in .NET Core.</value>
+  </data>
 </root>

--- a/src/Microsoft.NetCore.Analyzers/Core/Tasks/DoNotCallBeginInvokeOnDelegate.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Tasks/DoNotCallBeginInvokeOnDelegate.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.NetCore.Analyzers.Tasks
+{
+    /// <summary>
+    /// CA1069: Do not call BeginInvoke on a delegate in .NET Core and .NET Standard.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class DoNotCallBeginInvokeOnDelegate : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA1069";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallBeginInvokeOnDelegateTitle), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallBeginInvokeOnDelegateMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallBeginInvokeOnDelegateDescription), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
+                                                                             s_localizableTitle,
+                                                                             s_localizableMessage,
+                                                                             DiagnosticCategory.Design,
+                                                                             DiagnosticHelpers.DefaultDiagnosticSeverity,
+                                                                             isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+                                                                             description: s_localizableDescription,
+                                                                             helpLinkUri: null,
+                                                                             customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public sealed override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                compilationContext.RegisterOperationAction(operationContext =>
+                {
+                    var invocation = (IInvocationOperation)operationContext.Operation;
+                    var containingType = invocation.TargetMethod?.ContainingType;
+
+                    if (containingType != null &&
+                        containingType.TypeKind == TypeKind.Delegate &&
+                        invocation.TargetMethod.Name == "BeginInvoke")
+                    {
+                        operationContext.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation()));
+                    }
+                }, OperationKind.Invocation);
+            });
+        }
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/Core/Tasks/DoNotCallBeginInvokeOnDelegate.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Tasks/DoNotCallBeginInvokeOnDelegate.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -38,28 +37,28 @@ namespace Microsoft.NetCore.Analyzers.Tasks
         public sealed override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
             context.RegisterCompilationStartAction(compilationContext =>
             {
-                var isNetStandardAssembly = compilationContext.Compilation.ReferencedAssemblyNames.Any(identity => string.Equals(identity.Name, "netstandard", StringComparison.OrdinalIgnoreCase));
-
-                // Run diagnostic only on .NET Standard and .NET Core assemblies, because BeginInvoke is not implemented in .NET Core
-                if (isNetStandardAssembly)
+                if (compilationContext.Compilation.DoesTargetDotNetFramework())
                 {
-                    compilationContext.RegisterOperationAction(operationContext =>
-                    {
-                        var invocation = (IInvocationOperation)operationContext.Operation;
-                        var containingType = invocation.TargetMethod?.ContainingType;
-
-                        if (containingType != null &&
-                            containingType.TypeKind == TypeKind.Delegate &&
-                            invocation.TargetMethod.Name == "BeginInvoke")
-                        {
-                            operationContext.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation()));
-                        }
-                    }, OperationKind.Invocation);
+                    // Run diagnostic only on .NET Standard and .NET Core assemblies
+                    return;
                 }
+
+                compilationContext.RegisterOperationAction(operationContext =>
+                {
+                    var invocation = (IInvocationOperation)operationContext.Operation;
+                    var containingType = invocation.TargetMethod?.ContainingType;
+
+                    if (containingType != null &&
+                        containingType.TypeKind == TypeKind.Delegate &&
+                        invocation.TargetMethod.Name == "BeginInvoke")
+                    {
+                        operationContext.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation()));
+                    }
+                }, OperationKind.Invocation);
             });
         }
     }

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Toto přetížení metody Add je potenciálně nebezpečné, protože může překládat nebezpečné externí odkazy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">Nevolejte nebezpečné metody při deserializaci</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Diese Überladung der Add-Methode ist möglicherweise unsicher, weil dadurch gefährliche externe Verweise aufgelöst werden können.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">Keine gefährlichen Methoden bei der Deserialisierung aufrufen</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Esta sobrecarga del método Add es potencialmente insegura porque puede resolver referencias externas peligrosas.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">No llame a métodos peligrosos durante la deserialización</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Cette surcharge de la méthode Add est potentiellement non sécurisée, car elle peut résoudre des références externes dangereuses</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">Ne pas appeler de méthodes dangereuses dans la désérialisation</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Questo overload del metodo Add è potenzialmente insicuro perché può risolvere riferimenti esterni pericolosi</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">Non chiamare metodi pericolosi durante la deserializzazione</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Add メソッドのこのオーバーロードは、危険な外部参照を解決することが考えられるため、安全ではない可能性があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">逆シリアル化で危険なメソッドを呼び出さないでください</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Add 메서드의 이 오버로드는 위험한 외부 참조를 확인할 수 있으므로 잠재적으로 안전하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">역직렬화에서 위험한 메서드를 호출하면 안 됨</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -327,6 +327,21 @@
         <target state="translated">To przeciążenie metody Add jest potencjalnie niebezpieczne, ponieważ może spowodować powstanie niebezpiecznych odwołań zewnętrznych</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">Nie wywołuj niebezpiecznych metod w deserializacji</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Esta sobrecarga do método Add possivelmente não é segura porque pode resolver referências externas perigosas</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">Não Chame Métodos Perigosos Durante a Desserialização</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Эта перегрузка метода Add потенциально небезопасна, так как может разрешать опасные внешние ссылки</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">Не вызывать опасные методы десериализации</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Tehlikeli dış başvuruları çözümleyebileceğinden Add metodunun bu aşırı yüklemesi güvenli olmayabilir</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">Seri Durumdan Çıkarırken Tehlikeli Metotlar Çağırma</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -327,6 +327,21 @@
         <target state="translated">Add 方法的此项重载可能不安全，因为它可能会解析危险的外部引用</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">在反序列化中不要调用危险方法</target>

--- a/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.NetCore.Analyzers/Core/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -327,6 +327,21 @@
         <target state="translated">因為 Add 方法的此項多載可能解析了危險的外部參考，而有可能不安全</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateDescription">
+        <source>BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</source>
+        <target state="new">BeginInvoke method is not supported in .NET Core and throws NotSupportedException. BeginInvoke uses deprecated IAsyncResult pattern. Consider using Task.Run method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateMessage">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallBeginInvokeOnDelegateTitle">
+        <source>Do not call BeginInvoke on a delegate in .NET Core.</source>
+        <target state="new">Do not call BeginInvoke on a delegate in .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
         <source>Do Not Call Dangerous Methods In Deserialization</source>
         <target state="translated">不要在還原序列化期間呼叫危險的方法</target>

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCallBeginInvokeOnDelegateTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCallBeginInvokeOnDelegateTests.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
+{
+    public class DoNotCallBeginInvokeOnDelegateTests : DiagnosticAnalyzerTestBase
+    {
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            return new DoNotCallBeginInvokeOnDelegate();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DoNotCallBeginInvokeOnDelegate();
+        }
+
+        #region CSharp Tests
+
+        [Fact]
+        public void BeginInvokeOnAction()
+        {
+            var code = @"
+using System;
+
+class C
+{
+    public void M()
+    {
+        var action = new Action(D);
+        action.BeginInvoke(Callback, null);
+    }
+
+    private void D()
+    {
+        Console.WriteLine(""Test"");
+    }
+
+    private void Callback(IAsyncResult ar)
+    {
+        Console.WriteLine(ar.ToString());
+    }
+}
+";
+            VerifyCSharp(code, GetCSharpResultAt(9, 9));
+        }
+
+        [Fact]
+        public void BeginInvokeOnFunc()
+        {
+            var code = @"
+using System;
+
+class C
+{
+    private Func<object> func;
+
+    public void M()
+    {
+        this.func.BeginInvoke(Callback, ""test"");
+    }
+
+    private void Callback(IAsyncResult ar)
+    {
+        Console.WriteLine(ar.ToString());
+    }
+}
+";
+            VerifyCSharp(code, GetCSharpResultAt(10, 9));
+        }
+
+        [Fact]
+        public void BeginInvokeOnActionWith2Parameters()
+        {
+            var code = @"
+using System;
+
+class C
+{
+    public void M()
+    {
+        var action = new Action<string, int>(D);
+        action.BeginInvoke(""Value: {0}"", 10, Callback, this);
+    }
+
+    private void D(string format, int value)
+    {
+        Console.WriteLine(format, value);
+    }
+
+    private void Callback(IAsyncResult ar)
+    {
+        Console.WriteLine(ar.ToString());
+    }
+}
+";
+            VerifyCSharp(code, GetCSharpResultAt(9, 9));
+        }
+
+        [Fact]
+        public void BeginInvokeOnFuncWith2Parameters()
+        {
+            var code = @"
+using System;
+
+class C
+{
+    private IAsyncResult asyncResult;
+
+    public void M()
+    {
+        var func = new Func<string, int, string>(D);
+        asyncResult = func.BeginInvoke(""Value: {0}"", 10, Callback, null);
+    }
+
+    private string D(string format, int value)
+    {
+        return string.Format(format, value);
+    }
+
+    private void Callback(IAsyncResult ar)
+    {
+        Console.WriteLine(ar.ToString());
+    }
+}
+";
+            VerifyCSharp(code, GetCSharpResultAt(11, 23));
+        }
+
+        [Fact]
+        public void BeginInvokeOnCustomDelegate()
+        {
+            var code = @"
+using System;
+
+public delegate void D(object sender, EventArgs e);
+
+class C
+{
+    private IAsyncResult asyncResult;
+
+    public void M()
+    {
+        var d = new D(H1);
+        d += new D(H2);
+        asyncResult = d.BeginInvoke(this, EventArgs.Empty, Callback, 10);
+    }
+
+    private void H1(object sender, EventArgs e)
+    {
+        Console.WriteLine(e);
+    }
+
+    private static void H2(object sender, EventArgs e)
+    {
+        Console.WriteLine(e);
+    }
+
+    private void Callback(IAsyncResult ar)
+    {
+        Console.WriteLine(ar.ToString());
+    }
+}
+";
+            VerifyCSharp(code, GetCSharpResultAt(14, 23));
+        }
+
+        [Fact]
+        public void BeginInvokeOnEvent()
+        {
+            var code = @"
+using System;
+
+class C
+{
+    public event EventHandler E;
+
+    public void M()
+    {
+        E.BeginInvoke(this, EventArgs.Empty, Callback, null);
+    }
+
+    private void Callback(IAsyncResult ar)
+    {
+        Console.WriteLine(ar.ToString());
+    }
+}
+";
+            VerifyCSharp(code, GetCSharpResultAt(10, 9));
+        }
+        #endregion
+
+        private object D(string format, int value)
+        {
+            return string.Format(format, value);
+        }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
+        {
+            return GetCSharpResultAt(line, column, DoNotCallBeginInvokeOnDelegate.RuleId, MicrosoftNetCoreAnalyzersResources.DoNotCallBeginInvokeOnDelegateMessage);
+        }
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
+        {
+            return GetBasicResultAt(line, column, DoNotCallBeginInvokeOnDelegate.RuleId, MicrosoftNetCoreAnalyzersResources.DoNotCallBeginInvokeOnDelegateMessage);
+        }
+    }
+}

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCallBeginInvokeOnDelegateTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCallBeginInvokeOnDelegateTests.cs
@@ -3,11 +3,11 @@
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Tasks.DoNotCallBeginInvokeOnDelegate,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+using VerifyVB = Test.Utilities.VisualBasicSecurityCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Tasks.DoNotCallBeginInvokeOnDelegate,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCallBeginInvokeOnDelegateTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCallBeginInvokeOnDelegateTests.cs
@@ -1,28 +1,24 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Tasks.DoNotCallBeginInvokeOnDelegate,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Tasks.DoNotCallBeginInvokeOnDelegate,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
 {
-    public class DoNotCallBeginInvokeOnDelegateTests : DiagnosticAnalyzerTestBase
+    public class DoNotCallBeginInvokeOnDelegateTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotCallBeginInvokeOnDelegate();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotCallBeginInvokeOnDelegate();
-        }
-
         #region Basic diagnostic tests
 
         [Fact]
-        public void BasicBeginInvokeOnAction()
+        public async void BasicBeginInvokeOnAction()
         {
             var code = @"
 Imports System
@@ -42,11 +38,11 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(7, 9));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetVBResultAt(7, 9));
         }
 
         [Fact]
-        public void BasicBeginInvokeOnFunc()
+        public async void BasicBeginInvokeOnFunc()
         {
             var code = @"
 Imports System
@@ -63,11 +59,11 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(8, 9));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetVBResultAt(8, 9));
         }
 
         [Fact]
-        public void BasicBeginInvokeOnActionWith2Parameters()
+        public async void BasicBeginInvokeOnActionWith2Parameters()
         {
             var code = @"
 Imports System
@@ -87,11 +83,11 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(7, 9));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetVBResultAt(7, 9));
         }
 
         [Fact]
-        public void BasicBeginInvokeOnFuncWith2Parameters()
+        public async void BasicBeginInvokeOnFuncWith2Parameters()
         {
             var code = @"
 Imports System
@@ -109,11 +105,11 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(9, 14));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetVBResultAt(9, 14));
         }
 
         [Fact]
-        public void BasicBeginInvokeOnCustomDelegate()
+        public async void BasicBeginInvokeOnCustomDelegate()
         {
             var code = @"
 Imports System
@@ -142,7 +138,7 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(12, 14));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetVBResultAt(12, 14));
         }
 
         #endregion
@@ -150,7 +146,7 @@ End Class
         #region Basic no diagnostic tests
 
         [Fact]
-        public void BasicInvokeOnAction()
+        public async void BasicInvokeOnAction()
         {
             var code = @"
 Imports System
@@ -166,11 +162,11 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicInvokeOnFunc()
+        public async void BasicInvokeOnFunc()
         {
             var code = @"
 Imports System
@@ -182,11 +178,11 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicInvokeOnCustomDelegate()
+        public async void BasicInvokeOnCustomDelegate()
         {
             var code = @"
 Imports System
@@ -209,11 +205,11 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicCallCustomDelegate()
+        public async void BasicCallCustomDelegate()
         {
             var code = @"
 Imports System
@@ -238,11 +234,11 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicBeginInvokeOnCustomClass()
+        public async void BasicBeginInvokeOnCustomClass()
         {
             var code = @"
 Imports System
@@ -265,11 +261,11 @@ Class T
     End Function
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicBeginInvokeOnCustomStruct()
+        public async void BasicBeginInvokeOnCustomStruct()
         {
             var code = @"
 Imports System
@@ -292,7 +288,7 @@ Structure T
     End Function
 End Structure
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         #endregion
@@ -300,7 +296,7 @@ End Structure
         #region CSharp diagnostic tests
 
         [Fact]
-        public void CSharpBeginInvokeOnAction()
+        public async void CSharpBeginInvokeOnAction()
         {
             var code = @"
 using System;
@@ -324,11 +320,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(9, 9));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSResultAt(9, 9));
         }
 
         [Fact]
-        public void CSharpBeginInvokeOnFunc()
+        public async void CSharpBeginInvokeOnFunc()
         {
             var code = @"
 using System;
@@ -348,11 +344,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(10, 9));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSResultAt(10, 9));
         }
 
         [Fact]
-        public void CSharpBeginInvokeOnActionWith2Parameters()
+        public async void CSharpBeginInvokeOnActionWith2Parameters()
         {
             var code = @"
 using System;
@@ -376,11 +372,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(9, 9));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSResultAt(9, 9));
         }
 
         [Fact]
-        public void CSharpBeginInvokeOnFuncWith2Parameters()
+        public async void CSharpBeginInvokeOnFuncWith2Parameters()
         {
             var code = @"
 using System;
@@ -401,11 +397,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(11, 23));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSResultAt(11, 23));
         }
 
         [Fact]
-        public void CSharpBeginInvokeOnCustomDelegate()
+        public async void CSharpBeginInvokeOnCustomDelegate()
         {
             var code = @"
 using System;
@@ -439,11 +435,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(14, 23));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSResultAt(14, 23));
         }
 
         [Fact]
-        public void CSharpBeginInvokeOnEvent()
+        public async void CSharpBeginInvokeOnEvent()
         {
             var code = @"
 using System;
@@ -463,7 +459,7 @@ class C
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(10, 9));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSResultAt(10, 9));
         }
 
         #endregion
@@ -471,7 +467,7 @@ class C
         #region CSharp no diagnostic tests
 
         [Fact]
-        public void CSharpInvokeOnAction()
+        public async void CSharpInvokeOnAction()
         {
             var code = @"
 using System;
@@ -490,11 +486,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpInvokeOnFunc()
+        public async void CSharpInvokeOnFunc()
         {
             var code = @"
 using System;
@@ -508,11 +504,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpInvokeOnCustomDelegate()
+        public async void CSharpInvokeOnCustomDelegate()
         {
             var code = @"
 using System;
@@ -539,11 +535,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpCallCustomDelegate()
+        public async void CSharpCallCustomDelegate()
         {
             var code = @"
 using System;
@@ -572,11 +568,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpBeginInvokeOnCustomClass()
+        public async void CSharpBeginInvokeOnCustomClass()
         {
             var code = @"
 using System;
@@ -605,11 +601,11 @@ class T
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpBeginInvokeOnCustomStruct()
+        public async void CSharpBeginInvokeOnCustomStruct()
         {
             var code = @"
 using System;
@@ -638,19 +634,23 @@ struct T
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         #endregion
 
-        private static DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSResultAt(int line, int column)
         {
-            return GetCSharpResultAt(line, column, DoNotCallBeginInvokeOnDelegate.RuleId, MicrosoftNetCoreAnalyzersResources.DoNotCallBeginInvokeOnDelegateMessage);
+            return VerifyCS.Diagnostic(DoNotCallBeginInvokeOnDelegate.RuleId)
+                .WithMessage(MicrosoftNetCoreAnalyzersResources.DoNotCallBeginInvokeOnDelegateMessage)
+                .WithLocation(line, column);
         }
 
-        private static DiagnosticResult GetBasicResultAt(int line, int column)
+        private static DiagnosticResult GetVBResultAt(int line, int column)
         {
-            return GetBasicResultAt(line, column, DoNotCallBeginInvokeOnDelegate.RuleId, MicrosoftNetCoreAnalyzersResources.DoNotCallBeginInvokeOnDelegateMessage);
+            return VerifyVB.Diagnostic(DoNotCallBeginInvokeOnDelegate.RuleId)
+                .WithMessage(MicrosoftNetCoreAnalyzersResources.DoNotCallBeginInvokeOnDelegateMessage)
+                .WithLocation(line, column);
         }
     }
 }

--- a/src/Utilities/Compiler/Extensions/CompilationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/CompilationExtensions.cs
@@ -40,13 +40,6 @@ namespace Analyzer.Utilities.Extensions
         /// <returns><c>True</c> if the compilation targets .NET Framework; otherwise <c>false</c>.</returns>
         internal static bool DoesTargetDotNetFramework(this Compilation compilation)
         {
-            // This condition should be removed in future.
-            // It only ensures that tests are successful, because tests compilate to .NET Framework.
-            if (compilation.ReferencedAssemblyNames.Any(identity => string.Equals(identity.Name, "netstandard", StringComparison.OrdinalIgnoreCase)))
-            {
-                return false;
-            }
-
             var objectType = compilation.GetSpecialType(SpecialType.System_Object);
             var assemblyIdentity = objectType.ContainingAssembly.Identity;
             if (assemblyIdentity.Name == "mscorlib" &&

--- a/src/Utilities/Compiler/Extensions/CompilationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/CompilationExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace Analyzer.Utilities.Extensions
@@ -9,6 +11,9 @@ namespace Analyzer.Utilities.Extensions
     /// </summary>
     internal static class CompilationExtensions
     {
+        private static readonly byte[] mscorlibPublicKeyToken = new byte[]
+            { 0xB7, 0x7A, 0x5C, 0x56, 0x19, 0x34, 0xE0, 0x89 };
+
         /// <summary>
         /// Gets a type by its full type name and cache it at the compilation level.
         /// </summary>
@@ -26,5 +31,41 @@ namespace Analyzer.Utilities.Extensions
         /// <returns>The <see cref="INamedTypeSymbol"/> if found, null otherwise.</returns>
         internal static bool TryGetOrCreateTypeByMetadataName(this Compilation compilation, string fullTypeName, out INamedTypeSymbol namedTypeSymbol) =>
             WellKnownTypeProvider.GetOrCreate(compilation).TryGetOrCreateTypeByMetadataName(fullTypeName, out namedTypeSymbol);
+
+        /// <summary>
+        /// Gets a value indicating, whether the compilation of assembly targets .NET Framework.
+        /// This method differentiates between .NET Framework and other frameworks (.NET Core, .NET Standard, .NET 5 in future).
+        /// </summary>
+        /// <param name="compilation">The compilation</param>
+        /// <returns><c>True</c> if the compilation targets .NET Framework; otherwise <c>false</c>.</returns>
+        internal static bool DoesTargetDotNetFramework(this Compilation compilation)
+        {
+            // This condition should be removed in future.
+            // It only ensures that tests are successful, because tests compilate to .NET Framework.
+            if (compilation.ReferencedAssemblyNames.Any(identity => string.Equals(identity.Name, "netstandard", StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            var objectType = compilation.GetSpecialType(SpecialType.System_Object);
+            var assemblyIdentity = objectType.ContainingAssembly.Identity;
+            if (assemblyIdentity.Name == "mscorlib" &&
+                assemblyIdentity.IsStrongName &&
+                (assemblyIdentity.Version == new System.Version(4, 0, 0, 0) || assemblyIdentity.Version == new System.Version(2, 0, 0, 0)) &&
+                assemblyIdentity.PublicKeyToken.Length == mscorlibPublicKeyToken.Length)
+            {
+                for (int i = 0; i < mscorlibPublicKeyToken.Length; i++)
+                {
+                    if (assemblyIdentity.PublicKeyToken[i] != mscorlibPublicKeyToken[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Implements #2807

New analyzer: CA2069:DoNotCallBeginInvokeOnDelegate

Analyzer reports warning on a call of `BeginInvoke` method on Delegate. It reports only on compilation targeting .NET Standard or .NET Core, because BeginInvoke is not implemented in .NET Core.