### PR TITLE
CA1024: Do not report on implicit interface implementation

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
@@ -4,14 +4,14 @@ using System;
 using System.Collections.Immutable;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
     /// CA1024: Use properties where appropriate
-    /// 
+    ///
     /// Cause:
     /// A public or protected method has a name that starts with Get, takes no parameters, and returns a value that is not an array.
     /// </summary>
@@ -59,12 +59,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 // A few additional checks to reduce the noise for this diagnostic:
                 // Ensure that the method is non-generic, non-virtual/override, has no overloads and doesn't have special names: 'GetHashCode' or 'GetEnumerator'.
                 // Also avoid generating this diagnostic if the method body has any invocation expressions.
+                // Also avoid implicit interface implementation (explicit are handled through the member accessibility)
                 if (methodSymbol.IsGenericMethod ||
                     methodSymbol.IsVirtual ||
                     methodSymbol.IsOverride ||
                     methodSymbol.ContainingType.GetMembers(methodSymbol.Name).Length > 1 ||
                     methodSymbol.Name == GetHashCodeName ||
-                    methodSymbol.Name == GetEnumeratorName)
+                    methodSymbol.Name == GetEnumeratorName ||
+                    methodSymbol.IsImplementationOfAnyImplicitInterfaceMember())
                 {
                     return;
                 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -4,6 +4,12 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UsePropertiesWhereAppropriateAnalyzer,
+    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpUsePropertiesWhereAppropriateFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UsePropertiesWhereAppropriateAnalyzer,
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicUsePropertiesWhereAppropriateFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -422,6 +422,25 @@ public class Foo : IFoo
 ");
         }
 
+        [Fact, WorkItem(1551, "https://github.com/dotnet/roslyn-analyzers/issues/1551")]
+        public void CA1024_ImplicitInterfaceImplementation_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public interface IFoo
+{
+    object GetContent();
+}
+
+public class Foo : IFoo
+{
+    public object GetContent()
+    {
+        return null;
+    }
+}
+");
+        }
+
         private static DiagnosticResult GetCA1024CSharpResultAt(int line, int column, string methodName)
         {
             return GetCSharpResultAt(line, column, UsePropertiesWhereAppropriateAnalyzer.RuleId,

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UsePropertiesWhereAppropriateAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpUsePropertiesWhereAppropriateFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UsePropertiesWhereAppropriateAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicUsePropertiesWhereAppropriateFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
@@ -406,6 +400,25 @@ Public Class Class1
         End Function
     End Class
 End Class
+");
+        }
+
+        [Fact, WorkItem(1551, "https://github.com/dotnet/roslyn-analyzers/issues/1551")]
+        public void CA1024_ExplicitInterfaceImplementation_NoDiagnostic()
+        {
+            VerifyCSharp(@"
+public interface IFoo
+{
+    object GetContent();
+}
+
+public class Foo : IFoo
+{
+    object IFoo.GetContent()
+    {
+        return null;
+    }
+}
 ");
         }
 


### PR DESCRIPTION
- Add a test to show that no issue is reported on explicit interface.

- Update the rule (and add a test) to stop reporting on implicit interface implementation.

- Do nothing regarding `override` as it is already handled.

Fix #1551