### PR TITLE
Update tests to stop relying on DiagnosticAnalyzerTestBase

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
@@ -72,7 +72,7 @@ public class MyDerivedCodeActionWithEquivalenceKey : MyAbstractCodeActionWithEqu
 {
 }
 ";
-        private async Task TestCSharpCore(string source, DiagnosticResult missingGetFixAllProviderOverrideDiagnostic,
+        private async Task TestCSharpCoreAsync(string source, DiagnosticResult missingGetFixAllProviderOverrideDiagnostic,
             bool withCustomCodeActions = false, CompilerDiagnostics compilerDiagnostics = CompilerDiagnostics.Errors,
             params DiagnosticResult[] expected)
         {
@@ -151,7 +151,7 @@ class C1 : CodeFixProvider
 
             // Test0.cs(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
             var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
-            await TestCSharpCore(source, missingGetFixAllProviderOverrideDiagnostic, expected: expected);
+            await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, expected: expected);
         }
 
         [Fact]
@@ -213,7 +213,7 @@ class C1 : CodeFixProvider
             // Test0.cs(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
             var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
 
-            await TestCSharpCore(source, missingGetFixAllProviderOverrideDiagnostic, compilerDiagnostics: CompilerDiagnostics.None);
+            await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, compilerDiagnostics: CompilerDiagnostics.None);
         }
 
         [Fact]
@@ -251,7 +251,7 @@ class C1 : CodeFixProvider
             // Test0.cs(12,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
             var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(12, 7, "C1");
 
-            await TestCSharpCore(source, missingGetFixAllProviderOverrideDiagnostic, compilerDiagnostics: CompilerDiagnostics.None);
+            await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, compilerDiagnostics: CompilerDiagnostics.None);
         }
 
         [Fact]
@@ -293,7 +293,7 @@ abstract class C1 : CodeFixProvider
             // Test0.cs(12,16): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
             var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(12, 16, "C1");
 
-            await TestCSharpCore(source, missingGetFixAllProviderOverrideDiagnostic, expected: expected);
+            await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, expected: expected);
         }
 
         [Fact]
@@ -332,7 +332,7 @@ class C1 : CodeFixProvider
             // Test0.cs(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
             var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
 
-            await TestCSharpCore(source, missingGetFixAllProviderOverrideDiagnostic, withCustomCodeActions: true, expected: expected);
+            await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, withCustomCodeActions: true, expected: expected);
         }
 
         [Fact]
@@ -373,7 +373,7 @@ class C1 : CodeFixProvider
             // Test0.cs(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
             var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
 
-            await TestCSharpCore(source, missingGetFixAllProviderOverrideDiagnostic, withCustomCodeActions: true);
+            await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, withCustomCodeActions: true);
         }
 
         #endregion

--- a/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/ApiDesignGuidelines/EquatableAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static readonly LocalizableString s_localizableMessageImplementIEquatable = new LocalizableResourceString(nameof(MicrosoftCodeQualityAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsMessage), MicrosoftCodeQualityAnalyzersResources.ResourceManager, typeof(MicrosoftCodeQualityAnalyzersResources));
         private static readonly LocalizableString s_localizableDescriptionImplementIEquatable = new LocalizableResourceString(nameof(MicrosoftCodeQualityAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsDescription), MicrosoftCodeQualityAnalyzersResources.ResourceManager, typeof(MicrosoftCodeQualityAnalyzersResources));
 
-        private static readonly DiagnosticDescriptor s_implementIEquatableDescriptor = new DiagnosticDescriptor(
+        internal static readonly DiagnosticDescriptor ImplementIEquatableDescriptor = new DiagnosticDescriptor(
             ImplementIEquatableRuleId,
             s_localizableTitleImplementIEquatable,
             s_localizableMessageImplementIEquatable,
@@ -33,7 +33,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private static readonly LocalizableString s_localizableMessageOverridesObjectEquals = new LocalizableResourceString(nameof(MicrosoftCodeQualityAnalyzersResources.OverrideObjectEqualsMessage), MicrosoftCodeQualityAnalyzersResources.ResourceManager, typeof(MicrosoftCodeQualityAnalyzersResources));
         private static readonly LocalizableString s_localizableDescriptionOverridesObjectEquals = new LocalizableResourceString(nameof(MicrosoftCodeQualityAnalyzersResources.OverrideObjectEqualsDescription), MicrosoftCodeQualityAnalyzersResources.ResourceManager, typeof(MicrosoftCodeQualityAnalyzersResources));
 
-        private static readonly DiagnosticDescriptor s_overridesObjectEqualsDescriptor = new DiagnosticDescriptor(
+        internal static readonly DiagnosticDescriptor OverridesObjectEqualsDescriptor = new DiagnosticDescriptor(
             OverrideObjectEqualsRuleId,
             s_localizableTitleOverridesObjectEquals,
             s_localizableMessageOverridesObjectEquals,
@@ -43,7 +43,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             description: s_localizableDescriptionOverridesObjectEquals,
             helpLinkUri: "http://go.microsoft.com/fwlink/?LinkId=734909");
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_implementIEquatableDescriptor, s_overridesObjectEqualsDescriptor);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ImplementIEquatableDescriptor, OverridesObjectEqualsDescriptor);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -99,12 +99,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             if (overridesObjectEquals && !implementsEquatable && namedType.TypeKind == TypeKind.Struct)
             {
-                context.ReportDiagnostic(namedType.CreateDiagnostic(s_implementIEquatableDescriptor, namedType));
+                context.ReportDiagnostic(namedType.CreateDiagnostic(ImplementIEquatableDescriptor, namedType));
             }
 
             if (!overridesObjectEquals && implementsEquatable)
             {
-                context.ReportDiagnostic(namedType.CreateDiagnostic(s_overridesObjectEqualsDescriptor, namedType));
+                context.ReportDiagnostic(namedType.CreateDiagnostic(OverridesObjectEqualsDescriptor, namedType));
             }
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructorsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructorsTests.cs
@@ -1,27 +1,23 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AbstractTypesShouldNotHaveConstructorsAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AbstractTypesShouldNotHaveConstructorsFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AbstractTypesShouldNotHaveConstructorsAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AbstractTypesShouldNotHaveConstructorsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public partial class CA1012Tests : DiagnosticAnalyzerTestBase
+    public class CA1012Tests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new AbstractTypesShouldNotHaveConstructorsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new AbstractTypesShouldNotHaveConstructorsAnalyzer();
-        }
-
         [Fact]
-        public void TestCSPublicAbstractClass()
+        public async Task TestCSPublicAbstractClass()
         {
             var code = @"
 public abstract class C
@@ -31,11 +27,11 @@ public abstract class C
     }
 }
 ";
-            VerifyCSharp(code, GetCA1012CSharpResultAt(2, 23, "C"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1012CSharpResultAt(2, 23, "C"));
         }
 
         [Fact]
-        public void TestVBPublicAbstractClass()
+        public async Task TestVBPublicAbstractClass()
         {
             var code = @"
 Public MustInherit Class C
@@ -43,11 +39,11 @@ Public MustInherit Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code, GetCA1012BasicResultAt(2, 26, "C"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1012BasicResultAt(2, 26, "C"));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestCSInternalAbstractClass()
+        public async Task TestCSInternalAbstractClass()
         {
             var code = @"
 abstract class C
@@ -57,11 +53,11 @@ abstract class C
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestVBInternalAbstractClass()
+        public async Task TestVBInternalAbstractClass()
         {
             var code = @"
 MustInherit Class C
@@ -69,11 +65,11 @@ MustInherit Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void TestCSAbstractClassWithProtectedConstructor()
+        public async Task TestCSAbstractClassWithProtectedConstructor()
         {
             var code = @"
 public abstract class C
@@ -83,11 +79,11 @@ public abstract class C
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void TestVBAbstractClassWithProtectedConstructor()
+        public async Task TestVBAbstractClassWithProtectedConstructor()
         {
             var code = @"
 Public MustInherit Class C
@@ -95,11 +91,11 @@ Public MustInherit Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestCSNestedAbstractClassWithPublicConstructor1()
+        public async Task TestCSNestedAbstractClassWithPublicConstructor1()
         {
             var code = @"
 public struct C
@@ -110,11 +106,11 @@ public struct C
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void TestVBNestedAbstractClassWithPublicConstructor1()
+        public async Task TestVBNestedAbstractClassWithPublicConstructor1()
         {
             var code = @"
 Public Structure C
@@ -124,11 +120,11 @@ Public Structure C
     End Class
 End Structure
 ";
-            VerifyBasic(code, GetCA1012BasicResultAt(3, 23, "D"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1012BasicResultAt(3, 23, "D"));
         }
 
         [Fact]
-        public void TestNestedAbstractClassWithPublicConstructor2()
+        public async Task TestNestedAbstractClassWithPublicConstructor2()
         {
             var code = @"
 public abstract class C
@@ -139,11 +135,11 @@ public abstract class C
     }
 }
 ";
-            VerifyCSharp(code, GetCA1012CSharpResultAt(4, 27, "D"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1012CSharpResultAt(4, 27, "D"));
         }
 
         [Fact]
-        public void TestVBNestedAbstractClassWithPublicConstructor2()
+        public async Task TestVBNestedAbstractClassWithPublicConstructor2()
         {
             var code = @"
 Public MustInherit Class C
@@ -153,11 +149,11 @@ Public MustInherit Class C
     End Class
 End Class
 ";
-            VerifyBasic(code, GetCA1012BasicResultAt(3, 39, "D"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1012BasicResultAt(3, 39, "D"));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestNestedAbstractClassWithPublicConstructor3()
+        public async Task TestNestedAbstractClassWithPublicConstructor3()
         {
             var code = @"
 internal abstract class C
@@ -168,11 +164,11 @@ internal abstract class C
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestVBNestedAbstractClassWithPublicConstructor3()
+        public async Task TestVBNestedAbstractClassWithPublicConstructor3()
         {
             var code = @"
 MustInherit Class C
@@ -182,19 +178,19 @@ MustInherit Class C
     End Class
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         internal static readonly string CA1012Message = MicrosoftCodeQualityAnalyzersResources.AbstractTypesShouldNotHaveConstructorsMessage;
 
         private static DiagnosticResult GetCA1012CSharpResultAt(int line, int column, string objectName)
-        {
-            return GetCSharpResultAt(line, column, AbstractTypesShouldNotHaveConstructorsAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, CA1012Message, objectName));
-        }
+            => new DiagnosticResult(AbstractTypesShouldNotHaveConstructorsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1012Message, objectName));
 
         private static DiagnosticResult GetCA1012BasicResultAt(int line, int column, string objectName)
-        {
-            return GetBasicResultAt(line, column, AbstractTypesShouldNotHaveConstructorsAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, CA1012Message, objectName));
-        }
+            => new DiagnosticResult(AbstractTypesShouldNotHaveConstructorsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1012Message, objectName));
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructorsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructorsTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -181,16 +180,14 @@ End Class
             await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
-        internal static readonly string CA1012Message = MicrosoftCodeQualityAnalyzersResources.AbstractTypesShouldNotHaveConstructorsMessage;
-
         private static DiagnosticResult GetCA1012CSharpResultAt(int line, int column, string objectName)
             => new DiagnosticResult(AbstractTypesShouldNotHaveConstructorsAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1012Message, objectName));
+                .WithArguments(objectName);
 
         private static DiagnosticResult GetCA1012BasicResultAt(int line, int column, string objectName)
             => new DiagnosticResult(AbstractTypesShouldNotHaveConstructorsAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1012Message, objectName));
+                .WithArguments(objectName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
@@ -6,10 +6,10 @@ using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AvoidEmptyInterfacesAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpAvoidEmptyInterfacesFixer>;
 using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AvoidEmptyInterfacesAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicAvoidEmptyInterfacesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
@@ -1,68 +1,58 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AvoidEmptyInterfacesAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpAvoidEmptyInterfacesFixer>;
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AvoidEmptyInterfacesAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicAvoidEmptyInterfacesFixer>;
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class AvoidEmptyInterfacesTests : DiagnosticAnalyzerTestBase
+    public class AvoidEmptyInterfacesTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new AvoidEmptyInterfacesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new AvoidEmptyInterfacesAnalyzer();
-        }
-
         [Fact]
-        public void TestCSharpEmptyPublicInterface()
+        public async Task TestCSharpEmptyPublicInterface()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface I
 {
 }", CreateCSharpResult(2, 18));
         }
 
         [Fact]
-        public void TestBasicEmptyPublicInterface()
+        public async Task TestBasicEmptyPublicInterface()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface I
 End Interface", CreateBasicResult(2, 18));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestCSharpEmptyInternalInterface()
+        public async Task TestCSharpEmptyInternalInterface()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 interface I
 {
 }");
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestBasicEmptyInternalInterface()
+        public async Task TestBasicEmptyInternalInterface()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Interface I
 End Interface");
         }
 
         [Fact]
-        public void TestCSharpNonEmptyInterface1()
+        public async Task TestCSharpNonEmptyInterface1()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface I
 {
     void DoStuff();
@@ -70,18 +60,18 @@ public interface I
         }
 
         [Fact]
-        public void TestBasicNonEmptyInterface1()
+        public async Task TestBasicNonEmptyInterface1()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface I
     Function GetStuff() as Integer
 End Interface");
         }
 
         [Fact]
-        public void TestCSharpEmptyInterfaceWithNoInheritedMembers()
+        public async Task TestCSharpEmptyInterfaceWithNoInheritedMembers()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface I : IBase
 {
 }
@@ -90,9 +80,9 @@ public interface IBase { }", CreateCSharpResult(2, 18), CreateCSharpResult(6, 18
         }
 
         [Fact]
-        public void TestBasicEmptyInterfaceWithNoInheritedMembers()
+        public async Task TestBasicEmptyInterfaceWithNoInheritedMembers()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface I
     Inherits IBase
 End Interface
@@ -102,23 +92,23 @@ End Interface", CreateBasicResult(2, 18), CreateBasicResult(6, 18));
         }
 
         [Fact]
-        public void TestCSharpEmptyInterfaceWithInheritedMembers()
+        public async Task TestCSharpEmptyInterfaceWithInheritedMembers()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface I : IBase
 {
 }
 
-public interface IBase 
+public interface IBase
 {
-    void DoStuff(); 
+    void DoStuff();
 }");
         }
 
         [Fact]
-        public void TestBasicEmptyInterfaceWithInheritedMembers()
+        public async Task TestBasicEmptyInterfaceWithInheritedMembers()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface I
     Inherits IBase
 End Interface
@@ -153,14 +143,14 @@ End Interface");
         // Invalid analyzer option ignored
         [InlineData("internal", @"dotnet_code_quality.api_surface = all
                                   dotnet_code_quality.CA1040.api_surface_2 = private")]
-        public void TestCSharpEmptyInterface_AnalyzerOptions_Diagnostic(string accessibility, string editorConfigText)
+        public async Task TestCSharpEmptyInterface_AnalyzerOptions_Diagnostic(string accessibility, string editorConfigText)
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync($@"
 public class C
 {{
     {accessibility} interface I {{ }}
 }}",
-                GetEditorConfigAdditionalFile(editorConfigText),
+                editorConfigText,
                 CreateCSharpResult(4, 16 + accessibility.Length));
         }
 
@@ -189,14 +179,14 @@ public class C
         // Invalid analyzer option ignored
         [InlineData("Friend", @"dotnet_code_quality.api_surface = All
                                 dotnet_code_quality.CA1040.api_surface_2 = Private")]
-        public void TestBasicEmptyInterface_AnalyzerOptions_Diagnostic(string accessibility, string editorConfigText)
+        public async Task TestBasicEmptyInterface_AnalyzerOptions_Diagnostic(string accessibility, string editorConfigText)
         {
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync($@"
 Public Class C
     {accessibility} Interface I
     End Interface
 End Class",
-                GetEditorConfigAdditionalFile(editorConfigText),
+                editorConfigText,
                 CreateBasicResult(3, 16 + accessibility.Length));
         }
 
@@ -206,14 +196,14 @@ End Class",
         [InlineData("public", "dotnet_code_quality.Design.api_surface = internal, private")]
         [InlineData("public", @"dotnet_code_quality.api_surface = all
                                   dotnet_code_quality.CA1040.api_surface = private")]
-        public void TestCSharpEmptyInterface_AnalyzerOptions_NoDiagnostic(string accessibility, string editorConfigText)
+        public async Task TestCSharpEmptyInterface_AnalyzerOptions_NoDiagnostic(string accessibility, string editorConfigText)
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync($@"
 public class C
 {{
     {accessibility} interface I {{ }}
 }}",
-                GetEditorConfigAdditionalFile(editorConfigText));
+                editorConfigText);
         }
 
         [Theory]
@@ -222,24 +212,24 @@ public class C
         [InlineData("Public", "dotnet_code_quality.Design.api_surface = Friend, Private")]
         [InlineData("Public", @"dotnet_code_quality.api_surface = All
                                 dotnet_code_quality.CA1040.api_surface = Private")]
-        public void TestBasicEmptyInterface_AnalyzerOptions_NoDiagnostic(string accessibility, string editorConfigText)
+        public async Task TestBasicEmptyInterface_AnalyzerOptions_NoDiagnostic(string accessibility, string editorConfigText)
         {
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync($@"
 Public Class C
     {accessibility} Interface I
     End Interface
 End Class",
-                GetEditorConfigAdditionalFile(editorConfigText));
+                editorConfigText);
         }
 
         private static DiagnosticResult CreateCSharpResult(int line, int col)
-        {
-            return GetCSharpResultAt(line, col, AvoidEmptyInterfacesAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.AvoidEmptyInterfacesMessage);
-        }
+            => new DiagnosticResult(AvoidEmptyInterfacesAnalyzer.Rule)
+                .WithLocation(line, col)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.AvoidEmptyInterfacesMessage);
 
         private static DiagnosticResult CreateBasicResult(int line, int col)
-        {
-            return GetBasicResultAt(line, col, AvoidEmptyInterfacesAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.AvoidEmptyInterfacesMessage);
-        }
+            => new DiagnosticResult(AvoidEmptyInterfacesAnalyzer.Rule)
+                .WithLocation(line, col)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.AvoidEmptyInterfacesMessage);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
@@ -145,13 +145,25 @@ End Interface");
                                   dotnet_code_quality.CA1040.api_surface_2 = private")]
         public async Task TestCSharpEmptyInterface_AnalyzerOptions_Diagnostic(string accessibility, string editorConfigText)
         {
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync($@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 public class C
 {{
     {accessibility} interface I {{ }}
-}}",
-                editorConfigText,
-                CreateCSharpResult(4, 16 + accessibility.Length));
+}}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                },
+                ExpectedDiagnostics =
+                {
+                    CreateCSharpResult(4, 16 + accessibility.Length)
+                }
+            }.RunAsync();
         }
 
         [Theory]
@@ -181,13 +193,25 @@ public class C
                                 dotnet_code_quality.CA1040.api_surface_2 = Private")]
         public async Task TestBasicEmptyInterface_AnalyzerOptions_Diagnostic(string accessibility, string editorConfigText)
         {
-            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync($@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 Public Class C
     {accessibility} Interface I
     End Interface
-End Class",
-                editorConfigText,
-                CreateBasicResult(3, 16 + accessibility.Length));
+End Class"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                },
+                ExpectedDiagnostics =
+                {
+                    CreateBasicResult(3, 16 + accessibility.Length)
+                }
+            }.RunAsync();
         }
 
         [Theory]
@@ -198,12 +222,21 @@ End Class",
                                   dotnet_code_quality.CA1040.api_surface = private")]
         public async Task TestCSharpEmptyInterface_AnalyzerOptions_NoDiagnostic(string accessibility, string editorConfigText)
         {
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync($@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 public class C
 {{
     {accessibility} interface I {{ }}
-}}",
-                editorConfigText);
+}}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         [Theory]
@@ -214,12 +247,21 @@ public class C
                                 dotnet_code_quality.CA1040.api_surface = Private")]
         public async Task TestBasicEmptyInterface_AnalyzerOptions_NoDiagnostic(string accessibility, string editorConfigText)
         {
-            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync($@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 Public Class C
     {accessibility} Interface I
     End Interface
-End Class",
-                editorConfigText);
+End Class"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         private static DiagnosticResult CreateCSharpResult(int line, int col)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CancellationTokenParametersMustComeLastTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CancellationTokenParametersMustComeLastTests.cs
@@ -1,24 +1,30 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.CancellationTokenParametersMustComeLastAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.CancellationTokenParametersMustComeLastAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class CancellationTokenParametersMustComeLast : DiagnosticAnalyzerTestBase
+    public class CancellationTokenParametersMustComeLast
     {
         [Fact]
-        public void NoDiagnosticInEmptyFile()
+        public async Task NoDiagnosticInEmptyFile()
         {
             var test = @"";
 
-            VerifyCSharp(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [Fact]
-        public void DiagnosticForMethod()
+        public async Task DiagnosticForMethod()
         {
             var source = @"
 using System.Threading;
@@ -29,11 +35,11 @@ class T
     }
 }";
             var expected = new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(5, 10).WithArguments("T.M(System.Threading.CancellationToken, int)");
-            VerifyCSharp(source, expected);
+            await VerifyCS.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
-        public void DiagnosticWhenFirstAndLastByOtherInBetween()
+        public async Task DiagnosticWhenFirstAndLastByOtherInBetween()
         {
             var source = @"
 using System.Threading;
@@ -44,11 +50,11 @@ class T
     }
 }";
             var expected = new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(5, 10).WithArguments("T.M(System.Threading.CancellationToken, int, System.Threading.CancellationToken)");
-            VerifyCSharp(source, expected);
+            await VerifyCS.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
-        public void NoDiagnosticWhenLastParam()
+        public async Task NoDiagnosticWhenLastParam()
         {
             var test = @"
 using System.Threading;
@@ -58,11 +64,11 @@ class T
     {
     }
 }";
-            VerifyCSharp(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [Fact]
-        public void NoDiagnosticWhenOnlyParam()
+        public async Task NoDiagnosticWhenOnlyParam()
         {
             var test = @"
 using System.Threading;
@@ -72,11 +78,11 @@ class T
     {
     }
 }";
-            VerifyCSharp(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [Fact]
-        public void NoDiagnosticWhenParamsComesAfter()
+        public async Task NoDiagnosticWhenParamsComesAfter()
         {
             var test = @"
 using System.Threading;
@@ -86,11 +92,11 @@ class T
     {
     }
 }";
-            VerifyCSharp(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [Fact]
-        public void NoDiagnosticWhenOutComesAfter()
+        public async Task NoDiagnosticWhenOutComesAfter()
         {
             var test = @"
 using System.Threading;
@@ -101,11 +107,11 @@ class T
         i = 2;
     }
 }";
-            VerifyCSharp(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [Fact]
-        public void NoDiagnosticWhenRefComesAfter()
+        public async Task NoDiagnosticWhenRefComesAfter()
         {
             var test = @"
 using System.Threading;
@@ -115,11 +121,11 @@ class T
     {
     }
 }";
-            VerifyCSharp(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [Fact]
-        public void NoDiagnosticWhenOptionalParameterComesAfterNonOptionalCancellationToken()
+        public async Task NoDiagnosticWhenOptionalParameterComesAfterNonOptionalCancellationToken()
         {
             var test = @"
 using System.Threading;
@@ -129,11 +135,11 @@ class T
     {
     }
 }";
-            VerifyCSharp(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [Fact]
-        public void NoDiagnosticOnOverride()
+        public async Task NoDiagnosticOnOverride()
         {
             var test = @"
 using System.Threading;
@@ -149,11 +155,11 @@ class T : B
 
             // One diagnostic for the virtual, but none for the override.
             var expected = new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(5, 28).WithArguments("B.M(System.Threading.CancellationToken, int)");
-            VerifyCSharp(test, expected);
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
         [Fact]
-        public void NoDiagnosticOnImplicitInterfaceImplementation()
+        public async Task NoDiagnosticOnImplicitInterfaceImplementation()
         {
             var test = @"
 using System.Threading;
@@ -169,11 +175,11 @@ class T : I
 
             // One diagnostic for the interface, but none for the implementation.
             var expected = new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(5, 10).WithArguments("I.M(System.Threading.CancellationToken, int)");
-            VerifyCSharp(test, expected);
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
         [Fact]
-        public void NoDiagnosticOnExplicitInterfaceImplementation()
+        public async Task NoDiagnosticOnExplicitInterfaceImplementation()
         {
             var test = @"
 using System.Threading;
@@ -189,11 +195,11 @@ class T : I
 
             // One diagnostic for the interface, but none for the implementation.
             var expected = new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(5, 10).WithArguments("I.M(System.Threading.CancellationToken, int)");
-            VerifyCSharp(test, expected);
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
         [Fact, WorkItem(1491, "https://github.com/dotnet/roslyn-analyzers/issues/1491")]
-        public void NoDiagnosticOnCancellationTokenExtensionMethod()
+        public async Task NoDiagnosticOnCancellationTokenExtensionMethod()
         {
             var test = @"
 using System.Threading;
@@ -203,11 +209,11 @@ static class C1
     {
     }
 }";
-            VerifyCSharp(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [Fact, WorkItem(1816, "https://github.com/dotnet/roslyn-analyzers/issues/1816")]
-        public void NoDiagnosticWhenMultipleAtEndOfParameterList()
+        public async Task NoDiagnosticWhenMultipleAtEndOfParameterList()
         {
             var test = @"
 using System.Threading;
@@ -219,11 +225,11 @@ static class C1
     public static void M4(CancellationToken token1, CancellationToken token2 = default(CancellationToken)) { }
     public static void M5(CancellationToken token1 = default(CancellationToken), CancellationToken token2 = default(CancellationToken)) { }
 }";
-            VerifyCSharp(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [Fact]
-        public void DiagnosticOnExtensionMethodWhenCancellationTokenIsNotFirstParameter()
+        public async Task DiagnosticOnExtensionMethodWhenCancellationTokenIsNotFirstParameter()
         {
             var test = @"
 using System.Threading;
@@ -235,13 +241,13 @@ static class C1
 }";
 
             var expected = new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(5, 24).WithArguments("C1.M1(object, System.Threading.CancellationToken, object)");
-            VerifyCSharp(test, expected);
+            VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
         [Fact, WorkItem(2281, "https://github.com/dotnet/roslyn-analyzers/issues/2281")]
-        public void CA1068_DoNotReportOnIProgressLastAndCancellationTokenBeforeLast()
+        public async Task CA1068_DoNotReportOnIProgressLastAndCancellationTokenBeforeLast()
         {
-            VerifyCSharp(@"
+            VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -254,7 +260,7 @@ public class C
     }
 }");
 
-            VerifyBasic(@"
+            VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading
 Imports System.Threading.Tasks
@@ -267,9 +273,9 @@ End Class");
         }
 
         [Fact, WorkItem(2281, "https://github.com/dotnet/roslyn-analyzers/issues/2281")]
-        public void CA1068_ReportOnIProgressLastAndCancellationTokenNotBeforeLast()
+        public async Task CA1068_ReportOnIProgressLastAndCancellationTokenNotBeforeLast()
         {
-            VerifyCSharp(@"
+            VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -284,7 +290,7 @@ public class C
             new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(8, 17)
                 .WithArguments("C.SomeAsync(System.Threading.CancellationToken, object, System.IProgress<int>)"));
 
-            VerifyBasic(@"
+            VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading
 Imports System.Threading.Tasks
@@ -299,9 +305,9 @@ End Class",
         }
 
         [Fact, WorkItem(2281, "https://github.com/dotnet/roslyn-analyzers/issues/2281")]
-        public void CA1068_OnlyExcludeOneIProgressAtTheEnd()
+        public async Task CA1068_OnlyExcludeOneIProgressAtTheEnd()
         {
-            VerifyCSharp(@"
+            VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -316,7 +322,7 @@ public class C
             new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(8, 17)
                 .WithArguments("C.SomeAsync(System.Threading.CancellationToken, System.IProgress<int>, System.IProgress<int>)"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading
 Imports System.Threading.Tasks
@@ -328,16 +334,6 @@ Public Class C
 End Class",
             new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(7, 21)
                 .WithArguments("Public Function SomeAsync(cancellationToken As System.Threading.CancellationToken, progress1 As System.IProgress(Of Integer), progress2 As System.IProgress(Of Integer)) As System.Threading.Tasks.Task"));
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CancellationTokenParametersMustComeLastAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new CancellationTokenParametersMustComeLastAnalyzer();
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CancellationTokenParametersMustComeLastTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CancellationTokenParametersMustComeLastTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.CancellationTokenParametersMustComeLastAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-using VerifyVB = Test.Utilities.CSharpCodeFixVerifier<
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.CancellationTokenParametersMustComeLastAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
@@ -241,13 +241,13 @@ static class C1
 }";
 
             var expected = new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(5, 24).WithArguments("C1.M1(object, System.Threading.CancellationToken, object)");
-            VerifyCS.VerifyAnalyzerAsync(test, expected);
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
         [Fact, WorkItem(2281, "https://github.com/dotnet/roslyn-analyzers/issues/2281")]
         public async Task CA1068_DoNotReportOnIProgressLastAndCancellationTokenBeforeLast()
         {
-            VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -260,7 +260,7 @@ public class C
     }
 }");
 
-            VerifyVB.VerifyAnalyzerAsync(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading
 Imports System.Threading.Tasks
@@ -275,7 +275,7 @@ End Class");
         [Fact, WorkItem(2281, "https://github.com/dotnet/roslyn-analyzers/issues/2281")]
         public async Task CA1068_ReportOnIProgressLastAndCancellationTokenNotBeforeLast()
         {
-            VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -290,7 +290,7 @@ public class C
             new DiagnosticResult(CancellationTokenParametersMustComeLastAnalyzer.Rule).WithLocation(8, 17)
                 .WithArguments("C.SomeAsync(System.Threading.CancellationToken, object, System.IProgress<int>)"));
 
-            VerifyVB.VerifyAnalyzerAsync(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading
 Imports System.Threading.Tasks
@@ -307,7 +307,7 @@ End Class",
         [Fact, WorkItem(2281, "https://github.com/dotnet/roslyn-analyzers/issues/2281")]
         public async Task CA1068_OnlyExcludeOneIProgressAtTheEnd()
         {
-            VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
@@ -1,43 +1,35 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.CollectionPropertiesShouldBeReadOnlyAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.CollectionPropertiesShouldBeReadOnlyAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class CollectionPropertiesShouldBeReadOnlyTests : DiagnosticAnalyzerTestBase
+    public class CollectionPropertiesShouldBeReadOnlyTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new CollectionPropertiesShouldBeReadOnlyAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CollectionPropertiesShouldBeReadOnlyAnalyzer();
-        }
-
         private DiagnosticResult GetBasicResultAt(int line, int column, string propertyName)
-        {
-            return GetBasicResultAt(line, column,
-                id: CollectionPropertiesShouldBeReadOnlyAnalyzer.RuleId,
-                message: string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.CollectionPropertiesShouldBeReadOnlyMessage, propertyName));
-        }
+            => new DiagnosticResult(CollectionPropertiesShouldBeReadOnlyAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.CollectionPropertiesShouldBeReadOnlyMessage, propertyName));
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string propertyName)
-        {
-            return GetCSharpResultAt(line, column,
-                id: CollectionPropertiesShouldBeReadOnlyAnalyzer.RuleId,
-                message: string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.CollectionPropertiesShouldBeReadOnlyMessage, propertyName));
-        }
+            => new DiagnosticResult(CollectionPropertiesShouldBeReadOnlyAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.CollectionPropertiesShouldBeReadOnlyMessage, propertyName));
 
         [Fact]
-        public void CSharp_CA2227_Test()
+        public async Task CSharp_CA2227_Test()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A
@@ -48,9 +40,9 @@ public class A
         }
 
         [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
-        public void CSharp_CA2227_Test_GenericCollection()
+        public async Task CSharp_CA2227_Test_GenericCollection()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A
@@ -61,9 +53,9 @@ public class A
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_CA2227_Test_Internal()
+        public async Task CSharp_CA2227_Test_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 internal class A
@@ -92,9 +84,9 @@ public class A4
         }
 
         [Fact]
-        public void Basic_CA2227_Test()
+        public async Task Basic_CA2227_Test()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A
@@ -104,9 +96,9 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void Basic_CA2227_Test_Internal()
+        public async Task Basic_CA2227_Test_Internal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Friend Class A
@@ -148,9 +140,9 @@ End Class
         }
 
         [Fact]
-        public void CSharp_CA2227_Inherited()
+        public async Task CSharp_CA2227_Inherited()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A<T>
@@ -161,9 +153,9 @@ public class A<T>
         }
 
         [Fact]
-        public void CSharp_CA2227_NotPublic()
+        public async Task CSharp_CA2227_NotPublic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A
@@ -179,9 +171,9 @@ class A
         }
 
         [Fact]
-        public void CSharp_CA2227_Array()
+        public async Task CSharp_CA2227_Array()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A
@@ -192,9 +184,9 @@ public class A
         }
 
         [Fact]
-        public void CSharp_CA2227_Indexer()
+        public async Task CSharp_CA2227_Indexer()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A
@@ -209,9 +201,9 @@ public class A
         }
 
         [Fact]
-        public void CSharp_CA2227_NonCollection()
+        public async Task CSharp_CA2227_NonCollection()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A
@@ -222,11 +214,11 @@ public class A
         }
 
         [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
-        public void CSharp_CA2227_ReadOnlyCollections()
+        public async Task CSharp_CA2227_ReadOnlyCollections()
         {
             // NOTE: ReadOnlyCollection<T> and ReadOnlyDictionary<Key, Value> implement ICollection and hence are flagged.
             //       IReadOnlyCollection<T> does not implement ICollection or ICollection<T>, hence is not flagged.
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -244,9 +236,9 @@ public class A
         }
 
         [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
-        public void CSharp_CA2227_ImmutableCollection()
+        public async Task CSharp_CA2227_ImmutableCollection()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Immutable;
 
 public class A
@@ -260,9 +252,9 @@ public class A
         }
 
         [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
-        public void CSharp_CA2227_ImmutableCollection_02()
+        public async Task CSharp_CA2227_ImmutableCollection_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Immutable;
 
 public class A
@@ -277,9 +269,9 @@ public class A
         }
 
         [Fact, WorkItem(1900, "https://github.com/dotnet/roslyn-analyzers/issues/1900")]
-        public void CSharp_CA2227_ImmutableCollection_03()
+        public async Task CSharp_CA2227_ImmutableCollection_03()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -407,9 +399,9 @@ public class CustomImmutableList : IImmutableList<int>, ICollection<int>
         }
 
         [Fact]
-        public void CSharp_CA2227_DataMember()
+        public async Task CSharp_CA2227_DataMember()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 namespace System.Runtime.Serialization

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -14,49 +14,33 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class CollectionsShouldImplementGenericInterfaceTests : DiagnosticAnalyzerTestBase
+    public class CollectionsShouldImplementGenericInterfaceTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new CollectionsShouldImplementGenericInterfaceAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CollectionsShouldImplementGenericInterfaceAnalyzer();
-        }
-
         private static readonly string CA1010Message = MicrosoftCodeQualityAnalyzersResources.CollectionsShouldImplementGenericInterfaceMessage;
 
         private DiagnosticResult GetCA1010CSharpResultAt(int line, int column, string typeName, string interfaceName)
-        {
-            return GetCSharpResultAt(line,
-                                     column,
-                                     CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId,
-                                     string.Format(CultureInfo.CurrentCulture, CA1010Message, typeName, interfaceName, $"{interfaceName}<T>"));
-        }
+            => new DiagnosticResult(CollectionsShouldImplementGenericInterfaceAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1010Message, typeName, interfaceName, $"{interfaceName}<T>"));
 
         private DiagnosticResult GetCA1010BasicResultAt(int line, int column, string typeName, string interfaceName)
-        {
-            return GetBasicResultAt(line,
-                                     column,
-                                     CollectionsShouldImplementGenericInterfaceAnalyzer.RuleId,
-                                     string.Format(CultureInfo.CurrentCulture, CA1010Message, typeName, interfaceName, $"{interfaceName}(Of T)"));
-        }
+            => new DiagnosticResult(CollectionsShouldImplementGenericInterfaceAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1010Message, typeName, interfaceName, $"{interfaceName}(Of T)"));
 
         [Fact]
-        public void Test_WithCollectionBase()
+        public async Task Test_WithCollectionBase()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections;
 
 public class TestClass : CollectionBase { }",
                 GetCA1010CSharpResultAt(4, 14, "TestClass", "IList"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Collections
 
-Public Class TestClass 
+Public Class TestClass
     Inherits CollectionBase
 End Class
 ",
@@ -64,26 +48,26 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void Test_WithCollectionBase_Internal()
+        public async Task Test_WithCollectionBase_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections;
 
 internal class TestClass : CollectionBase { }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Collections
 
-Friend Class TestClass 
+Friend Class TestClass
     Inherits CollectionBase
 End Class
 ");
         }
 
         [Fact]
-        public void Test_WithCollection()
+        public async Task Test_WithCollection()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 
@@ -99,7 +83,7 @@ public class TestClass : ICollection
 ",
                 GetCA1010CSharpResultAt(5, 14, "TestClass", "ICollection"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 
@@ -123,9 +107,9 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void Test_WithCollection_Internal()
+        public async Task Test_WithCollection_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 
@@ -140,7 +124,7 @@ internal class TestClass : ICollection
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 
@@ -163,9 +147,9 @@ End Class
         }
 
         [Fact]
-        public void Test_WithEnumerable()
+        public async Task Test_WithEnumerable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 
@@ -176,7 +160,7 @@ public class TestClass : IEnumerable
 ",
                 GetCA1010CSharpResultAt(5, 14, "TestClass", "IEnumerable"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 
@@ -192,9 +176,9 @@ End Class
         }
 
         [Fact]
-        public void Test_WithList()
+        public async Task Test_WithList()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 
@@ -225,7 +209,7 @@ public class TestClass : IList
 ",
                 GetCA1010CSharpResultAt(5, 14, "TestClass", "IList"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 
@@ -288,9 +272,9 @@ End Class
         }
 
         [Fact]
-        public void Test_WithGenericCollection()
+        public async Task Test_WithGenericCollection()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -310,7 +294,7 @@ public class TestClass : ICollection<int>
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
@@ -353,9 +337,9 @@ End Class
         }
 
         [Fact]
-        public void Test_WithGenericEnumerable()
+        public async Task Test_WithGenericEnumerable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -367,7 +351,7 @@ public class TestClass : IEnumerable<int>
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
@@ -387,9 +371,9 @@ End Class
         }
 
         [Fact]
-        public void Test_WithGenericList()
+        public async Task Test_WithGenericList()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -418,7 +402,7 @@ public class TestClass : IList<int>
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
@@ -482,9 +466,9 @@ End Class
         }
 
         [Fact]
-        public void Test_WithCollectionBaseAndGenerics()
+        public async Task Test_WithCollectionBaseAndGenerics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -515,7 +499,7 @@ public class TestClass : CollectionBase, ICollection<int>, IEnumerable<int>, ILi
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
@@ -578,9 +562,9 @@ End Class
         }
 
         [Fact]
-        public void Test_WithCollectionAndGenericCollection()
+        public async Task Test_WithCollectionAndGenericCollection()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -612,7 +596,7 @@ public class TestClass : ICollection, ICollection<int>
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
@@ -664,9 +648,9 @@ End Class
         }
 
         [Fact]
-        public void Test_WithBaseAndDerivedClassFailureCase()
+        public async Task Test_WithBaseAndDerivedClassFailureCase()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 
@@ -687,7 +671,7 @@ public class IntCollection : BaseClass
                 GetCA1010CSharpResultAt(5, 14, "BaseClass", "ICollection"),
                 GetCA1010CSharpResultAt(15, 14, "IntCollection", "ICollection"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 
@@ -716,9 +700,9 @@ End Class
         }
 
         [Fact]
-        public void Test_InheritsCollectionBaseAndReadOnlyCollectionBase()
+        public async Task Test_InheritsCollectionBaseAndReadOnlyCollectionBase()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections;
 
 public class C : CollectionBase { }
@@ -728,7 +712,7 @@ public class R : ReadOnlyCollectionBase { }
                 GetCA1010CSharpResultAt(4, 14, "C", "IList"),
                 GetCA1010CSharpResultAt(6, 14, "R", "ICollection"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Collections
 
 Public Class C
@@ -744,9 +728,9 @@ End Class
         }
 
         [Fact]
-        public void Test_InheritsCollectionBaseAndReadOnlyCollectionBase_DoesFullyImplementGenerics()
+        public async Task Test_InheritsCollectionBaseAndReadOnlyCollectionBase_DoesFullyImplementGenerics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -793,7 +777,7 @@ public class R : ReadOnlyCollectionBase, IEnumerable<int>
                 GetCA1010CSharpResultAt(6, 14, "C", "IList"),
                 GetCA1010CSharpResultAt(37, 14, "R", "ICollection"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
@@ -854,9 +838,9 @@ End Class
 
 
         [Fact]
-        public void Test_InheritsCollectionBaseAndReadOnlyCollectionBaseAndGenericIEnumerable_NoDiagnostic()
+        public async Task Test_InheritsCollectionBaseAndReadOnlyCollectionBaseAndGenericIEnumerable_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections;
 using System.Collections.Generic;
 
@@ -877,7 +861,7 @@ class R : ReadOnlyCollectionBase, IEnumerable<int>
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Collections
 Imports System.Collections.Generic
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DeclareTypesInNamespacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DeclareTypesInNamespacesTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DeclareTypesInNamespacesAnalyzer,
@@ -13,34 +12,34 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class DeclareTypesInNamespacesTests : DiagnosticAnalyzerTestBase
+    public class DeclareTypesInNamespacesTests
     {
         [Fact]
-        public void OuterTypeInGlobalNamespace_Warns()
+        public async Task OuterTypeInGlobalNamespace_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                 }",
                 GetCSharpExpectedResult(2, 30));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                 End Class",
                 GetBasicExpectedResult(2, 30));
         }
 
         [Fact]
-        public void NestedTypeInGlobalNamespace_WarnsOnlyOnce()
+        public async Task NestedTypeInGlobalNamespace_WarnsOnlyOnce()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public class Nested {}
                 }",
                 GetCSharpExpectedResult(2, 30));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Class Nested
                     End Class
@@ -49,15 +48,15 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void InternalClassInGlobalNamespace_DoesNotWarn()
+        public async Task InternalClassInGlobalNamespace_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 internal class Class
                 {
                     public class Nested {}
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Friend Class [MyClass]
                     Public Class Nested
                     End Class
@@ -65,9 +64,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void PublicClassInNonGlobalNamespace_DoesNotWarn()
+        public async Task PublicClassInNonGlobalNamespace_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 namespace NS
                 {
                     public class Class
@@ -76,7 +75,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Namespace NS
                     Public Class [MyClass]
                         Public Class Nested
@@ -85,24 +84,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                 End Namespace");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DeclareTypesInNamespacesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DeclareTypesInNamespacesAnalyzer();
-        }
-
         private static DiagnosticResult GetCSharpExpectedResult(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, DeclareTypesInNamespacesAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.DeclareTypesInNamespacesMessage);
-        }
+            => new DiagnosticResult(DeclareTypesInNamespacesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DeclareTypesInNamespacesMessage);
 
         private static DiagnosticResult GetBasicExpectedResult(int line, int column)
-        {
-            return GetBasicResultAt(line, column, DeclareTypesInNamespacesAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.DeclareTypesInNamespacesMessage);
-        }
+            => new DiagnosticResult(DeclareTypesInNamespacesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DeclareTypesInNamespacesMessage);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
@@ -1,30 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotCatchGeneralExceptionTypesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotCatchGeneralExceptionTypesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
 {
-    public class DoNotCatchGeneralExceptionTypesTests : DiagnosticAnalyzerTestBase
+    public class DoNotCatchGeneralExceptionTypesTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotCatchGeneralExceptionTypesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotCatchGeneralExceptionTypesAnalyzer();
-        }
-
         [Fact]
-        public void CSharp_Diagnostic_GeneralCatch()
+        public async Task CSharp_Diagnostic_GeneralCatch()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -51,9 +47,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_Diagnostic_GeneralCatch()
+        public async Task Basic_Diagnostic_GeneralCatch()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System.IO
 
             Namespace TestNamespace
@@ -72,9 +68,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_Diagnostic_GeneralCatchInGetAccessor()
+        public async Task CSharp_Diagnostic_GeneralCatchInGetAccessor()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -105,9 +101,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_Diagnostic_GeneralCatchInGetAccessor()
+        public async Task Basic_Diagnostic_GeneralCatchInGetAccessor()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System.IO
 
             Namespace TestNamespace
@@ -129,9 +125,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_NoDiagnostic_GeneralCatchRethrow()
+        public async Task CSharp_NoDiagnostic_GeneralCatchRethrow()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -158,9 +154,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_NoDiagnostic_GeneralCatchRethrow()
+        public async Task Basic_NoDiagnostic_GeneralCatchRethrow()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System.IO
 
             Namespace TestNamespace
@@ -179,9 +175,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_NoDiagnostic_GeneralCatchThrowNew()
+        public async Task CSharp_NoDiagnostic_GeneralCatchThrowNew()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -208,9 +204,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_NoDiagnostic_GeneralCatchThrowNew()
+        public async Task Basic_NoDiagnostic_GeneralCatchThrowNew()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System.IO
 
             Namespace TestNamespace
@@ -229,9 +225,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_Diagnostic_GeneralCatchWithRethrowFromSpecificCatch()
+        public async Task CSharp_Diagnostic_GeneralCatchWithRethrowFromSpecificCatch()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -259,9 +255,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_Diagnostic_GeneralCatchWithRethrowFromSpecificCatch()
+        public async Task Basic_Diagnostic_GeneralCatchWithRethrowFromSpecificCatch()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System.IO
 
             Namespace TestNamespace
@@ -281,9 +277,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_Diagnostic_GenericException()
+        public async Task CSharp_Diagnostic_GenericException()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -307,9 +303,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_Diagnostic_GenericException()
+        public async Task Basic_Diagnostic_GenericException()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
             Imports System.IO
 
@@ -328,9 +324,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_NoDiagnostic_GenericExceptionRethrown()
+        public async Task CSharp_NoDiagnostic_GenericExceptionRethrown()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -354,9 +350,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_NoDiagnostic_GenericExceptionRethrown()
+        public async Task Basic_NoDiagnostic_GenericExceptionRethrown()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
             Imports System.IO
 
@@ -375,9 +371,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_NoDiagnostic_ThrowNewWrapped()
+        public async Task CSharp_NoDiagnostic_ThrowNewWrapped()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -401,9 +397,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_NoDiagnostic_ThrowNewWrapped()
+        public async Task Basic_NoDiagnostic_ThrowNewWrapped()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
             Imports System.IO
 
@@ -422,9 +418,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_Diagnostic_SystemException()
+        public async Task CSharp_Diagnostic_SystemException()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -448,9 +444,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_Diagnostic_SystemException()
+        public async Task Basic_Diagnostic_SystemException()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System.IO
 
             Namespace TestNamespace
@@ -468,9 +464,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_Diagnostic_GeneralCatchWithFilter()
+        public async Task CSharp_Diagnostic_GeneralCatchWithFilter()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
             namespace TestNamespace
@@ -493,9 +489,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_Diagnostic_GeneralCatchWithFilter()
+        public async Task Basic_Diagnostic_GeneralCatchWithFilter()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System.IO
             Namespace TestNamespace
                 Class TestClass
@@ -512,9 +508,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_Diagnostic_GenericExceptionWithoutVariableWithFilter()
+        public async Task CSharp_Diagnostic_GenericExceptionWithoutVariableWithFilter()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
             namespace TestNamespace
@@ -537,9 +533,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_NoDiagnostic_GenericExceptionWithVariableWithFilter()
+        public async Task CSharp_NoDiagnostic_GenericExceptionWithVariableWithFilter()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
             namespace TestNamespace
@@ -561,9 +557,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_NoDiagnostic_GenericExceptionWithVariableWithFilter()
+        public async Task Basic_NoDiagnostic_GenericExceptionWithVariableWithFilter()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
             Imports System.IO
             Namespace TestNamespace
@@ -580,9 +576,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void CSharp_Diagnostic_GeneralCatchInLambdaExpression()
+        public async Task CSharp_Diagnostic_GeneralCatchInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             using System.IO;
 
@@ -609,9 +605,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact]
-        public void Basic_Diagnostic_GeneralCatchInLambdaExpression()
+        public async Task Basic_Diagnostic_GeneralCatchInLambdaExpression()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
             Imports System.IO
 
@@ -630,7 +626,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
             ",
             GetCA1031BasicResultAt(11, 29, "TestMethod"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
             Imports System.IO
 
@@ -652,9 +648,9 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         }
 
         [Fact, WorkItem(2518, "https://github.com/dotnet/roslyn-analyzers/issues/2518")]
-        public void CSharp_NoDiagnostic_SpecificExceptionWithoutVariable()
+        public async Task CSharp_NoDiagnostic_SpecificExceptionWithoutVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
 
             public class Class1
@@ -682,7 +678,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
         [InlineData("dotnet_code_quality." + DoNotCatchGeneralExceptionTypesAnalyzer.RuleId + ".disallowed_symbol_names = NullReferenceException")]
         // Match by type documentation ID
         [InlineData(@"dotnet_code_quality.disallowed_symbol_names = T:System.NullReferenceException")]
-        public void EditorConfigConfiguration_DisallowedExceptionTypes(string editorConfigText)
+        public async Task EditorConfigConfiguration_DisallowedExceptionTypes(string editorConfigText)
         {
             var expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length > 0)
@@ -693,7 +689,7 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                 };
             }
 
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
 class Test
 {
     void M1(string param)
@@ -701,7 +697,7 @@ class Test
         try { }
         catch (System.NullReferenceException ex) { }
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}", editorConfigText, expected);
 
             expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length > 0)
@@ -713,24 +709,24 @@ class Test
                 };
             }
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
 Class Test
     Private Sub M1(param As String)
         Try
         Catch ex As System.NullReferenceException
         End Try
     End Sub
-End Class", GetEditorConfigAdditionalFile(editorConfigText), expected);
+End Class", editorConfigText, expected);
         }
 
         private static DiagnosticResult GetCA1031CSharpResultAt(int line, int column, string signature)
-        {
-            return GetCSharpResultAt(line, column, DoNotCatchGeneralExceptionTypesAnalyzer.Rule, signature);
-        }
+            => VerifyCS.Diagnostic(DoNotCatchGeneralExceptionTypesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(signature);
 
         private static DiagnosticResult GetCA1031BasicResultAt(int line, int column, string signature)
-        {
-            return GetBasicResultAt(line, column, DoNotCatchGeneralExceptionTypesAnalyzer.Rule, signature);
-        }
+            => VerifyVB.Diagnostic(DoNotCatchGeneralExceptionTypesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(signature);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
@@ -689,7 +689,13 @@ namespace Microsoft.ApiDesignGuidelines.Analyzers.UnitTests
                 };
             }
 
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
+            var csTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 class Test
 {
     void M1(string param)
@@ -697,7 +703,13 @@ class Test
         try { }
         catch (System.NullReferenceException ex) { }
     }
-}", editorConfigText, expected);
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                },
+            };
+            csTest.ExpectedDiagnostics.AddRange(expected);
+            await csTest.RunAsync();
 
             expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length > 0)
@@ -709,14 +721,26 @@ class Test
                 };
             }
 
-            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
+            var vbTest = new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Class Test
     Private Sub M1(param As String)
         Try
         Catch ex As System.NullReferenceException
         End Try
     End Sub
-End Class", editorConfigText, expected);
+End Class"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+            vbTest.ExpectedDiagnostics.AddRange(expected);
+            await vbTest.RunAsync();
         }
 
         private static DiagnosticResult GetCA1031CSharpResultAt(int line, int column, string signature)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypesTests.cs
@@ -1,28 +1,25 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotDeclareStaticMembersOnGenericTypesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotDeclareStaticMembersOnGenericTypesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class DoNotDeclareStaticMembersOnGenericTypesTests : DiagnosticAnalyzerTestBase
+    public class DoNotDeclareStaticMembersOnGenericTypesTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotDeclareStaticMembersOnGenericTypesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotDeclareStaticMembersOnGenericTypesAnalyzer();
-        }
-
         [Fact]
-        public void CSharp_CA1000_ShouldGenerate()
+        public async Task CSharp_CA1000_ShouldGenerate()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class GenericType1<T>
@@ -54,17 +51,17 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             get { return string.Empty; }
         }
     }",
-    GetCSharpResultAt(10, 28, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.RuleId, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)),
-    GetCSharpResultAt(15, 30, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.RuleId, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)),
-    GetCSharpResultAt(23, 28, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.RuleId, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)),
-    GetCSharpResultAt(28, 30, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.RuleId, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture))
+    GetCSharpResultAt(10, 28),
+    GetCSharpResultAt(15, 30),
+    GetCSharpResultAt(23, 28),
+    GetCSharpResultAt(28, 30)
     );
         }
 
         [Fact]
-        public void Basic_CA1000_ShouldGenerate()
+        public async Task Basic_CA1000_ShouldGenerate()
         {
-            VerifyBasic(@"Imports System
+            await VerifyVB.VerifyAnalyzerAsync(@"Imports System
 Public Class GenericType1(Of T)
     Private Sub New()
     End Sub
@@ -91,17 +88,17 @@ Public NotInheritable Class GenericType2(Of T)
         End Get
     End Property
 End Class",
-    GetBasicResultAt(6, 23, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.RuleId, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)),
-    GetBasicResultAt(10, 37, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.RuleId, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)),
-    GetBasicResultAt(18, 23, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.RuleId, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)),
-    GetBasicResultAt(22, 37, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.RuleId, DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture))
+    GetBasicResultAt(6, 23),
+    GetBasicResultAt(10, 37),
+    GetBasicResultAt(18, 23),
+    GetBasicResultAt(22, 37)
     );
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_CA1000_ShouldNotGenerate_ContainingTypeIsNotExternallyVisible()
+        public async Task CSharp_CA1000_ShouldNotGenerate_ContainingTypeIsNotExternallyVisible()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     internal class GenericType1<T>
@@ -137,9 +134,9 @@ End Class",
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void Basic_CA1000_ShouldNotGenerate_ContainingTypeIsNotExternallyVisible()
+        public async Task Basic_CA1000_ShouldNotGenerate_ContainingTypeIsNotExternallyVisible()
         {
-            VerifyBasic(@"Imports System
+            await VerifyVB.VerifyAnalyzerAsync(@"Imports System
 Friend Class GenericType1(Of T)
     Private Sub New()
     End Sub
@@ -169,9 +166,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharp_CA1000_ShouldNotGenerate_MemberIsNotPublicStatic()
+        public async Task CSharp_CA1000_ShouldNotGenerate_MemberIsNotPublicStatic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class GenericType1<T>
@@ -264,9 +261,9 @@ public sealed class ClosedType : OpenType<String>
         }
 
         [Fact]
-        public void Basic_CA1000_ShouldNotGenerate_MemberIsNotPublicStatic()
+        public async Task Basic_CA1000_ShouldNotGenerate_MemberIsNotPublicStatic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class GenericType1(Of T)
@@ -351,9 +348,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharp_CA1000_ShouldNotGenerate_ConversionOperator()
+        public async Task CSharp_CA1000_ShouldNotGenerate_ConversionOperator()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1<T>
 {
     public static implicit operator Class1<T>(T value) => new Class1<T>();
@@ -363,9 +360,9 @@ public class Class1<T>
         }
 
         [Fact]
-        public void Basic_CA1000_ShouldNotGenerate_ConversionOperator()
+        public async Task Basic_CA1000_ShouldNotGenerate_ConversionOperator()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1(Of T)
     Public Shared Narrowing Operator CType(value As T) As Class1(Of T)
         Return New Class1(Of T)()
@@ -379,9 +376,9 @@ End Class
         }
 
         [Fact, WorkItem(1791, "https://github.com/dotnet/roslyn-analyzers/issues/1791")]
-        public void CSharp_CA1000_ShouldNotGenerate_OperatorOverloads()
+        public async Task CSharp_CA1000_ShouldNotGenerate_OperatorOverloads()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public abstract class TestObject<T2> : IEquatable<TestObject<T2>>, IComparable<TestObject<T2>>
@@ -431,5 +428,15 @@ public abstract class TestObject<T2> : IEquatable<TestObject<T2>>, IComparable<T
 }
 ");
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
+            => new DiagnosticResult(DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
+            => new DiagnosticResult(DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareStaticMembersOnGenericTypesTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -430,13 +429,9 @@ public abstract class TestObject<T2> : IEquatable<TestObject<T2>>, IComparable<T
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-            => new DiagnosticResult(DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+            => VerifyCS.Diagnostic().WithLocation(line, column);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column)
-            => new DiagnosticResult(DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(DoNotDeclareStaticMembersOnGenericTypesAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+            => VerifyVB.Diagnostic().WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFieldsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFieldsTests.cs
@@ -1,47 +1,44 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotDeclareVisibleInstanceFieldsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotDeclareVisibleInstanceFieldsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class DoNotDeclareVisibleInstanceFieldsTests : DiagnosticAnalyzerTestBase
+    public class DoNotDeclareVisibleInstanceFieldsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotDeclareVisibleInstanceFieldsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotDeclareVisibleInstanceFieldsAnalyzer();
-        }
-
         [Fact]
-        public void CSharp_PublicVariable_PublicContainingType()
+        public async Task CSharp_PublicVariable_PublicContainingType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public string field; 
-}", GetCSharpResultAt(4, 19, DoNotDeclareVisibleInstanceFieldsAnalyzer.RuleId, DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)));
+}", GetCSharpResultAt(4, 19));
         }
 
         [Fact]
-        public void VisualBasic_PublicVariable_PublicContainingType()
+        public async Task VisualBasic_PublicVariable_PublicContainingType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Public field As System.String
-End Class", GetBasicResultAt(3, 12, DoNotDeclareVisibleInstanceFieldsAnalyzer.RuleId, DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)));
+End Class", GetBasicResultAt(3, 12));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_PublicVariable_InternalContainingType()
+        public async Task CSharp_PublicVariable_InternalContainingType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class A
 {
     public string field; 
@@ -54,9 +51,9 @@ internal class A
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VisualBasic_PublicVariable_InternalContainingType()
+        public async Task VisualBasic_PublicVariable_InternalContainingType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Class A
     Public field As System.String
 
@@ -68,9 +65,9 @@ End Class
         }
 
         [Fact]
-        public void CSharp_DefaultVisibility()
+        public async Task CSharp_DefaultVisibility()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     string field; 
@@ -78,18 +75,18 @@ public class A
         }
 
         [Fact]
-        public void VisualBasic_DefaultVisibility()
+        public async Task VisualBasic_DefaultVisibility()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Dim field As System.String
 End Class");
         }
 
         [Fact]
-        public void CSharp_PublicStaticVariable()
+        public async Task CSharp_PublicStaticVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static string field; 
@@ -97,18 +94,18 @@ public class A
         }
 
         [Fact]
-        public void VisualBasic_PublicStaticVariable()
+        public async Task VisualBasic_PublicStaticVariable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Public Shared field as System.String
 End Class");
         }
 
         [Fact]
-        public void CSharp_PublicStaticReadonlyVariable()
+        public async Task CSharp_PublicStaticReadonlyVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static readonly string field; 
@@ -116,56 +113,56 @@ public class A
         }
 
         [Fact]
-        public void VisualBasic_PublicStaticReadonlyVariable()
+        public async Task VisualBasic_PublicStaticReadonlyVariable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Public Shared ReadOnly field as System.String
 End Class");
         }
 
         [Fact]
-        public void CSharp_PublicConstVariable()
+        public async Task CSharp_PublicConstVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
-    public const string field = ""X""; 
+    public const string field = ""X"";
 }");
         }
 
         [Fact]
-        public void VisualBasic_PublicConstVariable()
+        public async Task VisualBasic_PublicConstVariable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Public Const field as System.String = ""X""
 End Class");
         }
 
         [Fact]
-        public void CSharp_ProtectedVariable_PublicContainingType()
+        public async Task CSharp_ProtectedVariable_PublicContainingType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     protected string field;
-}", GetCSharpResultAt(4, 22, DoNotDeclareVisibleInstanceFieldsAnalyzer.RuleId, DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)));
+}", GetCSharpResultAt(4, 22));
         }
 
         [Fact]
-        public void VisualBasic_ProtectedVariable_PublicContainingType()
+        public async Task VisualBasic_ProtectedVariable_PublicContainingType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Protected field As System.String
-End Class", GetBasicResultAt(3, 15, DoNotDeclareVisibleInstanceFieldsAnalyzer.RuleId, DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)));
+End Class", GetBasicResultAt(3, 15));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_ProtectedVariable_InternalContainingType()
+        public async Task CSharp_ProtectedVariable_InternalContainingType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
         internal class A
         {
             protected string field; 
@@ -178,9 +175,9 @@ End Class", GetBasicResultAt(3, 15, DoNotDeclareVisibleInstanceFieldsAnalyzer.Ru
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VisualBasic_ProtectedVariable_InternalContainingType()
+        public async Task VisualBasic_ProtectedVariable_InternalContainingType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
         Friend Class A
             Protected field As System.String
 
@@ -192,9 +189,9 @@ End Class", GetBasicResultAt(3, 15, DoNotDeclareVisibleInstanceFieldsAnalyzer.Ru
         }
 
         [Fact]
-        public void CSharp_ProtectedStaticVariable()
+        public async Task CSharp_ProtectedStaticVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
         public class A
         {
             protected static string field; 
@@ -202,18 +199,18 @@ End Class", GetBasicResultAt(3, 15, DoNotDeclareVisibleInstanceFieldsAnalyzer.Ru
         }
 
         [Fact]
-        public void VisualBasic_ProtectedStaticVariable()
+        public async Task VisualBasic_ProtectedStaticVariable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
         Public Class A
             Protected Shared field as System.String
         End Class");
         }
 
         [Fact]
-        public void CSharp_ProtectedStaticReadonlyVariable()
+        public async Task CSharp_ProtectedStaticReadonlyVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
         public class A
         {
             protected static readonly string field; 
@@ -221,56 +218,56 @@ End Class", GetBasicResultAt(3, 15, DoNotDeclareVisibleInstanceFieldsAnalyzer.Ru
         }
 
         [Fact]
-        public void VisualBasic_ProtectedStaticReadonlyVariable()
+        public async Task VisualBasic_ProtectedStaticReadonlyVariable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
         Public Class A
             Protected Shared ReadOnly field as System.String
         End Class");
         }
 
         [Fact]
-        public void CSharp_ProtectedConstVariable()
+        public async Task CSharp_ProtectedConstVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
         public class A
         {
-            protected const string field = ""X""; 
+            protected const string field = ""X"";
         }");
         }
 
         [Fact]
-        public void VisualBasic_ProtectedConstVariable()
+        public async Task VisualBasic_ProtectedConstVariable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
         Public Class A
             Protected Const field as System.String = ""X""
         End Class");
         }
 
         [Fact]
-        public void CSharp_ProtectedInternalVariable_PublicContainingType()
+        public async Task CSharp_ProtectedInternalVariable_PublicContainingType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     protected internal string field;
-}", GetCSharpResultAt(4, 31, DoNotDeclareVisibleInstanceFieldsAnalyzer.RuleId, DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)));
+}", GetCSharpResultAt(4, 31));
         }
 
         [Fact]
-        public void VisualBasic_ProtectedFriendVariable_PublicContainingType()
+        public async Task VisualBasic_ProtectedFriendVariable_PublicContainingType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Protected Friend field As System.String
-End Class", GetBasicResultAt(3, 22, DoNotDeclareVisibleInstanceFieldsAnalyzer.RuleId, DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)));
+End Class", GetBasicResultAt(3, 22));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_ProtectedInternalVariable_InternalContainingType()
+        public async Task CSharp_ProtectedInternalVariable_InternalContainingType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
         internal class A
         {
             protected internal string field; 
@@ -283,9 +280,9 @@ End Class", GetBasicResultAt(3, 22, DoNotDeclareVisibleInstanceFieldsAnalyzer.Ru
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VisualBasic_ProtectedFriendVariable_InternalContainingType()
+        public async Task VisualBasic_ProtectedFriendVariable_InternalContainingType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
         Friend Class A
             Protected Friend field As System.String
 
@@ -297,9 +294,9 @@ End Class", GetBasicResultAt(3, 22, DoNotDeclareVisibleInstanceFieldsAnalyzer.Ru
         }
 
         [Fact]
-        public void CSharp_ProtectedInternalStaticVariable()
+        public async Task CSharp_ProtectedInternalStaticVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
         public class A
         {
             protected internal static string field; 
@@ -307,18 +304,18 @@ End Class", GetBasicResultAt(3, 22, DoNotDeclareVisibleInstanceFieldsAnalyzer.Ru
         }
 
         [Fact]
-        public void VisualBasic_ProtectedFriendStaticVariable()
+        public async Task VisualBasic_ProtectedFriendStaticVariable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
         Public Class A
             Protected Friend Shared field as System.String
         End Class");
         }
 
         [Fact]
-        public void CSharp_ProtectedInternalStaticReadonlyVariable()
+        public async Task CSharp_ProtectedInternalStaticReadonlyVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
         public class A
         {
             protected internal static readonly string field; 
@@ -326,31 +323,41 @@ End Class", GetBasicResultAt(3, 22, DoNotDeclareVisibleInstanceFieldsAnalyzer.Ru
         }
 
         [Fact]
-        public void VisualBasic_ProtectedFriendStaticReadonlyVariable()
+        public async Task VisualBasic_ProtectedFriendStaticReadonlyVariable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
         Public Class A
             Protected Friend Shared ReadOnly field as System.String
         End Class");
         }
 
         [Fact]
-        public void CSharp_ProtectedInternalConstVariable()
+        public async Task CSharp_ProtectedInternalConstVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
         public class A
         {
-            protected internal const string field = ""X""; 
+            protected internal const string field = ""X"";
         }");
         }
 
         [Fact]
-        public void VisualBasic_ProtectedFriendConstVariable()
+        public async Task VisualBasic_ProtectedFriendConstVariable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
         Public Class A
             Protected Friend Const field as System.String = ""X""
         End Class");
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
+            => new DiagnosticResult(DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
+            => new DiagnosticResult(DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFieldsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDeclareVisibleInstanceFieldsTests.cs
@@ -351,13 +351,9 @@ End Class", GetBasicResultAt(3, 22));
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-            => new DiagnosticResult(DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+            => VerifyCS.Diagnostic().WithLocation(line, column);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column)
-            => new DiagnosticResult(DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(DoNotDeclareVisibleInstanceFieldsAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+            => VerifyVB.Diagnostic().WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
@@ -324,7 +324,14 @@ public class C
         await t.ConfigureAwait(false);
     }
 }";
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(code, editorConfigText);
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { code },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         [Theory, WorkItem(1953, "https://github.com/dotnet/roslyn-analyzers/issues/1953")]
@@ -348,7 +355,15 @@ public class C
         await t.ConfigureAwait(false);
     }
 }";
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(code, editorConfigText, GetCSharpResultAt(9, 15));
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { code },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                },
+                ExpectedDiagnostics = { GetCSharpResultAt(9, 15) }
+            }.RunAsync();
         }
 
         [Fact, WorkItem(1953, "https://github.com/dotnet/roslyn-analyzers/issues/1953")]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
@@ -1,11 +1,18 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotDirectlyAwaitATaskAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotDirectlyAwaitATaskAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
@@ -22,7 +29,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CSharpSimpleAwaitTask()
+        public async Task CSharpSimpleAwaitTask()
         {
             var code = @"
 using System.Threading.Tasks;
@@ -36,11 +43,11 @@ public class C
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(9, 15));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(9, 15));
         }
 
         [Fact]
-        public void BasicSimpleAwaitTask()
+        public async Task BasicSimpleAwaitTask()
         {
             var code = @"
 Imports System.Threading.Tasks
@@ -52,11 +59,11 @@ Public Class C
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(7, 15));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(7, 15));
         }
 
         [Fact]
-        public void CSharpSimpleAwaitTaskOfT()
+        public async Task CSharpSimpleAwaitTaskOfT()
         {
             var code = @"
 using System.Threading.Tasks;
@@ -70,11 +77,11 @@ public class C
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(9, 23));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(9, 23));
         }
 
         [Fact]
-        public void BasicSimpleAwaitTaskOfT()
+        public async Task BasicSimpleAwaitTaskOfT()
         {
             var code = @"
 Imports System.Threading.Tasks
@@ -86,11 +93,11 @@ Public Class C
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(7, 34));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(7, 34));
         }
 
         [Fact]
-        public void CSharpNoDiagnostic()
+        public async Task CSharpNoDiagnostic()
         {
             var code = @"
 using System;
@@ -132,11 +139,11 @@ public class SomeAwaiter : INotifyCompletion
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void BasicNoDiagnostic()
+        public async Task BasicNoDiagnostic()
         {
             var code = @"
 Imports System
@@ -176,11 +183,11 @@ Public Class SomeAwaiter
     End Sub
 End Class
 ";
-            VerifyBasic(code, TestValidationMode.AllowCompileErrors);
+            await VerifyVB.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CSharpAwaitAwaitTask()
+        public async Task CSharpAwaitAwaitTask()
         {
             var code = @"
 using System.Threading.Tasks;
@@ -196,7 +203,7 @@ public class C
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                 GetCSharpResultAt(9, 15),
                 GetCSharpResultAt(9, 21),
                 GetCSharpResultAt(10, 15),
@@ -204,7 +211,7 @@ public class C
         }
 
         [Fact]
-        public void BasicAwaitAwaitTask()
+        public async Task BasicAwaitAwaitTask()
         {
             var code = @"
 Imports System.Threading.Tasks
@@ -218,7 +225,7 @@ Public Class C
     End Function
 End Class
 ";
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                 GetBasicResultAt(7, 15),
                 GetBasicResultAt(7, 21),
                 GetBasicResultAt(8, 15),
@@ -226,7 +233,7 @@ End Class
         }
 
         [Fact]
-        public void CSharpComplexAwaitTask()
+        public async Task CSharpComplexAwaitTask()
         {
             var code = @"
 using System;
@@ -244,14 +251,14 @@ public class C
     public Task<int> GetTask() { throw new NotImplementedException(); }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                 GetCSharpResultAt(9, 28),
                 GetCSharpResultAt(10, 47),
                 GetCSharpResultAt(11, 33));
         }
 
         [Fact]
-        public void BasicComplexeAwaitTask()
+        public async Task BasicComplexeAwaitTask()
         {
             var code = @"
 Imports System
@@ -268,14 +275,14 @@ Public Class C
     End Function
 End Class
 ";
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                 GetBasicResultAt(7, 39),
                 GetBasicResultAt(8, 69),
                 GetBasicResultAt(9, 33));
         }
 
         [Fact, WorkItem(1953, "https://github.com/dotnet/roslyn-analyzers/issues/1953")]
-        public void CSharpAsyncVoidMethod_Diagnostic()
+        public async Task CSharpAsyncVoidMethod_Diagnostic()
         {
             var code = @"
 using System.Threading.Tasks;
@@ -293,13 +300,13 @@ public class C
         await t.ConfigureAwait(false);
     }
 }";
-            VerifyCSharp(code, GetCSharpResultAt(9, 15));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(9, 15));
         }
 
         [Theory, WorkItem(1953, "https://github.com/dotnet/roslyn-analyzers/issues/1953")]
         [InlineData("dotnet_code_quality.exclude_async_void_methods = true")]
         [InlineData("dotnet_code_quality.CA2007.exclude_async_void_methods = true")]
-        public void CSharpAsyncVoidMethod_AnalyzerOption_NoDiagnostic(string editorConfigText)
+        public async Task CSharpAsyncVoidMethod_AnalyzerOption_NoDiagnostic(string editorConfigText)
         {
             var code = @"
 using System.Threading.Tasks;
@@ -317,13 +324,13 @@ public class C
         await t.ConfigureAwait(false);
     }
 }";
-            VerifyCSharp(code, GetEditorConfigAdditionalFile(editorConfigText));
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(code, editorConfigText);
         }
 
         [Theory, WorkItem(1953, "https://github.com/dotnet/roslyn-analyzers/issues/1953")]
         [InlineData("dotnet_code_quality.exclude_async_void_methods = false")]
         [InlineData("dotnet_code_quality.CA2007.exclude_async_void_methods = false")]
-        public void CSharpAsyncVoidMethod_AnalyzerOption_Diagnostic(string editorConfigText)
+        public async Task CSharpAsyncVoidMethod_AnalyzerOption_Diagnostic(string editorConfigText)
         {
             var code = @"
 using System.Threading.Tasks;
@@ -341,7 +348,7 @@ public class C
         await t.ConfigureAwait(false);
     }
 }";
-            VerifyCSharp(code, GetEditorConfigAdditionalFile(editorConfigText), GetCSharpResultAt(9, 15));
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(code, editorConfigText, GetCSharpResultAt(9, 15));
         }
 
         [Fact, WorkItem(1953, "https://github.com/dotnet/roslyn-analyzers/issues/1953")]
@@ -380,7 +387,7 @@ public class C
         }
 
         [Fact, WorkItem(2393, "https://github.com/dotnet/roslyn-analyzers/issues/2393")]
-        public void CSharpSimpleAwaitTaskInLocalFunction()
+        public async Task CSharpSimpleAwaitTaskInLocalFunction()
         {
             var code = @"
 using System.Threading.Tasks;
@@ -397,17 +404,17 @@ public class C
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(11, 19));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(11, 19));
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, DoNotDirectlyAwaitATaskAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.DoNotDirectlyAwaitATaskMessage);
-        }
+            => new DiagnosticResult(DoNotDirectlyAwaitATaskAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DoNotDirectlyAwaitATaskMessage);
 
         private DiagnosticResult GetBasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, DoNotDirectlyAwaitATaskAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.DoNotDirectlyAwaitATaskMessage);
-        }
+            => new DiagnosticResult(DoNotDirectlyAwaitATaskAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DoNotDirectlyAwaitATaskMessage);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotHideBaseClassMethodsAnalyzer,
@@ -14,22 +13,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class DoNotHideBaseClassMethodsTests : DiagnosticAnalyzerTestBase
+    public class DoNotHideBaseClassMethodsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotHideBaseClassMethodsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotHideBaseClassMethodsAnalyzer();
-        }
-
         [Fact]
-        public void CA1061_DerivedMethodMatchesBaseMethod_NoDiagnostic()
+        public async Task CA1061_DerivedMethodMatchesBaseMethod_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public void Method(string input)
@@ -44,7 +33,7 @@ class Derived : Base
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Public Sub Method(input As String)
     End Sub
@@ -59,9 +48,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasMoreDerivedParameter_NoDiagnostic()
+        public async Task CA1061_DerivedMethodHasMoreDerivedParameter_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public void Method(object input)
@@ -76,7 +65,7 @@ class Derived : Base
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Public Sub Method(input As Object)
     End Sub
@@ -91,9 +80,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_Diagnostic()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public void Method(string input)
@@ -109,7 +98,7 @@ class Derived : Base
 }",
                 GetCA1061CSharpResultAt(11, 17, "Derived.Method(object)", "Base.Method(string)"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Public Sub Method(input As String)
     End Sub
@@ -125,9 +114,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1061_ConstructorCallsBaseConstructorWithDifferentParameterType_NoDiagnostic()
+        public async Task CA1061_ConstructorCallsBaseConstructorWithDifferentParameterType_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public Base(string input)
@@ -145,9 +134,9 @@ class Derived : Base
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_MultipleMethodsHidden_Diagnostics()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_MultipleMethodsHidden_Diagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Parent
 {
     public void Method(string input)
@@ -171,7 +160,7 @@ class Grandchild : Child
                 GetCA1061CSharpResultAt(18, 17, "Grandchild.Method(object)", "Child.Method(string)"),
                 GetCA1061CSharpResultAt(18, 17, "Grandchild.Method(object)", "Parent.Method(string)"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Parent
     Public Sub Method(input As String)
     End Sub
@@ -195,9 +184,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_ImplementsInterface_CompileError()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_ImplementsInterface_CompileError()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 interface IFace
 {
     void Method(string input);
@@ -209,9 +198,9 @@ class Derived : IFace
     {
     }
 }",
-                TestValidationMode.AllowCompileErrors);
+                CompilerDiagnostics.None);
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Interface IFace
     Sub Method(input As String)
 End Interface
@@ -222,13 +211,13 @@ Class Derived
     Public Sub Method(input As Object) Implements IFace.Method
     End Sub
 End Class",
-                TestValidationMode.AllowCompileErrors);
+                CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_OverridesVirtualBaseMethod_CompileError()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_OverridesVirtualBaseMethod_CompileError()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public virtual void Method(string input);
@@ -240,9 +229,9 @@ class Derived : Base
     {
     }
 }",
-                TestValidationMode.AllowCompileErrors);
+                CompilerDiagnostics.None);
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Public Overridable Sub Method(input As String)
     End Sub
@@ -254,14 +243,14 @@ Class Derived
     Public Overrides Sub Method(input As Object)
     End Sub
 End Class",
-                TestValidationMode.AllowCompileErrors);
+                CompilerDiagnostics.None);
         }
 
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_OverridesAbstractBaseMethod_CompileError()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_OverridesAbstractBaseMethod_CompileError()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 abstract class Base
 {
     public abstract void Method(string input);
@@ -273,9 +262,9 @@ class Derived : Base
     {
     }
 }",
-                TestValidationMode.AllowCompileErrors);
+                CompilerDiagnostics.None);
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 MustInherit Class Base
     Public MustOverride Sub Method(input As String)
     End Sub
@@ -287,13 +276,13 @@ Class Derived
     Public Overrides Sub Method(input As Object)
     End Sub
 End Class",
-                TestValidationMode.AllowCompileErrors);
+                CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_DerivedMethodPrivate_Diagnostic()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_DerivedMethodPrivate_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public void Method(string input)
@@ -309,7 +298,7 @@ class Derived : Base
 }",
                 GetCA1061CSharpResultAt(11, 18, "Derived.Method(object)", "Base.Method(string)"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Public Sub Method(input As String)
     End Sub
@@ -326,10 +315,10 @@ End Class
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_BaseMethodPrivate_NoDiagnostic()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_BaseMethodPrivate_NoDiagnostic()
         {
             // Note: This behavior differs from FxCop's CA1061
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     private void Method(string input)
@@ -344,7 +333,7 @@ class Derived : Base
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Private Sub Method(input As String)
     End Sub
@@ -360,9 +349,9 @@ End Class
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_ArityMismatch_NoDiagnostic()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_ArityMismatch_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public void Method(string input, string input2)
@@ -377,7 +366,7 @@ class Derived : Base
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Private Sub Method(input As String, input2 As String)
     End Sub
@@ -393,9 +382,9 @@ End Class
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_ReturnTypeMismatch_NoDiagnostic()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_ReturnTypeMismatch_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public void Method(string input)
@@ -411,7 +400,7 @@ class Derived : Base
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Private Sub Method(input As String)
     End Sub
@@ -428,9 +417,9 @@ End Class
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_ParameterTypeMismatchAtStart_NoDiagnostic()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_ParameterTypeMismatchAtStart_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public void Method(int input, string input2)
@@ -445,7 +434,7 @@ class Derived : Base
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Private Sub Method(input As Integer, input2 As String)
     End Sub
@@ -461,9 +450,9 @@ End Class
         }
 
         [Fact]
-        public void CA1061_DerivedMethodHasLessDerivedParameter_ParameterTypeMismatchAtEnd_NoDiagnostic()
+        public async Task CA1061_DerivedMethodHasLessDerivedParameter_ParameterTypeMismatchAtEnd_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Base
 {
     public void Method(string input, int input2)
@@ -478,7 +467,7 @@ class Derived : Base
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Private Sub Method(input As String, input2 As Integer)
     End Sub
@@ -500,7 +489,9 @@ End Class
                 derivedMethod,
                 baseMethod);
 
-            return GetCSharpResultAt(line, column, DoNotHideBaseClassMethodsAnalyzer.RuleId, message);
+            return new DiagnosticResult(DoNotHideBaseClassMethodsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private DiagnosticResult GetCA1061BasicResultAt(int line, int column, string derivedMethod, string baseMethod)
@@ -510,7 +501,9 @@ End Class
                 derivedMethod,
                 baseMethod);
 
-            return GetBasicResultAt(line, column, DoNotHideBaseClassMethodsAnalyzer.RuleId, message);
+            return new DiagnosticResult(DoNotHideBaseClassMethodsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
@@ -1,28 +1,24 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotPrefixEnumValuesWithTypeNameAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotPrefixEnumValuesWithTypeNameAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
 {
-    public class DoNotPrefixEnumValuesWithTypeNameTests : DiagnosticAnalyzerTestBase
+    public class DoNotPrefixEnumValuesWithTypeNameTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotPrefixEnumValuesWithTypeNameAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotPrefixEnumValuesWithTypeNameAnalyzer();
-        }
-
         [Fact]
-        public void CSharp_NoDiagnostic_NoPrefix()
+        public async Task CSharp_NoDiagnostic_NoPrefix()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 class A
                 { 
                     enum State
@@ -35,9 +31,9 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
         }
 
         [Fact]
-        public void Basic_NoDiagnostic_NoPrefix()
+        public async Task Basic_NoDiagnostic_NoPrefix()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Class A
                     Private Enum State
                         Ok = 0
@@ -48,9 +44,9 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
         }
 
         [Fact]
-        public void CSharp_Diagnostic_EachValuePrefixed()
+        public async Task CSharp_Diagnostic_EachValuePrefixed()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 class A
                 {
                     enum State
@@ -60,15 +56,15 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                         StateUnknown = 2
                     };
                 }",
-                GetCSharpResultAt(6, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
-                GetCSharpResultAt(7, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
-                GetCSharpResultAt(8, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+                GetCSharpResultAt(6, 25, "State"),
+                GetCSharpResultAt(7, 25, "State"),
+                GetCSharpResultAt(8, 25, "State"));
         }
 
         [Fact]
-        public void Basic_Diagnostic_EachValuePrefixed()
+        public async Task Basic_Diagnostic_EachValuePrefixed()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Class A
                     Private Enum State
                         StateOk = 0
@@ -77,15 +73,15 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                     End Enum
                 End Class
                 ",
-                GetBasicResultAt(4, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
-                GetBasicResultAt(5, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
-                GetBasicResultAt(6, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+                GetBasicResultAt(4, 25, "State"),
+                GetBasicResultAt(5, 25, "State"),
+                GetBasicResultAt(6, 25, "State"));
         }
 
         [Fact]
-        public void CSharp_NoDiagnostic_HalfOfValuesPrefixed()
+        public async Task CSharp_NoDiagnostic_HalfOfValuesPrefixed()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 class A
                 {
                     enum State
@@ -99,9 +95,9 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
         }
 
         [Fact]
-        public void CSharp_Diagnostic_ThreeOfFourValuesPrefixed()
+        public async Task CSharp_Diagnostic_ThreeOfFourValuesPrefixed()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 class A
                 {
                     enum State
@@ -112,15 +108,15 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                         Invalid = 3
                     };
                 }",
-                GetCSharpResultAt(6, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
-                GetCSharpResultAt(7, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"),
-                GetCSharpResultAt(8, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+                GetCSharpResultAt(6, 25, "State"),
+                GetCSharpResultAt(7, 25, "State"),
+                GetCSharpResultAt(8, 25, "State"));
         }
 
         [Fact]
-        public void CSharp_Diagnostic_PrefixCaseDiffers()
+        public async Task CSharp_Diagnostic_PrefixCaseDiffers()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 class A
                 {
                     enum State
@@ -128,13 +124,13 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                         stateOk = 0
                     };
                 }",
-                GetCSharpResultAt(6, 25, DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule, "State"));
+                GetCSharpResultAt(6, 25, "State"));
         }
 
         [Fact]
-        public void CSharp_NoDiagnostic_EmptyEnum()
+        public async Task CSharp_NoDiagnostic_EmptyEnum()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 class A
                 {
                     enum State
@@ -142,5 +138,15 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
                     };
                 }");
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => new DiagnosticResult(DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => new DiagnosticResult(DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocationsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocationsTests.cs
@@ -1,30 +1,25 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpDoNotRaiseExceptionsInUnexpectedLocationsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicDoNotRaiseExceptionsInUnexpectedLocationsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class DoNotRaiseExceptionsInUnexpectedLocationsTests : DiagnosticAnalyzerTestBase
+    public class DoNotRaiseExceptionsInUnexpectedLocationsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicDoNotRaiseExceptionsInUnexpectedLocationsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpDoNotRaiseExceptionsInUnexpectedLocationsAnalyzer();
-        }
-
         #region Property and Event Tests
 
         [Fact]
-        public void CSharpPropertyNoDiagnostics()
+        public async Task CSharpPropertyNoDiagnostics()
         {
             var code = @"
 using System;
@@ -42,11 +37,11 @@ class NonPublic
     public int PropWithException { get { throw new Exception(); } set { throw new NotSupportedException(); } }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpPropertyWithDerivedExceptionNoDiagnostics()
+        public async Task CSharpPropertyWithDerivedExceptionNoDiagnostics()
         {
             var code = @"
 using System;
@@ -56,11 +51,11 @@ public class C
     public int this[int x] { get { throw new ArgumentOutOfRangeException(); } set { throw new ArgumentOutOfRangeException(); } }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicPropertyNoDiagnostics()
+        public async Task BasicPropertyNoDiagnostics()
         {
             var code = @"
 Imports System
@@ -109,11 +104,11 @@ Class NonPublic
     End Property
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicPropertyWithDerivedExceptionNoDiagnostics()
+        public async Task BasicPropertyWithDerivedExceptionNoDiagnostics()
         {
             var code = @"
 Imports System
@@ -129,11 +124,11 @@ Public Class C
     End Property
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpPropertyWithInvalidExceptions()
+        public async Task CSharpPropertyWithInvalidExceptions()
         {
             var code = @"
 using System;
@@ -145,7 +140,7 @@ public class C
     public event EventHandler Event1 { add { throw new Exception(); } remove { throw new Exception(); } }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpPropertyResultAt(6, 30, "get_Prop1", "Exception"),
                          GetCSharpPropertyResultAt(7, 36, "get_Item", "Exception"),
                          GetCSharpAllowedExceptionsResultAt(8, 46, "add_Event1", "Exception"),
@@ -153,7 +148,7 @@ public class C
         }
 
         [Fact]
-        public void BasicPropertyWithInvalidExceptions()
+        public async Task BasicPropertyWithInvalidExceptions()
         {
             var code = @"
 Imports System
@@ -192,7 +187,7 @@ Public Class C
     End Event
 End Class
 ";
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicPropertyResultAt(7, 12, "get_Prop1", "Exception"),
                         GetBasicPropertyResultAt(15, 12, "get_Item", "Exception"),
                         GetBasicAllowedExceptionsResultAt(24, 13, "add_Event1", "Exception"),
@@ -200,7 +195,7 @@ End Class
         }
 
         [Fact, WorkItem(1842, "https://github.com/dotnet/roslyn-analyzers/issues/1842")]
-        public void CSharpIndexer_KeyNotFoundException_NoDiagnostics()
+        public async Task CSharpIndexer_KeyNotFoundException_NoDiagnostics()
         {
             var code = @"
 using System.Collections.Generic;
@@ -209,7 +204,7 @@ public class C
 {
     public int this[int x] { get { throw new KeyNotFoundException(); } }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         #endregion
@@ -217,7 +212,7 @@ public class C
         #region Equals, GetHashCode, Dispose and ToString Tests
 
         [Fact]
-        public void CSharpEqualsAndGetHashCodeWithExceptions()
+        public async Task CSharpEqualsAndGetHashCodeWithExceptions()
         {
             var code = @"
 using System;
@@ -235,13 +230,13 @@ public class C
 }
 ";
 
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpNoExceptionsResultAt(8, 9, "Equals", "Exception"),
                          GetCSharpNoExceptionsResultAt(12, 9, "GetHashCode", "ArgumentException"));
         }
 
         [Fact]
-        public void BasicEqualsAndGetHashCodeWithExceptions()
+        public async Task BasicEqualsAndGetHashCodeWithExceptions()
         {
             var code = @"
 Imports System
@@ -256,13 +251,13 @@ Public Class C
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicNoExceptionsResultAt(6, 9, "Equals", "Exception"),
                         GetBasicNoExceptionsResultAt(9, 9, "GetHashCode", "ArgumentException"));
         }
 
         [Fact]
-        public void CSharpEqualsAndGetHashCodeNoDiagnostics()
+        public async Task CSharpEqualsAndGetHashCodeNoDiagnostics()
         {
             var code = @"
 using System;
@@ -280,11 +275,11 @@ public class C
 }
 ";
 
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicEqualsAndGetHashCodeNoDiagnostics()
+        public async Task BasicEqualsAndGetHashCodeNoDiagnostics()
         {
             var code = @"
 Imports System
@@ -299,11 +294,11 @@ Public Class C
 End Class
 ";
 
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpIEquatableEqualsWithExceptions()
+        public async Task CSharpIEquatableEqualsWithExceptions()
         {
             var code = @"
 using System;
@@ -316,12 +311,12 @@ public class C : IEquatable<C>
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpNoExceptionsResultAt(8, 9, "Equals", "Exception"));
         }
 
         [Fact]
-        public void BasicIEquatableEqualsExceptions()
+        public async Task BasicIEquatableEqualsExceptions()
         {
             var code = @"
 Imports System
@@ -334,12 +329,12 @@ Public Class C
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicNoExceptionsResultAt(7, 9, "Equals", "Exception"));
         }
 
         [Fact]
-        public void CSharpIHashCodeProviderGetHashCode()
+        public async Task CSharpIHashCodeProviderGetHashCode()
         {
             var code = @"
 using System;
@@ -360,12 +355,12 @@ public class D : IHashCodeProvider
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpAllowedExceptionsResultAt(8, 9, "GetHashCode", "Exception"));
         }
 
         [Fact]
-        public void BasicIHashCodeProviderGetHashCode()
+        public async Task BasicIHashCodeProviderGetHashCode()
         {
             var code = @"
 Imports System
@@ -385,12 +380,12 @@ Public Class D
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicAllowedExceptionsResultAt(7, 9, "GetHashCode", "Exception"));
         }
 
         [Fact]
-        public void CSharpIEqualityComparer()
+        public async Task CSharpIEqualityComparer()
         {
             var code = @"
 using System;
@@ -407,13 +402,13 @@ public class C : IEqualityComparer<C>
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpNoExceptionsResultAt(8, 9, "Equals", "Exception"),
                          GetCSharpAllowedExceptionsResultAt(12, 9, "GetHashCode", "Exception"));
         }
 
         [Fact]
-        public void BasicIEqualityComparer()
+        public async Task BasicIEqualityComparer()
         {
             var code = @"
 Imports System
@@ -429,13 +424,13 @@ Public Class C
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicNoExceptionsResultAt(7, 9, "Equals", "Exception"),
                         GetBasicAllowedExceptionsResultAt(10, 9, "GetHashCode", "Exception"));
         }
 
         [Fact]
-        public void CSharpIDisposable()
+        public async Task CSharpIDisposable()
         {
             var code = @"
 using System;
@@ -448,12 +443,12 @@ public class C : IDisposable
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpNoExceptionsResultAt(8, 9, "Dispose", "Exception"));
         }
 
         [Fact]
-        public void BasicIDisposable()
+        public async Task BasicIDisposable()
         {
             var code = @"
 Imports System
@@ -466,12 +461,12 @@ Public Class C
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicNoExceptionsResultAt(7, 9, "Dispose", "Exception"));
         }
 
         [Fact]
-        public void CSharpToStringWithExceptions()
+        public async Task CSharpToStringWithExceptions()
         {
             var code = @"
 using System;
@@ -485,12 +480,12 @@ public class C
 }
 ";
 
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpNoExceptionsResultAt(8, 9, "ToString", "Exception"));
         }
 
         [Fact]
-        public void BasicToStringWithExceptions()
+        public async Task BasicToStringWithExceptions()
         {
             var code = @"
 Imports System
@@ -502,7 +497,7 @@ Public Class C
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicNoExceptionsResultAt(6, 9, "ToString", "Exception"));
         }
 
@@ -510,7 +505,7 @@ End Class
 
         #region Constructor and Destructor tests
         [Fact]
-        public void CSharpStaticConstructorWithExceptions()
+        public async Task CSharpStaticConstructorWithExceptions()
         {
             var code = @"
 using System;
@@ -523,12 +518,12 @@ class NonPublic
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpNoExceptionsResultAt(8, 9, ".cctor", "Exception"));
         }
 
         [Fact]
-        public void BasicStaticConstructorWithExceptions()
+        public async Task BasicStaticConstructorWithExceptions()
         {
             var code = @"
 Imports System
@@ -540,12 +535,12 @@ Class NonPublic
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicNoExceptionsResultAt(6, 9, ".cctor", "Exception"));
         }
 
         [Fact]
-        public void CSharpFinalizerWithExceptions()
+        public async Task CSharpFinalizerWithExceptions()
         {
             var code = @"
 using System;
@@ -558,12 +553,12 @@ class NonPublic
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpNoExceptionsResultAt(8, 9, "Finalize", "Exception"));
         }
 
         [Fact]
-        public void BasicFinalizerWithExceptions()
+        public async Task BasicFinalizerWithExceptions()
         {
             var code = @"
 Imports System
@@ -575,14 +570,14 @@ Class NonPublic
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicNoExceptionsResultAt(6, 9, "Finalize", "Exception"));
         }
         #endregion
 
         #region Operator tests
         [Fact]
-        public void CSharpEqualityOperatorWithExceptions()
+        public async Task CSharpEqualityOperatorWithExceptions()
         {
             var code = @"
 using System;
@@ -600,13 +595,13 @@ public class C
 }
 ";
 
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpNoExceptionsResultAt(8, 9, "op_Equality", "Exception"),
                          GetCSharpNoExceptionsResultAt(12, 9, "op_Inequality", "Exception"));
         }
 
         [Fact]
-        public void BasicEqualityOperatorWithExceptions()
+        public async Task BasicEqualityOperatorWithExceptions()
         {
             var code = @"
 Imports System
@@ -621,13 +616,13 @@ Public Class C
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicNoExceptionsResultAt(6, 9, "op_Equality", "Exception"),
                         GetBasicNoExceptionsResultAt(9, 9, "op_Inequality", "Exception"));
         }
 
         [Fact]
-        public void CSharpImplicitOperatorWithExceptions()
+        public async Task CSharpImplicitOperatorWithExceptions()
         {
             var code = @"
 using System;
@@ -645,12 +640,12 @@ public class C
 }
 ";
 
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                          GetCSharpNoExceptionsResultAt(8, 9, "op_Implicit", "Exception"));
         }
 
         [Fact]
-        public void BasicImplicitOperatorWithExceptions()
+        public async Task BasicImplicitOperatorWithExceptions()
         {
             var code = @"
 Imports System
@@ -665,7 +660,7 @@ Public Class C
 End Class
 ";
 
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                         GetBasicNoExceptionsResultAt(6, 9, "op_Implicit", "Exception"));
         }
         #endregion
@@ -695,5 +690,15 @@ End Class
         {
             return GetBasicResultAt(line, column, DoNotRaiseExceptionsInUnexpectedLocationsAnalyzer.NoAllowedExceptionsRule, methodName, exceptionName);
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumStorageShouldBeInt32Tests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumStorageShouldBeInt32Tests.cs
@@ -1,29 +1,26 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumStorageShouldBeInt32Analyzer,
+    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpEnumStorageShouldBeInt32Fixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumStorageShouldBeInt32Analyzer,
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicEnumStorageShouldBeInt32Fixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class EnumStorageShouldBeInt32Tests : DiagnosticAnalyzerTestBase
+    public class EnumStorageShouldBeInt32Tests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new EnumStorageShouldBeInt32Analyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new EnumStorageShouldBeInt32Analyzer();
-        }
-
         #region CSharpUnitTests
 
         [Fact]
-        public void CSharp_CA1028_NoDiagnostic()
+        public async Task CSharp_CA1028_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 namespace Test
 {
@@ -60,9 +57,9 @@ namespace Test
         }
 
         [Fact]
-        public void CSharp_CA1028_DiagnosticForInt64WithNoFlags()
+        public async Task CSharp_CA1028_DiagnosticForInt64WithNoFlags()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 namespace Test
 {
@@ -77,9 +74,9 @@ namespace Test
         }
 
         [Fact]
-        public void CSharp_CA1028_DiagnosticForSByte()
+        public async Task CSharp_CA1028_DiagnosticForSByte()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 namespace Test
 {
@@ -94,9 +91,9 @@ namespace Test
         }
 
         [Fact]
-        public void CSharp_CA1028_DiagnosticForUShort()
+        public async Task CSharp_CA1028_DiagnosticForUShort()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 namespace Test
 {
@@ -114,9 +111,9 @@ namespace Test
         #region BasicUnitTests
 
         [Fact]
-        public void Basic_CA1028_NoDiagnostic()
+        public async Task Basic_CA1028_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Public Module Module1
     Public Enum TestEnum1 'no violation - because underlying type is Int32
@@ -146,9 +143,9 @@ End Module
         }
 
         [Fact]
-        public void Basic_CA1028_DiagnosticForInt64WithNoFlags()
+        public async Task Basic_CA1028_DiagnosticForInt64WithNoFlags()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Public Module Module1
     Public Enum TestEnum1 As Long 'violation - because underlying type is Int64 and has no Flags attribute
@@ -161,9 +158,9 @@ End Module
         }
 
         [Fact]
-        public void Basic_CA1028_DiagnosticForByte()
+        public async Task Basic_CA1028_DiagnosticForByte()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Public Module Module1
     Public Enum TestEnum2 As Byte 'violation - because underlying type is not Int32
@@ -176,9 +173,9 @@ End Module
         }
 
         [Fact]
-        public void Basic_CA1028_DiagnosticForUShort()
+        public async Task Basic_CA1028_DiagnosticForUShort()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Public Module Module1
     Public Enum TestEnum3 As UShort 'violation - because underlying type is not Int32
@@ -190,5 +187,15 @@ End Module
             GetBasicResultAt(4, 17, EnumStorageShouldBeInt32Analyzer.Rule, "TestEnum3", "UShort"));
         }
         #endregion
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumWithFlagsAttributeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumWithFlagsAttributeTests.cs
@@ -1,10 +1,17 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumWithFlagsAttributeAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumWithFlagsAttributeFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumWithFlagsAttributeAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumWithFlagsAttributeFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
@@ -33,7 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CSharp_EnumWithFlagsAttributes_SimpleCase()
+        public async Task CSharp_EnumWithFlagsAttributes_SimpleCase()
         {
             var code = @"{0}
 public enum SimpleFlagsEnumClass
@@ -55,17 +62,17 @@ public enum HexFlagsEnumClass
 
             // Verify CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyCSharp(codeWithoutFlags,
+            await VerifyCS.VerifyAnalyzerAsync(codeWithoutFlags,
                 GetCA1027CSharpResultAt(2, 13, "SimpleFlagsEnumClass"),
                 GetCA1027CSharpResultAt(11, 13, "HexFlagsEnumClass"));
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyCSharp(codeWithFlags);
+            await VerifyCS.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_EnumWithFlagsAttributes_SimpleCase_Internal()
+        public async Task CSharp_EnumWithFlagsAttributes_SimpleCase_Internal()
         {
             var code = @"{0}
 internal enum SimpleFlagsEnumClass
@@ -90,11 +97,11 @@ internal class OuterClass
 
             // Verify no CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyCSharp(codeWithoutFlags);
+            await VerifyCS.VerifyAnalyzerAsync(codeWithoutFlags);
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyCSharp(codeWithFlags);
+            await VerifyCS.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact]
@@ -125,7 +132,7 @@ public enum SimpleFlagsEnumClass
         }
 
         [Fact]
-        public void VisualBasic_EnumWithFlagsAttributes_SimpleCase()
+        public async Task VisualBasic_EnumWithFlagsAttributes_SimpleCase()
         {
             var code = @"{0}
 Public Enum SimpleFlagsEnumClass
@@ -145,17 +152,17 @@ End Enum";
 
             // Verify CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyBasic(codeWithoutFlags,
+            await VerifyVB.VerifyAnalyzerAsync(codeWithoutFlags,
                 GetCA1027BasicResultAt(2, 13, "SimpleFlagsEnumClass"),
                 GetCA1027BasicResultAt(10, 13, "HexFlagsEnumClass"));
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyBasic(codeWithFlags);
+            await VerifyVB.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VisualBasic_EnumWithFlagsAttributes_SimpleCase_Internal()
+        public async Task VisualBasic_EnumWithFlagsAttributes_SimpleCase_Internal()
         {
             var code = @"{0}
 Friend Enum SimpleFlagsEnumClass
@@ -177,11 +184,11 @@ End Class";
 
             // Verify no CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyBasic(codeWithoutFlags);
+            await VerifyVB.VerifyAnalyzerAsync(codeWithoutFlags);
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyBasic(codeWithFlags);
+            await VerifyVB.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact]
@@ -210,7 +217,7 @@ End Enum|]";
         }
 
         [Fact]
-        public void CSharp_EnumWithFlagsAttributes_DuplicateValues()
+        public async Task CSharp_EnumWithFlagsAttributes_DuplicateValues()
         {
             string code = @"{0}
 public enum DuplicateValuesEnumClass
@@ -226,16 +233,16 @@ public enum DuplicateValuesEnumClass
 
             // Verify CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyCSharp(codeWithoutFlags,
+            await VerifyCS.VerifyAnalyzerAsync(codeWithoutFlags,
                 GetCA1027CSharpResultAt(2, 13, "DuplicateValuesEnumClass"));
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyCSharp(codeWithFlags);
+            await VerifyCS.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact]
-        public void VisualBasic_EnumWithFlagsAttributes_DuplicateValues()
+        public async Task VisualBasic_EnumWithFlagsAttributes_DuplicateValues()
         {
             string code = @"{0}
 Public Enum DuplicateValuesEnumClass
@@ -250,16 +257,16 @@ End Enum
 
             // Verify CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyBasic(codeWithoutFlags,
+            await VerifyVB.VerifyAnalyzerAsync(codeWithoutFlags,
                 GetCA1027BasicResultAt(2, 13, "DuplicateValuesEnumClass"));
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyBasic(codeWithFlags);
+            await VerifyVB.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact]
-        public void CSharp_EnumWithFlagsAttributes_MissingPowerOfTwo()
+        public async Task CSharp_EnumWithFlagsAttributes_MissingPowerOfTwo()
         {
             string code = @"
 {0}
@@ -284,17 +291,17 @@ public enum MultipleMissingPowerOfTwoEnumClass
 
             // Verify CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyCSharp(codeWithoutFlags,
+            await VerifyCS.VerifyAnalyzerAsync(codeWithoutFlags,
                 GetCA1027CSharpResultAt(3, 13, "MissingPowerOfTwoEnumClass"),
                 GetCA1027CSharpResultAt(13, 13, "MultipleMissingPowerOfTwoEnumClass"));
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyCSharp(codeWithFlags);
+            await VerifyCS.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact]
-        public void CSharp_EnumWithFlagsAttributes_IncorrectNumbers()
+        public async Task CSharp_EnumWithFlagsAttributes_IncorrectNumbers()
         {
             string code = @"
 {0}
@@ -308,16 +315,16 @@ public enum AnotherTestValue
 
             // Verify no CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyCSharp(codeWithoutFlags);
+            await VerifyCS.VerifyAnalyzerAsync(codeWithoutFlags);
 
             // Verify CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyCSharp(codeWithFlags,
+            await VerifyCS.VerifyAnalyzerAsync(codeWithFlags,
                 GetCA2217CSharpResultAt(3, 13, "AnotherTestValue", "2"));
         }
 
         [Fact]
-        public void VisualBasic_EnumWithFlagsAttributes_MissingPowerOfTwo()
+        public async Task VisualBasic_EnumWithFlagsAttributes_MissingPowerOfTwo()
         {
             string code = @"
 {0}
@@ -341,17 +348,17 @@ End Enum
 
             // Verify CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyBasic(codeWithoutFlags,
+            await VerifyVB.VerifyAnalyzerAsync(codeWithoutFlags,
                 GetCA1027BasicResultAt(3, 13, "MissingPowerOfTwoEnumClass"),
                 GetCA1027BasicResultAt(12, 13, "MultipleMissingPowerOfTwoEnumClass"));
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyBasic(codeWithFlags);
+            await VerifyVB.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact]
-        public void VisualBasic_EnumWithFlagsAttributes_IncorrectNumbers()
+        public async Task VisualBasic_EnumWithFlagsAttributes_IncorrectNumbers()
         {
             string code = @"
 {0}
@@ -365,16 +372,16 @@ End Enum
 
             // Verify no CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyBasic(codeWithoutFlags);
+            await VerifyVB.VerifyAnalyzerAsync(codeWithoutFlags);
 
             // Verify CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyBasic(codeWithFlags,
+            await VerifyVB.VerifyAnalyzerAsync(codeWithFlags,
                 GetCA2217BasicResultAt(3, 13, "AnotherTestValue", "2"));
         }
 
         [Fact]
-        public void CSharp_EnumWithFlagsAttributes_ContiguousValues()
+        public async Task CSharp_EnumWithFlagsAttributes_ContiguousValues()
         {
             var code = @"
 {0}
@@ -420,15 +427,15 @@ public enum ShortUnderlyingType: short
 
             // Verify no CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyCSharp(codeWithoutFlags);
+            await VerifyCS.VerifyAnalyzerAsync(codeWithoutFlags);
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyCSharp(codeWithFlags);
+            await VerifyCS.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact]
-        public void VisualBasic_EnumWithFlagsAttributes_ContiguousValues()
+        public async Task VisualBasic_EnumWithFlagsAttributes_ContiguousValues()
         {
             var code = @"
 {0}
@@ -471,15 +478,15 @@ End Enum
 
             // Verify no CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyBasic(codeWithoutFlags);
+            await VerifyVB.VerifyAnalyzerAsync(codeWithoutFlags);
 
             // Verify no CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyBasic(codeWithFlags);
+            await VerifyVB.VerifyAnalyzerAsync(codeWithFlags);
         }
 
         [Fact]
-        public void CSharp_EnumWithFlagsAttributes_NonSimpleFlags()
+        public async Task CSharp_EnumWithFlagsAttributes_NonSimpleFlags()
         {
             var code = @"
 {0}
@@ -515,18 +522,18 @@ public enum LabelsClass
 
             // Verify no CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyCSharp(codeWithoutFlags);
+            await VerifyCS.VerifyAnalyzerAsync(codeWithoutFlags);
 
             // Verify CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyCSharp(codeWithFlags,
+            await VerifyCS.VerifyAnalyzerAsync(codeWithFlags,
                 GetCA2217CSharpResultAt(3, 13, "NonSimpleFlagEnumClass", "4, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824, 2147483648, 4294967296, 8589934592, 17179869184, 34359738368, 68719476736, 137438953472, 274877906944, 549755813888, 1099511627776, 2199023255552, 4398046511104, 8796093022208, 17592186044416, 35184372088832, 70368744177664, 140737488355328, 281474976710656, 562949953421312, 1125899906842624, 2251799813685248, 4503599627370496, 9007199254740992, 18014398509481984, 36028797018963968, 72057594037927936, 144115188075855872, 288230376151711744, 576460752303423488, 1152921504606846976, 2305843009213693952, 4611686018427387904, 9223372036854775808"),
                 GetCA2217CSharpResultAt(14, 13, "BitValuesClass", "4"),
                 GetCA2217CSharpResultAt(24, 13, "LabelsClass", "2"));
         }
 
         [Fact]
-        public void VisualBasic_EnumWithFlagsAttributes_NonSimpleFlags()
+        public async Task VisualBasic_EnumWithFlagsAttributes_NonSimpleFlags()
         {
             var code = @"
 {0}
@@ -560,34 +567,34 @@ End Enum
 
             // Verify no CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyBasic(codeWithoutFlags);
+            await VerifyVB.VerifyAnalyzerAsync(codeWithoutFlags);
 
             // Verify CA2217: Do not mark enums with FlagsAttribute
             string codeWithFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: true);
-            VerifyBasic(codeWithFlags,
+            await VerifyVB.VerifyAnalyzerAsync(codeWithFlags,
                 GetCA2217BasicResultAt(3, 13, "NonSimpleFlagEnumClass", "4, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824, 2147483648, 4294967296, 8589934592, 17179869184, 34359738368, 68719476736, 137438953472, 274877906944, 549755813888, 1099511627776, 2199023255552, 4398046511104, 8796093022208, 17592186044416, 35184372088832, 70368744177664, 140737488355328, 281474976710656, 562949953421312, 1125899906842624, 2251799813685248, 4503599627370496, 9007199254740992, 18014398509481984, 36028797018963968, 72057594037927936, 144115188075855872, 288230376151711744, 576460752303423488, 1152921504606846976, 2305843009213693952, 4611686018427387904, 9223372036854775808"),
                 GetCA2217BasicResultAt(13, 13, "BitValuesClass", "4"),
                 GetCA2217BasicResultAt(22, 13, "LabelsClass", "2"));
         }
 
         private static DiagnosticResult GetCA1027CSharpResultAt(int line, int column, string enumTypeName)
-        {
-            return GetCSharpResultAt(line, column, EnumWithFlagsAttributeAnalyzer.RuleIdMarkEnumsWithFlags, string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkEnumsWithFlagsMessage, enumTypeName));
-        }
+            => new DiagnosticResult(EnumWithFlagsAttributeAnalyzer.Rule1027)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkEnumsWithFlagsMessage, enumTypeName));
 
         private static DiagnosticResult GetCA1027BasicResultAt(int line, int column, string enumTypeName)
-        {
-            return GetBasicResultAt(line, column, EnumWithFlagsAttributeAnalyzer.RuleIdMarkEnumsWithFlags, string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkEnumsWithFlagsMessage, enumTypeName));
-        }
+            => new DiagnosticResult(EnumWithFlagsAttributeAnalyzer.Rule1027)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkEnumsWithFlagsMessage, enumTypeName));
 
         private static DiagnosticResult GetCA2217CSharpResultAt(int line, int column, string enumTypeName, string missingValuesString)
-        {
-            return GetCSharpResultAt(line, column, EnumWithFlagsAttributeAnalyzer.RuleIdDoNotMarkEnumsWithFlags, string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotMarkEnumsWithFlagsMessage, enumTypeName, missingValuesString));
-        }
+            => new DiagnosticResult(EnumWithFlagsAttributeAnalyzer.Rule2217)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotMarkEnumsWithFlagsMessage, enumTypeName, missingValuesString));
 
         private static DiagnosticResult GetCA2217BasicResultAt(int line, int column, string enumTypeName, string missingValuesString)
-        {
-            return GetBasicResultAt(line, column, EnumWithFlagsAttributeAnalyzer.RuleIdDoNotMarkEnumsWithFlags, string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotMarkEnumsWithFlagsMessage, enumTypeName, missingValuesString));
-        }
+            => new DiagnosticResult(EnumWithFlagsAttributeAnalyzer.Rule2217)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotMarkEnumsWithFlagsMessage, enumTypeName, missingValuesString));
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -14,22 +14,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class EnumsShouldHavePluralNamesTests : DiagnosticAnalyzerTestBase
+    public class EnumsShouldHavePluralNamesTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new EnumsShouldHavePluralNamesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new EnumsShouldHavePluralNamesAnalyzer();
-        }
-
         [Fact]
-        public void CA1714_CA1717_Test_EnumWithNoFlags_SingularName()
+        public async Task CA1714_CA1717_Test_EnumWithNoFlags_SingularName()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                public enum Day 
@@ -42,7 +32,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                             }"
                           );
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                         Public Class A
 	                        Public Enum Day
 		                           Sunday = 0
@@ -55,9 +45,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1714_CA1717__Test_EnumWithNoFlags_PluralName()
+        public async Task CA1714_CA1717__Test_EnumWithNoFlags_PluralName()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                public enum Days 
@@ -70,7 +60,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                             }",
                             GetCSharpNoPluralResultAt(4, 44));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                         Public Class A
 	                        Public Enum Days
 		                           Sunday = 0
@@ -84,9 +74,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1714_CA1717__Test_EnumWithNoFlags_PluralName_Internal()
+        public async Task CA1714_CA1717__Test_EnumWithNoFlags_PluralName_Internal()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class A 
 { 
     enum Days 
@@ -121,7 +111,7 @@ internal class A3
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class A
 	Private Enum Days
 		Sunday = 0
@@ -149,9 +139,9 @@ End Class
         }
 
         [Fact]
-        public void CA1714_CA1717__Test_EnumWithNoFlags_PluralName_UpperCase()
+        public async Task CA1714_CA1717__Test_EnumWithNoFlags_PluralName_UpperCase()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                public enum DAYS 
@@ -164,7 +154,7 @@ End Class
                             }",
                             GetCSharpNoPluralResultAt(4, 44));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                         Public Class A
 	                        Public Enum DAYS
 		                           Sunday = 0
@@ -178,9 +168,9 @@ End Class
         }
 
         [Fact]
-        public void CA1714_CA1717_Test_EnumWithFlags_SingularName()
+        public async Task CA1714_CA1717_Test_EnumWithFlags_SingularName()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                [System.Flags] 
@@ -194,7 +184,7 @@ End Class
                             }",
                             GetCSharpPluralResultAt(5, 44));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
 	                    <System.Flags> _
 	                    Public Enum Day
@@ -207,9 +197,9 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1714_CA1717_Test_EnumWithFlags_SingularName_Internal()
+        public async Task CA1714_CA1717_Test_EnumWithFlags_SingularName_Internal()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class A 
 { 
     [System.Flags] 
@@ -247,7 +237,7 @@ internal class A3
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class A
     <System.Flags> _
     Enum Day
@@ -278,9 +268,9 @@ End Class
         }
 
         [Fact]
-        public void CA1714_CA1717_Test_EnumWithFlags_PluralName()
+        public async Task CA1714_CA1717_Test_EnumWithFlags_PluralName()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                [System.Flags] 
@@ -293,7 +283,7 @@ End Class
                                 };
                             }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
 	                    <System.Flags> _
 	                    Public Enum Days
@@ -305,9 +295,9 @@ End Class
         }
 
         [Fact]
-        public void CA1714_CA1717_Test_EnumWithFlags_PluralName_UpperCase()
+        public async Task CA1714_CA1717_Test_EnumWithFlags_PluralName_UpperCase()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                [System.Flags] 
@@ -316,11 +306,11 @@ End Class
                                     sunday = 0,
                                     Monday = 1,
                                     Tuesday = 2
-                                       
+
                                 };
                             }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
 	                    <System.Flags> _
 	                    Public Enum DAYS
@@ -332,9 +322,9 @@ End Class
         }
 
         [Fact, WorkItem(1323, "https://github.com/dotnet/roslyn-analyzers/issues/1323")]
-        public void CA1714_CA1717_Test_EnumWithFlags_NonPluralNameEndsWithS()
+        public async Task CA1714_CA1717_Test_EnumWithFlags_NonPluralNameEndsWithS()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                [System.Flags] 
@@ -348,7 +338,7 @@ End Class
                             }",
                             GetCSharpPluralResultAt(5, 44));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
 	                    <System.Flags> _
 	                    Public Enum Axis
@@ -361,9 +351,9 @@ End Class
         }
 
         [Fact, WorkItem(1323, "https://github.com/dotnet/roslyn-analyzers/issues/1323")]
-        public void CA1714_CA1717_Test_EnumWithFlags_PluralNameEndsWithS()
+        public async Task CA1714_CA1717_Test_EnumWithFlags_PluralNameEndsWithS()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                [System.Flags] 
@@ -376,7 +366,7 @@ End Class
                                 };
                             }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
 	                    <System.Flags> _
 	                    Public Enum Axes
@@ -388,9 +378,9 @@ End Class
         }
 
         [Fact, WorkItem(1323, "https://github.com/dotnet/roslyn-analyzers/issues/1323")]
-        public void CA1714_CA1717_Test_EnumWithFlags_PluralName_NotEndingWithS()
+        public async Task CA1714_CA1717_Test_EnumWithFlags_PluralName_NotEndingWithS()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                [System.Flags] 
@@ -403,7 +393,7 @@ End Class
                                 };
                             }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
                         < System.Flags > _
                         Public Enum Men
@@ -415,9 +405,9 @@ End Class
         }
 
         [Fact, WorkItem(1323, "https://github.com/dotnet/roslyn-analyzers/issues/1323")]
-        public void CA1714_CA1717_Test_EnumWithNoFlags_PluralWord_NotEndingWithS()
+        public async Task CA1714_CA1717_Test_EnumWithNoFlags_PluralWord_NotEndingWithS()
         {
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                public enum Men 
@@ -430,7 +420,7 @@ End Class
                             }",
                             GetCSharpNoPluralResultAt(4, 44));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
                         Public Enum Men
                             M1 = 0
@@ -442,10 +432,10 @@ End Class
         }
 
         [Fact, WorkItem(1323, "https://github.com/dotnet/roslyn-analyzers/issues/1323")]
-        public void CA1714_CA1717_Test_EnumWithNoFlags_irregularPluralWord_EndingWith_ae()
+        public async Task CA1714_CA1717_Test_EnumWithNoFlags_irregularPluralWord_EndingWith_ae()
         {
             // Humanizer does not recognize 'formulae' as plural, but we skip words ending with 'ae'
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                [System.Flags] 
@@ -458,7 +448,7 @@ End Class
                                 };
                             }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
                         < System.Flags > _
                         Public Enum formulae
@@ -470,10 +460,10 @@ End Class
         }
 
         [Fact, WorkItem(1323, "https://github.com/dotnet/roslyn-analyzers/issues/1323")]
-        public void CA1714_CA1717_Test_EnumWithNoFlags_irregularPluralWord_EndingWith_i()
+        public async Task CA1714_CA1717_Test_EnumWithNoFlags_irregularPluralWord_EndingWith_i()
         {
             // Humanizer does not recognize 'trophi' as plural, but we skip words ending with 'i'
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                [System.Flags] 
@@ -486,7 +476,7 @@ End Class
                                 };
                             }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
                         < System.Flags > _
                         Public Enum trophi
@@ -498,10 +488,10 @@ End Class
         }
 
         [Fact, WorkItem(1323, "https://github.com/dotnet/roslyn-analyzers/issues/1323")]
-        public void CA1714_CA1717_Test_EnumWithNoFlags_NonAscii()
+        public async Task CA1714_CA1717_Test_EnumWithNoFlags_NonAscii()
         {
             // We skip non-ASCII names.
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                [System.Flags] 
@@ -514,7 +504,7 @@ End Class
                                 };
                             }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                        Public Class A
                         < System.Flags > _
                         Public Enum UnicodeNameΔ
@@ -531,12 +521,12 @@ End Class
         [InlineData("pl-PL")]
         [InlineData("fi-FI")]
         [InlineData("de-DE")]
-        public void CA1714_CA1717__Test_EnumWithNoFlags_PluralName_MultipleCultures(string culture)
+        public async Task CA1714_CA1717__Test_EnumWithNoFlags_PluralName_MultipleCultures(string culture)
         {
             var currentCulture = CultureInfo.DefaultThreadCurrentCulture;
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.GetCultureInfo(culture);
 
-            VerifyCSharp(@" 
+            await VerifyCS.VerifyAnalyzerAsync(@"
                             public class A 
                             { 
                                public enum Days 
@@ -549,7 +539,7 @@ End Class
                             }",
                             GetCSharpNoPluralResultAt(4, 44));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                         Public Class A
 	                        Public Enum Days
 		                           Sunday = 0
@@ -565,23 +555,23 @@ End Class
         }
 
         private static DiagnosticResult GetCSharpPluralResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, MicrosoftCodeQualityAnalyzersResources.FlagsEnumsShouldHavePluralNamesMessage);
-        }
+            => new DiagnosticResult(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.FlagsEnumsShouldHavePluralNamesMessage);
 
         private static DiagnosticResult GetBasicPluralResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, EnumsShouldHavePluralNamesAnalyzer.RuleId_Plural, MicrosoftCodeQualityAnalyzersResources.FlagsEnumsShouldHavePluralNamesMessage);
-        }
+            => new DiagnosticResult(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.FlagsEnumsShouldHavePluralNamesMessage);
 
         private static DiagnosticResult GetCSharpNoPluralResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, EnumsShouldHavePluralNamesAnalyzer.RuleId_NoPlural, MicrosoftCodeQualityAnalyzersResources.OnlyFlagsEnumsShouldHavePluralNamesMessage);
-        }
+            => new DiagnosticResult(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.OnlyFlagsEnumsShouldHavePluralNamesMessage);
 
         private static DiagnosticResult GetBasicNoPluralResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, EnumsShouldHavePluralNamesAnalyzer.RuleId_NoPlural, MicrosoftCodeQualityAnalyzersResources.OnlyFlagsEnumsShouldHavePluralNamesMessage);
-        }
+            => new DiagnosticResult(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.OnlyFlagsEnumsShouldHavePluralNamesMessage);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHaveZeroValueTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHaveZeroValueTests.cs
@@ -1,26 +1,23 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Xunit;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using System.Globalization;
+using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumsShouldHaveZeroValueAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EquatableFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumsShouldHaveZeroValueAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EquatableFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class EnumsShouldHaveZeroValueTests : DiagnosticAnalyzerTestBase
+    public class EnumsShouldHaveZeroValueTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new EnumsShouldHaveZeroValueAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new EnumsShouldHaveZeroValueAnalyzer();
-        }
-
         [Fact]
-        public void CSharp_EnumsShouldZeroValueFlagsRename()
+        public async Task CSharp_EnumsShouldZeroValueFlagsRename()
         {
             // In enum '{0}', change the name of '{1}' to 'None'.
             string expectedMessage1 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsRename, "E", "A");
@@ -66,15 +63,15 @@ public enum NoZeroValuedField
     A5 = 1,
     B5 = 2
 }";
-            VerifyCSharp(code,
-                GetCSharpResultAt(7, 9, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetCSharpResultAt(15, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
-                GetCSharpResultAt(22, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3),
-                GetCSharpResultAt(29, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage4));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                GetCSharpRenameResultAt(7, 9, expectedMessage1),
+                GetCSharpRenameResultAt(15, 5, expectedMessage2),
+                GetCSharpRenameResultAt(22, 5, expectedMessage3),
+                GetCSharpRenameResultAt(29, 5, expectedMessage4));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_EnumsShouldZeroValueFlagsRename_Internal()
+        public async Task CSharp_EnumsShouldZeroValueFlagsRename_Internal()
         {
             var code = @"
 class Outer
@@ -114,11 +111,11 @@ internal enum NoZeroValuedField
     A5 = 1,
     B5 = 2
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharp_EnumsShouldZeroValueFlagsMultipleZero()
+        public async Task CSharp_EnumsShouldZeroValueFlagsMultipleZero()
         {
             // Remove all members that have the value zero from {0} except for one member that is named 'None'.
             string expectedMessage1 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsMultipleZeros, "E");
@@ -142,13 +139,13 @@ public enum E2
     None = 0,
     A = None
 }";
-            VerifyCSharp(code,
-                GetCSharpResultAt(5, 17, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetCSharpResultAt(14, 13, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                GetCSharpMultipleZeroResultAt(5, 17, expectedMessage1),
+                GetCSharpMultipleZeroResultAt(14, 13, expectedMessage2));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_EnumsShouldZeroValueFlagsMultipleZero_Internal()
+        public async Task CSharp_EnumsShouldZeroValueFlagsMultipleZero_Internal()
         {
             var code = @"// Some comment
 public class Outer
@@ -168,11 +165,11 @@ internal enum E2
     None = 0,
     A = None
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharp_EnumsShouldZeroValueNotFlagsNoZeroValue()
+        public async Task CSharp_EnumsShouldZeroValueNotFlagsNoZeroValue()
         {
             // Add a member to {0} that has a value of zero with a suggested name of 'None'.
             string expectedMessage1 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue, "E");
@@ -205,13 +202,13 @@ public enum E4
     A = 0
 }
 ";
-            VerifyCSharp(code,
-                GetCSharpResultAt(4, 17, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetCSharpResultAt(9, 17, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                GetCSharpNoZeroResultAt(4, 17, expectedMessage1),
+                GetCSharpNoZeroResultAt(9, 17, expectedMessage2));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_EnumsShouldZeroValueNotFlagsNoZeroValue_Internal()
+        public async Task CSharp_EnumsShouldZeroValueNotFlagsNoZeroValue_Internal()
         {
             var code = @"
 public class Outer
@@ -240,11 +237,11 @@ internal enum E4
     A = 0
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void VisualBasic_EnumsShouldZeroValueFlagsRename()
+        public async Task VisualBasic_EnumsShouldZeroValueFlagsRename()
         {
             // In enum '{0}', change the name of '{1}' to 'None'.
             string expectedMessage1 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsRename, "E", "A");
@@ -278,14 +275,14 @@ Public Enum NoZeroValuedField
     B5 = 2
 End Enum
 ";
-            VerifyBasic(code,
-                GetBasicResultAt(5, 9, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetBasicResultAt(12, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
-                GetBasicResultAt(18, 5, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3));
+            await VerifyVB.VerifyAnalyzerAsync(code,
+                GetBasicRenameResultAt(5, 9, expectedMessage1),
+                GetBasicRenameResultAt(12, 5, expectedMessage2),
+                GetBasicRenameResultAt(18, 5, expectedMessage3));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VisualBasic_EnumsShouldZeroValueFlagsRename_Internal()
+        public async Task VisualBasic_EnumsShouldZeroValueFlagsRename_Internal()
         {
             var code = @"
 Public Class C
@@ -314,12 +311,12 @@ Friend Enum NoZeroValuedField
     B5 = 2
 End Enum
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [WorkItem(836193, "DevDiv")]
         [Fact]
-        public void VisualBasic_EnumsShouldZeroValueFlagsRename_AttributeListHasTrivia()
+        public async Task VisualBasic_EnumsShouldZeroValueFlagsRename_AttributeListHasTrivia()
         {
             // In enum '{0}', change the name of '{1}' to 'None'.
             string expectedMessage1 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsRename, "E", "A");
@@ -353,14 +350,14 @@ Public Enum NoZeroValuedField
 	B5 = 2
 End Enum
 ";
-            VerifyBasic(code,
-                GetBasicResultAt(5, 6, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetBasicResultAt(12, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
-                GetBasicResultAt(18, 2, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3));
+            await VerifyVB.VerifyAnalyzerAsync(code,
+                GetBasicRenameResultAt(5, 6, expectedMessage1),
+                GetBasicRenameResultAt(12, 2, expectedMessage2),
+                GetBasicRenameResultAt(18, 2, expectedMessage3));
         }
 
         [Fact]
-        public void VisualBasic_EnumsShouldZeroValueFlagsMultipleZero()
+        public async Task VisualBasic_EnumsShouldZeroValueFlagsMultipleZero()
         {
             // Remove all members that have the value zero from {0} except for one member that is named 'None'.
             string expectedMessage1 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.EnumsShouldHaveZeroValueMessageFlagsMultipleZeros, "E");
@@ -384,18 +381,18 @@ End Enum
 
 <System.Flags>
 Public Enum E3
-	A3 = 0
-	B3 = CUInt(0)  ' Not a constant
+    A3 = 0
+    B3 = CUInt(0)  ' Not a constant
 End Enum";
 
-            VerifyBasic(code,
-                GetBasicResultAt(4, 17, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetBasicResultAt(11, 13, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2),
-                GetBasicResultAt(17, 13, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage3));
+            await VerifyVB.VerifyAnalyzerAsync(code,
+                GetBasicMultipleZeroResultAt(4, 17, expectedMessage1),
+                GetBasicMultipleZeroResultAt(11, 13, expectedMessage2),
+                GetBasicMultipleZeroResultAt(17, 13, expectedMessage3));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VisualBasic_EnumsShouldZeroValueFlagsMultipleZero_Internal()
+        public async Task VisualBasic_EnumsShouldZeroValueFlagsMultipleZero_Internal()
         {
             var code = @"
 Public Class Outer
@@ -418,11 +415,11 @@ Friend Enum E3
 	B3 = CUInt(0)  ' Not a constant
 End Enum";
 
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void VisualBasic_EnumsShouldZeroValueNotFlagsNoZeroValue()
+        public async Task VisualBasic_EnumsShouldZeroValueNotFlagsNoZeroValue()
         {
             // Add a member to {0} that has a value of zero with a suggested name of 'None'.
             string expectedMessage1 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue, "E");
@@ -451,13 +448,13 @@ Public Enum E4
 End Enum
 ";
 
-            VerifyBasic(code,
-                GetBasicResultAt(3, 17, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage1),
-                GetBasicResultAt(7, 17, EnumsShouldHaveZeroValueAnalyzer.RuleId, expectedMessage2));
+            await VerifyVB.VerifyAnalyzerAsync(code,
+                GetBasicNoZeroResultAt(3, 17, expectedMessage1),
+                GetBasicNoZeroResultAt(7, 17, expectedMessage2));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VisualBasic_EnumsShouldZeroValueNotFlagsNoZeroValue_Internal()
+        public async Task VisualBasic_EnumsShouldZeroValueNotFlagsNoZeroValue_Internal()
         {
             var code = @"
 Public Class Outer
@@ -482,7 +479,37 @@ Friend Enum E4
 End Enum
 ";
 
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
+
+        private static DiagnosticResult GetCSharpMultipleZeroResultAt(int line, int column, string message)
+            => VerifyCS.Diagnostic(EnumsShouldHaveZeroValueAnalyzer.RuleMultipleZero)
+                .WithLocation(line, column)
+                .WithMessage(message);
+
+        private static DiagnosticResult GetBasicMultipleZeroResultAt(int line, int column, string message)
+            => VerifyCS.Diagnostic(EnumsShouldHaveZeroValueAnalyzer.RuleMultipleZero)
+                .WithLocation(line, column)
+                .WithMessage(message);
+
+        private static DiagnosticResult GetCSharpNoZeroResultAt(int line, int column, string message)
+            => VerifyCS.Diagnostic(EnumsShouldHaveZeroValueAnalyzer.RuleNoZero)
+                .WithLocation(line, column)
+                .WithMessage(message);
+
+        private static DiagnosticResult GetBasicNoZeroResultAt(int line, int column, string message)
+            => VerifyCS.Diagnostic(EnumsShouldHaveZeroValueAnalyzer.RuleNoZero)
+                .WithLocation(line, column)
+                .WithMessage(message);
+
+        private static DiagnosticResult GetCSharpRenameResultAt(int line, int column, string message)
+            => VerifyCS.Diagnostic(EnumsShouldHaveZeroValueAnalyzer.RuleRename)
+                .WithLocation(line, column)
+                .WithMessage(message);
+
+        private static DiagnosticResult GetBasicRenameResultAt(int line, int column, string message)
+            => VerifyCS.Diagnostic(EnumsShouldHaveZeroValueAnalyzer.RuleRename)
+                .WithLocation(line, column)
+                .WithMessage(message);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
@@ -1,39 +1,44 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EquatableAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EquatableFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class EquatableAnalyzerTests : DiagnosticAnalyzerTestBase
+    public class EquatableAnalyzerTests
     {
         [Fact]
-        public void NoDiagnosticForStructWithNoEqualsOverrideAndNoIEquatableImplementation()
+        public async Task NoDiagnosticForStructWithNoEqualsOverrideAndNoIEquatableImplementation()
         {
             var code = @"
 struct S
 {
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithNoEqualsOverrideAndNoIEquatableImplementation()
+        public async Task NoDiagnosticForClassWithNoEqualsOverrideAndNoIEquatableImplementation()
         {
             var code = @"
 class C
 {
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void DiagnosticForStructWithEqualsOverrideButNoIEquatableImplementation()
+        public async Task DiagnosticForStructWithEqualsOverrideButNoIEquatableImplementation()
         {
             var code = @"
 struct S
@@ -45,12 +50,12 @@ struct S
 }
 ";
             string expectedMessage = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsMessage, "S");
-            VerifyCSharp(code,
-                GetCSharpResultAt(2, 8, EquatableAnalyzer.ImplementIEquatableRuleId, expectedMessage));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                GetCSharpResultAt(2, 8, EquatableAnalyzer.ImplementIEquatableDescriptor, expectedMessage));
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithEqualsOverrideAndNoIEquatableImplementation()
+        public async Task NoDiagnosticForClassWithEqualsOverrideAndNoIEquatableImplementation()
         {
             var code = @"
 class C
@@ -61,11 +66,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void DiagnosticForStructWithIEquatableImplementationButNoEqualsOverride()
+        public async Task DiagnosticForStructWithIEquatableImplementationButNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -79,12 +84,12 @@ struct S : IEquatable<S>
 }
 ";
             string expectedMessage = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideObjectEqualsMessage, "S");
-            VerifyCSharp(code,
-                GetCSharpResultAt(4, 8, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                GetCSharpResultAt(4, 8, EquatableAnalyzer.OverridesObjectEqualsDescriptor, expectedMessage));
         }
 
         [Fact]
-        public void DiagnosticForClassWithIEquatableImplementationButNoEqualsOverride()
+        public async Task DiagnosticForClassWithIEquatableImplementationButNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -98,12 +103,12 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
-                GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                GetCSharpResultAt(4, 7, EquatableAnalyzer.OverridesObjectEqualsDescriptor, expectedMessage));
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithIEquatableImplementationWithNoParameterListAndNoEqualsOverride()
+        public async Task NoDiagnosticForClassWithIEquatableImplementationWithNoParameterListAndNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -116,11 +121,11 @@ class C : IEquatable<C>
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithIEquatableImplementationWithMalformedParameterListAndNoEqualsOverride()
+        public async Task NoDiagnosticForClassWithIEquatableImplementationWithMalformedParameterListAndNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -133,11 +138,11 @@ class C : IEquatable<C>
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithIEquatableImplementationWithMalformedParameterListAndNoEqualsOverride2()
+        public async Task NoDiagnosticForClassWithIEquatableImplementationWithMalformedParameterListAndNoEqualsOverride2()
         {
             var code = @"
 using System;
@@ -150,11 +155,11 @@ class C : IEquatable<C>
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithIEquatableImplementationWithNoParametersAndNoEqualsOverride()
+        public async Task NoDiagnosticForClassWithIEquatableImplementationWithNoParametersAndNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -167,11 +172,11 @@ class C : IEquatable<C>
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithIEquatableImplementationWithMalformedParameterDeclarationAndNoEqualsOverride()
+        public async Task NoDiagnosticForClassWithIEquatableImplementationWithMalformedParameterDeclarationAndNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -184,11 +189,11 @@ class C : IEquatable<C>
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithIEquatableImplementationWithWrongReturnTypeAndNoEqualsOverride()
+        public async Task NoDiagnosticForClassWithIEquatableImplementationWithWrongReturnTypeAndNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -201,11 +206,11 @@ class C : IEquatable<C>
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void DiagnosticForClassWithIEquatableImplementationWithNoBodyAndNoEqualsOverride()
+        public async Task DiagnosticForClassWithIEquatableImplementationWithNoBodyAndNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -216,12 +221,12 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
-                GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None,
+                GetCSharpResultAt(4, 7, EquatableAnalyzer.OverridesObjectEqualsDescriptor, expectedMessage));
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithIEquatableImplementationWithNoReturnTypeAndNoEqualsOverride()
+        public async Task NoDiagnosticForClassWithIEquatableImplementationWithNoReturnTypeAndNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -234,11 +239,11 @@ class C : IEquatable<C>
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void NoDiagnosticForClassWithEqualsOverrideWithWrongSignatureAndNoIEquatableImplementation()
+        public async Task NoDiagnosticForClassWithEqualsOverrideWithWrongSignatureAndNoIEquatableImplementation()
         {
             var code = @"
 using System;
@@ -251,11 +256,11 @@ class C
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void DiagnosticForClassWithExplicitIEquatableImplementationAndNoEqualsOverride()
+        public async Task DiagnosticForClassWithExplicitIEquatableImplementationAndNoEqualsOverride()
         {
             var code = @"
 using System;
@@ -269,12 +274,12 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            VerifyCSharp(code,
-                GetCSharpResultAt(4, 7, EquatableAnalyzer.OverrideObjectEqualsRuleId, expectedMessage));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                GetCSharpResultAt(4, 7, EquatableAnalyzer.OverridesObjectEqualsDescriptor, expectedMessage));
         }
 
         [Fact]
-        public void DiagnosticForDerivedStructWithEqualsOverrideAndNoIEquatableImplementation()
+        public async Task DiagnosticForDerivedStructWithEqualsOverrideAndNoIEquatableImplementation()
         {
             var code = @"
 using System;
@@ -297,13 +302,13 @@ struct C : B
 ";
             string expectedMessage1 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsMessage, "B");
             string expectedMessage2 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsMessage, "C");
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors,
-                GetCSharpResultAt(4, 8, EquatableAnalyzer.ImplementIEquatableRuleId, expectedMessage1),
-                GetCSharpResultAt(12, 8, EquatableAnalyzer.ImplementIEquatableRuleId, expectedMessage2));
+            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None,
+                GetCSharpResultAt(4, 8, EquatableAnalyzer.ImplementIEquatableDescriptor, expectedMessage1),
+                GetCSharpResultAt(12, 8, EquatableAnalyzer.ImplementIEquatableDescriptor, expectedMessage2));
         }
 
         [Fact, WorkItem(1914, "https://github.com/dotnet/roslyn-analyzers/issues/1914")]
-        public void NoDiagnosticForParentClassWithIEquatableImplementation()
+        public async Task NoDiagnosticForParentClassWithIEquatableImplementation()
         {
             var code = @"
 using System;
@@ -320,11 +325,11 @@ public struct S : IValueObject<S>
 
     public override int GetHashCode() => value;
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact, WorkItem(2027, "https://github.com/dotnet/roslyn-analyzers/issues/2027")]
-        public void NoDiagnosticForDerivedTypesWithBaseTypeWithIEquatableImplementation_01()
+        public async Task NoDiagnosticForDerivedTypesWithBaseTypeWithIEquatableImplementation_01()
         {
             var code = @"
 using System;
@@ -340,11 +345,11 @@ public class A<T> : IEquatable<T>
 public class B : A<B>
 {
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact, WorkItem(2027, "https://github.com/dotnet/roslyn-analyzers/issues/2027")]
-        public void NoDiagnosticForDerivedTypesWithBaseTypeWithIEquatableImplementation_02()
+        public async Task NoDiagnosticForDerivedTypesWithBaseTypeWithIEquatableImplementation_02()
         {
             var code = @"
 using System;
@@ -369,13 +374,15 @@ public class C<T> : A<T>
 public class D : C<D>
 {
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact, WorkItem(2324, "https://github.com/dotnet/roslyn-analyzers/issues/2324")]
-        public void CA1066_CSharp_RefStruct_NoDiagnostic()
+        public async Task CA1066_CSharp_RefStruct_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 public ref struct S
 {
     public override bool Equals(object other)
@@ -384,13 +391,13 @@ public ref struct S
     }
 }
 ",
-            parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+                LanguageVersion = LanguageVersion.CSharp8
+            }.RunAsync();
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-            => new EquatableAnalyzer();
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-            => new EquatableAnalyzer();
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string message)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithMessage(message);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ExceptionsShouldBePublicTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ExceptionsShouldBePublicTests.cs
@@ -1,28 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
-
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ExceptionsShouldBePublicAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ExceptionsShouldBePublicFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ExceptionsShouldBePublicAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ExceptionsShouldBePublicFixer>;
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class ExceptionsShouldBePublicTests : DiagnosticAnalyzerTestBase
+    public class ExceptionsShouldBePublicTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new ExceptionsShouldBePublicAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new ExceptionsShouldBePublicAnalyzer();
-        }
-
         [Fact]
-        public void TestCSharpNonPublicException()
+        public async Task TestCSharpNonPublicException()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class InternalException : Exception
 {
@@ -31,9 +25,9 @@ class InternalException : Exception
         }
 
         [Fact]
-        public void TestCSharpNonPublicException2()
+        public async Task TestCSharpNonPublicException2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 internal class Outer
 {
@@ -45,9 +39,9 @@ internal class Outer
         }
 
         [Fact]
-        public void TestCSharpPublicException()
+        public async Task TestCSharpPublicException()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 public class BasicException : Exception
 {
@@ -55,9 +49,9 @@ public class BasicException : Exception
         }
 
         [Fact]
-        public void TestCSharpNonExceptionType()
+        public async Task TestCSharpNonExceptionType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 public class NonException : StringWriter
 {
@@ -65,9 +59,9 @@ public class NonException : StringWriter
         }
 
         [Fact]
-        public void TestVBasicNonPublicException()
+        public async Task TestVBasicNonPublicException()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class InternalException
    Inherits Exception
@@ -76,9 +70,9 @@ End Class",
         }
 
         [Fact]
-        public void TestVBasicNonPublicException2()
+        public async Task TestVBasicNonPublicException2()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Public Class Outer
     Private Class PrivateException
@@ -89,9 +83,9 @@ End Class",
         }
 
         [Fact]
-        public void TestVBasicPublicException()
+        public async Task TestVBasicPublicException()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Public Class BasicException
    Inherits Exception
@@ -99,9 +93,9 @@ End Class");
         }
 
         [Fact]
-        public void TestVBasicNonExceptionType()
+        public async Task TestVBasicNonExceptionType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.IO
 Imports System.Text
 Public Class NonException
@@ -109,12 +103,14 @@ Public Class NonException
 End Class");
         }
 
-        private DiagnosticResult GetCA1064CSharpResultAt(int line, int column) =>
-            GetCSharpResultAt(line, column, ExceptionsShouldBePublicAnalyzer.RuleId,
-                MicrosoftCodeQualityAnalyzersResources.ExceptionsShouldBePublicMessage);
+        private DiagnosticResult GetCA1064CSharpResultAt(int line, int column)
+            => new DiagnosticResult(ExceptionsShouldBePublicAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.ExceptionsShouldBePublicMessage);
 
-        private DiagnosticResult GetCA1064VBasicResultAt(int line, int column) =>
-            GetBasicResultAt(line, column, ExceptionsShouldBePublicAnalyzer.RuleId,
-                MicrosoftCodeQualityAnalyzersResources.ExceptionsShouldBePublicMessage);
+        private DiagnosticResult GetCA1064VBasicResultAt(int line, int column)
+            => new DiagnosticResult(ExceptionsShouldBePublicAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.ExceptionsShouldBePublicMessage);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCaseTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCaseTests.cs
@@ -3,10 +3,14 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldDifferByMoreThanCaseAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
@@ -25,9 +29,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         #region Namespace Level
 
         [Fact]
-        public void TestGlobalNamespaceNames()
+        public async Task TestGlobalNamespaceNames()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace N
 {
     public class C { }
@@ -41,9 +45,9 @@ namespace n
         }
 
         [Fact]
-        public void TestNestedNamespaceNames()
+        public async Task TestNestedNamespaceNames()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace N
 {
     class C { }
@@ -67,9 +71,9 @@ namespace n
         }
 
         [Fact]
-        public void TestGlobalTypeNames()
+        public async Task TestGlobalTypeNames()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Ni
 {
 }
@@ -84,9 +88,9 @@ public interface nI
         }
 
         [Fact]
-        public void TestGenericClasses()
+        public async Task TestGenericClasses()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C<T>
 {
 }
@@ -121,7 +125,7 @@ namespace N
     }
     public partial class F
     {
-        public int x;    
+        public int x;
     }
 }
 ",
@@ -137,7 +141,7 @@ namespace N
     }
 }"
                 },
-                GetCA1708CSharpResult(Type, GetSymbolDisplayString("N.C", "N.c")),
+                GetGlobalCA1708CSharpResult(Type, GetSymbolDisplayString("N.C", "N.c")),
                 GetCA1708CSharpResultAt(Member, GetSymbolDisplayString("N.C.x", "N.C.X"), "Test0.cs(4,26)", "Test0.cs(8,26)"),
                 GetCA1708CSharpResultAt(Member, GetSymbolDisplayString("N.F.x", "N.F.X"), "Test0.cs(12,26)", "Test1.cs(7,26)"));
         }
@@ -237,9 +241,9 @@ namespace NI
         }
 
         [Fact]
-        public void TestMethodOverloads()
+        public async Task TestMethodOverloads()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace NI
 {
     public class C
@@ -253,9 +257,9 @@ namespace NI
         }
 
         [Fact]
-        public void TestGenericMethods()
+        public async Task TestGenericMethods()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace NI
 {
     public class C
@@ -272,9 +276,9 @@ namespace NI
         }
 
         [Fact]
-        public void TestMembers()
+        public async Task TestMembers()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace NI
 {
     public class CASE1
@@ -307,9 +311,9 @@ namespace NI
         }
 
         [Fact]
-        public void TestCultureSpecificNames()
+        public async Task TestCultureSpecificNames()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int γ;
@@ -320,9 +324,9 @@ public class C
         }
 
         [Fact]
-        public void TestParameters()
+        public async Task TestParameters()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace N
 {
     public class C
@@ -386,19 +390,19 @@ namespace N
         }
 
         private static DiagnosticResult GetCA1708CSharpResult(string typeName, string objectName)
-        {
-            return GetGlobalResult(RuleName, string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName));
-        }
+            => VerifyCS.Diagnostic(RuleName)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName));
+
+        private static DiagnosticResult GetGlobalCA1708CSharpResult(string typeName, string objectName)
+            => GetGlobalResult(RuleName, string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName));
 
         private static DiagnosticResult GetCA1708CSharpResultAt(string typeName, string objectName, int line, int column)
-        {
-            return GetCSharpResultAt(line, column, RuleName, string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName));
-        }
+            => VerifyCS.Diagnostic(RuleName)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName));
 
         private static DiagnosticResult GetCA1708CSharpResultAt(string typeName, string objectName, params string[] locations)
-        {
-            return GetCSharpResultAt(RuleName, string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName), locations);
-        }
+            => GetCSharpResultAt(RuleName, string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName), locations);
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffixTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using Xunit.Abstractions;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldHaveCorrectSuffixAnalyzer,
     Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldHaveCorrectSuffixFixer>;
@@ -15,27 +14,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class IdentifiersShouldHaveCorrectSuffixTests : DiagnosticAnalyzerTestBase
+    public class IdentifiersShouldHaveCorrectSuffixTests
     {
-        public IdentifiersShouldHaveCorrectSuffixTests(ITestOutputHelper output)
-            : base(output)
-        {
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldHaveCorrectSuffixAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldHaveCorrectSuffixAnalyzer();
-        }
-
         [Fact]
-        public void CA1710_AllScenarioDiagnostics_CSharp()
+        public async Task CA1710_AllScenarioDiagnostics_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -253,9 +237,9 @@ GetCA1710CSharpResultAt(line: 186, column: 14, symbolName: "DataTableWithWrongSu
         }
 
         [Fact]
-        public void CA1710_NoDiagnostics_CSharp()
+        public async Task CA1710_NoDiagnostics_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -431,9 +415,9 @@ public class MyCollectionDataTable : DataTable, IEnumerable
         }
 
         [Fact]
-        public void CA1710_AllScenarioDiagnostics_VisualBasic()
+        public async Task CA1710_AllScenarioDiagnostics_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
@@ -782,9 +766,9 @@ GetCA1710BasicResultAt(line: 263, column: 14, symbolName: "WronglyNamedType", re
         }
 
         [Fact]
-        public void CA1710_NoDiagnostics_VisualBasic()
+        public async Task CA1710_NoDiagnostics_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
@@ -1091,9 +1075,9 @@ End Class");
         }
 
         [Fact, WorkItem(1822, "https://github.com/dotnet/roslyn-analyzers/issues/1822")]
-        public void CA1710_SystemAction_CSharp()
+        public async Task CA1710_SystemAction_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -1103,9 +1087,9 @@ public class C
         }
 
         [Fact, WorkItem(1822, "https://github.com/dotnet/roslyn-analyzers/issues/1822")]
-        public void CA1710_CustomDelegate_CSharp()
+        public async Task CA1710_CustomDelegate_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -1117,30 +1101,28 @@ public class C
 
         private static DiagnosticResult GetCA1710BasicResultAt(int line, int column, string symbolName, string replacementName, bool isSpecial = false)
         {
-            return GetBasicResultAt(
-                line,
-                column,
-                IdentifiersShouldHaveCorrectSuffixAnalyzer.RuleId,
-                string.Format(CultureInfo.CurrentCulture,
-                    isSpecial ?
-                        MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection :
-                        MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageDefault,
-                    symbolName,
-                    replacementName));
+            var message = string.Format(CultureInfo.CurrentCulture,
+                isSpecial ?
+                    MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection :
+                    MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageDefault,
+                symbolName,
+                replacementName);
+            return new DiagnosticResult(IdentifiersShouldHaveCorrectSuffixAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetCA1710CSharpResultAt(int line, int column, string symbolName, string replacementName, bool isSpecial = false)
         {
-            return GetCSharpResultAt(
-                line,
-                column,
-                IdentifiersShouldHaveCorrectSuffixAnalyzer.RuleId,
-                string.Format(CultureInfo.CurrentCulture,
-                    isSpecial ?
-                        MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection :
-                        MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageDefault,
-                    symbolName,
-                    replacementName));
+            var message = string.Format(CultureInfo.CurrentCulture,
+               isSpecial ?
+                   MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection :
+                   MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageDefault,
+               symbolName,
+               replacementName);
+            return new DiagnosticResult(IdentifiersShouldHaveCorrectSuffixAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNamesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNamesTests.cs
@@ -1,29 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotContainTypeNames,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class IdentifiersShouldNotContainTypeNamesTests : DiagnosticAnalyzerTestBase
+    public class IdentifiersShouldNotContainTypeNamesTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotContainTypeNames();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotContainTypeNames();
-        }
-
         [Fact]
-        public void CSharp_CA1720_NoDiagnostic()
+        public async Task CSharp_CA1720_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class IntA
 {
 }
@@ -31,9 +24,9 @@ public class IntA
         }
 
         [Fact]
-        public void CSharp_CA1720_SomeDiagnostic1()
+        public async Task CSharp_CA1720_SomeDiagnostic1()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Int
 {
 }
@@ -42,9 +35,9 @@ public class Int
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_CA1720_Internal_NoDiagnostic()
+        public async Task CSharp_CA1720_Internal_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Int
 {
 }
@@ -66,9 +59,9 @@ internal class C2
         }
 
         [Fact]
-        public void CSharp_CA1720_SomeDiagnostic2()
+        public async Task CSharp_CA1720_SomeDiagnostic2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct Int32
 {
 }
@@ -77,9 +70,9 @@ public struct Int32
         }
 
         [Fact]
-        public void CSharp_CA1720_SomeDiagnostic3()
+        public async Task CSharp_CA1720_SomeDiagnostic3()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public enum Int64
 {
 }
@@ -88,9 +81,9 @@ public enum Int64
         }
 
         [Fact]
-        public void CSharp_CA1720_SomeDiagnostic4()
+        public async Task CSharp_CA1720_SomeDiagnostic4()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Derived
 {
    public void Int()
@@ -102,9 +95,9 @@ public class Derived
         }
 
         [Fact]
-        public void CSharp_CA1720_SomeDiagnostic5()
+        public async Task CSharp_CA1720_SomeDiagnostic5()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Bar
 {
    public void BarMethod(int Int)
@@ -116,9 +109,9 @@ public class Bar
         }
 
         [Fact]
-        public void CSharp_CA1720_SomeDiagnostic6()
+        public async Task CSharp_CA1720_SomeDiagnostic6()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class DerivedBar
 {
    public int Int;
@@ -128,9 +121,9 @@ public class DerivedBar
         }
 
         [Fact]
-        public void CSharp_CA1720_NoDiagnosticOnEqualsOverride()
+        public async Task CSharp_CA1720_NoDiagnosticOnEqualsOverride()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Bar
 {
    public override bool Equals(object obj)
@@ -142,9 +135,9 @@ public class Bar
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnAbstractBaseNotImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnAbstractBaseNotImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public abstract class Base
@@ -169,9 +162,9 @@ public class Derived : Base
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnBaseNotImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnBaseNotImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class Base
@@ -202,9 +195,9 @@ public class Derived : Base
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnBaseNotNestedImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnBaseNotNestedImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Base
 {
     public virtual void BaseMethod(object okay, object obj)
@@ -226,9 +219,9 @@ public class Bar : Derived
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnInterfaceNotImplicitImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnInterfaceNotImplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IDerived
@@ -246,9 +239,9 @@ public class Derived : IDerived
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnInterfaceNotExplicitImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnInterfaceNotExplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IDerived
@@ -266,9 +259,9 @@ public class Derived : IDerived
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnGenericInterfaceNotImplicitImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnGenericInterfaceNotImplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IDerived<in T1, in T2>
@@ -287,9 +280,9 @@ public class Derived : IDerived<int, string>
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnGenericInterfaceNotExplicitImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnGenericInterfaceNotExplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IDerived<in T1, in T2>
@@ -308,9 +301,9 @@ public class Derived : IDerived<int, string>
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnInterfaceNotNestedImplicitImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnInterfaceNotNestedImplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IDerived
@@ -332,9 +325,9 @@ public class Derived : IBar
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnInterfaceNotNestedExplicitImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnInterfaceNotNestedExplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IDerived
@@ -356,9 +349,9 @@ public class Derived : IBar
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnGenericInterfaceNotNestedImplicitImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnGenericInterfaceNotNestedImplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IDerived<in T1, in T2>
@@ -381,9 +374,9 @@ public class Derived : IBar<int, string>
         }
 
         [Fact]
-        public void CSharp_CA1720_DiagnosticOnGenericInterfaceNotNestedExplicitImplementation()
+        public async Task CSharp_CA1720_DiagnosticOnGenericInterfaceNotNestedExplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IDerived<in T1, in T2>
@@ -406,9 +399,9 @@ public class Derived : IBar<int, string>
         }
 
         [Fact]
-        public void CSharp_CA1720_NoDiagnosticOnIEqualityComparerGetHashCodeImplicitImplementation()
+        public async Task CSharp_CA1720_NoDiagnosticOnIEqualityComparerGetHashCodeImplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -432,9 +425,9 @@ public sealed class SomeEqualityComparer : IEqualityComparer<string>, IEqualityC
         }
 
         [Fact]
-        public void CSharp_CA1720_NoDiagnosticOnIEqualityComparerGetHashCodeExplicitImplementation()
+        public async Task CSharp_CA1720_NoDiagnosticOnIEqualityComparerGetHashCodeExplicitImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -460,11 +453,9 @@ public sealed class SomeEqualityComparer : IEqualityComparer<string>, IEqualityC
         #region Helpers
 
         private static DiagnosticResult GetCA1720CSharpResultAt(int line, int column, string identifierName)
-        {
-            // Add a public read-only property accessor for positional argument '{0}' of attribute '{1}'.
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldNotContainTypeNamesMessage, identifierName);
-            return GetCSharpResultAt(line, column, IdentifiersShouldNotContainTypeNames.RuleId, message);
-        }
+            => new DiagnosticResult(IdentifiersShouldNotContainTypeNames.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldNotContainTypeNamesMessage, identifierName));
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotHaveIncorrectSuffixAnalyzer,
@@ -12,12 +13,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class IdentifiersShouldNotHaveIncorrectSuffixTests : DiagnosticAnalyzerTestBase
+    public class IdentifiersShouldNotHaveIncorrectSuffixTests
     {
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromAttribute()
+        public async Task CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromAttribute()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBadAttribute {}",
                 GetCSharpResultAt(
                     1, 14,
@@ -27,9 +28,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromAttribute()
+        public async Task CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromAttribute()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadAttribute
 End Class",
                 GetBasicResultAt(
@@ -40,9 +41,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromAttribute()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromAttribute()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 
 public class MyAttribute : Attribute {}
@@ -50,9 +51,9 @@ public class MyOtherAttribute : MyAttribute {}");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromAttribute()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromAttribute()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 
 Public Class MyAttribute
@@ -65,9 +66,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromEventArgs()
+        public async Task CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromEventArgs()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
                 "public class MyBadEventArgs {}",
                 GetCSharpResultAt(
                     1, 14,
@@ -77,9 +78,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromEventArgs()
+        public async Task CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromEventArgs()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadEventArgs
 End Class",
                 GetBasicResultAt(
@@ -90,9 +91,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromEventArgs()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromEventArgs()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 
 public class MyEventArgs : EventArgs {}
@@ -100,9 +101,9 @@ public class MyOtherEventArgs : MyEventArgs {}");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromEventArgs()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromEventArgs()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 
 Public Class MyEventArgs
@@ -117,9 +118,9 @@ End Class");
         // There's no need for a test case where the type is derived from EventHandler
         // or EventHandler<T>, because they're sealed.
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeNameEndsWithEventHandler()
+        public async Task CA1711_CSharp_Diagnostic_TypeNameEndsWithEventHandler()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBadEventHandler {}",
                 GetCSharpResultAt(
                     1, 14,
@@ -129,9 +130,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeNameEndsWithEventHandler()
+        public async Task CA1711_Basic_Diagnostic_TypeNameEndsWithEventHandler()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadEventHandler
 End Class",
                 GetBasicResultAt(
@@ -142,9 +143,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromException()
+        public async Task CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromException()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBadException {}",
                 GetCSharpResultAt(
                     1, 14,
@@ -154,9 +155,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromException()
+        public async Task CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromException()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadException
 End Class",
                 GetBasicResultAt(
@@ -167,9 +168,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromException()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromException()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 
 public class MyException : Exception {}
@@ -177,9 +178,9 @@ public class MyOtherException : MyException {}");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromException()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromException()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 
 Public Class MyException
@@ -192,9 +193,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromIPermission()
+        public async Task CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromIPermission()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBadPermission {}",
                 GetCSharpResultAt(
                     1, 14,
@@ -204,9 +205,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromIPermission()
+        public async Task CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromIPermission()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadPermission
 End Class",
                 GetBasicResultAt(
@@ -217,9 +218,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromIPermission()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromIPermission()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Security;
 
 public class MyPermission : IPermission
@@ -237,9 +238,9 @@ public class MyOtherPermission : MyPermission {}");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromIPermission()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromIPermission()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Security
 
 Public Class MyPermission
@@ -278,9 +279,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromStream()
+        public async Task CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromStream()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBadStream {}",
                 GetCSharpResultAt(
                     1, 14,
@@ -290,9 +291,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromStream()
+        public async Task CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromStream()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadStream
 End Class",
                 GetBasicResultAt(
@@ -303,9 +304,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromStream()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromStream()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.IO;
 
 public class MyStream : Stream
@@ -342,9 +343,9 @@ public class MyOtherStream : MyStream { }");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromStream()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromStream()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.IO
 
 Public Class MyStream
@@ -409,9 +410,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeNameEndsWithDelegate()
+        public async Task CA1711_CSharp_Diagnostic_TypeNameEndsWithDelegate()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public delegate void MyBadDelegate();",
                 GetCSharpResultAt(
                     1, 22,
@@ -421,9 +422,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeNameEndsWithDelegate()
+        public async Task CA1711_Basic_Diagnostic_TypeNameEndsWithDelegate()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Delegate Sub MyBadDelegate()",
                 GetBasicResultAt(
                     1, 21,
@@ -433,9 +434,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeNameEndsWithEnum()
+        public async Task CA1711_CSharp_Diagnostic_TypeNameEndsWithEnum()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public enum MyBadEnum { X }",
                 GetCSharpResultAt(
                     1, 13,
@@ -445,9 +446,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeNameEndsWithEnum()
+        public async Task CA1711_Basic_Diagnostic_TypeNameEndsWithEnum()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Enum MyBadEnum
     X
 End Enum",
@@ -459,9 +460,9 @@ End Enum",
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeNameEndsWithImpl()
+        public async Task CA1711_CSharp_Diagnostic_TypeNameEndsWithImpl()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClassImpl {}",
                 GetCSharpResultAt(
                     1, 14,
@@ -472,9 +473,9 @@ End Enum",
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeNameEndsWithImpl()
+        public async Task CA1711_Basic_Diagnostic_TypeNameEndsWithImpl()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyClassImpl
 End Class",
                 GetBasicResultAt(
@@ -486,32 +487,32 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeNamingRulesAreCaseSensitiveEvenInVB()
+        public async Task CA1711_Basic_NoDiagnostic_TypeNamingRulesAreCaseSensitiveEvenInVB()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyClassimpl
 End Class");
         }
 
         [Fact]
-        public void CSharp_No_Diagnostic_MisnamedTypeIsInternal()
+        public async Task CSharp_No_Diagnostic_MisnamedTypeIsInternal()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal class MyClassImpl {}");
         }
 
         [Fact]
-        public void Basic_No_Diagnostic_MisnamedTypeIsInternal()
+        public async Task Basic_No_Diagnostic_MisnamedTypeIsInternal()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Class MyClassImpl
 End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_MisnamedTypeIsNestedPublic()
+        public async Task CA1711_CSharp_Diagnostic_MisnamedTypeIsNestedPublic()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClass
 {
     public class MyNestedClassImpl {}
@@ -525,9 +526,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_MisnamedTypeIsNestedPublic()
+        public async Task CA1711_Basic_Diagnostic_MisnamedTypeIsNestedPublic()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class [MyClass]
     Public Class MyNestedClassImpl
     End Class
@@ -541,9 +542,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_MisnamedTypeIsNestedProtected()
+        public async Task CA1711_CSharp_Diagnostic_MisnamedTypeIsNestedProtected()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClass
 {
     protected class MyNestedClassImpl {}
@@ -557,9 +558,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_MisnamedTypeIsNestedProtected()
+        public async Task CA1711_Basic_Diagnostic_MisnamedTypeIsNestedProtected()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class [MyClass]
     Protected Class MyNestedClassImpl
     End Class
@@ -573,9 +574,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_MisnamedTypeIsNestedPrivate()
+        public async Task CA1711_CSharp_NoDiagnostic_MisnamedTypeIsNestedPrivate()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClass
 {
     private class MyNestedClassImpl {}
@@ -583,9 +584,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_MisnamedTypeIsNestedPrivate()
+        public async Task CA1711_Basic_NoDiagnostic_MisnamedTypeIsNestedPrivate()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class [MyClass]
     Private Class MyNestedClassImpl
     End Class
@@ -593,9 +594,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromDictionary()
+        public async Task CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromDictionary()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBadDictionary {}",
                 GetCSharpResultAt(
                     1, 14,
@@ -605,9 +606,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromDictionary()
+        public async Task CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromDictionary()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadDictionary
 End Class",
                 GetBasicResultAt(
@@ -618,9 +619,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeImplementsIReadOnlyDictionary()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeImplementsIReadOnlyDictionary()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections;
 using System.Collections.Generic;
 
@@ -630,7 +631,7 @@ public class MyReadOnlyDictionary : IReadOnlyDictionary<string, int>
     public int Count => 0;
     public IEnumerable<string> Keys => new string[0];
     public IEnumerable<int> Values => new int[0];
-    
+
     public bool ContainsKey(string key) { return false; }
     public IEnumerator<KeyValuePair<string, int>> GetEnumerator() { return null; }
     IEnumerator IEnumerable.GetEnumerator() { return null; }
@@ -644,9 +645,9 @@ public class MyReadOnlyDictionary : IReadOnlyDictionary<string, int>
         }
 
         [Fact]
-        public void CA1711_BasicNoDiagnostic_TypeImplementsIReadOnlyDictionary()
+        public async Task CA1711_BasicNoDiagnostic_TypeImplementsIReadOnlyDictionary()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections
 Imports System.Collections.Generic
 
@@ -697,9 +698,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeImplementsGenericIDictionary()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeImplementsGenericIDictionary()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -760,9 +761,9 @@ public class MyGenericDictionary : IDictionary<string, string>
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeImplementsGenericIDictionary()
+        public async Task CA1711_Basic_NoDiagnostic_TypeImplementsGenericIDictionary()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections
 Imports System.Collections.Generic
 
@@ -844,9 +845,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeImplementsNonGenericIDictionary()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeImplementsNonGenericIDictionary()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.Collections;
 using System.Runtime.Serialization;
@@ -891,9 +892,9 @@ public class MyNonGenericDictionary : IDictionary
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeImplementsNonGenericIDictionary()
+        public async Task CA1711_Basic_NoDiagnostic_TypeImplementsNonGenericIDictionary()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 Imports System.Collections
 Imports System.Runtime.Serialization
@@ -981,9 +982,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromGenericDictionary()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromGenericDictionary()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -999,9 +1000,9 @@ public class MyGenericDictionary<K, V> : Dictionary<K, V>
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromGenericDictionary()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromGenericDictionary()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 Imports System.Collections.Generic
 Imports System.Runtime.Serialization
@@ -1016,9 +1017,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromPartiallyInstantiatedGenericDictionary()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromPartiallyInstantiatedGenericDictionary()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -1034,9 +1035,9 @@ public class MyStringDictionary<V> : Dictionary<string, V>
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromPartiallyInstantiatedGenericDictionary()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromPartiallyInstantiatedGenericDictionary()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 Imports System.Collections.Generic
 Imports System.Runtime.Serialization
@@ -1051,9 +1052,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromFullyInstantiatedGenericDictionary()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromFullyInstantiatedGenericDictionary()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -1069,9 +1070,9 @@ public class MyStringToIntDictionary : Dictionary<string, int>
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromFullyInstantiatedGenericDictionary()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromFullyInstantiatedGenericDictionary()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 Imports System.Collections.Generic
 Imports System.Runtime.Serialization
@@ -1086,9 +1087,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromCollection()
+        public async Task CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromCollection()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBadCollection {}",
                 GetCSharpResultAt(
                     1, 14,
@@ -1098,9 +1099,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromCollection()
+        public async Task CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromCollection()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadCollection
 End Class",
                 GetBasicResultAt(
@@ -1111,9 +1112,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeImplementsNonGenericICollection()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeImplementsNonGenericICollection()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections;
 
 public class MyNonGenericCollection : ICollection
@@ -1131,9 +1132,9 @@ public class MyNonGenericCollection : ICollection
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeImplementsNonGenericICollection()
+        public async Task CA1711_Basic_NoDiagnostic_TypeImplementsNonGenericICollection()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections
 
 Public Class MyNonGenericCollection
@@ -1168,9 +1169,9 @@ End Class
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeImplementsNonGenericIEnumerable()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeImplementsNonGenericIEnumerable()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections;
 
 public class MyEnumerableCollection : IEnumerable
@@ -1183,9 +1184,9 @@ public class MyEnumerableCollection : IEnumerable
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeImplementsNonGenericIEnumerable()
+        public async Task CA1711_Basic_NoDiagnostic_TypeImplementsNonGenericIEnumerable()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections
 
 Public Class MyEnumerableCollection
@@ -1198,9 +1199,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeImplementsInstantiatedGenericICollection()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeImplementsInstantiatedGenericICollection()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections;
 using System.Collections.Generic;
 
@@ -1237,9 +1238,9 @@ public class MyIntCollection : ICollection<int>
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeImplementsInstantiatedGenericICollection()
+        public async Task CA1711_Basic_NoDiagnostic_TypeImplementsInstantiatedGenericICollection()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections
 Imports System.Collections.Generic
 
@@ -1286,18 +1287,18 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromNonGenericQueue()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromNonGenericQueue()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections;
 
 public class MyNonGenericQueue : Queue { }");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromNonGenericQueue()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromNonGenericQueue()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections
 
 Public Class MyNonGenericQueue
@@ -1306,18 +1307,18 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromGenericQueue()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromGenericQueue()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections.Generic;
 
 public class MyGenericQueue<T> : Queue<T> { }");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromGenericQueue()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromGenericQueue()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections.Generic
 
 Public Class MyGenericQueue(Of T)
@@ -1326,18 +1327,18 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromInstantiatedGenericQueue()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromInstantiatedGenericQueue()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections.Generic;
 
 public class MyIntQueue : Queue<int> { }");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromInstantiatedGenericQueue()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromInstantiatedGenericQueue()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections.Generic
 
 Public Class MyIntQueue
@@ -1346,9 +1347,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromQueue()
+        public async Task CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromQueue()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBadQueue { }",
                 GetCSharpResultAt(
                     1, 14,
@@ -1359,9 +1360,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromQueue()
+        public async Task CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromQueue()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadQueue
 End Class",
                 GetBasicResultAt(
@@ -1373,18 +1374,18 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromNonGenericStack()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromNonGenericStack()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections;
 
 public class MyNonGenericStack : Stack { }");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromNonGenericStack()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromNonGenericStack()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections
 
 Public Class MyNonGenericStack
@@ -1393,18 +1394,18 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromGenericStack()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromGenericStack()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections.Generic;
 
 public class MyGenericStack<T> : Stack<T> { }");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromGenericStack()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromGenericStack()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections.Generic
 
 Public Class MyGenericStack(Of T)
@@ -1413,18 +1414,18 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeDerivesFromInstantiatedGenericStack()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeDerivesFromInstantiatedGenericStack()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Collections.Generic;
 
 public class MyIntStack : Stack<int> { }");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeDerivesFromInstantiatedGenericStack()
+        public async Task CA1711_Basic_NoDiagnostic_TypeDerivesFromInstantiatedGenericStack()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Collections.Generic
 
 Public Class MyIntStack
@@ -1433,9 +1434,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromStack()
+        public async Task CA1711_CSharp_Diagnostic_TypeDoesNotDeriveFromStack()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBadStack { }",
                 GetCSharpResultAt(
                     1, 14,
@@ -1446,9 +1447,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromStack()
+        public async Task CA1711_Basic_Diagnostic_TypeDoesNotDeriveFromStack()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBadStack
 End Class",
                 GetBasicResultAt(
@@ -1462,9 +1463,9 @@ End Class",
         // MSDN says that DataSet and DataTable can be called "Collection",
         // but FxCop disagrees.
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDerivesFromDataSet()
+        public async Task CA1711_CSharp_Diagnostic_TypeDerivesFromDataSet()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.Data;
 
@@ -1478,9 +1479,9 @@ public class MyBadDataSetCollection : DataSet { }",
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDerivesFromDataSet()
+        public async Task CA1711_Basic_Diagnostic_TypeDerivesFromDataSet()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 Imports System.Data
 
@@ -1496,9 +1497,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeDerivesFromDataTable()
+        public async Task CA1711_CSharp_Diagnostic_TypeDerivesFromDataTable()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.Data;
 
@@ -1512,9 +1513,9 @@ public class MyBadDataTableCollection : DataTable { }",
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeDerivesFromDataTable()
+        public async Task CA1711_Basic_Diagnostic_TypeDerivesFromDataTable()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 Imports System.Data
 
@@ -1530,9 +1531,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeNameEndsWithEx()
+        public async Task CA1711_CSharp_Diagnostic_TypeNameEndsWithEx()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClassEx { }",
                 GetCSharpResultAt(
                     1, 14,
@@ -1542,9 +1543,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeNameEndsWithEx()
+        public async Task CA1711_Basic_Diagnostic_TypeNameEndsWithEx()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyClassEx
 End Class",
                 GetBasicResultAt(
@@ -1555,24 +1556,24 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_TypeNameNameIsEx()
+        public async Task CA1711_CSharp_NoDiagnostic_TypeNameNameIsEx()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class Ex { }");
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_TypeNameNameIsEx()
+        public async Task CA1711_Basic_NoDiagnostic_TypeNameNameIsEx()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class Ex
 End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_TypeNameEndsWithNew()
+        public async Task CA1711_CSharp_Diagnostic_TypeNameEndsWithNew()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClassNew { }",
 
                 GetCSharpResultAt(
@@ -1583,9 +1584,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_TypeNameEndsWithNew()
+        public async Task CA1711_Basic_Diagnostic_TypeNameEndsWithNew()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyClassNew
 End Class",
                 GetBasicResultAt(
@@ -1596,9 +1597,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_MethodNameEndsWithNew()
+        public async Task CA1711_CSharp_NoDiagnostic_MethodNameEndsWithNew()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClass
 {
     public void MyMethodNew() { }
@@ -1606,9 +1607,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_MethodNameEndsWithNew()
+        public async Task CA1711_Basic_NoDiagnostic_MethodNameEndsWithNew()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class [MyClass]
     Public Sub MyMethodNew()
     End Sub
@@ -1616,9 +1617,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInSameClass()
+        public async Task CA1711_CSharp_Diagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInSameClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBaseClass
 {
     public void MyMethod() { }
@@ -1632,9 +1633,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInSameClass()
+        public async Task CA1711_Basic_Diagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInSameClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBaseClass
     Public Sub MyMethod()
     End Sub
@@ -1650,9 +1651,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInAncestorClass()
+        public async Task CA1711_CSharp_Diagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInAncestorClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBaseClass
 {
     public void MyMethod() { }
@@ -1674,9 +1675,9 @@ public class MyClass : MyDerivedClass
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInAncestorClass()
+        public async Task CA1711_Basic_Diagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInAncestorClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBaseClass
     Public Sub MyMethod()
     End Sub
@@ -1700,9 +1701,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_MethodNameEndingWithNewImplementsInterfaceMethod()
+        public async Task CA1711_CSharp_NoDiagnostic_MethodNameEndingWithNewImplementsInterfaceMethod()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public interface MyBaseInterface
 {
     void MyMethodNew();
@@ -1719,9 +1720,9 @@ public class MyClass : MyDerivedInterface
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInImplementedInterface()
+        public async Task CA1711_Basic_NoDiagnostic_MethodNameEndsWithNewAndMethodNameWithoutNewExistsInImplementedInterface()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Interface MyBaseInterface
     Sub MyMethodNew()
 End Interface
@@ -1738,9 +1739,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_MethodNameEndsWithEx()
+        public async Task CA1711_CSharp_Diagnostic_MethodNameEndsWithEx()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClass
 {
     public void MyMethodEx() { }
@@ -1754,9 +1755,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_MethodNameEndsWithEx()
+        public async Task CA1711_Basic_Diagnostic_MethodNameEndsWithEx()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class [MyClass]
     Public Sub MyMethodEx()
     End Sub
@@ -1769,9 +1770,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_PrivateMethodNameEndsWithEx()
+        public async Task CA1711_CSharp_NoDiagnostic_PrivateMethodNameEndsWithEx()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClass
 {
     private void MyMethodEx() { }
@@ -1779,9 +1780,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_PrivateMethodNameEndsWithEx()
+        public async Task CA1711_Basic_NoDiagnostic_PrivateMethodNameEndsWithEx()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class [MyClass]
     Private Sub MyMethodEx()
     End Sub
@@ -1789,9 +1790,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1711_CSharp_NoDiagnostic_OverriddenMethodNameEndsWithEx()
+        public async Task CA1711_CSharp_NoDiagnostic_OverriddenMethodNameEndsWithEx()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyBaseClass
 {
     public virtual void MyMethodEx() { }
@@ -1810,9 +1811,9 @@ public class MyClass : MyBaseClass
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_MethodNameEndingWithExImplementsInterfaceMethod()
+        public async Task CA1711_CSharp_Diagnostic_MethodNameEndingWithExImplementsInterfaceMethod()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public interface MyBaseInterface
 {
     void MyMethodEx();
@@ -1835,9 +1836,9 @@ public class MyClass : MyDerivedInterface
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_MethodNameEndingWithExImplementsInterfaceMethod()
+        public async Task CA1711_Basic_Diagnostic_MethodNameEndingWithExImplementsInterfaceMethod()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Interface MyBaseInterface
     Sub MyMethodEx()
 End Interface
@@ -1861,9 +1862,9 @@ End Class",
 
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_MethodNameEndsWithImpl()
+        public async Task CA1711_CSharp_Diagnostic_MethodNameEndsWithImpl()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClass
 {
     public void MyMethodImpl() { }
@@ -1877,9 +1878,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_MethodNameEndsWithImpl()
+        public async Task CA1711_Basic_Diagnostic_MethodNameEndsWithImpl()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class [MyClass]
     Public Sub MyMethodImpl()
     End Sub
@@ -1893,9 +1894,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_NoDiagnostic_OverriddenMethodNameEndsWithEx()
+        public async Task CA1711_Basic_NoDiagnostic_OverriddenMethodNameEndsWithEx()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class MyBaseClass
     Public Overridable Sub MyMethodEx()
     End Sub
@@ -1916,9 +1917,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_EventNameEndsWithEx()
+        public async Task CA1711_CSharp_Diagnostic_EventNameEndsWithEx()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 
 public class MyClass
@@ -1934,9 +1935,9 @@ public class MyClass
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_EventNameEndsWithEx()
+        public async Task CA1711_Basic_Diagnostic_EventNameEndsWithEx()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 
 Public Class [MyClass]
@@ -1951,9 +1952,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_PropertyNameEndsWithEx()
+        public async Task CA1711_CSharp_Diagnostic_PropertyNameEndsWithEx()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClass
 {
     public int MyPropertyEx { get; set; }
@@ -1966,9 +1967,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_PropertyNameEndsWithEx()
+        public async Task CA1711_Basic_Diagnostic_PropertyNameEndsWithEx()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class [MyClass]
     Public Property MyPropertyEx As Integer
         Get
@@ -1986,9 +1987,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_CSharp_Diagnostic_FieldNameEndsWithEx()
+        public async Task CA1711_CSharp_Diagnostic_FieldNameEndsWithEx()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class MyClass
 {
     public int MyFieldEx;
@@ -2001,9 +2002,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1711_Basic_Diagnostic_FieldNameEndsWithEx()
+        public async Task CA1711_Basic_Diagnostic_FieldNameEndsWithEx()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class [MyClass]
     Public MyFieldEx As Integer
 End Class",
@@ -2014,14 +2015,14 @@ End Class",
                     "MyFieldEx"));
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotHaveIncorrectSuffixAnalyzer();
-        }
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotHaveIncorrectSuffixAnalyzer();
-        }
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
@@ -16,22 +17,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
     /// Contains those unit tests for the IdentifiersShouldNotMatchKeywords analyzer that
     /// pertain to the MemberParameterRule, which applies to the names of type member parameters.
     /// </summary>
-    public class IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests : DiagnosticAnalyzerTestBase
+    public class IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
-        }
-
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void F(int @int) {}
@@ -40,9 +31,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub F([int] As Integer)
     End Sub
@@ -51,9 +42,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForEachKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
+        public async Task CSharpDiagnosticForEachKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void F(int @int, float @float) {}
@@ -63,9 +54,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForEachKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
+        public async Task BasicDiagnosticForEachKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub F([int] As Integer, [float] As Single)
     End Sub
@@ -75,9 +66,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForCaseSensitiveKeywordNamedParameterOfPublicVirtualMethodInPublicClassWithDifferentCasing()
+        public async Task CSharpNoDiagnosticForCaseSensitiveKeywordNamedParameterOfPublicVirtualMethodInPublicClassWithDifferentCasing()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void F(int @iNt) {}
@@ -85,18 +76,18 @@ public class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForCaseSensitiveKeywordNamedParameterOfPublicVirtualMethodInPublicClassWithDifferentCasing()
+        public async Task BasicNoDiagnosticForCaseSensitiveKeywordNamedParameterOfPublicVirtualMethodInPublicClassWithDifferentCasing()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub F([iNt] As Integer)
     End Sub
 End Class");
         }
         [Fact]
-        public void CSharpDiagnosticForCaseInsensitiveKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
+        public async Task CSharpDiagnosticForCaseInsensitiveKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void F(int @aDdHaNdLeR) {}
@@ -105,9 +96,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForCaseInsensitiveKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
+        public async Task BasicDiagnosticForCaseInsensitiveKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub F([aDdHaNdLeR] As Integer)
     End Sub
@@ -116,9 +107,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     protected virtual void F(int @int) {}
@@ -127,9 +118,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Protected Overridable Sub F([int] As Integer)
     End Sub
@@ -138,9 +129,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedParameterOfInternalVirtualMethodInPublicClass()
+        public async Task CSharpNoDiagnosticForKeywordNamedParameterOfInternalVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     internal virtual void F(int @int) {}
@@ -148,9 +139,9 @@ public class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedParameterOfInternalVirtualMethodInPublicClass()
+        public async Task BasicNoDiagnosticForKeywordNamedParameterOfInternalVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Friend Overridable Sub F([int] As Integer)
     End Sub
@@ -158,9 +149,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForParameterOfPublicNonVirtualMethodInPublicClass()
+        public async Task CSharpNoDiagnosticForParameterOfPublicNonVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void F(int @int) {}
@@ -168,9 +159,9 @@ public class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedParameterOfPublicNonVirtualMethodInPublicClass()
+        public async Task BasicNoDiagnosticForKeywordNamedParameterOfPublicNonVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Sub F([int] As Integer)
     End Sub
@@ -178,9 +169,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForNonKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
+        public async Task CSharpNoDiagnosticForNonKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void F(int int2) {}
@@ -188,9 +179,9 @@ public class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForNonKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
+        public async Task BasicNoDiagnosticForNonKeywordNamedParameterOfPublicVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub F([int2] As Integer)
     End Sub
@@ -198,9 +189,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedParameterOfPublicVirtualMethodInInternalClass()
+        public async Task CSharpNoDiagnosticForKeywordNamedParameterOfPublicVirtualMethodInInternalClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class C
 {
     public void F(int @int) {}
@@ -208,9 +199,9 @@ internal class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedParameterOfPublicVirtualMethodInInternalClass()
+        public async Task BasicNoDiagnosticForKeywordNamedParameterOfPublicVirtualMethodInInternalClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Class C
     Public Overridable Sub F([int] As Integer)
     End Sub
@@ -218,9 +209,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedParameterOfMethodInPublicInterface()
+        public async Task CSharpDiagnosticForKeywordNamedParameterOfMethodInPublicInterface()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface I
 {
     void F(int @int);
@@ -229,9 +220,9 @@ public interface I
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedParameterOfMethodInPublicInterface()
+        public async Task BasicDiagnosticForKeywordNamedParameterOfMethodInPublicInterface()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface I
     Sub F([int] As Integer)
 End Interface",
@@ -239,9 +230,9 @@ End Interface",
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedParameterOfMethodInInternalInterface()
+        public async Task CSharpNoDiagnosticForKeywordNamedParameterOfMethodInInternalInterface()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface I
 {
     void F(int @int);
@@ -249,18 +240,18 @@ internal interface I
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedParameterOfMethodInInternalInterface()
+        public async Task BasicNoDiagnosticForKeywordNamedParameterOfMethodInInternalInterface()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface I
     Sub F([int] As Integer)
 End Interface");
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedParameterOfOverrideOfPublicMethodInPublicClass()
+        public async Task CSharpNoDiagnosticForKeywordNamedParameterOfOverrideOfPublicMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void F(int @int) {}
@@ -275,9 +266,9 @@ public class D : C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedParameterOfOverrideOfMethodInPublicClass()
+        public async Task BasicNoDiagnosticForKeywordNamedParameterOfOverrideOfMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub F([int] As Integer)
     End Sub
@@ -294,9 +285,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedParameterOfNewMethodInPublicClass()
+        public async Task CSharpNoDiagnosticForKeywordNamedParameterOfNewMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void F(int @int) {}
@@ -311,9 +302,9 @@ public class D : C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedParameterOfNewMethodInPublicClass()
+        public async Task BasicNoDiagnosticForKeywordNamedParameterOfNewMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub F([int] As Integer)
     End Sub
@@ -330,9 +321,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedParameterOfVirtualNewMethodInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedParameterOfVirtualNewMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void F(int @int) {}
@@ -348,9 +339,9 @@ public class D : C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedParameterOfVirtualNewMethodInPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedParameterOfVirtualNewMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub F([int] As Integer)
     End Sub
@@ -368,9 +359,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedParameterOfVirtualPublicIndexerInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedParameterOfVirtualPublicIndexerInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual int this[int @int]
@@ -384,9 +375,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedParameterOfVirtualPublicParameterizedPropertyInPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedParameterOfVirtualPublicParameterizedPropertyInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable ReadOnly Property P([int] As Integer) As Integer
         Get
@@ -398,9 +389,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     protected class D
@@ -412,9 +403,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedParameterOfProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Protected Class D
         Protected Overridable Sub F([iNtEgEr] As Integer)
@@ -423,5 +414,15 @@ Public Class C
 End Class",
                 GetBasicResultAt(4, 37, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberParameterRule, "C.D.F(Integer)", "iNtEgEr", "Integer"));
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
@@ -16,22 +17,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
     /// Contains those unit tests for the IdentifiersShouldNotMatchKeywords analyzer that
     /// pertain to the MemberRule, which applies to the names of type members.
     /// </summary>
-    public class IdentifiersShouldNotMatchKeywordsMemberRuleTests : DiagnosticAnalyzerTestBase
+    public class IdentifiersShouldNotMatchKeywordsMemberRuleTests
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
-        }
-
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedPublicVirtualMethodInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedPublicVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void @internal() {}
@@ -40,9 +31,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedPublicVirtualMethodInPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedPublicVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub internal()
     End Sub
@@ -52,9 +43,9 @@ End Class
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForCaseSensitiveKeywordNamedPublicVirtualMethodInPublicClassWithDifferentCasing()
+        public async Task CSharpNoDiagnosticForCaseSensitiveKeywordNamedPublicVirtualMethodInPublicClassWithDifferentCasing()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void @iNtErNaL() {}
@@ -62,9 +53,9 @@ public class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForCaseSensitiveKeywordNamedPublicVirtualMethodInPublicClassWithDifferentCasing()
+        public async Task BasicNoDiagnosticForCaseSensitiveKeywordNamedPublicVirtualMethodInPublicClassWithDifferentCasing()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub iNtErNaL()
     End Sub
@@ -72,9 +63,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharpDiagnosticForCaseInsensitiveKeywordNamedPublicVirtualMethodInPublicClass()
+        public async Task CSharpDiagnosticForCaseInsensitiveKeywordNamedPublicVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     // Matches VB AddHandler keyword:
@@ -84,9 +75,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForCaseInsensitiveKeywordNamedPublicVirtualMethodInPublicClass()
+        public async Task BasicDiagnosticForCaseInsensitiveKeywordNamedPublicVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     ' Matches VB AddHandler keyword:
     Public Overridable Sub [aDdHaNdLeR]()
@@ -96,9 +87,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedProtectedVirtualMethodInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedProtectedVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     protected virtual void @for() {}
@@ -107,9 +98,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedProtectedVirtualMethodInPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedProtectedVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Protected Overridable Sub [for]()
     End Sub
@@ -118,9 +109,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedInternalVirtualMethodInPublicClass()
+        public async Task CSharpNoDiagnosticForKeywordNamedInternalVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     internal virtual void @for() {}
@@ -128,9 +119,9 @@ public class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedInternalVirtualMethodInPublicClass()
+        public async Task BasicNoDiagnosticForKeywordNamedInternalVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Friend Overridable Sub [for]()
     End Sub
@@ -138,9 +129,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedPublicNonVirtualMethodInPublicClass()
+        public async Task CSharpNoDiagnosticForKeywordNamedPublicNonVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void @for() {}
@@ -148,9 +139,9 @@ public class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedPublicNonVirtualMethodInPublicClass()
+        public async Task BasicNoDiagnosticForKeywordNamedPublicNonVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Sub [for]()
     End Sub
@@ -158,9 +149,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForNonKeywordNamedPublicVirtualMethodInPublicClass()
+        public async Task CSharpNoDiagnosticForNonKeywordNamedPublicVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void fort() {}
@@ -168,9 +159,9 @@ public class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForNonKeywordNamedPublicVirtualMethodInPublicClass()
+        public async Task BasicNoDiagnosticForNonKeywordNamedPublicVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub fort()
     End Sub
@@ -178,9 +169,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedVirtualMethodInInternalClass()
+        public async Task CSharpNoDiagnosticForKeywordNamedVirtualMethodInInternalClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class C
 {
     public virtual void @for() {}
@@ -188,9 +179,9 @@ internal class C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedVirtualMethodInInternalClass()
+        public async Task BasicNoDiagnosticForKeywordNamedVirtualMethodInInternalClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Class C
     Public Overridable Sub [for]()
     End Sub
@@ -198,9 +189,9 @@ End Class");
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedMethodInPublicInterface()
+        public async Task CSharpDiagnosticForKeywordNamedMethodInPublicInterface()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface I
 {
     void @for();
@@ -209,9 +200,9 @@ public interface I
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedMethodInPublicInterface()
+        public async Task BasicDiagnosticForKeywordNamedMethodInPublicInterface()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface I
     Sub [for]()
 End Interface",
@@ -219,9 +210,9 @@ End Interface",
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedMethodOfInternalInterface()
+        public async Task CSharpNoDiagnosticForKeywordNamedMethodOfInternalInterface()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface I
 {
     void @for();
@@ -229,18 +220,18 @@ internal interface I
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedMethodOfInternalInterface()
+        public async Task BasicNoDiagnosticForKeywordNamedMethodOfInternalInterface()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface I
     Sub [for]()
 End Interface");
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeyWordNamedPublicVirtualPropertyOfPublicClass()
+        public async Task CSharpDiagnosticForKeyWordNamedPublicVirtualPropertyOfPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     private int _for;
@@ -260,9 +251,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeyWordNamedPublicVirtualPropertyOfPublicClass()
+        public async Task BasicDiagnosticForKeyWordNamedPublicVirtualPropertyOfPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Private _for As Integer
     Public Overridable Property [Sub] As Integer
@@ -278,9 +269,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeyWordNamedPublicVirtualAutoPropertyOfPublicClass()
+        public async Task CSharpDiagnosticForKeyWordNamedPublicVirtualAutoPropertyOfPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual int @for { get; set; }
@@ -289,9 +280,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeyWordNamedPublicVirtualAutoPropertyOfPublicClass()
+        public async Task BasicDiagnosticForKeyWordNamedPublicVirtualAutoPropertyOfPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Property [Sub] As Integer
 End Class",
@@ -299,9 +290,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeyWordNamedPublicVirtualReadOnlyPropertyOfPublicClass()
+        public async Task CSharpDiagnosticForKeyWordNamedPublicVirtualReadOnlyPropertyOfPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     private int _for;
@@ -317,9 +308,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeyWordNamedPublicVirtualReadOnlyPropertyOfPublicClass()
+        public async Task BasicDiagnosticForKeyWordNamedPublicVirtualReadOnlyPropertyOfPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Private _for As Integer
     Public Overridable ReadOnly Property [Sub] As Integer
@@ -332,9 +323,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeyWordNamedPublicVirtualWriteOnlyPropertyOfPublicClass()
+        public async Task CSharpDiagnosticForKeyWordNamedPublicVirtualWriteOnlyPropertyOfPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     private int _for;
@@ -350,9 +341,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeyWordNamedPublicVirtualWriteOnlyPropertyOfPublicClass()
+        public async Task BasicDiagnosticForKeyWordNamedPublicVirtualWriteOnlyPropertyOfPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Private _for As Integer
     Public Overridable WriteOnly Property [Sub] As Integer
@@ -365,9 +356,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeyWordNamedPublicVirtualExpressionBodyPropertyOfPublicClass()
+        public async Task CSharpDiagnosticForKeyWordNamedPublicVirtualExpressionBodyPropertyOfPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     private int _for;
@@ -377,9 +368,9 @@ public class C
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForOverrideOfKeywordNamedPublicVirtualMethodOfPublicClass()
+        public async Task CSharpNoDiagnosticForOverrideOfKeywordNamedPublicVirtualMethodOfPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void @internal() {}
@@ -394,9 +385,9 @@ public class D : C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForOverrideOfKeywordNamedPublicVirtualMethodOfPublicClass()
+        public async Task BasicNoDiagnosticForOverrideOfKeywordNamedPublicVirtualMethodOfPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub [internal]()
     End Sub
@@ -412,9 +403,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForSealedOverrideOfKeywordNamedPublicVirtualMethodOfPublicClass()
+        public async Task CSharpNoDiagnosticForSealedOverrideOfKeywordNamedPublicVirtualMethodOfPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void @internal() {}
@@ -429,9 +420,9 @@ public class D : C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForSealedOverrideOfKeywordNamedPublicVirtualMethodOfPublicClass()
+        public async Task BasicNoDiagnosticForSealedOverrideOfKeywordNamedPublicVirtualMethodOfPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub [friend]()
     End Sub
@@ -447,9 +438,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForEachOverloadOfCaseSensitiveKeywordNamedPublicVirtualMethodInPublicClass()
+        public async Task CSharpDiagnosticForEachOverloadOfCaseSensitiveKeywordNamedPublicVirtualMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void @internal() {}
@@ -460,9 +451,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForEachOverloadOfCaseSensitiveKeywordNamedPublicVirtualMethodInPublicClass()
+        public async Task BasicDiagnosticForEachOverloadOfCaseSensitiveKeywordNamedPublicVirtualMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub internal()
     End Sub
@@ -474,9 +465,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedNewMethodInPublicClass()
+        public async Task CSharpNoDiagnosticForKeywordNamedNewMethodInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void @for() {}
@@ -491,9 +482,9 @@ public class D : C
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedNewMethodInPublicClass()
+        public async Task BasicNoDiagnosticForKeywordNamedNewMethodInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub [for]()
     End Sub
@@ -510,9 +501,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForVirtualNewMethod()
+        public async Task CSharpDiagnosticForVirtualNewMethod()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public virtual void @for() {}
@@ -528,9 +519,9 @@ public class D : C
         }
 
         [Fact]
-        public void BasicDiagnosticForVirtualNewMethod()
+        public async Task BasicDiagnosticForVirtualNewMethod()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Overridable Sub [for]()
     End Sub
@@ -548,9 +539,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     protected class D
@@ -562,9 +553,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedProtectedVirtualMethodInProtectedTypeNestedInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Protected Class D
         Protected Overridable Sub [Protected]()
@@ -575,9 +566,9 @@ End Class",
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedPublicVirtualEventInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedPublicVirtualEventInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public delegate void Callback(object sender, System.EventArgs e);
@@ -590,9 +581,9 @@ public class C
         // These tests are just to verify that the formatting of the displayed member name
         // is consistent with FxCop, for the case where the class is in a namespace.
         [Fact]
-        public void CSharpDiagnosticForVirtualPublicMethodInPublicClassInNamespace()
+        public async Task CSharpDiagnosticForVirtualPublicMethodInPublicClassInNamespace()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace N
 {
     public class C
@@ -605,9 +596,9 @@ namespace N
         }
 
         [Fact]
-        public void BasicDiagnosticForVirtualPublicMethodInPublicClassInNamespace()
+        public async Task BasicDiagnosticForVirtualPublicMethodInPublicClassInNamespace()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Namespace N
     Public Class C
         Public Overridable Sub [for]()
@@ -621,9 +612,9 @@ End Namespace",
         // These tests are just to verify that the formatting of the displayed member name
         // is consistent with FxCop, for the case where the class is generic.
         [Fact]
-        public void CSharpDiagnosticForVirtualPublicMethodInPublicGenericClass()
+        public async Task CSharpDiagnosticForVirtualPublicMethodInPublicGenericClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C<T> where T : class
 {
     public virtual void @for() {}
@@ -633,9 +624,9 @@ public class C<T> where T : class
         }
 
         [Fact]
-        public void BasicDiagnosticForVirtualPublicMethodInPublicGenericClass()
+        public async Task BasicDiagnosticForVirtualPublicMethodInPublicGenericClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C(Of T As Class)
     Public Overridable Sub [for]()
     End Sub
@@ -643,5 +634,15 @@ End Class",
                 // Include the type parameter name but not the constraint.
                 GetBasicResultAt(3, 28, IdentifiersShouldNotMatchKeywordsAnalyzer.MemberRule, "C(Of T).for()", "for"));
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
@@ -20,22 +21,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
     /// FxCop does not report a violation unless the namespace contains a publicly visible
     /// class, and we follow that implementation.
     /// </remarks>
-    public class IdentifiersShouldNotMatchKeywordsNamespaceRuleTests : DiagnosticAnalyzerTestBase
+    public class IdentifiersShouldNotMatchKeywordsNamespaceRuleTests
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
-        }
-
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedNamespaceContainingPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedNamespaceContainingPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace @namespace
 {
     public class C {}
@@ -45,9 +36,9 @@ namespace @namespace
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedNamespaceContainingPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedNamespaceContainingPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Namespace [Namespace]
     Public Class C
     End Class
@@ -57,9 +48,9 @@ End Namespace
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForNonKeywordNamedNamespaceContainingPublicClass()
+        public async Task CSharpNoDiagnosticForNonKeywordNamedNamespaceContainingPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace namespace2
 {
     public class C {}
@@ -68,9 +59,9 @@ namespace namespace2
         }
 
         [Fact]
-        public void BasicNoDiagnosticForNonKeywordNamedNamespaceContainingPublicClass()
+        public async Task BasicNoDiagnosticForNonKeywordNamedNamespaceContainingPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Namespace Namespace2
     Public Class C
     End Class
@@ -79,9 +70,9 @@ End Namespace
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedNamespaceContainingInternalClass()
+        public async Task CSharpNoDiagnosticForKeywordNamedNamespaceContainingInternalClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace @namespace
 {
     internal class C {}
@@ -90,9 +81,9 @@ namespace @namespace
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedNamespaceContainingInternalClass()
+        public async Task BasicNoDiagnosticForKeywordNamedNamespaceContainingInternalClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Namespace [Namespace]
     Friend Class C
     End Class
@@ -101,9 +92,9 @@ End Namespace
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedMultiComponentNamespaceContainingPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedMultiComponentNamespaceContainingPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace N1.@namespace.N2.@for.N3
 {
     public class C {}
@@ -114,9 +105,9 @@ namespace N1.@namespace.N2.@for.N3
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedMultiComponentNamespaceContainingPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedMultiComponentNamespaceContainingPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Namespace N1.[Namespace].N2.[For].N3
     Public Class C
     End Class
@@ -127,26 +118,26 @@ End Namespace
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForPublicClassInGlobalNamespace()
+        public async Task CSharpNoDiagnosticForPublicClassInGlobalNamespace()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C {}
 ");
         }
 
         [Fact]
-        public void BasicNoDiagnosticForPublicClassInGlobalNamespace()
+        public async Task BasicNoDiagnosticForPublicClassInGlobalNamespace()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
 End Class
 ");
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForRepeatedOccurrencesOfSameKeywordNamedNamespace()
+        public async Task CSharpNoDiagnosticForRepeatedOccurrencesOfSameKeywordNamedNamespace()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace @namespace
 {
     public class C {}
@@ -161,9 +152,9 @@ namespace @namespace
         }
 
         [Fact]
-        public void BasicNoDiagnosticForRepeatedOccurrencesOfSameKeywordNamedNamespace()
+        public async Task BasicNoDiagnosticForRepeatedOccurrencesOfSameKeywordNamedNamespace()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Namespace [Namespace]
     Public Class C
     End Class
@@ -176,5 +167,15 @@ End Namespace
 ",
                 GetBasicResultAt(2, 11, IdentifiersShouldNotMatchKeywordsAnalyzer.NamespaceRule, "Namespace", "Namespace"));
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
@@ -16,31 +17,21 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
     /// Contains those unit tests for the IdentifiersShouldNotMatchKeywords analyzer that
     /// pertain to the TypeRule, which applies to the names of types.
     /// </summary>
-    public class IdentifiersShouldNotMatchKeywordsTypeRuleTests : DiagnosticAnalyzerTestBase
+    public class IdentifiersShouldNotMatchKeywordsTypeRuleTests
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotMatchKeywordsAnalyzer();
-        }
-
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedPublicType()
+        public async Task CSharpDiagnosticForKeywordNamedPublicType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class @class {}
 ",
                 GetCSharpResultAt(2, 14, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "class", "class"));
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedPublicType()
+        public async Task BasicDiagnosticForKeywordNamedPublicType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class [Class]
 End Class
 ",
@@ -48,77 +39,77 @@ End Class
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForCaseSensitiveKeywordNamedPublicTypeWithDifferentCasing()
+        public async Task CSharpNoDiagnosticForCaseSensitiveKeywordNamedPublicTypeWithDifferentCasing()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class iNtErNaL {}
 ");
         }
 
         [Fact]
-        public void BasicNoDiagnosticForCaseSensitiveKeywordNamedPublicTypeWithDifferentCasing()
+        public async Task BasicNoDiagnosticForCaseSensitiveKeywordNamedPublicTypeWithDifferentCasing()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class iNtErNaL
 End Class");
         }
 
         [Fact]
-        public void CSharpDiagnosticForCaseInsensitiveKeywordNamedPublicType()
+        public async Task CSharpDiagnosticForCaseInsensitiveKeywordNamedPublicType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct aDdHaNdLeR {}
 ",
                 GetCSharpResultAt(2, 15, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "aDdHaNdLeR", "AddHandler"));
         }
 
         [Fact]
-        public void BasicDiagnosticForCaseInsensitiveKeywordNamedPublicType()
+        public async Task BasicDiagnosticForCaseInsensitiveKeywordNamedPublicType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure [aDdHaNdLeR]
 End Structure",
                 GetBasicResultAt(2, 18, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "aDdHaNdLeR", "AddHandler"));
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForKeywordNamedInternalype()
+        public async Task CSharpNoDiagnosticForKeywordNamedInternalype()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class @class {}
 ");
         }
 
         [Fact]
-        public void BasicNoDiagnosticForKeywordNamedInternalType()
+        public async Task BasicNoDiagnosticForKeywordNamedInternalType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Class [Class]
 End Class
 ");
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForNonKeywordNamedPublicType()
+        public async Task CSharpNoDiagnosticForNonKeywordNamedPublicType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class classic {}
 ");
         }
 
         [Fact]
-        public void BasicNoDiagnosticForNonKeywordNamedPublicType()
+        public async Task BasicNoDiagnosticForNonKeywordNamedPublicType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Classic
 End Class
 ");
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedPublicTypeInNamespace()
+        public async Task CSharpDiagnosticForKeywordNamedPublicTypeInNamespace()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace N
 {
     public enum @enum {}
@@ -128,9 +119,9 @@ namespace N
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedPublicTypeInNamespace()
+        public async Task BasicDiagnosticForKeywordNamedPublicTypeInNamespace()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Namespace N
     Public Enum [Enum]
         X
@@ -141,9 +132,9 @@ End Namespace
         }
 
         [Fact]
-        public void CSharpDiagnosticForKeywordNamedProtectedTypeNestedInPublicClass()
+        public async Task CSharpDiagnosticForKeywordNamedProtectedTypeNestedInPublicClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     protected class @protected {}
@@ -153,9 +144,9 @@ public class C
         }
 
         [Fact]
-        public void BasicDiagnosticForKeywordNamedProtectedTypeNestedInPublicClass()
+        public async Task BasicDiagnosticForKeywordNamedProtectedTypeNestedInPublicClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Protected Class [Protected]
     End Class
@@ -163,5 +154,15 @@ End Class
 ",
                 GetBasicResultAt(3, 21, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "C.Protected", "Protected"));
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2) =>
+            new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2) =>
+            new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementStandardExceptionConstructorsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementStandardExceptionConstructorsTests.cs
@@ -1,32 +1,26 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpImplementStandardExceptionConstructorsAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ImplementStandardExceptionConstructorsFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicImplementStandardExceptionConstructorsAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ImplementStandardExceptionConstructorsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class ImplementStandardExceptionConstructorsTests : DiagnosticAnalyzerTestBase
+    public class ImplementStandardExceptionConstructorsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicImplementStandardExceptionConstructorsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpImplementStandardExceptionConstructorsAnalyzer();
-        }
         #region CSharp Unit Tests
 
         [Fact]
-        public void CSharp_CA1032_NoDiagnostic_NotDerivingFromException()
+        public async Task CSharp_CA1032_NoDiagnostic_NotDerivingFromException()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 //example of a class that doesn't derive from Exception type
 public class NotDerivingFromException
 {
@@ -36,9 +30,9 @@ public class NotDerivingFromException
         }
 
         [Fact]
-        public void CSharp_CA1032_NoDiagnostic_GoodException1()
+        public async Task CSharp_CA1032_NoDiagnostic_GoodException1()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 //example of a class that derives from Exception type with all the minimum needed constructors
 public class GoodException1 : Exception
@@ -58,9 +52,9 @@ public class GoodException1 : Exception
         }
 
         [Fact]
-        public void CSharp_CA1032_NoDiagnostic_GoodException2()
+        public async Task CSharp_CA1032_NoDiagnostic_GoodException2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 //example of a class that derives from Exception type with all the minimum needed constructors plus an extra constructor
 public class GoodException2 : Exception
@@ -83,9 +77,9 @@ public class GoodException2 : Exception
         }
 
         [Fact]
-        public void CSharp_CA1032_Diagnostic_MissingAllConstructors()
+        public async Task CSharp_CA1032_Diagnostic_MissingAllConstructors()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 //example of a class that derives from Exception type and missing all minimum required constructors - in this case system creates a default parameterless constructor
 public class BadException1 : Exception
@@ -97,9 +91,9 @@ public class BadException1 : Exception
         }
 
         [Fact]
-        public void CSharp_CA1032_Diagnostic_MissingTwoConstructors()
+        public async Task CSharp_CA1032_Diagnostic_MissingTwoConstructors()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 //example of a class that derives from Exception type and missing 2 minimum required constructors 
 public class BadException2 : Exception
@@ -114,9 +108,9 @@ public class BadException2 : Exception
         }
 
         [Fact]
-        public void CSharp_CA1032_Diagnostic_MissingDefaultConstructor()
+        public async Task CSharp_CA1032_Diagnostic_MissingDefaultConstructor()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 //example of a class that derives from Exception type with missing default constructor 
 public class BadException3 : Exception
@@ -133,9 +127,9 @@ public class BadException3 : Exception
         }
 
         [Fact]
-        public void CSharp_CA1032_Diagnostic_MissingConstructor2()
+        public async Task CSharp_CA1032_Diagnostic_MissingConstructor2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 //example of a class that derives from Exception type with missing constructor containing string type parameter
 public class BadException4 : Exception
@@ -152,9 +146,9 @@ public class BadException4 : Exception
         }
 
         [Fact]
-        public void CSharp_CA1032_Diagnostic_MissingConstructor3()
+        public async Task CSharp_CA1032_Diagnostic_MissingConstructor3()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 //example of a class that derives from Exception type with missing constructor containing string type and exception type parameter
 public class BadException5 : Exception
@@ -171,9 +165,9 @@ public class BadException5 : Exception
         }
 
         [Fact]
-        public void CSharp_CA1032_Diagnostic_SurplusButMissingConstructor3()
+        public async Task CSharp_CA1032_Diagnostic_SurplusButMissingConstructor3()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 //example of a class that derives from Exception type, and has 3 constructors but missing constructor containing string type parameter only
 public class BadException6 : Exception
@@ -197,9 +191,9 @@ public class BadException6 : Exception
         #region VB Unit Test
 
         [Fact]
-        public void Basic_CA1032_NoDiagnostic_NotDerivingFromException()
+        public async Task Basic_CA1032_NoDiagnostic_NotDerivingFromException()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 'example of a class that doesn't derive from Exception type
 Public Class NotDerivingFromException
 End Class
@@ -208,9 +202,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1032_NoDiagnostic_GoodException1()
+        public async Task Basic_CA1032_NoDiagnostic_GoodException1()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 'example of a class that derives from Exception type with all the minimum needed constructors
 Public Class GoodException1 : Inherits Exception
@@ -226,9 +220,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1032_NoDiagnostic_GoodException2()
+        public async Task Basic_CA1032_NoDiagnostic_GoodException2()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 'example of a class that derives from Exception type with all the minimum needed constructors plus an extra constructor
 Public Class GoodException2 : Inherits Exception
@@ -246,9 +240,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1032_Diagnostic_MissingAllConstructors()
+        public async Task Basic_CA1032_Diagnostic_MissingAllConstructors()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 'example of a class that derives from Exception type and missing all minimum required constructors - in this case system creates a default parameterless constructor
 Public Class BadException1 : Inherits Exception
@@ -259,9 +253,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1032_Diagnostic_MissingTwoConstructors()
+        public async Task Basic_CA1032_Diagnostic_MissingTwoConstructors()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 'example of a class that derives from Exception type and missing 2 minimum required constructors 
 Public Class BadException2 : Inherits Exception
@@ -274,9 +268,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1032_Diagnostic_MissingDefaultConstructor()
+        public async Task Basic_CA1032_Diagnostic_MissingDefaultConstructor()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 'example of a class that derives from Exception type with missing default constructor 
 Public Class BadException3 : Inherits Exception
@@ -290,9 +284,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1032_Diagnostic_MissingConstructor2()
+        public async Task Basic_CA1032_Diagnostic_MissingConstructor2()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 'example of a class that derives from Exception type with missing constructor containing string type parameter
 Public Class BadException4 : Inherits Exception
@@ -306,9 +300,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1032_Diagnostic_MissingConstructor3()
+        public async Task Basic_CA1032_Diagnostic_MissingConstructor3()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 'example of a class that derives from Exception type with missing constructor containing string type and exception type parameter
 Public Class BadException5 : Inherits Exception
@@ -322,9 +316,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1032_Diagnostic_SurplusButMissingConstructor3()
+        public async Task Basic_CA1032_Diagnostic_SurplusButMissingConstructor3()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 'example of a class that derives from Exception type, and has 3 constructors but missing constructor containing string type parameter only
 Public Class BadException6 : Inherits Exception
@@ -343,18 +337,15 @@ End Class
         #region Helpers
 
         private static DiagnosticResult GetCA1032CSharpMissingConstructorResultAt(int line, int column, string typeName, string constructor)
-        {
-            // Add a public read-only property accessor for positional argument '{0}' of attribute '{1}'.
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementStandardExceptionConstructorsMessageMissingConstructor, typeName, constructor);
-            return GetCSharpResultAt(line, column, ImplementStandardExceptionConstructorsAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(ImplementStandardExceptionConstructorsAnalyzer.MissingConstructorRule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementStandardExceptionConstructorsMessageMissingConstructor, typeName, constructor));
 
         private static DiagnosticResult GetCA1032BasicMissingConstructorResultAt(int line, int column, string typeName, string constructor)
-        {
-            // Add a public read-only property accessor for positional argument '{0}' of attribute '{1}'.
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementStandardExceptionConstructorsMessageMissingConstructor, typeName, constructor);
-            return GetBasicResultAt(line, column, ImplementStandardExceptionConstructorsAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(ImplementStandardExceptionConstructorsAnalyzer.MissingConstructorRule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementStandardExceptionConstructorsMessageMissingConstructor, typeName, constructor));
+
         #endregion
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
@@ -1,44 +1,39 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.InterfaceMethodsShouldBeCallableByChildTypesAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.InterfaceMethodsShouldBeCallableByChildTypesFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.InterfaceMethodsShouldBeCallableByChildTypesAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.InterfaceMethodsShouldBeCallableByChildTypesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class InterfaceMethodsShouldBeCallableByChildTypesTests : DiagnosticAnalyzerTestBase
+    public class InterfaceMethodsShouldBeCallableByChildTypesTests
     {
         #region Verifiers
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new InterfaceMethodsShouldBeCallableByChildTypesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new InterfaceMethodsShouldBeCallableByChildTypesAnalyzer();
-        }
-
         private static DiagnosticResult CSharpResult(int line, int column, string className, string methodName)
-        {
-            return GetCSharpResultAt(line, column, InterfaceMethodsShouldBeCallableByChildTypesAnalyzer.Rule, className, methodName);
-        }
+            => new DiagnosticResult(InterfaceMethodsShouldBeCallableByChildTypesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(className, methodName);
 
         private static DiagnosticResult BasicResult(int line, int column, string className, string methodName)
-        {
-            return GetBasicResultAt(line, column, InterfaceMethodsShouldBeCallableByChildTypesAnalyzer.Rule, className, methodName);
-        }
+            => new DiagnosticResult(InterfaceMethodsShouldBeCallableByChildTypesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(className, methodName);
 
         #endregion
 
         #region CSharp
 
         [Fact]
-        public void CA1033SimpleDiagnosticCasesCSharp()
+        public async Task CA1033SimpleDiagnosticCasesCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IGeneral
@@ -146,9 +141,9 @@ public class ImplementsGeneralThree : IGeneral
         }
 
         [Fact]
-        public void CA1033NestedDiagnosticCasesCSharp()
+        public async Task CA1033NestedDiagnosticCasesCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class NestedExplicitInterfaceImplementation
@@ -211,9 +206,9 @@ public class NestedExplicitInterfaceImplementation
         }
 
         [Fact]
-        public void CA1033NoDiagnosticCasesCSharp()
+        public async Task CA1033NoDiagnosticCasesCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IGeneral
@@ -359,9 +354,9 @@ public class NestedExplicitInterfaceImplementation
         }
 
         [Fact]
-        public void CA1033ExpressionBodiedMemberCSharp()
+        public async Task CA1033ExpressionBodiedMemberCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface IGeneral
@@ -394,9 +389,9 @@ public class ImplementsGeneralThree : IGeneral
         #region VisualBasic
 
         [Fact]
-        public void CA1033SimpleDiagnosticCasesBasic()
+        public async Task CA1033SimpleDiagnosticCasesBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Interface IGeneral
@@ -504,9 +499,9 @@ End Class
         }
 
         [Fact]
-        public void CA1033NestedDiagnosticCasesBasic()
+        public async Task CA1033NestedDiagnosticCasesBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class NestedExplicitInterfaceImplementation
@@ -573,9 +568,9 @@ End Class
         }
 
         [Fact]
-        public void CA1033NoUnderlyingImplementationsDiagnostics()
+        public async Task CA1033NoUnderlyingImplementationsDiagnostics()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Interface IGeneral

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAssembliesWithAssemblyVersionTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAssembliesWithAssemblyVersionTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Analyzer.Utilities;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -15,22 +14,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class MarkAssembliesWithAssemblyVersionAttributeTests : DiagnosticAnalyzerTestBase
+    public class MarkAssembliesWithAssemblyVersionAttributeTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new MarkAssembliesWithAttributesDiagnosticAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new MarkAssembliesWithAttributesDiagnosticAnalyzer();
-        }
-
         [Fact]
-        public void CA1016BasicTestWithNoComplianceAttribute()
+        public async Task CA1016BasicTestWithNoComplianceAttribute()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"
 imports System.IO
 imports System.Reflection
@@ -47,9 +36,9 @@ imports System
         }
 
         [Fact]
-        public void CA1016CSharpTestWithVersionAttributeNotFromBCL()
+        public async Task CA1016CSharpTestWithVersionAttributeNotFromBCL()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 using System;
 [assembly:System.CLSCompliantAttribute(true)]
@@ -68,9 +57,9 @@ class AssemblyVersionAttribute : Attribute {
         }
 
         [Fact]
-        public void CA1016CSharpTestWithNoVersionAttribute()
+        public async Task CA1016CSharpTestWithNoVersionAttribute()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 [assembly:System.CLSCompliantAttribute(true)]
 
@@ -85,9 +74,9 @@ class AssemblyVersionAttribute : Attribute {
         }
 
         [Fact]
-        public void CA1016CSharpTestWithVersionAttribute()
+        public async Task CA1016CSharpTestWithVersionAttribute()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 using System.Reflection;
 [assembly:AssemblyVersionAttribute(""1.2.3.4"")]
@@ -103,10 +92,14 @@ using System.Reflection;
         }
 
         [Fact]
-        public void CA1016CSharpTestWithTwoFilesWithAttribute()
+        public async Task CA1016CSharpTestWithTwoFilesWithAttribute()
         {
-            VerifyCSharp(new[]
+            await new VerifyCS.Test
+            {
+                TestState =
                 {
+                    Sources =
+                    {
 @"
 [assembly:System.CLSCompliantAttribute(true)]
 
@@ -121,13 +114,15 @@ using System.Reflection;
 using System.Reflection;
 [assembly: AssemblyVersionAttribute(""1.2.3.4"")]
 "
-                });
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1016CSharpTestWithVersionAttributeTruncated()
+        public async Task CA1016CSharpTestWithVersionAttributeTruncated()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 using System.Reflection;
 [assembly:AssemblyVersion(""1.2.3.4"")]
@@ -142,9 +137,9 @@ using System.Reflection;
         }
 
         [Fact]
-        public void CA1016CSharpTestWithVersionAttributeFullyQualified()
+        public async Task CA1016CSharpTestWithVersionAttributeFullyQualified()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 [assembly:System.CLSCompliantAttribute(true)]
 
@@ -159,9 +154,9 @@ using System.Reflection;
         }
 
         [Fact, WorkItem(2143, "https://github.com/dotnet/roslyn-analyzers/issues/2143")]
-        public void CA1016CSharpTestWithRazorCompiledItemAttribute()
+        public async Task CA1016CSharpTestWithRazorCompiledItemAttribute()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 
 [assembly:Microsoft.AspNetCore.Razor.Hosting.RazorCompiledItemAttribute((Type)null, null, null)]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAssembliesWithClsCompliantTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAssembliesWithClsCompliantTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -15,22 +13,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class MarkAssembliesWithCLSCompliantAttributeTests : DiagnosticAnalyzerTestBase
+    public class MarkAssembliesWithCLSCompliantAttributeTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new MarkAssembliesWithAttributesDiagnosticAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new MarkAssembliesWithAttributesDiagnosticAnalyzer();
-        }
-
         [Fact]
-        public void CA1014CA1016BasicTestWithCLSCompliantAttributeNone()
+        public async Task CA1014CA1016BasicTestWithCLSCompliantAttributeNone()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"
 imports System.Reflection
 
@@ -44,15 +32,15 @@ imports System.Reflection
         }
 
         [Fact]
-        public void CA1014BasicTestWithNoVersionAttribute()
+        public async Task CA1014BasicTestWithNoVersionAttribute()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"
 imports System.Reflection
 
 < Assembly: AssemblyVersionAttribute(""1.1.3.4"")>
     class Program
-    
+
         Sub Main
         End Sub
     End class
@@ -61,9 +49,9 @@ imports System.Reflection
         }
 
         [Fact]
-        public void CA1014CSharpTestWithComplianceAttributeNotFromBCL()
+        public async Task CA1014CSharpTestWithComplianceAttributeNotFromBCL()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 using System;
 using System.Reflection;
@@ -84,9 +72,9 @@ class CLSCompliantAttribute : Attribute {
         }
 
         [Fact]
-        public void CA1014CSharpTestWithNoCLSComplianceAttribute()
+        public async Task CA1014CSharpTestWithNoCLSComplianceAttribute()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 using System.Reflection;
 [assembly:AssemblyVersionAttribute(""1.2.3.4"")]
@@ -102,9 +90,9 @@ class Program
         }
 
         [Fact]
-        public void CA1014CSharpTestWithCLSCompliantAttribute()
+        public async Task CA1014CSharpTestWithCLSCompliantAttribute()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 using System;
 using System.Reflection;
@@ -121,10 +109,14 @@ class Program
         }
 
         [Fact]
-        public void CA1014CSharpTestWithTwoFilesWithAttribute()
+        public async Task CA1014CSharpTestWithTwoFilesWithAttribute()
         {
-            VerifyCSharp(new[]
+            await new VerifyCS.Test
+            {
+                TestState =
                 {
+                    Sources =
+                    {
 @"
 using System.Reflection;
 [assembly:AssemblyVersionAttribute(""1.2.3.4"")]
@@ -140,13 +132,15 @@ class Program
 using System;
 [assembly:CLSCompliantAttribute(true)]
 "
-                });
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1014CSharpTestWithCLSCompliantAttributeTruncated()
+        public async Task CA1014CSharpTestWithCLSCompliantAttributeTruncated()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 using System;
 using System.Reflection;
@@ -163,9 +157,9 @@ class Program
         }
 
         [Fact]
-        public void CA1014CSharpTestWithCLSCompliantAttributeFullyQualified()
+        public async Task CA1014CSharpTestWithCLSCompliantAttributeFullyQualified()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 using System.Reflection;
 [assembly:AssemblyVersionAttribute(""1.2.3.4"")]
@@ -180,9 +174,9 @@ class Program
         }
 
         [Fact]
-        public void CA1014CSharpTestWithCLSCompliantAttributeNone()
+        public async Task CA1014CSharpTestWithCLSCompliantAttributeNone()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 using System.Reflection;
 class Program
@@ -196,9 +190,9 @@ class Program
         }
 
         [Fact, WorkItem(2143, "https://github.com/dotnet/roslyn-analyzers/issues/2143")]
-        public void CA1014CSharpTestWithRazorCompiledItemAttribute()
+        public async Task CA1014CSharpTestWithRazorCompiledItemAttribute()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 
 [assembly:Microsoft.AspNetCore.Razor.Hosting.RazorCompiledItemAttribute((Type)null, null, null)]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAssembliesWithComVisibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAssembliesWithComVisibleTests.cs
@@ -1,59 +1,45 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithComVisibleAnalyzer,
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithComVisibleFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithComVisibleAnalyzer,
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithComVisibleFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class MarkAllAssembliesWithComVisibleTests : DiagnosticAnalyzerTestBase
+    public class MarkAllAssembliesWithComVisibleTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        [Fact]
+        public async Task NoTypesComVisibleMissing()
         {
-            return new MarkAssembliesWithComVisibleAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new MarkAssembliesWithComVisibleAnalyzer();
+            await VerifyCS.VerifyAnalyzerAsync("");
         }
 
         [Fact]
-        public void NoTypesComVisibleMissing()
+        public async Task NoTypesComVisibleTrue()
         {
-            VerifyCSharp("");
-        }
-
-        [Fact]
-        public void NoTypesComVisibleTrue()
-        {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 [assembly: ComVisible(true)]");
         }
 
         [Fact]
-        public void NoTypesComVisibleFalse()
+        public async Task NoTypesComVisibleFalse()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]");
         }
 
         [Fact]
-        public void PublicTypeComVisibleMissing()
+        public async Task PublicTypeComVisibleMissing()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
 }",
@@ -61,9 +47,9 @@ public class C
         }
 
         [Fact]
-        public void PublicTypeComVisibleTrue()
+        public async Task PublicTypeComVisibleTrue()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 [assembly: ComVisible(true)]
@@ -75,9 +61,9 @@ public class C
         }
 
         [Fact]
-        public void PublicTypeComVisibleFalse()
+        public async Task PublicTypeComVisibleFalse()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
@@ -88,18 +74,18 @@ public class C
         }
 
         [Fact]
-        public void InternalTypeComVisibleMissing()
+        public async Task InternalTypeComVisibleMissing()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class C
 {
 }");
         }
 
         [Fact]
-        public void InternalTypeComVisibleTrue()
+        public async Task InternalTypeComVisibleTrue()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 [assembly: ComVisible(true)]
@@ -110,9 +96,9 @@ internal class C
         }
 
         [Fact]
-        public void InternalTypeComVisibleFalse()
+        public async Task InternalTypeComVisibleFalse()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
@@ -124,12 +110,14 @@ internal class C
 
         private static DiagnosticResult GetExposeIndividualTypesResult()
         {
-            return GetGlobalResult(MarkAssembliesWithComVisibleAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ChangeAssemblyLevelComVisibleToFalse, "TestProject"));
+            return new DiagnosticResult(MarkAssembliesWithComVisibleAnalyzer.RuleA)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ChangeAssemblyLevelComVisibleToFalse, "TestProject"));
         }
 
         private static DiagnosticResult GetAddComVisibleFalseResult()
         {
-            return GetGlobalResult(MarkAssembliesWithComVisibleAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.AddAssemblyLevelComVisibleFalse, "TestProject"));
+            return new DiagnosticResult(MarkAssembliesWithComVisibleAnalyzer.RuleB)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.AddAssemblyLevelComVisibleFalse, "TestProject"));
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAttributesWithAttributeUsageTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAttributesWithAttributeUsageTests.cs
@@ -1,29 +1,25 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAttributesWithAttributeUsageAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAttributesWithAttributeUsageAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public partial class MarkAttributesWithAttributeUsageTests : DiagnosticAnalyzerTestBase
+    public partial class MarkAttributesWithAttributeUsageTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new MarkAttributesWithAttributeUsageAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new MarkAttributesWithAttributeUsageAnalyzer();
-        }
-
         [Fact]
-        public void TestCSSimpleAttributeClass()
+        public async Task TestCSSimpleAttributeClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class C : Attribute
@@ -33,9 +29,9 @@ class C : Attribute
         }
 
         [Fact, WorkItem(1732, "https://github.com/dotnet/roslyn-analyzers/issues/1732")]
-        public void TestCSInheritedAttributeClass()
+        public async Task TestCSInheritedAttributeClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [AttributeUsage(AttributeTargets.Method)]
@@ -49,9 +45,9 @@ class D : C
         }
 
         [Fact]
-        public void TestCSAbstractAttributeClass()
+        public async Task TestCSAbstractAttributeClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 abstract class C : Attribute
@@ -61,9 +57,9 @@ abstract class C : Attribute
         }
 
         [Fact]
-        public void TestVBSimpleAttributeClass()
+        public async Task TestVBSimpleAttributeClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class C
@@ -73,9 +69,9 @@ End Class
         }
 
         [Fact, WorkItem(1732, "https://github.com/dotnet/roslyn-analyzers/issues/1732")]
-        public void TestVBInheritedAttributeClass()
+        public async Task TestVBInheritedAttributeClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 <AttributeUsage(AttributeTargets.Method)>
@@ -89,9 +85,9 @@ End Class
         }
 
         [Fact]
-        public void TestVBAbstractAttributeClass()
+        public async Task TestVBAbstractAttributeClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 MustInherit Class C
@@ -101,15 +97,13 @@ End Class
         }
 
         private static DiagnosticResult GetCA1018CSharpResultAt(int line, int column, string objectName)
-        {
-            return GetCSharpResultAt(line, column, MarkAttributesWithAttributeUsageAnalyzer.RuleId,
-                string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkAttributesWithAttributeUsageMessageDefault, objectName));
-        }
+            => new DiagnosticResult(MarkAttributesWithAttributeUsageAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkAttributesWithAttributeUsageMessageDefault, objectName));
 
         private static DiagnosticResult GetCA1018BasicResultAt(int line, int column, string objectName)
-        {
-            return GetBasicResultAt(line, column, MarkAttributesWithAttributeUsageAnalyzer.RuleId,
-                string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkAttributesWithAttributeUsageMessageDefault, objectName));
-        }
+            => new DiagnosticResult(MarkAttributesWithAttributeUsageAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkAttributesWithAttributeUsageMessageDefault, objectName));
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -29,21 +30,21 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult CSharpResult(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, MovePInvokesToNativeMethodsClassAnalyzer.Rule.Id, MovePInvokesToNativeMethodsClassAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
-        }
+            => new DiagnosticResult(MovePInvokesToNativeMethodsClassAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MovePInvokesToNativeMethodsClassAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
 
         private static DiagnosticResult BasicResult(int line, int column)
-        {
-            return GetBasicResultAt(line, column, MovePInvokesToNativeMethodsClassAnalyzer.Rule.Id, MovePInvokesToNativeMethodsClassAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
-        }
+            => new DiagnosticResult(MovePInvokesToNativeMethodsClassAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MovePInvokesToNativeMethodsClassAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
 
         #endregion
 
         [Fact]
-        public void CA1060ProperlyNamedClassCSharp()
+        public async Task CA1060ProperlyNamedClassCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 class NativeMethods
@@ -67,9 +68,9 @@ class UnsafeNativeMethods
         }
 
         [Fact]
-        public void CA1060ProperlyNamedClassBasic()
+        public async Task CA1060ProperlyNamedClassBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Runtime.InteropServices
 
 Class NativeMethods
@@ -93,9 +94,9 @@ End Class
         }
 
         [Fact]
-        public void CA1060ImproperlyNamedClassCSharp()
+        public async Task CA1060ImproperlyNamedClassCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 class FooClass
@@ -149,9 +150,9 @@ class BazClass
         }
 
         [Fact]
-        public void CA1060ImproperlyNamedClassBasic()
+        public async Task CA1060ImproperlyNamedClassBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Runtime.InteropServices
 
 Class FooClass
@@ -205,9 +206,9 @@ End Class
         }
 
         [Fact]
-        public void CA1060ClassesInNamespaceCSharp()
+        public async Task CA1060ClassesInNamespaceCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 namespace MyNamespace
@@ -229,9 +230,9 @@ namespace MyNamespace
         }
 
         [Fact]
-        public void CA1060ClassesInNamespaceBasic()
+        public async Task CA1060ClassesInNamespaceBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Runtime.InteropServices
 
 Namespace MyNamespace
@@ -252,9 +253,9 @@ End Namespace
         }
 
         [Fact]
-        public void CA1060NestedClassesCSharp()
+        public async Task CA1060NestedClassesCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 class Outer
@@ -270,9 +271,9 @@ class Outer
         }
 
         [Fact]
-        public void CA1060NestedClassesBasic()
+        public async Task CA1060NestedClassesBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Runtime.InteropServices
 
 Class Outer

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NestedTypesShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NestedTypesShouldNotBeVisibleTests.cs
@@ -1,16 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.NestedTypesShouldNotBeVisibleAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.NestedTypesShouldNotBeVisibleAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class NestedTypesShouldNotBeVisibleTests : DiagnosticAnalyzerTestBase
+    public class NestedTypesShouldNotBeVisibleTests
     {
         [Fact]
-        public void CSharpDiagnosticPublicNestedClass()
+        public async Task CSharpDiagnosticPublicNestedClass()
         {
             var code = @"
 public class Outer
@@ -20,11 +26,11 @@ public class Outer
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpCA1034ResultAt(4, 18, "Inner"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpCA1034ResultAt(4, 18, "Inner"));
         }
 
         [Fact]
-        public void BasicDiagnosticPublicNestedClass()
+        public async Task BasicDiagnosticPublicNestedClass()
         {
             var code = @"
 Public Class Outer
@@ -32,11 +38,11 @@ Public Class Outer
     End Class
 End Class
 ";
-            VerifyBasic(code, GetBasicCA1034ResultAt(3, 18, "Inner"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicCA1034ResultAt(3, 18, "Inner"));
         }
 
         [Fact]
-        public void CSharpDiagnosticPublicNestedStruct()
+        public async Task CSharpDiagnosticPublicNestedStruct()
         {
             var code = @"
 public class Outer
@@ -46,11 +52,11 @@ public class Outer
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpCA1034ResultAt(4, 19, "Inner"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpCA1034ResultAt(4, 19, "Inner"));
         }
 
         [Fact]
-        public void BasicDiagnosticPublicNestedStructure()
+        public async Task BasicDiagnosticPublicNestedStructure()
         {
             var code = @"
 Public Class Outer
@@ -58,11 +64,11 @@ Public Class Outer
     End Structure
 End Class
 ";
-            VerifyBasic(code, GetBasicCA1034ResultAt(3, 22, "Inner"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicCA1034ResultAt(3, 22, "Inner"));
         }
 
         [Fact]
-        public void CSharpNoDiagnosticPublicNestedEnum()
+        public async Task CSharpNoDiagnosticPublicNestedEnum()
         {
             var code = @"
 public class Outer
@@ -73,11 +79,11 @@ public class Outer
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticPublicNestedEnum()
+        public async Task BasicNoDiagnosticPublicNestedEnum()
         {
             var code = @"
 Public Class Outer
@@ -86,11 +92,11 @@ Public Class Outer
     End Enum
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicDiagnosticPublicTypeNestedInModule()
+        public async Task BasicDiagnosticPublicTypeNestedInModule()
         {
             var code = @"
 Public Module Outer
@@ -98,11 +104,11 @@ Public Module Outer
     End Class
 End Module
 ";
-            VerifyBasic(code, GetBasicCA1034ModuleResultAt(3, 18, "Inner"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicCA1034ModuleResultAt(3, 18, "Inner"));
         }
 
         [Fact, WorkItem(1347, "https://github.com/dotnet/roslyn-analyzers/issues/1347")]
-        public void CSharpDiagnosticPublicNestedDelegate()
+        public async Task CSharpDiagnosticPublicNestedDelegate()
         {
             var code = @"
 public class Outer
@@ -110,22 +116,22 @@ public class Outer
     public delegate void Inner();
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact, WorkItem(1347, "https://github.com/dotnet/roslyn-analyzers/issues/1347")]
-        public void BasicDiagnosticPublicNestedDelegate()
+        public async Task BasicDiagnosticPublicNestedDelegate()
         {
             var code = @"
 Public Class Outer
     Delegate Sub Inner()
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticPrivateNestedType()
+        public async Task CSharpNoDiagnosticPrivateNestedType()
         {
             var code = @"
 public class Outer
@@ -135,11 +141,11 @@ public class Outer
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticPrivateNestedType()
+        public async Task BasicNoDiagnosticPrivateNestedType()
         {
             var code = @"
 Public Class Outer
@@ -147,11 +153,11 @@ Public Class Outer
     End Class
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticProtectedNestedType()
+        public async Task CSharpNoDiagnosticProtectedNestedType()
         {
             var code = @"
 public class Outer
@@ -161,11 +167,11 @@ public class Outer
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticProtectedNestedType()
+        public async Task BasicNoDiagnosticProtectedNestedType()
         {
             var code = @"
 Public Class Outer
@@ -173,11 +179,11 @@ Public Class Outer
     End Class
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticInternalNestedType()
+        public async Task CSharpNoDiagnosticInternalNestedType()
         {
             var code = @"
 public class Outer
@@ -187,11 +193,11 @@ public class Outer
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticFriendNestedType()
+        public async Task BasicNoDiagnosticFriendNestedType()
         {
             var code = @"
 Public Class Outer
@@ -199,11 +205,11 @@ Public Class Outer
     End Class
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticProtectedOrInternalNestedType()
+        public async Task CSharpNoDiagnosticProtectedOrInternalNestedType()
         {
             var code = @"
 public class Outer
@@ -213,11 +219,11 @@ public class Outer
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticProtectedOrFriendNestedType()
+        public async Task BasicNoDiagnosticProtectedOrFriendNestedType()
         {
             var code = @"
 Public Class Outer
@@ -225,11 +231,11 @@ Public Class Outer
     End Class
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticNonPublicTypeNestedInModule()
+        public async Task BasicNoDiagnosticNonPublicTypeNestedInModule()
         {
             var code = @"
 Public Module Outer
@@ -237,11 +243,11 @@ Public Module Outer
     End Class
 End Module
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticPublicNestedEnumerator()
+        public async Task CSharpNoDiagnosticPublicNestedEnumerator()
         {
             var code = @"
 using System.Collections;
@@ -256,11 +262,11 @@ public class Outer
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticPublicTypeNestedInInternalType()
+        public async Task CSharpNoDiagnosticPublicTypeNestedInInternalType()
         {
             var code = @"
 internal class Outer
@@ -270,11 +276,11 @@ internal class Outer
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticPublicTypeNestedInFriendType()
+        public async Task BasicNoDiagnosticPublicTypeNestedInFriendType()
         {
             var code = @"
 Friend Class Outer
@@ -282,11 +288,11 @@ Friend Class Outer
     End Class
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticPublicNestedEnumerator()
+        public async Task BasicNoDiagnosticPublicNestedEnumerator()
         {
             var code = @"
 Imports System
@@ -311,11 +317,11 @@ Public Class Outer
     End Class
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticDataSetSpecialCases()
+        public async Task CSharpNoDiagnosticDataSetSpecialCases()
         {
             var code = @"
 using System.Data;
@@ -334,11 +340,11 @@ public class MyDataSet : DataSet
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticDataSetSpecialCases()
+        public async Task BasicNoDiagnosticDataSetSpecialCases()
         {
             var code = @"
 Imports System.Data
@@ -359,11 +365,11 @@ Public Class MyDataSet
     End Class
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpDiagnosticDataSetWithOtherNestedClass()
+        public async Task CSharpDiagnosticDataSetWithOtherNestedClass()
         {
             var code = @"
 using System.Data;
@@ -386,11 +392,11 @@ public class MyDataSet : DataSet
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpCA1034ResultAt(17, 18, "Inner"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpCA1034ResultAt(17, 18, "Inner"));
         }
 
         [Fact]
-        public void BasicDiagnosticDataSetWithOtherNestedClass()
+        public async Task BasicDiagnosticDataSetWithOtherNestedClass()
         {
             var code = @"
 Imports System.Data
@@ -414,11 +420,11 @@ Public Class MyDataSet
     End Class
 End Class
 ";
-            VerifyBasic(code, GetBasicCA1034ResultAt(19, 18, "Inner"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicCA1034ResultAt(19, 18, "Inner"));
         }
 
         [Fact]
-        public void CSharpDiagnosticNestedDataClassesWithinOtherClass()
+        public async Task CSharpDiagnosticNestedDataClassesWithinOtherClass()
         {
             var code = @"
 using System.Data;
@@ -437,13 +443,13 @@ public class Outer
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                 GetCSharpCA1034ResultAt(6, 18, "MyDataTable"),
                 GetCSharpCA1034ResultAt(10, 18, "MyDataRow"));
         }
 
         [Fact]
-        public void BasicDiagnosticNestedDataClassesWithinOtherClass()
+        public async Task BasicDiagnosticNestedDataClassesWithinOtherClass()
         {
             var code = @"
 Imports System.Data
@@ -462,34 +468,24 @@ Public Class Outer
     End Class
 End Class
 ";
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                 GetBasicCA1034ResultAt(5, 18, "MyDataTable"),
                 GetBasicCA1034ResultAt(9, 18, "MyDataRow"));
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new NestedTypesShouldNotBeVisibleAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new NestedTypesShouldNotBeVisibleAnalyzer();
-        }
-
         private DiagnosticResult GetCSharpCA1034ResultAt(int line, int column, string nestedTypeName)
-        {
-            return GetCSharpResultAt(line, column, NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule, nestedTypeName);
-        }
+            => new DiagnosticResult(NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithArguments(nestedTypeName);
 
         private DiagnosticResult GetBasicCA1034ResultAt(int line, int column, string nestedTypeName)
-        {
-            return GetBasicResultAt(line, column, NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule, nestedTypeName);
-        }
+            => new DiagnosticResult(NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithArguments(nestedTypeName);
 
         private DiagnosticResult GetBasicCA1034ModuleResultAt(int line, int column, string nestedTypeName)
-        {
-            return GetBasicResultAt(line, column, NestedTypesShouldNotBeVisibleAnalyzer.VisualBasicModuleRule, nestedTypeName);
-        }
+            => new DiagnosticResult(NestedTypesShouldNotBeVisibleAnalyzer.VisualBasicModuleRule)
+                .WithLocation(line, column)
+                .WithArguments(nestedTypeName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisibleTests.cs
@@ -1,28 +1,25 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.NonConstantFieldsShouldNotBeVisibleAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.NonConstantFieldsShouldNotBeVisibleAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class NonConstantFieldsShouldNotBeVisibleTests : DiagnosticAnalyzerTestBase
+    public class NonConstantFieldsShouldNotBeVisibleTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new NonConstantFieldsShouldNotBeVisibleAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new NonConstantFieldsShouldNotBeVisibleAnalyzer();
-        }
-
         [Fact]
-        public void DefaultVisibilityCS()
+        public async Task DefaultVisibilityCS()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     string field; 
@@ -30,18 +27,18 @@ public class A
         }
 
         [Fact]
-        public void DefaultVisibilityVB()
+        public async Task DefaultVisibilityVB()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Dim field As System.String
 End Class");
         }
 
         [Fact]
-        public void PublicVariableCS()
+        public async Task PublicVariableCS()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public string field; 
@@ -49,28 +46,28 @@ public class A
         }
 
         [Fact]
-        public void PublicVariableVB()
+        public async Task PublicVariableVB()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Public field As System.String
 End Class");
         }
 
         [Fact]
-        public void ExternallyVisibleStaticVariableCS()
+        public async Task ExternallyVisibleStaticVariableCS()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static string field; 
-}", GetCSharpResultAt(4, 26, NonConstantFieldsShouldNotBeVisibleAnalyzer.RuleId, NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)));
+}", GetCSharpResultAt(4, 26));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void PublicNotExternallyVisibleStaticVariableCS()
+        public async Task PublicNotExternallyVisibleStaticVariableCS()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class A
 {
     public static string field;
@@ -87,18 +84,18 @@ public class B
         }
 
         [Fact]
-        public void ExternallyVisibleStaticVariableVB()
+        public async Task ExternallyVisibleStaticVariableVB()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Public Shared field as System.String
-End Class", GetBasicResultAt(3, 19, NonConstantFieldsShouldNotBeVisibleAnalyzer.RuleId, NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture)));
+End Class", GetBasicResultAt(3, 19));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void PublicNotExternallyVisibleStaticVariableVB()
+        public async Task PublicNotExternallyVisibleStaticVariableVB()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class A
     Public Shared field as System.String
 End Class
@@ -112,9 +109,9 @@ End Class
         }
 
         [Fact]
-        public void PublicStaticReadonlyVariableCS()
+        public async Task PublicStaticReadonlyVariableCS()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static readonly string field; 
@@ -122,18 +119,18 @@ public class A
         }
 
         [Fact]
-        public void PublicStaticReadonlyVariableVB()
+        public async Task PublicStaticReadonlyVariableVB()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Public Shared ReadOnly field as System.String
 End Class");
         }
 
         [Fact]
-        public void PublicConstVariableCS()
+        public async Task PublicConstVariableCS()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public const string field = ""X""; 
@@ -141,12 +138,22 @@ public class A
         }
 
         [Fact]
-        public void PublicConstVariableVB()
+        public async Task PublicConstVariableVB()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
     Public Const field as System.String = ""X""
 End Class");
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
+            => new DiagnosticResult(NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
+            => new DiagnosticResult(NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.cs
@@ -1,70 +1,56 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OperatorOverloadsHaveNamedAlternatesAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OperatorOverloadsHaveNamedAlternatesFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OperatorOverloadsHaveNamedAlternatesAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OperatorOverloadsHaveNamedAlternatesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class OperatorOverloadsHaveNamedAlternatesTests : DiagnosticAnalyzerTestBase
+    public class OperatorOverloadsHaveNamedAlternatesTests
     {
         #region Boilerplate
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new OperatorOverloadsHaveNamedAlternatesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new OperatorOverloadsHaveNamedAlternatesAnalyzer();
-        }
-
         private static DiagnosticResult GetCA2225CSharpDefaultResultAt(int line, int column, string alternateName, string operatorName)
-        {
-            // Provide a method named '{0}' as a friendly alternate for operator {1}.
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageDefault, alternateName, operatorName);
-            return GetCSharpResultAt(line, column, OperatorOverloadsHaveNamedAlternatesAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageDefault, alternateName, operatorName));
 
         private static DiagnosticResult GetCA2225CSharpPropertyResultAt(int line, int column, string alternateName, string operatorName)
-        {
-            // Provide a property named '{0}' as a friendly alternate for operator {1}.
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageProperty, alternateName, operatorName);
-            return GetCSharpResultAt(line, column, OperatorOverloadsHaveNamedAlternatesAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.PropertyRule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageProperty, alternateName, operatorName));
 
         private static DiagnosticResult GetCA2225CSharpMultipleResultAt(int line, int column, string alternateName1, string alternateName2, string operatorName)
-        {
-            // Provide a method named '{0}' or '{1}' as an alternate for operator {2}
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageMultiple, alternateName1, alternateName2, operatorName);
-            return GetCSharpResultAt(line, column, OperatorOverloadsHaveNamedAlternatesAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.MultipleRule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageMultiple, alternateName1, alternateName2, operatorName));
 
         private static DiagnosticResult GetCA2225CSharpVisibilityResultAt(int line, int column, string alternateName, string operatorName)
-        {
-            // Mark {0} as public because it is a friendly alternate for operator {1}.
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageVisibility, alternateName, operatorName);
-            return GetCSharpResultAt(line, column, OperatorOverloadsHaveNamedAlternatesAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.VisibilityRule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageVisibility, alternateName, operatorName));
 
         private static DiagnosticResult GetCA2225BasicDefaultResultAt(int line, int column, string alternateName, string operatorName)
-        {
-            // Provide a method named '{0}' as a friendly alternate for operator {1}.
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageDefault, alternateName, operatorName);
-            return GetBasicResultAt(line, column, OperatorOverloadsHaveNamedAlternatesAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageDefault, alternateName, operatorName));
 
         #endregion
 
         #region C# tests
 
         [Fact]
-        public void HasAlternateMethod_CSharp()
+        public async Task HasAlternateMethod_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public static C operator +(C left, C right) { return new C(); }
@@ -74,9 +60,9 @@ public class C
         }
 
         [Fact]
-        public void HasMultipleAlternatePrimary_CSharp()
+        public async Task HasMultipleAlternatePrimary_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public static C operator %(C left, C right) { return new C(); }
@@ -86,9 +72,9 @@ public class C
         }
 
         [Fact]
-        public void HasMultipleAlternateSecondary_CSharp()
+        public async Task HasMultipleAlternateSecondary_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public static C operator %(C left, C right) { return new C(); }
@@ -98,9 +84,9 @@ public class C
         }
 
         [Fact]
-        public void HasAppropriateConversionAlternate_CSharp()
+        public async Task HasAppropriateConversionAlternate_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public static implicit operator int(C item) { return 0; }
@@ -110,9 +96,9 @@ public class C
         }
 
         [Fact, WorkItem(1717, "https://github.com/dotnet/roslyn-analyzers/issues/1717")]
-        public void HasAppropriateConversionAlternate02_CSharp()
+        public async Task HasAppropriateConversionAlternate02_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Bar
 {	
 	public int i {get; set;}
@@ -134,9 +120,9 @@ public class Foo
         }
 
         [Fact]
-        public void MissingAlternateMethod_CSharp()
+        public async Task MissingAlternateMethod_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public static C operator +(C left, C right) { return new C(); }
@@ -146,9 +132,9 @@ public class C
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void MissingAlternateMethod_CSharp_Internal()
+        public async Task MissingAlternateMethod_CSharp_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public static C operator +(C left, C right) { return new C(); }
@@ -165,9 +151,9 @@ public class C2
         }
 
         [Fact]
-        public void MissingAlternateProperty_CSharp()
+        public async Task MissingAlternateProperty_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public static bool operator true(C item) { return true; }
@@ -178,9 +164,9 @@ public class C
         }
 
         [Fact]
-        public void MissingMultipleAlternates_CSharp()
+        public async Task MissingMultipleAlternates_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public static C operator %(C left, C right) { return new C(); }
@@ -190,9 +176,9 @@ public class C
         }
 
         [Fact]
-        public void ImproperAlternateMethodVisibility_CSharp()
+        public async Task ImproperAlternateMethodVisibility_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public static C operator +(C left, C right) { return new C(); }
@@ -203,9 +189,9 @@ public class C
         }
 
         [Fact]
-        public void ImproperAlternatePropertyVisibility_CSharp()
+        public async Task ImproperAlternatePropertyVisibility_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public static bool operator true(C item) { return true; }
@@ -217,9 +203,9 @@ public class C
         }
 
         [Fact]
-        public void StructHasAlternateMethod_CSharp()
+        public async Task StructHasAlternateMethod_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 struct C
 {
     public static C operator +(C left, C right) { return new C(); }
@@ -237,9 +223,9 @@ struct C
         #region VB tests
 
         [Fact]
-        public void HasAlternateMethod_VisualBasic()
+        public async Task HasAlternateMethod_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
@@ -252,9 +238,9 @@ End Class
         }
 
         [Fact]
-        public void MissingAlternateMethod_VisualBasic()
+        public async Task MissingAlternateMethod_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
@@ -265,9 +251,9 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void MissingAlternateMethod_VisualBasic_Internal()
+        public async Task MissingAlternateMethod_VisualBasic_Internal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()
@@ -285,9 +271,9 @@ End Class
         }
 
         [Fact]
-        public void StructHasAlternateMethod_VisualBasic()
+        public async Task StructHasAlternateMethod_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure C
     Public Shared Operator +(left As C, right As C) As C
         Return New C()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
@@ -1,49 +1,44 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OperatorsShouldHaveSymmetricalOverloadsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class OperatorsShouldHaveSymmetricalOverloadsTests : DiagnosticAnalyzerTestBase
+    public class OperatorsShouldHaveSymmetricalOverloadsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new OperatorsShouldHaveSymmetricalOverloadsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new OperatorsShouldHaveSymmetricalOverloadsAnalyzer();
-        }
-
         [Fact]
-        public void CSharpTestMissingEquality()
+        public async Task CSharpTestMissingEquality()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static bool operator==(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
-}", TestValidationMode.AllowCompileErrors,
+}", CompilerDiagnostics.None,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="));
         }
 
         [Fact]
-        public void CSharpTestMissingInequality()
+        public async Task CSharpTestMissingInequality()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static bool operator!=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '==' to also be defined
-}", TestValidationMode.AllowCompileErrors,
+}", CompilerDiagnostics.None,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharpTestMissingEquality_Internal()
+        public async Task CSharpTestMissingEquality_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class A
 {
     public static bool operator==(A a1, A a2) { return false; }
@@ -62,13 +57,13 @@ public class B
     }
 }
 
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharpTestMissingInequality_Internal()
+        public async Task CSharpTestMissingInequality_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class A
 {
     public static bool operator!=(A a1, A a2) { return false; }
@@ -86,13 +81,13 @@ public class B
         internal static bool operator!=(D a1, D a2) { return false; }
     }
 }
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CSharpTestBothEqualityOperators()
+        public async Task CSharpTestBothEqualityOperators()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static bool operator==(A a1, A a2) { return false; }
@@ -101,20 +96,20 @@ public class A
         }
 
         [Fact]
-        public void CSharpTestMissingLessThan()
+        public async Task CSharpTestMissingLessThan()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static bool operator<(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>' to also be defined
-}", TestValidationMode.AllowCompileErrors,
+}", CompilerDiagnostics.None,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<", ">"));
         }
 
         [Fact]
-        public void CSharpTestNotMissingLessThan()
+        public async Task CSharpTestNotMissingLessThan()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static bool operator<(A a1, A a2) { return false; }
@@ -123,20 +118,20 @@ public class A
         }
 
         [Fact]
-        public void CSharpTestMissingLessThanOrEqualTo()
+        public async Task CSharpTestMissingLessThanOrEqualTo()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static bool operator<=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>=' to also be defined
-}", TestValidationMode.AllowCompileErrors,
+}", CompilerDiagnostics.None,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<=", ">="));
         }
 
         [Fact]
-        public void CSharpTestNotMissingLessThanOrEqualTo()
+        public async Task CSharpTestNotMissingLessThanOrEqualTo()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static bool operator<=(A a1, A a2) { return false; }
@@ -145,16 +140,21 @@ public class A
         }
 
         [Fact]
-        public void CSharpTestOperatorType()
+        public async Task CSharpTestOperatorType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public static bool operator==(A a1, int a2) { return false; }
     public static bool operator!=(A a1, string a2) { return false; }
-}", TestValidationMode.AllowCompileErrors,
+}", CompilerDiagnostics.None,
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
 GetCSharpResultAt(5, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="));
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -1,19 +1,25 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OverrideEqualsAndOperatorEqualsOnValueTypesAnalyzer,
+    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpOverrideEqualsAndOperatorEqualsOnValueTypesFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OverrideEqualsAndOperatorEqualsOnValueTypesAnalyzer,
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicOverrideEqualsAndOperatorEqualsOnValueTypesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class OverrideEqualsAndOperatorEqualsOnValueTypesTests : DiagnosticAnalyzerTestBase
+    public class OverrideEqualsAndOperatorEqualsOnValueTypesTests
     {
         [Fact]
-        public void CSharpDiagnosticForBothEqualsAndOperatorEqualsOnStruct()
+        public async Task CSharpDiagnosticForBothEqualsAndOperatorEqualsOnStruct()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct A
 {
     public int X;
@@ -24,9 +30,9 @@ public struct A
 
         [WorkItem(895, "https://github.com/dotnet/roslyn-analyzers/issues/895")]
         [Fact]
-        public void CSharpNoDiagnosticForInternalAndPrivateStruct()
+        public async Task CSharpNoDiagnosticForInternalAndPrivateStruct()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal struct A
 {
     public int X;
@@ -44,9 +50,9 @@ public class B
 
         [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
         [Fact]
-        public void CSharpNoDiagnosticForEnum()
+        public async Task CSharpNoDiagnosticForEnum()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public enum E
 {
     F = 0
@@ -56,9 +62,9 @@ public enum E
 
         [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
         [Fact]
-        public void CSharpNoDiagnosticForStructsWithoutMembers()
+        public async Task CSharpNoDiagnosticForStructsWithoutMembers()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct EmptyStruct
 {
 }
@@ -67,9 +73,9 @@ public struct EmptyStruct
 
         [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
         [Fact]
-        public void CSharpNoDiagnosticForEnumerators()
+        public async Task CSharpNoDiagnosticForEnumerators()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 
@@ -131,9 +137,9 @@ public struct MyGenericEnumerator<T> : System.Collections.Generic.IEnumerator<T>
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForEqualsOrOperatorEqualsOnClass()
+        public async Task CSharpNoDiagnosticForEqualsOrOperatorEqualsOnClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
     public int X;
@@ -141,9 +147,9 @@ public class A
         }
 
         [Fact]
-        public void CSharpNoDiagnosticWhenStructImplementsEqualsAndOperatorEquals()
+        public async Task CSharpNoDiagnosticWhenStructImplementsEqualsAndOperatorEquals()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct A
 {
     public override bool Equals(object other)
@@ -164,9 +170,9 @@ public struct A
         }
 
         [Fact]
-        public void CSharpDiagnosticWhenEqualsHasWrongSignature()
+        public async Task CSharpDiagnosticWhenEqualsHasWrongSignature()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct A
 {
     public bool Equals(A other)
@@ -188,9 +194,9 @@ public struct A
         }
 
         [Fact]
-        public void CSharpDiagnosticWhenEqualsIsNotAnOverride()
+        public async Task CSharpDiagnosticWhenEqualsIsNotAnOverride()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct A
 {
     public new bool Equals(object other)
@@ -212,9 +218,9 @@ public struct A
         }
 
         [Fact]
-        public void BasicDiagnosticsForEqualsOnStructure()
+        public async Task BasicDiagnosticsForEqualsOnStructure()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure A
     Public X As Integer
 End Structure
@@ -225,9 +231,9 @@ End Structure
 
         [WorkItem(895, "https://github.com/dotnet/roslyn-analyzers/issues/895")]
         [Fact]
-        public void BasicNoDiagnosticsForInternalAndPrivateStructure()
+        public async Task BasicNoDiagnosticsForInternalAndPrivateStructure()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Structure A
     Public X As Integer
 End Structure
@@ -242,9 +248,9 @@ End Class
 
         [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
         [Fact]
-        public void BasicNoDiagnosticForEnum()
+        public async Task BasicNoDiagnosticForEnum()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Enum E
     F = 0
 End Enum
@@ -253,9 +259,9 @@ End Enum
 
         [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
         [Fact]
-        public void BasicNoDiagnosticForStructsWithoutMembers()
+        public async Task BasicNoDiagnosticForStructsWithoutMembers()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure EmptyStruct
 End Structure
 ");
@@ -263,9 +269,9 @@ End Structure
 
         [WorkItem(899, "https://github.com/dotnet/roslyn-analyzers/issues/899")]
         [Fact]
-        public void BasicNoDiagnosticForEnumerators()
+        public async Task BasicNoDiagnosticForEnumerators()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
@@ -317,18 +323,18 @@ End Structure
         }
 
         [Fact]
-        public void BasicNoDiagnosticForEqualsOnClass()
+        public async Task BasicNoDiagnosticForEqualsOnClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
 End Class
 ");
         }
 
         [Fact]
-        public void BasicNoDiagnosticWhenStructureImplementsEqualsAndOperatorEquals()
+        public async Task BasicNoDiagnosticWhenStructureImplementsEqualsAndOperatorEquals()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure A
     Public Overrides Overloads Function Equals(obj As Object) As Boolean
         Return True
@@ -346,9 +352,9 @@ End Structure
         }
 
         [Fact]
-        public void BasicDiagnosticWhenEqualsHasWrongSignature()
+        public async Task BasicDiagnosticWhenEqualsHasWrongSignature()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure A
     Public Overrides Overloads Function Equals(obj As A) As Boolean
         Return True
@@ -362,14 +368,15 @@ Public Structure A
         Return False
     End Operator
 End Structure
-", TestValidationMode.AllowCompileErrors,
+",
+            CompilerDiagnostics.None,
             GetBasicOverrideEqualsDiagnostic(2, 18, "A"));
         }
 
         [Fact]
-        public void BasicDiagnosticWhenEqualsIsNotAnOverride()
+        public async Task BasicDiagnosticWhenEqualsIsNotAnOverride()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure A
    Public Shadows Function Equals(obj As Object) As Boolean
       Return True
@@ -388,23 +395,17 @@ End Structure
         }
 
         [Fact, WorkItem(2324, "https://github.com/dotnet/roslyn-analyzers/issues/2324")]
-        public void CSharp_RefStruct_NoDiagnostic()
+        public async Task CSharp_RefStruct_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 public ref struct A
 {
     public int X;
-}", parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new OverrideEqualsAndOperatorEqualsOnValueTypesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new OverrideEqualsAndOperatorEqualsOnValueTypesAnalyzer();
+}",
+                LanguageVersion = LanguageVersion.CSharp8
+            }.RunAsync();
         }
 
         private static DiagnosticResult GetCSharpOverrideEqualsDiagnostic(int line, int column, string typeName)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEqualsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEqualsTests.cs
@@ -1,29 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
 using Xunit;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicOverrideEqualsOnOverloadingOperatorEqualsAnalyzer,
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicOverrideEqualsOnOverloadingOperatorEqualsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class OverrideEqualsOnOverloadingOperatorEqualsTests : DiagnosticAnalyzerTestBase
+    public class OverrideEqualsOnOverloadingOperatorEqualsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicOverrideEqualsOnOverloadingOperatorEqualsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            throw new NotSupportedException("CA2224 is not applied to C# since it already reports CS0660");
-        }
-
         [Fact]
-        public void Good_Class_Operator()
+        public async Task Good_Class_Operator()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Shared Operator =(a As C, b As C)
         Return True
@@ -40,17 +33,17 @@ End Class");
         }
 
         [Fact]
-        public void Good_Class_NoOperator()
+        public async Task Good_Class_NoOperator()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
 End Class");
         }
 
         [Fact]
-        public void Good_Structure_Operator()
+        public async Task Good_Structure_Operator()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Structure C
     Public Shared Operator =(a As C, b As C)
         Return True
@@ -67,17 +60,17 @@ End Structure");
         }
 
         [Fact]
-        public void Good_Structure_NoOperator()
+        public async Task Good_Structure_NoOperator()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Structure C
 End Structure");
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7305")]
-        public void Ignored_Interace()
+        public async Task Ignored_Interace()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Interace I
     Public Shared Operator =(a As I, b As I)
         Return True
@@ -86,18 +79,18 @@ End Interface");
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7305")]
-        public void Ignored_TopLevel()
+        public async Task Ignored_TopLevel()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Shared Operator =(a As I, b As I)
     Return True
 End Operator");
         }
 
         [Fact]
-        public void Bad_Class()
+        public async Task Bad_Class()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Shared Operator =(a As C, b As C)
         Return True
@@ -112,9 +105,9 @@ End Class",
         }
 
         [Fact]
-        public void Bad_Structure()
+        public async Task Bad_Structure()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Structure C
     Public Shared Operator =(a As C, b As C)
         Return True
@@ -129,9 +122,9 @@ End Structure",
         }
 
         [Fact]
-        public void Bad_NotOverride()
+        public async Task Bad_NotOverride()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Shared Operator =(a As C, b As C)
         Return True
@@ -150,9 +143,9 @@ End Class",
         }
 
         [Fact]
-        public void Bad_FalseOverride()
+        public async Task Bad_FalseOverride()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Public Overridable Shadows Function Equals(o As Object) As Boolean
         Return True
@@ -175,5 +168,9 @@ End Class",
             // Test0.vb(8,7): warning CA2224: Override Equals on overloading operator equals
             GetBasicResultAt(8, 7, BasicOverrideEqualsOnOverloadingOperatorEqualsAnalyzer.Rule));
         }
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideGetHashCodeOnOverridingEqualsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideGetHashCodeOnOverridingEqualsTests.cs
@@ -1,29 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
 using Xunit;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicOverrideGetHashCodeOnOverridingEqualsAnalyzer,
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicOverrideGetHashCodeOnOverridingEqualsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class OverrideGetHashCodeOnOverridingEqualsTests : DiagnosticAnalyzerTestBase
+    public class OverrideGetHashCodeOnOverridingEqualsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicOverrideGetHashCodeOnOverridingEqualsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            throw new NotSupportedException("CA2218 is not applied to C# since it already reports CS0661");
-        }
-
         [Fact]
-        public void Good_Class_Equals()
+        public async Task Good_Class_Equals()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Overrides Function Equals(o As Object) As Boolean
         Return True
@@ -36,17 +29,17 @@ End Class");
         }
 
         [Fact]
-        public void Good_Class_NoEquals()
+        public async Task Good_Class_NoEquals()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
 End Class");
         }
 
         [Fact]
-        public void Good_Structure_Equals()
+        public async Task Good_Structure_Equals()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Structure C
     Public Overrides Function Equals(o As Object) As Boolean
         Return True
@@ -59,17 +52,17 @@ End Structure");
         }
 
         [Fact]
-        public void Good_Structure_NoEquals()
+        public async Task Good_Structure_NoEquals()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Structure C
 End Structure");
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7305")]
-        public void Ignored_Interace()
+        public async Task Ignored_Interace()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Interace I
     Public Overrides Function Equals(o As Object) As Boolean
         Return True
@@ -78,18 +71,18 @@ End Interface");
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7305")]
-        public void Ignored_TopLevel()
+        public async Task Ignored_TopLevel()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Overrides Function Equals(o As Object) As Boolean
     Return True
 End Function");
         }
 
         [Fact]
-        public void Bad_Class()
+        public async Task Bad_Class()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Overrides Function Equals(o As Object) As Boolean
         Return True
@@ -100,9 +93,9 @@ End Class",
         }
 
         [Fact]
-        public void Bad_Structure()
+        public async Task Bad_Structure()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Structure C
     Public Overrides Function Equals(o As Object) As Boolean
         Return True
@@ -113,9 +106,9 @@ End Structure",
         }
 
         [Fact]
-        public void Bad_NotOverride()
+        public async Task Bad_NotOverride()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Overrides Function Equals(o As Object) As Boolean
         Return True
@@ -130,9 +123,9 @@ End Class",
         }
 
         [Fact]
-        public void Bad_FalseOverride()
+        public async Task Bad_FalseOverride()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
     Public Overridable Shadows Function GetHashCode() As Integer
         Return 0
@@ -151,5 +144,9 @@ End Class",
             // Test0.vb(8,7): warning CA2224: Override GetHashCode on overriding Equals
             GetBasicResultAt(8, 7, BasicOverrideGetHashCodeOnOverridingEqualsAnalyzer.Rule));
         }
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
@@ -1,10 +1,17 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OverrideMethodsOnComparableTypesAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OverrideMethodsOnComparableTypesFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OverrideMethodsOnComparableTypesAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OverrideMethodsOnComparableTypesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
@@ -21,9 +28,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036ClassNoWarningCSharp()
+        public async Task CA1036ClassNoWarningCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -77,9 +84,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036ClassWrongEqualsCSharp()
+        public async Task CA1036ClassWrongEqualsCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -120,9 +127,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1036ClassWrongEqualsCSharp_Internal()
+        public async Task CA1036ClassWrongEqualsCSharp_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     internal class A : IComparable
@@ -302,9 +309,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036StructNoWarningCSharp()
+        public async Task CA1036StructNoWarningCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public struct A : IComparable
@@ -358,9 +365,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036PrivateClassNoOpLessThanNoWarningCSharp()
+        public async Task CA1036PrivateClassNoOpLessThanNoWarningCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class class1
@@ -397,9 +404,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036ClassNoEqualsOperatorCSharp()
+        public async Task CA1036ClassNoEqualsOperatorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -439,9 +446,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036ClassNoOpEqualsOperatorCSharp()
+        public async Task CA1036ClassNoOpEqualsOperatorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -476,9 +483,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036StructNoOpLessThanOperatorCSharp()
+        public async Task CA1036StructNoOpLessThanOperatorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public struct A : IComparable
@@ -513,9 +520,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1036StructNoOpLessThanOperatorCSharp_Internal()
+        public async Task CA1036StructNoOpLessThanOperatorCSharp_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     internal struct A : IComparable
@@ -580,9 +587,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036ClassWithGenericIComparableCSharp()
+        public async Task CA1036ClassWithGenericIComparableCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable<int>
@@ -617,9 +624,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036ClassWithDerivedIComparableCSharp()
+        public async Task CA1036ClassWithDerivedIComparableCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     interface  IDerived : IComparable<int> { }
@@ -656,9 +663,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036ClassNoWarningBasic()
+        public async Task CA1036ClassNoWarningBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A : Implements IComparable
@@ -704,9 +711,9 @@ End Class
         }
 
         [Fact]
-        public void CA1036StructWrongEqualsBasic()
+        public async Task CA1036StructWrongEqualsBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Structure A : Implements IComparable
@@ -743,9 +750,9 @@ End Structure
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1036StructWrongEqualsBasic_Internal()
+        public async Task CA1036StructWrongEqualsBasic_Internal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Friend Structure A : Implements IComparable
@@ -891,9 +898,9 @@ End Structure
         }
 
         [Fact]
-        public void CA1036StructNoWarningBasic()
+        public async Task CA1036StructNoWarningBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Structure A : Implements IComparable
@@ -939,9 +946,9 @@ End Structure
         }
 
         [Fact]
-        public void CA1036PrivateClassNoOpLessThanNoWarningBasic()
+        public async Task CA1036PrivateClassNoOpLessThanNoWarningBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class Class1
@@ -973,9 +980,9 @@ End Class
         }
 
         [Fact]
-        public void CA1036ClassNoEqualsOperatorBasic()
+        public async Task CA1036ClassNoEqualsOperatorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A : Implements IComparable
@@ -1010,9 +1017,9 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1036ClassNoEqualsOperatorBasic_Internal()
+        public async Task CA1036ClassNoEqualsOperatorBasic_Internal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Friend Class A 
@@ -1078,9 +1085,9 @@ End Class
         }
 
         [Fact]
-        public void CA1036ClassNoOpEqualsOperatorBasic()
+        public async Task CA1036ClassNoOpEqualsOperatorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A : Implements IComparable
@@ -1111,9 +1118,9 @@ End Class
         }
 
         [Fact]
-        public void CA1036ClassNoOpLessThanOperatorBasic()
+        public async Task CA1036ClassNoOpLessThanOperatorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Structure A : Implements IComparable
@@ -1144,9 +1151,9 @@ End Structure
         }
 
         [Fact]
-        public void CA1036ClassWithGenericIComparableBasic()
+        public async Task CA1036ClassWithGenericIComparableBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Structure A : Implements IComparable(Of Integer)
@@ -1177,9 +1184,9 @@ End Structure
         }
 
         [Fact]
-        public void CA1036ClassWithDerivedIComparableBasic()
+        public async Task CA1036ClassWithDerivedIComparableBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Interface IDerived 
@@ -1214,15 +1221,15 @@ End Structure
         }
 
         [Fact]
-        public void Bug1994CSharp()
+        public async Task Bug1994CSharp()
         {
-            VerifyCSharp("enum MyEnum {}");
+            await VerifyCS.VerifyAnalyzerAsync("enum MyEnum {}");
         }
 
         [Fact]
-        public void Bug1994VisualBasic()
+        public async Task Bug1994VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Enum MyEnum
     ValueOne
     ValueTwo
@@ -1230,9 +1237,9 @@ End Enum");
         }
 
         [Fact, WorkItem(1671, "https://github.com/dotnet/roslyn-analyzers/issues/1671")]
-        public void CA1036BaseTypeComparable_NoWarningOnDerived_CSharp()
+        public async Task CA1036BaseTypeComparable_NoWarningOnDerived_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class BaseClass : IComparable
@@ -1262,9 +1269,9 @@ public class DerivedClass : BaseClass
         }
 
         [Fact, WorkItem(1671, "https://github.com/dotnet/roslyn-analyzers/issues/1671")]
-        public void CA1036BaseTypeGenericComparable_NoWarningOnDerived_CSharp()
+        public async Task CA1036BaseTypeGenericComparable_NoWarningOnDerived_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class BaseClass<T> : IComparable<T>
@@ -1303,25 +1310,33 @@ public class DerivedClass<T> : BaseClass<T>
         private static DiagnosticResult GetCA1036CSharpOperatorsResultAt(int line, int column, string typeName, string operators)
         {
             var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideMethodsOnComparableTypesMessageOperator, typeName, operators);
-            return GetCSharpResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, message);
+            return new DiagnosticResult(OverrideMethodsOnComparableTypesAnalyzer.RuleOperator)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetCA1036BasicOperatorsResultAt(int line, int column, string typeName, string operators)
         {
             var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideMethodsOnComparableTypesMessageOperator, typeName, operators);
-            return GetBasicResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, message);
+            return new DiagnosticResult(OverrideMethodsOnComparableTypesAnalyzer.RuleOperator)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetCA1036CSharpBothResultAt(int line, int column, string typeName, string operators)
         {
             var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideMethodsOnComparableTypesMessageBoth, typeName, operators);
-            return GetCSharpResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, message);
+            return new DiagnosticResult(OverrideMethodsOnComparableTypesAnalyzer.RuleBoth)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetCA1036BasicBothResultAt(int line, int column, string typeName, string operators)
         {
             var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideMethodsOnComparableTypesMessageBoth, typeName, operators);
-            return GetBasicResultAt(line, column, OverrideMethodsOnComparableTypesAnalyzer.RuleId, message);
+            return new DiagnosticResult(OverrideMethodsOnComparableTypesAnalyzer.RuleBoth)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
@@ -1,57 +1,63 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ParameterNamesShouldMatchBaseDeclarationAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ParameterNamesShouldMatchBaseDeclarationFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ParameterNamesShouldMatchBaseDeclarationAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ParameterNamesShouldMatchBaseDeclarationFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class ParameterNamesShouldMatchBaseDeclarationTests : DiagnosticAnalyzerTestBase
+    public class ParameterNamesShouldMatchBaseDeclarationTests
     {
         [Fact]
-        public void VerifyNoFalsePositivesAreReported()
+        public async Task VerifyNoFalsePositivesAreReported()
         {
-            VerifyCSharp(@"public class TestClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public class TestClass
                            {
                                public void TestMethod() { }
                            }");
 
-            VerifyCSharp(@"public class TestClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public class TestClass
                            {
                                public void TestMethod(string arg1, string arg2) { }
                            }");
 
-            VerifyCSharp(@"public class TestClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public class TestClass
                            {
                                public void TestMethod(string arg1, string arg2, __arglist) { }
                            }");
 
-            VerifyCSharp(@"public class TestClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public class TestClass
                            {
                                public void TestMethod(string arg1, string arg2, params string[] arg3) { }
                            }");
 
-            VerifyBasic(@"Public Class TestClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Class TestClass
                               Public Sub TestMethod()
                               End Sub
                           End Class");
 
-            VerifyBasic(@"Public Class TestClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Class TestClass
                               Public Sub TestMethod(arg1 As String, arg2 As String)
                               End Sub
                           End Class");
 
-            VerifyBasic(@"Public Class TestClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Class TestClass
                               Public Sub TestMethod(arg1 As String, arg2 As String, ParamArray arg3() As String)
                               End Sub
                           End Class");
         }
 
         [Fact]
-        public void VerifyOverrideWithWrongParameterNames()
+        public async Task VerifyOverrideWithWrongParameterNames()
         {
-            VerifyCSharp(@"public abstract class BaseClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public abstract class BaseClass
                            {
                                public abstract void TestMethod(string baseArg1, string baseArg2);
                            }
@@ -63,7 +69,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetCSharpResultAt(8, 71, "void TestClass.TestMethod(string arg1, string arg2)", "arg1", "baseArg1", "void BaseClass.TestMethod(string baseArg1, string baseArg2)"),
                          GetCSharpResultAt(8, 84, "void TestClass.TestMethod(string arg1, string arg2)", "arg2", "baseArg2", "void BaseClass.TestMethod(string baseArg1, string baseArg2)"));
 
-            VerifyCSharp(@"public abstract class BaseClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public abstract class BaseClass
                            {
                                public abstract void TestMethod(string baseArg1, string baseArg2, __arglist);
                            }
@@ -75,7 +81,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetCSharpResultAt(8, 71, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg1", "baseArg1", "void BaseClass.TestMethod(string baseArg1, string baseArg2, __arglist)"),
                          GetCSharpResultAt(8, 84, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg2", "baseArg2", "void BaseClass.TestMethod(string baseArg1, string baseArg2, __arglist)"));
 
-            VerifyCSharp(@"public abstract class BaseClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public abstract class BaseClass
                            {
                                public abstract void TestMethod(string baseArg1, string baseArg2, params string[] baseArg3);
                            }
@@ -88,11 +94,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetCSharpResultAt(8, 84, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg2", "baseArg2", "void BaseClass.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
                          GetCSharpResultAt(8, 106, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg3", "baseArg3", "void BaseClass.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"));
 
-            VerifyBasic(@"Public MustInherit Class BaseClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public MustInherit Class BaseClass
                               Public MustOverride Sub TestMethod(baseArg1 As String, baseArg2 As String)
                           End Class
 
-                          Public Class TestClass 
+                          Public Class TestClass
                               Inherits BaseClass
 
                               Public Overrides Sub TestMethod(arg1 As String, arg2 As String)
@@ -101,7 +107,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetBasicResultAt(8, 63, "Sub TestClass.TestMethod(arg1 As String, arg2 As String)", "arg1", "baseArg1", "Sub BaseClass.TestMethod(baseArg1 As String, baseArg2 As String)"),
                          GetBasicResultAt(8, 79, "Sub TestClass.TestMethod(arg1 As String, arg2 As String)", "arg2", "baseArg2", "Sub BaseClass.TestMethod(baseArg1 As String, baseArg2 As String)"));
 
-            VerifyBasic(@"Public MustInherit Class BaseClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public MustInherit Class BaseClass
                               Public MustOverride Sub TestMethod(baseArg1 As String, baseArg2 As String, ParamArray baseArg3 As String())
                           End Class
 
@@ -117,9 +123,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VerifyInternalOverrideWithWrongParameterNames_NoDiagnostic()
+        public async Task VerifyInternalOverrideWithWrongParameterNames_NoDiagnostic()
         {
-            VerifyCSharp(@"public abstract class BaseClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public abstract class BaseClass
                            {
                                internal abstract void TestMethod(string baseArg1, string baseArg2);
                            }
@@ -129,7 +135,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                internal override void TestMethod(string arg1, string arg2) { }
                            }");
 
-            VerifyCSharp(@"internal abstract class BaseClass
+            await VerifyCS.VerifyAnalyzerAsync(@"internal abstract class BaseClass
                            {
                                public abstract void TestMethod(string baseArg1, string baseArg2, __arglist);
                            }
@@ -139,7 +145,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                public override void TestMethod(string arg1, string arg2, __arglist) { }
                            }");
 
-            VerifyCSharp(@"internal class OuterClass
+            await VerifyCS.VerifyAnalyzerAsync(@"internal class OuterClass
                            {
                                public abstract class BaseClass
                                {
@@ -152,7 +158,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                }
                            }");
 
-            VerifyBasic(@"Friend MustInherit Class BaseClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Friend MustInherit Class BaseClass
                               Public MustOverride Sub TestMethod(baseArg1 As String, baseArg2 As String)
                           End Class
 
@@ -163,7 +169,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                               End Sub
                           End Class");
 
-            VerifyBasic(@"Public MustInherit Class BaseClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public MustInherit Class BaseClass
                               Friend MustOverride Sub TestMethod(baseArg1 As String, baseArg2 As String, ParamArray baseArg3 As String())
                           End Class
 
@@ -174,7 +180,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                               End Sub
                           End Class");
 
-            VerifyBasic(@"Friend Class OuterClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Friend Class OuterClass
                               Public MustInherit Class BaseClass
                                   Public MustOverride Sub TestMethod(baseArg1 As String, baseArg2 As String, ParamArray baseArg3 As String())
                               End Class
@@ -189,9 +195,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void VerifyInterfaceImplementationWithWrongParameterNames()
+        public async Task VerifyInterfaceImplementationWithWrongParameterNames()
         {
-            VerifyCSharp(@"public interface IBase
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface IBase
                            {
                                void TestMethod(string baseArg1, string baseArg2);
                            }
@@ -203,7 +209,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetCSharpResultAt(8, 62, "void TestClass.TestMethod(string arg1, string arg2)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2)"),
                          GetCSharpResultAt(8, 75, "void TestClass.TestMethod(string arg1, string arg2)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2)"));
 
-            VerifyCSharp(@"public interface IBase
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface IBase
                            {
                                void TestMethod(string baseArg1, string baseArg2, __arglist);
                            }
@@ -215,7 +221,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetCSharpResultAt(8, 62, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg1", "baseArg1", "void IBase.TestMethod(string baseArg1, string baseArg2, __arglist)"),
                          GetCSharpResultAt(8, 75, "void TestClass.TestMethod(string arg1, string arg2, __arglist)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2, __arglist)"));
 
-            VerifyCSharp(@"public interface IBase
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface IBase
                            {
                                void TestMethod(string baseArg1, string baseArg2, params string[] baseArg3);
                            }
@@ -228,7 +234,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetCSharpResultAt(8, 75, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg2", "baseArg2", "void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"),
                          GetCSharpResultAt(8, 97, "void TestClass.TestMethod(string arg1, string arg2, params string[] arg3)", "arg3", "baseArg3", "void IBase.TestMethod(string baseArg1, string baseArg2, params string[] baseArg3)"));
 
-            VerifyBasic(@"Public Interface IBase
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Interface IBase
                               Sub TestMethod(baseArg1 As String, baseArg2 As String)
                           End Interface
 
@@ -241,7 +247,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                         GetBasicResultAt(8, 53, "Sub TestClass.TestMethod(arg1 As String, arg2 As String)", "arg1", "baseArg1", "Sub IBase.TestMethod(baseArg1 As String, baseArg2 As String)"),
                         GetBasicResultAt(8, 69, "Sub TestClass.TestMethod(arg1 As String, arg2 As String)", "arg2", "baseArg2", "Sub IBase.TestMethod(baseArg1 As String, baseArg2 As String)"));
 
-            VerifyBasic(@"Public Interface IBase
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Interface IBase
                               Sub TestMethod(baseArg1 As String, baseArg2 As String, ParamArray baseArg3() As String)
                           End Interface
 
@@ -257,9 +263,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VerifyExplicitInterfaceImplementationWithWrongParameterNames_NoDiagnostic()
+        public async Task VerifyExplicitInterfaceImplementationWithWrongParameterNames_NoDiagnostic()
         {
-            VerifyCSharp(@"public interface IBase
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface IBase
                            {
                                void TestMethod(string baseArg1, string baseArg2);
                            }
@@ -269,7 +275,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                void IBase.TestMethod(string arg1, string arg2) { }
                            }");
 
-            VerifyCSharp(@"public interface IBase
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface IBase
                            {
                                void TestMethod(string baseArg1, string baseArg2, __arglist);
                            }
@@ -279,7 +285,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                void IBase.TestMethod(string arg1, string arg2, __arglist) { }
                            }");
 
-            VerifyCSharp(@"public interface IBase
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface IBase
                            {
                                void TestMethod(string baseArg1, string baseArg2, params string[] baseArg3);
                            }
@@ -291,9 +297,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void VerifyInterfaceImplementationWithDifferentMethodName()
+        public async Task VerifyInterfaceImplementationWithDifferentMethodName()
         {
-            VerifyBasic(@"Public Interface IBase
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Interface IBase
                               Sub TestMethod(baseArg1 As String, baseArg2 As String)
                           End Interface
 
@@ -306,7 +312,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                         GetBasicResultAt(8, 60, "Sub TestClass.AnotherTestMethod(arg1 As String, arg2 As String)", "arg1", "baseArg1", "Sub IBase.TestMethod(baseArg1 As String, baseArg2 As String)"),
                         GetBasicResultAt(8, 76, "Sub TestClass.AnotherTestMethod(arg1 As String, arg2 As String)", "arg2", "baseArg2", "Sub IBase.TestMethod(baseArg1 As String, baseArg2 As String)"));
 
-            VerifyBasic(@"Public Interface IBase
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Interface IBase
                               Sub TestMethod(baseArg1 As String, baseArg2 As String, ParamArray baseArg3 As String())
                           End Interface
 
@@ -322,23 +328,23 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void VerifyThatInvalidOverrideIsNotReported()
+        public async Task VerifyThatInvalidOverrideIsNotReported()
         {
-            VerifyCSharp(@"public class TestClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public class TestClass
                            {
                                public override void TestMethod(string arg1, string arg2) { }
-                           }", TestValidationMode.AllowCompileErrors);
+                           }", CompilerDiagnostics.None);
 
-            VerifyBasic(@"Public Class TestClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Class TestClass
                               Public Overrides Sub TestMethod(arg1 As String, arg2 As String)
                               End Sub
-                          End Class", TestValidationMode.AllowCompileErrors);
+                          End Class", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void VerifyOverrideWithInheritanceChain()
+        public async Task VerifyOverrideWithInheritanceChain()
         {
-            VerifyCSharp(@"public abstract class BaseClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public abstract class BaseClass
                            {
                                public abstract void TestMethod(string baseArg1, string baseArg2);
                            }
@@ -354,7 +360,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetCSharpResultAt(12, 71, "void TestClass.TestMethod(string arg1, string arg2)", "arg1", "baseArg1", "void BaseClass.TestMethod(string baseArg1, string baseArg2)"),
                          GetCSharpResultAt(12, 84, "void TestClass.TestMethod(string arg1, string arg2)", "arg2", "baseArg2", "void BaseClass.TestMethod(string baseArg1, string baseArg2)"));
 
-            VerifyBasic(@"Public MustInherit Class BaseClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public MustInherit Class BaseClass
                               Public MustOverride Sub TestMethod(baseArg1 As String, baseArg2 As String)
                           End Class
 
@@ -373,9 +379,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void VerifyNewOverrideWithInheritance()
+        public async Task VerifyNewOverrideWithInheritance()
         {
-            VerifyCSharp(@"public class BaseClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public class BaseClass
                            {
                                public void TestMethod(string baseArg1, string baseArg2) { }
                            }
@@ -385,7 +391,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                public new void TestMethod(string arg1, string arg2) { }
                            }");
 
-            VerifyBasic(@"Public Class BaseClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Class BaseClass
                               Public Sub TestMethod(baseArg1 As String, baseArg2 As String)
                               End Sub
                           End Class
@@ -399,9 +405,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void VerifyBaseClassNameHasPriority()
+        public async Task VerifyBaseClassNameHasPriority()
         {
-            VerifyCSharp(@"public abstract class BaseClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public abstract class BaseClass
                            {
                                public abstract void TestMethod(string arg1, string arg2);
                            }
@@ -416,7 +422,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                public override void TestMethod(string arg1, string arg2) { }
                            }");
 
-            VerifyCSharp(@"public abstract class BaseClass
+            await VerifyCS.VerifyAnalyzerAsync(@"public abstract class BaseClass
                            {
                                public abstract void TestMethod(string arg1, string arg2);
                            }
@@ -433,7 +439,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                          GetCSharpResultAt(13, 71, "void TestClass.TestMethod(string interfaceArg1, string interfaceArg2)", "interfaceArg1", "arg1", "void BaseClass.TestMethod(string arg1, string arg2)"),
                          GetCSharpResultAt(13, 93, "void TestClass.TestMethod(string interfaceArg1, string interfaceArg2)", "interfaceArg2", "arg2", "void BaseClass.TestMethod(string arg1, string arg2)"));
 
-            VerifyBasic(@"Public MustInherit Class BaseClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public MustInherit Class BaseClass
                               Public MustOverride Sub TestMethod(arg1 As String, arg2 As String)
                           End Class
 
@@ -449,7 +455,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                               End Sub
                           End Class");
 
-            VerifyBasic(@"Public MustInherit Class BaseClass
+            await VerifyVB.VerifyAnalyzerAsync(@"Public MustInherit Class BaseClass
                               Public MustOverride Sub TestMethod(arg1 As String, arg2 As String)
                           End Class
 
@@ -469,9 +475,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void VerifyMultipleClashingInterfacesWithFullMatch()
+        public async Task VerifyMultipleClashingInterfacesWithFullMatch()
         {
-            VerifyCSharp(@"public interface ITest1
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface ITest1
                            {
                                void TestMethod(string arg1, string arg2);
                            }
@@ -486,7 +492,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                public void TestMethod(string arg1, string arg2) { }
                            }");
 
-            VerifyBasic(@"Public Interface ITest1
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Interface ITest1
                               Sub TestMethod(arg1 As String, arg2 As String)
                           End Interface
 
@@ -503,9 +509,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void VerifyMultipleClashingInterfacesWithPartialMatch()
+        public async Task VerifyMultipleClashingInterfacesWithPartialMatch()
         {
-            VerifyCSharp(@"public interface ITest1
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface ITest1
                            {
                                void TestMethod(string arg1, string arg2, string arg3);
                            }
@@ -521,7 +527,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                            }",
                          GetCSharpResultAt(13, 88, "void TestClass.TestMethod(string arg1, string arg2, string otherArg3)", "otherArg3", "arg3", "void ITest1.TestMethod(string arg1, string arg2, string arg3)"));
 
-            VerifyBasic(@"Public Interface ITest1
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Interface ITest1
                               Sub TestMethod(arg1 As String, arg2 As String, arg3 As String)
                           End Interface
 
@@ -539,9 +545,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void VerifyIgnoresPropertiesWithTheSameName()
+        public async Task VerifyIgnoresPropertiesWithTheSameName()
         {
-            VerifyCSharp(@"public interface ITest1
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface ITest1
                            {
                                void TestMethod(string arg1, string arg2);
                            }
@@ -557,7 +563,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                int ITest2.TestMethod { get; set; }
                            }");
 
-            VerifyBasic(@"Public Interface ITest1
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Interface ITest1
                               Sub TestMethod(arg1 As String, arg2 As String)
                           End Interface
 
@@ -576,9 +582,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void VerifyHandlesMultipleBaseMethodsWithTheSameName()
+        public async Task VerifyHandlesMultipleBaseMethodsWithTheSameName()
         {
-            VerifyCSharp(@"public interface ITest
+            await VerifyCS.VerifyAnalyzerAsync(@"public interface ITest
                            {
                                void TestMethod(string arg1);
                                void TestMethod(string arg1, string arg2);
@@ -590,7 +596,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                public void TestMethod(string arg1, string arg2) { }
                            }");
 
-            VerifyBasic(@"Public Interface ITest
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Interface ITest
                               Sub TestMethod(arg1 As String)
                               Sub TestMethod(arg1 As String, arg2 As String)
                           End Interface
@@ -607,23 +613,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, string violatingMember, string violatingParameter, string baseParameter, string baseMember)
-        {
-            return GetCSharpResultAt(line, column, ParameterNamesShouldMatchBaseDeclarationAnalyzer.Rule, violatingMember, violatingParameter, baseParameter, baseMember);
-        }
+            => new DiagnosticResult(ParameterNamesShouldMatchBaseDeclarationAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(violatingMember, violatingParameter, baseParameter, baseMember);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, string violatingMember, string violatingParameter, string baseParameter, string baseMember)
-        {
-            return GetBasicResultAt(line, column, ParameterNamesShouldMatchBaseDeclarationAnalyzer.Rule, violatingMember, violatingParameter, baseParameter, baseMember);
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new ParameterNamesShouldMatchBaseDeclarationAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new ParameterNamesShouldMatchBaseDeclarationAnalyzer();
-        }
+            => new DiagnosticResult(ParameterNamesShouldMatchBaseDeclarationAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(violatingMember, violatingParameter, baseParameter, baseMember);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStringsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStringsTests.cs
@@ -1,30 +1,24 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpPassSystemUriObjectsInsteadOfStringsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicPassSystemUriObjectsInsteadOfStringsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class PassSystemUriObjectsInsteadOfStringsTests : DiagnosticAnalyzerTestBase
+    public class PassSystemUriObjectsInsteadOfStringsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicPassSystemUriObjectsInsteadOfStringsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpPassSystemUriObjectsInsteadOfStringsAnalyzer();
-        }
-
         [Fact]
-        public void CA2234NoWarningWithUrl()
+        public async Task CA2234NoWarningWithUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -42,9 +36,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningWithUri()
+        public async Task CA2234NoWarningWithUri()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -62,9 +56,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningWithUrn()
+        public async Task CA2234NoWarningWithUrn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -82,9 +76,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningWithUriButNoString()
+        public async Task CA2234NoWarningWithUriButNoString()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -103,9 +97,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningWithStringButNoUri()
+        public async Task CA2234NoWarningWithStringButNoUri()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -123,9 +117,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningWithStringButNoUrl()
+        public async Task CA2234NoWarningWithStringButNoUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -143,9 +137,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningWithStringButNoUrn()
+        public async Task CA2234NoWarningWithStringButNoUrn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -163,9 +157,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234WarningWithUri()
+        public async Task CA2234WarningWithUri()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -184,9 +178,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234WarningWithUrl()
+        public async Task CA2234WarningWithUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -205,9 +199,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234WarningWithUrn()
+        public async Task CA2234WarningWithUrn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -226,9 +220,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234WarningWithCompoundUri()
+        public async Task CA2234WarningWithCompoundUri()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -247,9 +241,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningWithSubstring()
+        public async Task CA2234NoWarningWithSubstring()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -268,9 +262,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234WarningWithMultipleParameter1()
+        public async Task CA2234WarningWithMultipleParameter1()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -289,9 +283,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234WarningWithMultipleParameter2()
+        public async Task CA2234WarningWithMultipleParameter2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -310,9 +304,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningForSelf()
+        public async Task CA2234NoWarningForSelf()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -330,9 +324,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningForSelf2()
+        public async Task CA2234NoWarningForSelf2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -351,9 +345,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234WarningWithMultipleUri()
+        public async Task CA2234WarningWithMultipleUri()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -372,9 +366,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234WarningWithMultipleOverload()
+        public async Task CA2234WarningWithMultipleOverload()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -396,9 +390,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningSignatureMismatchingNumberOfParameter()
+        public async Task CA2234NoWarningSignatureMismatchingNumberOfParameter()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -417,9 +411,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningSignatureMismatchingParameterType()
+        public async Task CA2234NoWarningSignatureMismatchingParameterType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -438,9 +432,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234NoWarningNotPublic()
+        public async Task CA2234NoWarningNotPublic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     internal class A : IComparable
@@ -459,11 +453,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2234WarningVB()
+        public async Task CA2234WarningVB()
         {
             // since VB and C# shares almost all code except to get method overload group expression
             // we only need to test that part
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Imports System
     
     Public Module A
@@ -481,9 +475,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(2688, "https://github.com/dotnet/roslyn-analyzers/issues/2688")]
-        public void CA2234NoWarningInvocationInUriOverload()
+        public async Task CA2234NoWarningInvocationInUriOverload()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : IComparable
@@ -497,13 +491,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCA2234CSharpResultAt(int line, int column, params string[] args)
-        {
-            return GetCSharpResultAt(line, column, PassSystemUriObjectsInsteadOfStringsAnalyzer.Rule, args);
-        }
+            => new DiagnosticResult(PassSystemUriObjectsInsteadOfStringsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(args);
 
         private static DiagnosticResult GetCA2234BasicResultAt(int line, int column, params string[] args)
-        {
-            return GetBasicResultAt(line, column, PassSystemUriObjectsInsteadOfStringsAnalyzer.Rule, args);
-        }
+            => new DiagnosticResult(PassSystemUriObjectsInsteadOfStringsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(args);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnlyTests.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.PropertiesShouldNotBeWriteOnlyAnalyzer,
@@ -14,21 +13,11 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class PropertiesShouldNotBeWriteOnlyTests : DiagnosticAnalyzerTestBase
+    public class PropertiesShouldNotBeWriteOnlyTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new PropertiesShouldNotBeWriteOnlyAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new PropertiesShouldNotBeWriteOnlyAnalyzer();
-        }
-
         // Valid C# Tests that should not be flagged based on CA1044 (good tests)
         [Fact]
-        public void CS_CA1044Good_Read_Write()
+        public async Task CS_CA1044Good_Read_Write()
         {
             var code = @"
 using System;
@@ -44,11 +33,11 @@ namespace CS_DesignLibrary
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Good_Read_Write1()
+        public async Task CS_CA1044Good_Read_Write1()
         {
             var code = @"
 using System;
@@ -64,11 +53,11 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests1
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Good_public_Read_private_Write()
+        public async Task CS_CA1044Good_public_Read_private_Write()
         {
             var code = @"
 using System;
@@ -84,11 +73,11 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests2
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Good_protected_Read_private_Write()
+        public async Task CS_CA1044Good_protected_Read_private_Write()
         {
             var code = @"
 using System;
@@ -104,11 +93,11 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests3
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Good_internal_Read_private_Write()
+        public async Task CS_CA1044Good_internal_Read_private_Write()
         {
             var code = @"
 using System;
@@ -124,11 +113,11 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests4
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Good_protected_internal_Read_internal_Write()
+        public async Task CS_CA1044Good_protected_internal_Read_internal_Write()
         {
             var code = @"
 using System;
@@ -144,11 +133,11 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests5
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Good_public_Read_internal_Write()
+        public async Task CS_CA1044Good_public_Read_internal_Write()
         {
             var code = @"
 using System;
@@ -164,11 +153,11 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests6
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Good_public_Read_protected_Write()
+        public async Task CS_CA1044Good_public_Read_protected_Write()
         {
             var code = @"
 using System;
@@ -184,11 +173,11 @@ namespace CS__GoodPropertiesShouldNotBeWriteOnlyTests7
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Good_public_override_Write()
+        public async Task CS_CA1044Good_public_override_Write()
         {
             var code = @"
 using System;
@@ -207,11 +196,11 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests8
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Interface()
+        public async Task CS_CA1044Interface()
         {
             var code = @"
 using System;
@@ -233,11 +222,11 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests9
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CS_CA1044Base_Write()
+        public async Task CS_CA1044Base_Write()
         {
             var code = @"
 using System;
@@ -259,12 +248,12 @@ namespace CS_GoodPropertiesShouldNotBeWriteOnlyTests10
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         // Valid VB Tests that should not be flagged based on CA1044 (good tests)
         [Fact]
-        public void VB_CA1044Good_Read_Write()
+        public async Task VB_CA1044Good_Read_Write()
         {
             var code = @"
 Imports System
@@ -282,11 +271,11 @@ Namespace VB_DesignLibrary
     End Class
 End Namespace
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void VB_CA1044Good_Read_Write1()
+        public async Task VB_CA1044Good_Read_Write1()
         {
             var code = @"
 Imports System
@@ -304,11 +293,11 @@ Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests1
     End Class
 End Namespace
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void VB_CA1044Good_public_Read_private_Write()
+        public async Task VB_CA1044Good_public_Read_private_Write()
         {
             var code = @"
 Imports System
@@ -326,11 +315,11 @@ Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests2
     End Class
 End NameSpace
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void VB_CA1044Good_protected_Read_private_Write()
+        public async Task VB_CA1044Good_protected_Read_private_Write()
         {
             var code = @"
 Imports System
@@ -348,11 +337,11 @@ Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests3
     End Class
 End NameSpace
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void VB_CA1044Good_internal_Read_private_Write()
+        public async Task VB_CA1044Good_internal_Read_private_Write()
         {
             var code = @"
 Imports System
@@ -370,11 +359,11 @@ Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests4
     End Class
 End NameSpace
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void VB_CA1044Good_protected_internal_Read_internal_Write()
+        public async Task VB_CA1044Good_protected_internal_Read_internal_Write()
         {
             var code = @"
 Imports System
@@ -392,11 +381,11 @@ Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests5
     End Class
 End NameSpace
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void VB_CA1044Good_public_Read_internal_Write()
+        public async Task VB_CA1044Good_public_Read_internal_Write()
         {
             var code = @"
 Imports System
@@ -414,11 +403,11 @@ Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests6
     End Class
 End NameSpace
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void VB_CA1044Good_public_Read_protected_Write()
+        public async Task VB_CA1044Good_public_Read_protected_Write()
         {
             var code = @"
 Imports System
@@ -436,12 +425,12 @@ Namespace VB_GoodPropertiesShouldNotBeWriteOnlyTests7
     End Class
 End NameSpace
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         // C# Tests that should be flagged with CA1044 Addgetter
         [Fact]
-        public void CS_CA1044Bad_Write_with_NoRead()
+        public async Task CS_CA1044Bad_Write_with_NoRead()
         {
             var code = @"
 using System;
@@ -456,11 +445,11 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 23, CA1044MessageAddGetter, "CS_WriteOnlyProperty"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(8, 23, CA1044MessageAddGetter, "CS_WriteOnlyProperty"));
         }
 
         [Fact]
-        public void CS_CA1044Bad_Write_with_NoRead1()
+        public async Task CS_CA1044Bad_Write_with_NoRead1()
         {
             var code = @"
 using System;
@@ -475,11 +464,11 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests1
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 23, CA1044MessageAddGetter, "CS_WriteOnlyProperty1"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(8, 23, CA1044MessageAddGetter, "CS_WriteOnlyProperty1"));
         }
 
         [Fact]
-        public void CS_CA1044Bad_Write_with_NoRead2()
+        public async Task CS_CA1044Bad_Write_with_NoRead2()
         {
             var code = @"
 using System;
@@ -494,11 +483,11 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests2
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 26, CA1044MessageAddGetter, "CS_WriteOnlyProperty2"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(8, 26, CA1044MessageAddGetter, "CS_WriteOnlyProperty2"));
         }
 
         [Fact]
-        public void CS_CA1044Bad_Write_with_NoRead3()
+        public async Task CS_CA1044Bad_Write_with_NoRead3()
         {
             var code = @"
 using System;
@@ -513,11 +502,11 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests3
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 26, CA1044MessageAddGetter, "CS_WriteOnlyProperty3"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(8, 26, CA1044MessageAddGetter, "CS_WriteOnlyProperty3"));
         }
 
         [Fact]
-        public void CS_CA1044Bad_Write_with_NoRead4()
+        public async Task CS_CA1044Bad_Write_with_NoRead4()
         {
             var code = @"
 using System;
@@ -532,11 +521,11 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests4
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 35, CA1044MessageAddGetter, "CS_WriteOnlyProperty4"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(8, 35, CA1044MessageAddGetter, "CS_WriteOnlyProperty4"));
         }
 
         [Fact]
-        public void CS_CA1044bad_Base_Write()
+        public async Task CS_CA1044bad_Base_Write()
         {
             var code = @"
 using System;
@@ -550,11 +539,11 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests5
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(7, 31, CA1044MessageAddGetter, "CS_BaseProperty5"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(7, 31, CA1044MessageAddGetter, "CS_BaseProperty5"));
         }
 
         [Fact]
-        public void CS_CA1044bad_Interface_Write()
+        public async Task CS_CA1044bad_Interface_Write()
         {
             var code = @"
 using System;
@@ -568,12 +557,12 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests6
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(7, 16, CA1044MessageAddGetter, "CS_InterfaceProperty6"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(7, 16, CA1044MessageAddGetter, "CS_InterfaceProperty6"));
         }
 
         // C# Tests that should be flagged with CA1044 MakeMoreAccessible
         [Fact]
-        public void CS_CA1044Bad_InaccessibleRead()
+        public async Task CS_CA1044Bad_InaccessibleRead()
         {
             var code = @"
 using System;
@@ -589,11 +578,11 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 24, CA1044MessageMakeMoreAccessible, "CS_InaccessibleProperty"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(8, 24, CA1044MessageMakeMoreAccessible, "CS_InaccessibleProperty"));
         }
 
         [Fact]
-        public void CS_CA1044Bad_InaccessibleRead1()
+        public async Task CS_CA1044Bad_InaccessibleRead1()
         {
             var code = @"
 using System;
@@ -609,11 +598,11 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests1
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 26, CA1044MessageMakeMoreAccessible, "CS_InaccessibleProperty1"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(8, 26, CA1044MessageMakeMoreAccessible, "CS_InaccessibleProperty1"));
         }
 
         [Fact]
-        public void CS_CA1044Bad_InaccessibleRead2()
+        public async Task CS_CA1044Bad_InaccessibleRead2()
         {
             var code = @"
 using System;
@@ -629,12 +618,12 @@ namespace CS_BadPropertiesShouldNotBeWriteOnlyTests2
         }
     }
 }";
-            VerifyCSharp(code, GetCA1044CSharpResultAt(8, 35, CA1044MessageMakeMoreAccessible, "CS_InaccessibleProperty2"));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCA1044CSharpResultAt(8, 35, CA1044MessageMakeMoreAccessible, "CS_InaccessibleProperty2"));
         }
 
         // VB Tests that should be flagged with CA1044 Addgetter
         [Fact]
-        public void VB_CA1044Bad_Write_with_NoRead()
+        public async Task VB_CA1044Bad_Write_with_NoRead()
         {
             var code = @"
 Imports System
@@ -649,11 +638,11 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 35, CA1044MessageAddGetter, "VB_WriteOnlyProperty"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 35, CA1044MessageAddGetter, "VB_WriteOnlyProperty"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_Write_with_NoRead1()
+        public async Task VB_CA1044Bad_Write_with_NoRead1()
         {
             var code = @"
 Imports System
@@ -668,11 +657,11 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests1
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 38, CA1044MessageAddGetter, "VB_WriteOnlyProperty1"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 38, CA1044MessageAddGetter, "VB_WriteOnlyProperty1"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_Write_with_NoRead2()
+        public async Task VB_CA1044Bad_Write_with_NoRead2()
         {
             var code = @"
 Imports System
@@ -687,11 +676,11 @@ Public Class VB_BadClassWithWriteOnlyProperty
    End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 35, CA1044MessageAddGetter, "VB_WriteOnlyProperty2"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 35, CA1044MessageAddGetter, "VB_WriteOnlyProperty2"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_Write_with_NoRead3()
+        public async Task VB_CA1044Bad_Write_with_NoRead3()
         {
             var code = @"
 Imports System
@@ -706,11 +695,11 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests3
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 45, CA1044MessageAddGetter, "VB_WriteOnlyProperty3"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 45, CA1044MessageAddGetter, "VB_WriteOnlyProperty3"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_Write_with_NoRead4()
+        public async Task VB_CA1044Bad_Write_with_NoRead4()
         {
             var code = @"
 Imports System
@@ -725,11 +714,11 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests4
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 35, CA1044MessageAddGetter, "VB_WriteOnlyProperty4"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 35, CA1044MessageAddGetter, "VB_WriteOnlyProperty4"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_Write_with_NoRead5()
+        public async Task VB_CA1044Bad_Write_with_NoRead5()
         {
             var code = @"
 Imports System
@@ -744,10 +733,10 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests5
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 35, CA1044MessageAddGetter, "VB_WriteOnlyProperty5"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 35, CA1044MessageAddGetter, "VB_WriteOnlyProperty5"));
         }
         [Fact]
-        public void VB_CA1044Bad_Interface_Write()
+        public async Task VB_CA1044Bad_Interface_Write()
         {
             var code = @"
 Imports System
@@ -764,11 +753,11 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(5, 28, CA1044MessageAddGetter, "InterfaceProperty"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(5, 28, CA1044MessageAddGetter, "InterfaceProperty"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_Interface_Write1()
+        public async Task VB_CA1044Bad_Interface_Write1()
         {
             var code = @"
 Imports System
@@ -778,11 +767,11 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests1
     End Interface
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(5, 28, CA1044MessageAddGetter, "VB_InterfaceProperty1"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(5, 28, CA1044MessageAddGetter, "VB_InterfaceProperty1"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_Write_with_NoRead6()
+        public async Task VB_CA1044Bad_Write_with_NoRead6()
         {
             var code = @"
 Imports System
@@ -799,10 +788,10 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests5
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(5, 28, CA1044MessageAddGetter, "InterfaceProperty"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(5, 28, CA1044MessageAddGetter, "InterfaceProperty"));
         }
         [Fact]
-        public void VB_CA1044Bad_Base_Write()
+        public async Task VB_CA1044Bad_Base_Write()
         {
             var code = @"
 Imports System
@@ -815,12 +804,12 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(5, 47, CA1044MessageAddGetter, "VB_BaseProperty"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(5, 47, CA1044MessageAddGetter, "VB_BaseProperty"));
         }
 
         // VB Tests that should be flagged with CA1044 MakeMoreAccessible
         [Fact]
-        public void VB_CA1044Bad_InaccessibleRead()
+        public async Task VB_CA1044Bad_InaccessibleRead()
         {
             var code = @"
 Imports System
@@ -838,11 +827,11 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 25, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 25, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_InaccessibleRead1()
+        public async Task VB_CA1044Bad_InaccessibleRead1()
         {
             var code = @"
 Imports System
@@ -860,11 +849,11 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests1
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 28, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty1"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 28, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty1"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_InaccessibleRead2()
+        public async Task VB_CA1044Bad_InaccessibleRead2()
         {
             var code = @"
 Imports System
@@ -882,11 +871,11 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests2
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 35, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty2"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 35, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty2"));
         }
 
         [Fact]
-        public void VB_CA1044Bad_InaccessibleRead3()
+        public async Task VB_CA1044Bad_InaccessibleRead3()
         {
             var code = @"
 Imports System
@@ -904,7 +893,7 @@ Namespace VB_BadPropertiesShouldNotBeWriteOnlyTests3
     End Class
 End NameSpace
 ";
-            VerifyBasic(code, GetCA1044BasicResultAt(6, 25, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty3"));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetCA1044BasicResultAt(6, 25, CA1044MessageMakeMoreAccessible, "VB_InaccessibleProperty3"));
         }
 
         private static readonly string CA1044MessageAddGetter = MicrosoftCodeQualityAnalyzersResources.PropertiesShouldNotBeWriteOnlyMessageAddGetter;
@@ -912,11 +901,21 @@ End NameSpace
 
         private static DiagnosticResult GetCA1044CSharpResultAt(int line, int column, string CA1044Message, string objectName)
         {
-            return GetCSharpResultAt(line, column, PropertiesShouldNotBeWriteOnlyAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, CA1044Message, objectName));
+            var rule = CA1044Message == CA1044MessageAddGetter
+                ? PropertiesShouldNotBeWriteOnlyAnalyzer.AddGetterRule
+                : PropertiesShouldNotBeWriteOnlyAnalyzer.MakeMoreAccessibleRule;
+            return new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1044Message, objectName));
         }
         private static DiagnosticResult GetCA1044BasicResultAt(int line, int column, string CA1044Message, string objectName)
         {
-            return GetBasicResultAt(line, column, PropertiesShouldNotBeWriteOnlyAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, CA1044Message, objectName));
+            var rule = CA1044Message == CA1044MessageAddGetter
+                ? PropertiesShouldNotBeWriteOnlyAnalyzer.AddGetterRule
+                : PropertiesShouldNotBeWriteOnlyAnalyzer.MakeMoreAccessibleRule;
+            return new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1044Message, objectName));
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotReturnArraysTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotReturnArraysTests.cs
@@ -1,30 +1,24 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.PropertiesShouldNotReturnArraysAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.PropertiesShouldNotReturnArraysAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class PropertiesShouldNotReturnArraysTests : DiagnosticAnalyzerTestBase
+    public class PropertiesShouldNotReturnArraysTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            //return new PropertiesShouldNotReturnArraysAnalyzer();
-            return new PropertiesShouldNotReturnArraysAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new PropertiesShouldNotReturnArraysAnalyzer();
-        }
-
         [Fact]
-        public void TestCSharpPropertiesShouldNotReturnArraysWarning1()
+        public async Task TestCSharpPropertiesShouldNotReturnArraysWarning1()
         {
             //Verify return type is array, warning...
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     public class Book
     {
         private string[] _Pages;
@@ -37,10 +31,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void TestCSharpPropertiesShouldNotReturnArraysNoWarning1()
+        public async Task TestCSharpPropertiesShouldNotReturnArraysNoWarning1()
         {
             //Verify if property is override, then no warning...
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     public abstract class Base
     {
         public virtual string[] Pages { get; }
@@ -57,10 +51,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void TestCSharpPropertiesShouldNotReturnArraysNoWarning2()
+        public async Task TestCSharpPropertiesShouldNotReturnArraysNoWarning2()
         {
             //No warning if property definition has no outside visibility
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Outer
 {
     private class Book
@@ -75,10 +69,10 @@ public class Outer
         }
 
         [Fact]
-        public void TestCSharpPropertiesShouldNotReturnArraysNoWarning3()
+        public async Task TestCSharpPropertiesShouldNotReturnArraysNoWarning3()
         {
             //Attributes can contain properties that return arrays
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     public class Book : System.Attribute
     {
         public string[] Pages 
@@ -90,10 +84,10 @@ public class Outer
         }
 
         [Fact]
-        public void TestBasicPropertiesShouldNotReturnArraysWarning1()
+        public async Task TestBasicPropertiesShouldNotReturnArraysWarning1()
         {
             //Display warning for property return type is Array
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Public Class Book
         Private _Pages As String()
         Public ReadOnly Property Pages() As String()
@@ -105,10 +99,10 @@ public class Outer
         }
 
         [Fact]
-        public void TestBasicPropertiesShouldNotReturnArraysNoWarning1()
+        public async Task TestBasicPropertiesShouldNotReturnArraysNoWarning1()
         {
             //No warning if property definition is override
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Public MustInherit Class Base
         Public Overridable ReadOnly Property Pages() As String()
     End Class
@@ -128,10 +122,10 @@ public class Outer
         }
 
         [Fact]
-        public void TestBasicPropertiesShouldNotReturnArraysWarning2()
+        public async Task TestBasicPropertiesShouldNotReturnArraysWarning2()
         {
             //No warning if property has no outside visibility
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Outer
     Private Class Book
         Private _Pages As String()
@@ -145,13 +139,13 @@ End Class");
         }
 
         private static DiagnosticResult CreateCSharpResult(int line, int col)
-        {
-            return GetCSharpResultAt(line, col, PropertiesShouldNotReturnArraysAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.PropertiesShouldNotReturnArraysMessage);
-        }
+            => new DiagnosticResult(PropertiesShouldNotReturnArraysAnalyzer.Rule)
+                .WithLocation(line, col)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.PropertiesShouldNotReturnArraysMessage);
 
         private static DiagnosticResult CreateBasicResult(int line, int col)
-        {
-            return GetBasicResultAt(line, col, PropertiesShouldNotReturnArraysAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.PropertiesShouldNotReturnArraysMessage);
-        }
+            => new DiagnosticResult(PropertiesShouldNotReturnArraysAnalyzer.Rule)
+                .WithLocation(line, col)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.PropertiesShouldNotReturnArraysMessage);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -14,7 +14,7 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class PropertyNamesShouldNotMatchGetMethodsTests : DiagnosticAnalyzerTestBase
+    public class PropertyNamesShouldNotMatchGetMethodsTests
     {
         private const string CSharpTestTemplate = @"
 using System;
@@ -74,20 +74,10 @@ Friend Class OuterClass
 End Class
 ";
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new PropertyNamesShouldNotMatchGetMethodsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new PropertyNamesShouldNotMatchGetMethodsAnalyzer();
-        }
-
         [Fact]
-        public void CSharp_CA1721_PropertyNameDoesNotMatchGetMethodName_Exposed_NoDiagnostic()
+        public async Task CSharp_CA1721_PropertyNameDoesNotMatchGetMethodName_Exposed_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class Test
@@ -110,9 +100,9 @@ public class Test
         [InlineData("protected internal", "public")]
         [InlineData("protected internal", "protected")]
         [InlineData("protected internal", "protected internal")]
-        public void CSharp_CA1721_PropertyNamesMatchGetMethodNames_Exposed_Diagnostics(string propertyAccessibility, string methodAccessibility)
+        public async Task CSharp_CA1721_PropertyNamesMatchGetMethodNames_Exposed_Diagnostics(string propertyAccessibility, string methodAccessibility)
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
                 string.Format(CultureInfo.InvariantCulture, CSharpTestTemplate, propertyAccessibility, methodAccessibility),
                 GetCA1721CSharpResultAt(
                     line: 6,
@@ -120,7 +110,7 @@ public class Test
                     identifierName: "Date",
                     otherIdentifierName: "GetDate"));
 
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
                 string.Format(CultureInfo.InvariantCulture, CSharpNotExternallyVisibleTestTemplate, propertyAccessibility, methodAccessibility));
         }
 
@@ -130,9 +120,9 @@ public class Test
         [InlineData("internal", "private")]
         [InlineData("internal", "internal")]
         [InlineData("", "")]
-        public void CSharp_CA1721_PropertyNamesMatchGetMethodNames_Unexposed_NoDiagnostics(string propertyAccessibility, string methodAccessibility)
+        public async Task CSharp_CA1721_PropertyNamesMatchGetMethodNames_Unexposed_NoDiagnostics(string propertyAccessibility, string methodAccessibility)
         {
-            VerifyCSharp(string.Format(CultureInfo.InvariantCulture, CSharpTestTemplate, propertyAccessibility, methodAccessibility));
+            await VerifyCS.VerifyAnalyzerAsync(string.Format(CultureInfo.InvariantCulture, CSharpTestTemplate, propertyAccessibility, methodAccessibility));
         }
 
         [Theory, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
@@ -154,15 +144,15 @@ public class Test
         [InlineData("", "public")]
         [InlineData("", "protected")]
         [InlineData("", "protected internal")]
-        public void CSharp_CA1721_PropertyNamesMatchGetMethodNames_MixedExposure_NoDiagnostics(string propertyAccessibility, string methodAccessibility)
+        public async Task CSharp_CA1721_PropertyNamesMatchGetMethodNames_MixedExposure_NoDiagnostics(string propertyAccessibility, string methodAccessibility)
         {
-            VerifyCSharp(string.Format(CultureInfo.InvariantCulture, CSharpTestTemplate, propertyAccessibility, methodAccessibility));
+            await VerifyCS.VerifyAnalyzerAsync(string.Format(CultureInfo.InvariantCulture, CSharpTestTemplate, propertyAccessibility, methodAccessibility));
         }
 
         [Fact]
-        public void CSharp_CA1721_PropertyNameMatchesBaseClassGetMethodName_Exposed_Diagnostic()
+        public async Task CSharp_CA1721_PropertyNameMatchesBaseClassGetMethodName_Exposed_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class Foo
@@ -185,9 +175,9 @@ public class Bar : Foo
 
 
         [Fact]
-        public void CSharp_CA1721_GetMethodNameMatchesBaseClassPropertyName_Exposed_Diagnostic()
+        public async Task CSharp_CA1721_GetMethodNameMatchesBaseClassPropertyName_Exposed_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class Foo
@@ -209,9 +199,9 @@ public class Bar : Foo
         }
 
         [Fact]
-        public void Basic_CA1721_PropertyNameDoesNotMatchGetMethodName_Exposed_NoDiagnostic()
+        public async Task Basic_CA1721_PropertyNameDoesNotMatchGetMethodName_Exposed_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class Test
@@ -236,9 +226,9 @@ End Class");
         [InlineData("Protected Friend", "Public")]
         [InlineData("Protected Friend", "Protected")]
         [InlineData("Protected Friend", "Protected Friend")]
-        public void Basic_CA1721_PropertyNamesMatchGetMethodNames_Exposed_Diagnostics(string propertyAccessibility, string methodAccessibility)
+        public async Task Basic_CA1721_PropertyNamesMatchGetMethodNames_Exposed_Diagnostics(string propertyAccessibility, string methodAccessibility)
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
                 string.Format(CultureInfo.InvariantCulture, BasicTestTemplate, propertyAccessibility, methodAccessibility),
                 GetCA1721BasicResultAt(
                     line: 5,
@@ -246,7 +236,7 @@ End Class");
                     identifierName: "Date",
                     otherIdentifierName: "GetDate"));
 
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
                 string.Format(CultureInfo.InvariantCulture, BasicNotExternallyVisibleTestTemplate, propertyAccessibility, methodAccessibility));
         }
 
@@ -255,9 +245,9 @@ End Class");
         [InlineData("Private", "Friend")]
         [InlineData("Friend", "Private")]
         [InlineData("Friend", "Friend")]
-        public void Basic_CA1721_PropertyNamesMatchGetMethodNames_Unexposed_NoDiagnostics(string propertyAccessibility, string methodAccessibility)
+        public async Task Basic_CA1721_PropertyNamesMatchGetMethodNames_Unexposed_NoDiagnostics(string propertyAccessibility, string methodAccessibility)
         {
-            VerifyBasic(string.Format(CultureInfo.InvariantCulture, BasicTestTemplate, propertyAccessibility, methodAccessibility));
+            await VerifyVB.VerifyAnalyzerAsync(string.Format(CultureInfo.InvariantCulture, BasicTestTemplate, propertyAccessibility, methodAccessibility));
         }
 
         [Theory]
@@ -273,15 +263,15 @@ End Class");
         [InlineData("Friend", "Public")]
         [InlineData("Friend", "Protected")]
         [InlineData("Friend", "Protected Friend")]
-        public void Basic_CA1721_PropertyNamesMatchGetMethodNames_MixedExposure_NoDiagnostics(string propertyAccessibility, string methodAccessibility)
+        public async Task Basic_CA1721_PropertyNamesMatchGetMethodNames_MixedExposure_NoDiagnostics(string propertyAccessibility, string methodAccessibility)
         {
-            VerifyBasic(string.Format(CultureInfo.InvariantCulture, BasicTestTemplate, propertyAccessibility, methodAccessibility));
+            await VerifyVB.VerifyAnalyzerAsync(string.Format(CultureInfo.InvariantCulture, BasicTestTemplate, propertyAccessibility, methodAccessibility));
         }
 
         [Fact]
-        public void Basic_CA1721_PropertyNameMatchesBaseClassGetMethodName_Exposed_Diagnostic()
+        public async Task Basic_CA1721_PropertyNameMatchesBaseClassGetMethodName_Exposed_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class Foo
@@ -303,9 +293,9 @@ End Class",
 
 
         [Fact]
-        public void Basic_CA1721_GetMethodNameMatchesBaseClassPropertyName_Exposed_Diagnostic()
+        public async Task Basic_CA1721_GetMethodNameMatchesBaseClassPropertyName_Exposed_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class Foo
@@ -325,16 +315,16 @@ End Class",
         }
 
         [Fact, WorkItem(1374, "https://github.com/dotnet/roslyn-analyzers/issues/1374")]
-        public void CA1721_TypePropertyNoDiagnostic()
+        public async Task CA1721_TypePropertyNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class T { }
 class C
 {
     public T Type { get; }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class T
 End Class
 Class C
@@ -343,9 +333,9 @@ End Class");
         }
 
         [Fact, WorkItem(2085, "https://github.com/dotnet/roslyn-analyzers/issues/2085")]
-        public void CA1721_StaticAndInstanceMismatchNoDiagnostic()
+        public async Task CA1721_StaticAndInstanceMismatchNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C1
 {
     public int Value { get; }
@@ -359,7 +349,7 @@ public class C2
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C1
     Public ReadOnly Property Value As Integer
 
@@ -378,9 +368,9 @@ End Class");
         }
 
         [Fact, WorkItem(2914, "https://github.com/dotnet/roslyn-analyzers/issues/2914")]
-        public void CA1721_OverrideNoDiagnosticButVirtualDiagnostic()
+        public async Task CA1721_OverrideNoDiagnosticButVirtualDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class BaseClass
 {
     public virtual int Value { get; }
@@ -405,7 +395,7 @@ public class C3 : BaseClass
 ",
             GetCA1721CSharpResultAt(line: 4, column: 24, identifierName: "Value", otherIdentifierName: "GetValue"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class BaseClass
     Public Overridable ReadOnly Property Value As Integer
 
@@ -450,9 +440,9 @@ End Class
         }
 
         [Fact, WorkItem(2914, "https://github.com/dotnet/roslyn-analyzers/issues/2914")]
-        public void CA1721_OverrideWithLocalMemberDiagnostic()
+        public async Task CA1721_OverrideWithLocalMemberDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class BaseClass1
 {
     public virtual int Value { get; }
@@ -478,7 +468,7 @@ public class C2 : BaseClass2
             GetCA1721CSharpResultAt(line: 10, column: 16, identifierName: "Value", otherIdentifierName: "GetValue"),
             GetCA1721CSharpResultAt(line: 20, column: 16, identifierName: "Value", otherIdentifierName: "GetValue"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class BaseClass1
     Public Overridable ReadOnly Property Value As Integer
 End Class
@@ -523,9 +513,9 @@ End Class
         }
 
         [Fact, WorkItem(2914, "https://github.com/dotnet/roslyn-analyzers/issues/2914")]
-        public void CA1721_OverrideMultiLevelDiagnostic()
+        public async Task CA1721_OverrideMultiLevelDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class MyBaseClass
 {
     public virtual int GetValue(int i) => i;
@@ -549,7 +539,7 @@ public class MySubClass : MyClass
             GetCA1721CSharpResultAt(line: 10, column: 24, identifierName: "Value", otherIdentifierName: "GetValue"),
             GetCA1721CSharpResultAt(line: 11, column: 24, identifierName: "Foo", otherIdentifierName: "GetFoo"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class MyBaseClass
     Public Overridable Function GetValue(ByVal i As Integer) As Integer
         Return i
@@ -602,14 +592,18 @@ End Class
         {
             // Add a public read-only property accessor for positional argument '{0}' of attribute '{1}'.
             string message = string.Format(CultureInfo.InvariantCulture, MicrosoftCodeQualityAnalyzersResources.PropertyNamesShouldNotMatchGetMethodsMessage, identifierName, otherIdentifierName);
-            return GetCSharpResultAt(line, column, PropertyNamesShouldNotMatchGetMethodsAnalyzer.RuleId, message);
+            return new DiagnosticResult(PropertyNamesShouldNotMatchGetMethodsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetCA1721BasicResultAt(int line, int column, string identifierName, string otherIdentifierName)
         {
             // Add a public read-only property accessor for positional argument '{0}' of attribute '{1}'.
             string message = string.Format(CultureInfo.InvariantCulture, MicrosoftCodeQualityAnalyzersResources.PropertyNamesShouldNotMatchGetMethodsMessage, identifierName, otherIdentifierName);
-            return GetBasicResultAt(line, column, PropertyNamesShouldNotMatchGetMethodsAnalyzer.RuleId, message);
+            return new DiagnosticResult(PropertyNamesShouldNotMatchGetMethodsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         #endregion

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
@@ -1,28 +1,24 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ProvideObsoleteAttributeMessageAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ProvideObsoleteAttributeMessageAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class ProvideObsoleteAttributeMessageTests : DiagnosticAnalyzerTestBase
+    public class ProvideObsoleteAttributeMessageTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new ProvideObsoleteAttributeMessageAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new ProvideObsoleteAttributeMessageAnalyzer();
-        }
-
         [Fact]
-        public void CSharpSimpleCases()
+        public async Task CSharpSimpleCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Obsolete]
@@ -55,9 +51,9 @@ public delegate void del(int x);
         }
 
         [Fact]
-        public void BasicSimpleCases()
+        public async Task BasicSimpleCases()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 <Obsolete>
@@ -92,9 +88,9 @@ Public Delegate Sub del(x As Integer)
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharpNoDiagnosticsForInternal()
+        public async Task CSharpNoDiagnosticsForInternal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Obsolete]
@@ -119,9 +115,9 @@ delegate void del(int x);
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void BasicNoDiagnosticsForInternal()
+        public async Task BasicNoDiagnosticsForInternal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 <Obsolete>
@@ -148,9 +144,9 @@ Delegate Sub del(x As Integer)
         }
 
         [Fact]
-        public void CSharpNoDiagnostics()
+        public async Task CSharpNoDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Obsolete(""message"")]
@@ -169,9 +165,9 @@ class A
         }
 
         [Fact]
-        public void BasicNoDiagnostics()
+        public async Task BasicNoDiagnostics()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 <Obsolete(""valid"")>
@@ -191,12 +187,13 @@ End Class
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
-        {
-            return GetCSharpResultAt(line, column, ProvideObsoleteAttributeMessageAnalyzer.Rule, symbolName);
-        }
+            => new DiagnosticResult(ProvideObsoleteAttributeMessageAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
+
         private DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
-        {
-            return GetBasicResultAt(line, column, ProvideObsoleteAttributeMessageAnalyzer.Rule, symbolName);
-        }
+            => new DiagnosticResult(ProvideObsoleteAttributeMessageAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -1,43 +1,39 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.StaticHolderTypesAnalyzer,
+    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpStaticHolderTypesFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.StaticHolderTypesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class StaticHolderTypeTests : DiagnosticAnalyzerTestBase
+    public class StaticHolderTypeTests
     {
         #region Verifiers
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new StaticHolderTypesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new StaticHolderTypesAnalyzer();
-        }
-
         private static DiagnosticResult CSharpResult(int line, int column, string objectName)
-        {
-            return GetCSharpResultAt(line, column, StaticHolderTypesAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.StaticHolderTypeIsNotStatic, objectName));
-        }
+            => new DiagnosticResult(StaticHolderTypesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.StaticHolderTypeIsNotStatic, objectName));
 
         private static DiagnosticResult BasicResult(int line, int column, string objectName)
-        {
-            return GetBasicResultAt(line, column, StaticHolderTypesAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.StaticHolderTypeIsNotStatic, objectName));
-        }
+            => new DiagnosticResult(StaticHolderTypesAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.StaticHolderTypeIsNotStatic, objectName));
 
         #endregion
 
         [Fact]
-        public void CA1052NoDiagnosticForEmptyNonStaticClassCSharp()
+        public async Task CA1052NoDiagnosticForEmptyNonStaticClassCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C1
 {
 }
@@ -45,9 +41,9 @@ public class C1
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForEmptyInheritableClassBasic()
+        public async Task CA1052NoDiagnosticForEmptyInheritableClassBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B1
 End Class
 ");
@@ -55,9 +51,9 @@ End Class
 
         [Fact]
 
-        public void CA1052NoDiagnosticForStaticClassWithOnlyStaticDeclaredMembersCSharp()
+        public async Task CA1052NoDiagnosticForStaticClassWithOnlyStaticDeclaredMembersCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public static class C2
 {
     public static void Foo() { }
@@ -66,9 +62,9 @@ public static class C2
         }
 
         [Fact, WorkItem(1320, "https://github.com/dotnet/roslyn-analyzers/issues/1320")]
-        public void CA1052NoDiagnosticForSealedClassWithOnlyStaticDeclaredMembersCSharp()
+        public async Task CA1052NoDiagnosticForSealedClassWithOnlyStaticDeclaredMembersCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public sealed class C3
 {
     public static void Foo() { }
@@ -77,9 +73,9 @@ public sealed class C3
         }
 
         [Fact, WorkItem(1320, "https://github.com/dotnet/roslyn-analyzers/issues/1320")]
-        public void CA1052NoDiagnosticForNonInheritableClassWithOnlySharedDeclaredMembersBasic()
+        public async Task CA1052NoDiagnosticForNonInheritableClassWithOnlySharedDeclaredMembersBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public NotInheritable Class B3
     Public Shared Sub Foo()
     End Sub
@@ -88,9 +84,9 @@ End Class
         }
 
         [Fact, WorkItem(1292, "https://github.com/dotnet/roslyn-analyzers/issues/1292")]
-        public void CA1052NoDiagnosticForSealedClassWithPublicConstructorAndStaticMembers()
+        public async Task CA1052NoDiagnosticForSealedClassWithPublicConstructorAndStaticMembers()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Threading;
 
 public sealed class ConcurrentCreationDummy
@@ -118,9 +114,9 @@ public sealed class ConcurrentCreationDummy
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersCSharp()
+        public async Task CA1052DiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C4
 {
     public static void Foo() { }
@@ -130,9 +126,9 @@ public class C4
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithOnlySharedDeclaredMembersBasic()
+        public async Task CA1052DiagnosticForNonStaticClassWithOnlySharedDeclaredMembersBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B4
     Public Shared Sub Foo()
     End Sub
@@ -142,9 +138,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithBothStaticAndInstanceDeclaredMembersCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithBothStaticAndInstanceDeclaredMembersCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C5
 {
     public void Moo() { }
@@ -154,9 +150,9 @@ public class C5
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithBothSharedAndInstanceDeclaredMembersBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithBothSharedAndInstanceDeclaredMembersBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B5
     Public Sub Moo()
     End Sub
@@ -168,9 +164,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForInternalClassWithOnlyStaticDeclaredMembersCSharp()
+        public async Task CA1052NoDiagnosticForInternalClassWithOnlyStaticDeclaredMembersCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class C6
 {
     public static void Foo() { }
@@ -179,9 +175,9 @@ internal class C6
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1052NoDiagnosticForEffectivelyInternalClassWithOnlyStaticDeclaredMembersCSharp()
+        public async Task CA1052NoDiagnosticForEffectivelyInternalClassWithOnlyStaticDeclaredMembersCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class C6
 {
     public class Inner
@@ -193,9 +189,9 @@ internal class C6
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForFriendClassWithOnlySharedDeclaredMembersBasic()
+        public async Task CA1052NoDiagnosticForFriendClassWithOnlySharedDeclaredMembersBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Class B6
     Public Shared Sub Foo()
     End Sub
@@ -204,9 +200,9 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1052NoDiagnosticForEffectivelyFriendClassWithOnlySharedDeclaredMembersBasic()
+        public async Task CA1052NoDiagnosticForEffectivelyFriendClassWithOnlySharedDeclaredMembersBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Class B6
     Public Class InnerClass
         Public Shared Sub Foo()
@@ -217,9 +213,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithUserDefinedOperatorCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithUserDefinedOperatorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C7
 {
     public static int operator +(C7 a, C7 b)
@@ -231,9 +227,9 @@ public class C7
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithUserDefinedOperatorBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithUserDefinedOperatorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B7
     Public Shared Operator +(a As B7, b As B7) As Integer
         Return 0
@@ -243,9 +239,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithStaticMethodAndUserDefinedOperatorCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithStaticMethodAndUserDefinedOperatorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C8
 {
     public static void Foo() { }
@@ -259,9 +255,9 @@ public class C8
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithSharedMethodAndUserDefinedOperatorBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithSharedMethodAndUserDefinedOperatorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B8
     Public Shared Sub Foo()
     End Sub
@@ -274,9 +270,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithPublicDefaultConstructorAndStaticMethodCSharp()
+        public async Task CA1052DiagnosticForNonStaticClassWithPublicDefaultConstructorAndStaticMethodCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C9
 {
     public C9() { }
@@ -288,9 +284,9 @@ public class C9
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithPublicDefaultConstructorAndSharedMethodBasic()
+        public async Task CA1052DiagnosticForNonStaticClassWithPublicDefaultConstructorAndSharedMethodBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B9
     Public Sub New()
     End Sub
@@ -303,9 +299,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithProtectedDefaultConstructorAndStaticMethodCSharp()
+        public async Task CA1052DiagnosticForNonStaticClassWithProtectedDefaultConstructorAndStaticMethodCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C10
 {
     protected C10() { }
@@ -317,9 +313,9 @@ public class C10
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithProtectedDefaultConstructorAndSharedMethodBasic()
+        public async Task CA1052DiagnosticForNonStaticClassWithProtectedDefaultConstructorAndSharedMethodBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B10
     Protected Sub New()
     End Sub
@@ -332,9 +328,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithPrivateDefaultConstructorAndStaticMethodCSharp()
+        public async Task CA1052DiagnosticForNonStaticClassWithPrivateDefaultConstructorAndStaticMethodCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C11
 {
     private C11() { }
@@ -346,9 +342,9 @@ public class C11
         }
 
         [Fact]
-        public void CA1052DiagnosticForNonStaticClassWithPrivateDefaultConstructorAndSharedMethodBasic()
+        public async Task CA1052DiagnosticForNonStaticClassWithPrivateDefaultConstructorAndSharedMethodBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B11
     Private Sub New()
     End Sub
@@ -361,9 +357,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithPublicNonDefaultConstructorAndStaticMethodCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithPublicNonDefaultConstructorAndStaticMethodCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C12
 {
     public C12(int i) { }
@@ -374,9 +370,9 @@ public class C12
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithPublicNonDefaultConstructorAndSharedMethodBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithPublicNonDefaultConstructorAndSharedMethodBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B12
     Public Sub New(i as Integer)
     End Sub
@@ -388,9 +384,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithPublicNonDefaultConstructorWithDefaultedParametersAndStaticMethodCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithPublicNonDefaultConstructorWithDefaultedParametersAndStaticMethodCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C13
 {
     public C13(int i = 0, string s = """") { }
@@ -401,9 +397,9 @@ public class C13
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithPublicNonDefaultConstructorWithOptionalParametersAndSharedMethodBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithPublicNonDefaultConstructorWithOptionalParametersAndSharedMethodBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B13
     Public Sub New(Optional i as Integer = 0, Optional s as String = """")
     End Sub
@@ -415,9 +411,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052DiagnosticForNestedPublicNonStaticClassWithPublicDefaultConstructorAndStaticMethodCSharp()
+        public async Task CA1052DiagnosticForNestedPublicNonStaticClassWithPublicDefaultConstructorAndStaticMethodCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C14
 {
     public void Moo() { }
@@ -433,9 +429,9 @@ public class C14
         }
 
         [Fact]
-        public void CA1052DiagnosticForNestedPublicNonStaticClassWithPublicDefaultConstructorAndSharedMethodBasic()
+        public async Task CA1052DiagnosticForNestedPublicNonStaticClassWithPublicDefaultConstructorAndSharedMethodBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B14
     Public Sub Moo()
     End Sub
@@ -453,9 +449,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForEmptyStaticClassCSharp()
+        public async Task CA1052NoDiagnosticForEmptyStaticClassCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public static class C15
 {
 }
@@ -463,9 +459,9 @@ public static class C15
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithStaticConstructorCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithStaticConstructorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C16
 {
     static C16() { }
@@ -474,9 +470,9 @@ public class C16
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithStaticConstructorBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithStaticConstructorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B16
     Shared Sub New()
     End Sub
@@ -485,9 +481,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForStaticClassWithStaticConstructorCSharp()
+        public async Task CA1052NoDiagnosticForStaticClassWithStaticConstructorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public static class C17
 {
     static C17() { }
@@ -496,9 +492,9 @@ public static class C17
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithStaticConstructorAndInstanceConstructorCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithStaticConstructorAndInstanceConstructorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C18
 {
     public C18() { }
@@ -508,9 +504,9 @@ public class C18
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithStaticConstructorAndInstanceConstructorBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithStaticConstructorAndInstanceConstructorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B18
     Sub New()
     End Sub
@@ -522,9 +518,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052DiagnosticForNestedPublicClassInOtherwiseEmptyNonStaticClassCSharp()
+        public async Task CA1052DiagnosticForNestedPublicClassInOtherwiseEmptyNonStaticClassCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C19
 {
     public class C19Inner
@@ -536,9 +532,9 @@ public class C19
         }
 
         [Fact]
-        public void CA1052DiagnosticForNestedPublicClassInOtherwiseEmptyNonStaticClassBasic()
+        public async Task CA1052DiagnosticForNestedPublicClassInOtherwiseEmptyNonStaticClassBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B19
     Public Class B19Inner
     End Class
@@ -548,9 +544,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticAnEnumCSharp()
+        public async Task CA1052NoDiagnosticAnEnumCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public enum E20
 {
     Unknown = 0
@@ -559,9 +555,9 @@ public enum E20
         }
 
         [Fact]
-        public void CA1052NoDiagnosticAnEnumBasic()
+        public async Task CA1052NoDiagnosticAnEnumBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Enum EB20
     Unknown = 0
 End Enum
@@ -569,9 +565,9 @@ End Enum
         }
 
         [Fact]
-        public void CA1052NoDiagnosticOnClassWithOnlyDefaultConstructorCSharp()
+        public async Task CA1052NoDiagnosticOnClassWithOnlyDefaultConstructorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C21
 {
     public C21() { }
@@ -580,9 +576,9 @@ public class C21
         }
 
         [Fact]
-        public void CA1052NoDiagnosticOnClassWithOnlyDefaultConstructorBasic()
+        public async Task CA1052NoDiagnosticOnClassWithOnlyDefaultConstructorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B21
     Public Sub New()
     End Sub
@@ -591,9 +587,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNestedPrivateNonStaticClassWithPublicDefaultConstructorAndStaticMethodCSharp()
+        public async Task CA1052NoDiagnosticForNestedPrivateNonStaticClassWithPublicDefaultConstructorAndStaticMethodCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C22
 {
     public void Moo() { }
@@ -608,9 +604,9 @@ public class C22
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNestedPrivateNonStaticClassWithPublicDefaultConstructorAndSharedMethodBasic()
+        public async Task CA1052NoDiagnosticForNestedPrivateNonStaticClassWithPublicDefaultConstructorAndSharedMethodBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B22
     Public Sub Moo()
     End Sub
@@ -627,9 +623,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndBaseClassCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndBaseClassCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C23Base
 {
 }
@@ -641,9 +637,9 @@ public class C23 : C23Base
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndBaseClassBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndBaseClassBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B23Base
 End Class
 Public Class B23
@@ -655,9 +651,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface IC24Base
 {
 }
@@ -669,9 +665,9 @@ public class C24 : IC24Base
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndEmptyBaseInterfaceBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface IB24Base
 End Interface
 Public Class B24
@@ -683,9 +679,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndNotEmptyBaseInterfaceCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndNotEmptyBaseInterfaceCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface IC25Base
 {
     void Moo();
@@ -699,9 +695,9 @@ public class C25 : IC25Base
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndNotEmptyBaseInterfaceBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndNotEmptyBaseInterfaceBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface IB25Base
     Sub Moo()
 End Interface
@@ -716,52 +712,52 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndIncompleteBaseClassDefinitionCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndIncompleteBaseClassDefinitionCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C26 :
 {
     public static void Foo() { }
 }
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndIncompleteBaseClassDefinitionBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyStaticDeclaredMembersAndIncompleteBaseClassDefinitionBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B26
 	Inherits
 	Public Shared Sub Foo()
 	End Sub
 End Class
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForEmptyNonStaticClassWithIncompleteBaseClassDefinitionCSharp()
+        public async Task CA1052NoDiagnosticForEmptyNonStaticClassWithIncompleteBaseClassDefinitionCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C27 :
 {
 }
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForEmptyNonStaticClassWithIncompleteBaseClassDefinitionBasic()
+        public async Task CA1052NoDiagnosticForEmptyNonStaticClassWithIncompleteBaseClassDefinitionBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B27
 	Inherits
 End Class
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyPrivateAndProtectedStaticMethodsCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyPrivateAndProtectedStaticMethodsCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C28
 {
     private static void Foo() {}
@@ -771,9 +767,9 @@ public class C28
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyPrivateAndProtectedStaticMethodsBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyPrivateAndProtectedStaticMethodsBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B28
 	Private Shared Sub Foo()
 	End Sub
@@ -784,9 +780,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyExplicitConversionOperatorsCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyExplicitConversionOperatorsCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C29
 {
     public static explicit operator C29(int foo) => new C29();
@@ -795,9 +791,9 @@ public class C29
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyImplicitConversionOperatorsCSharp()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyImplicitConversionOperatorsCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C29
 {
     public static implicit operator C29(int foo) => new C29();
@@ -806,9 +802,9 @@ public class C29
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForNonStaticClassWithOnlyExplicitConversionOperatorsBasic()
+        public async Task CA1052NoDiagnosticForNonStaticClassWithOnlyExplicitConversionOperatorsBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class B29
     Public Shared Widening Operator CType(ByVal foo As Integer) As B29
         Return New B29()
@@ -818,9 +814,9 @@ End Class
         }
 
         [Fact]
-        public void CA1052NoDiagnosticForAbstractNonStaticClassCSharp()
+        public async Task CA1052NoDiagnosticForAbstractNonStaticClassCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public abstract class C1
 {
     internal class C2 : C1 {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
@@ -84,14 +84,16 @@ internal class Outer2
         {
             await new VerifyCS.Test
             {
-                TestCode = @"
+                TestState =
+                {
+                    Sources =
+                    { @"
 public class Sdk
 {
 }
 ",
-                SolutionTransforms =
-                {
-                    (solution, projectId) => solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(Xunit.Sdk.AllException).Assembly.Location))
+                    },
+                    AdditionalReferences =  { MetadataReference.CreateFromFile(typeof(Xunit.Sdk.AllException).Assembly.Location) }
                 },
                 ExpectedDiagnostics =
                 {
@@ -280,12 +282,15 @@ End Class
         {
             await new VerifyVB.Test
             {
-                TestCode = @"
-Public Class Sdk
-End Class",
-                SolutionTransforms =
+                TestState =
                 {
-                    (solution, projectId) => solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(Xunit.Sdk.AllException).Assembly.Location))
+                    Sources =
+                    {
+                        @"
+Public Class Sdk
+End Class"
+                    },
+                    AdditionalReferences = { MetadataReference.CreateFromFile(typeof(Xunit.Sdk.AllException).Assembly.Location) }
                 },
                 ExpectedDiagnostics =
                 {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -1,18 +1,23 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines;
 using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.TypesThatOwnDisposableFieldsShouldBeDisposableFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.TypesThatOwnDisposableFieldsShouldBeDisposableFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public partial class TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzerTests : DiagnosticAnalyzerTestBase
+    public class TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzerTests : DiagnosticAnalyzerTestBase
     {
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
@@ -25,9 +30,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1001CSharpTestWithNoDisposableType()
+        public async Task CA1001CSharpTestWithNoDisposableType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     class Program
     {
         static void Main(string[] args)
@@ -38,9 +43,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1001CSharpTestWithNoCreationOfDisposableObject()
+        public async Task CA1001CSharpTestWithNoCreationOfDisposableObject()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 
     public class NoDisposeClass
@@ -51,9 +56,9 @@ using System.IO;
         }
 
         [Fact]
-        public void CA1001CSharpTestWithFieldInitAndNoDisposeMethod()
+        public async Task CA1001CSharpTestWithFieldInitAndNoDisposeMethod()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 
     public class NoDisposeClass
@@ -65,9 +70,9 @@ using System.IO;
         }
 
         [Fact]
-        public void CA1001CSharpTestWithCtorInitAndNoDisposeMethod()
+        public async Task CA1001CSharpTestWithCtorInitAndNoDisposeMethod()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 
     // This class violates the rule.
@@ -85,10 +90,10 @@ using System.IO;
         }
 
         [Fact]
-        public void CA1001CSharpTestWithCreationOfDisposableObjectInOtherClass()
+        public async Task CA1001CSharpTestWithCreationOfDisposableObjectInOtherClass()
         {
-            VerifyCSharp(@"
-using System.IO;                 
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.IO;
 
     public class NoDisposeClass
     {
@@ -104,8 +109,8 @@ using System.IO;
     }
 ");
 
-            VerifyCSharp(@"
-using System.IO;                 
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.IO;
 
     public class NoDisposeClass
     {
@@ -165,9 +170,9 @@ public class NoDisposeClass
         }
 
         [Fact]
-        public void CA1001CSharpTestWithADisposeMethod()
+        public async Task CA1001CSharpTestWithADisposeMethod()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 
@@ -201,9 +206,9 @@ public class HasDisposeMethod : IDisposable
         }
 
         [Fact, WorkItem(1562, "https://github.com/dotnet/roslyn-analyzers/issues/1562")]
-        public void CA1001CSharpTestWithIDisposableField()
+        public async Task CA1001CSharpTestWithIDisposableField()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 
@@ -219,9 +224,9 @@ namespace ClassLibrary1
         }
 
         [Fact, WorkItem(1562, "https://github.com/dotnet/roslyn-analyzers/issues/1562")]
-        public void CA1001CSharpTestWithIAsyncDisposable()
+        public async Task CA1001CSharpTestWithIAsyncDisposable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace System
 {
     public class ValueTask {}
@@ -253,9 +258,9 @@ namespace ClassLibrary1
         }
 
         [Fact]
-        public void CA1001BasicTestWithNoDisposableType()
+        public async Task CA1001BasicTestWithNoDisposableType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Module1
 
     Sub Main()
@@ -267,9 +272,9 @@ End Module
         }
 
         [Fact]
-        public void CA1001BasicTestWithNoCreationOfDisposableObject()
+        public async Task CA1001BasicTestWithNoCreationOfDisposableObject()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.IO
 
     Public Class NoDisposeClass
@@ -279,9 +284,9 @@ Imports System.IO
         }
 
         [Fact]
-        public void CA1001BasicTestWithFieldInitAndNoDisposeMethod()
+        public async Task CA1001BasicTestWithFieldInitAndNoDisposeMethod()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.IO
            
    ' This class violates the rule. 
@@ -291,7 +296,7 @@ Imports System.IO
 ",
             GetCA1001BasicResultAt(5, 18, "NoDisposeClass", "newFile"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.IO
       
    ' This class violates the rule. 
@@ -301,7 +306,7 @@ Imports System.IO
 ",
             GetCA1001BasicResultAt(5, 18, "NoDisposeClass", "newFile1, newFile2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.IO
     
    ' This class violates the rule. 
@@ -314,9 +319,9 @@ Imports System.IO
         }
 
         [Fact]
-        public void CA1001BasicTestWithCtorInitAndNoDisposeMethod()
+        public async Task CA1001BasicTestWithCtorInitAndNoDisposeMethod()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
    Imports System
    Imports System.IO
 
@@ -335,9 +340,9 @@ Imports System.IO
         }
 
         [Fact]
-        public void CA1001BasicTestWithCreationOfDisposableObjectInOtherClass()
+        public async Task CA1001BasicTestWithCreationOfDisposableObjectInOtherClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.IO
 
     Public Class NoDisposeClass
@@ -352,7 +357,7 @@ Imports System.IO
     End Class
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.IO
 
     Public Class NoDisposeClass
@@ -370,7 +375,7 @@ Imports System.IO
             VerifyBasic(@"
    Imports System.IO
 
-   ' This class violates the rule. 
+   ' This class violates the rule.
    [|Public Class NoDisposeMethod
 
       Dim newFile As FileStream
@@ -390,7 +395,7 @@ Imports System.IO
             VerifyBasic(@"
    Imports System.IO
 
-   ' This class violates the rule. 
+   ' This class violates the rule.
    Public Class NoDisposeMethod
 
       Dim newFile As FileStream
@@ -409,14 +414,14 @@ Imports System.IO
         }
 
         [Fact]
-        public void CA1001BasicTestWithADisposeMethod()
+        public async Task CA1001BasicTestWithADisposeMethod()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
    Imports System
    Imports System.IO
 
-   ' This class satisfies the rule. 
-   Public Class HasDisposeMethod 
+   ' This class satisfies the rule.
+   Public Class HasDisposeMethod
       Implements IDisposable
 
       Dim newFile As FileStream
@@ -449,9 +454,9 @@ Imports System.IO
         }
 
         [Fact, WorkItem(1562, "https://github.com/dotnet/roslyn-analyzers/issues/1562")]
-        public void CA1001BasicTestWithIDisposableField()
+        public async Task CA1001BasicTestWithIDisposableField()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 
@@ -465,15 +470,13 @@ End Namespace
         }
 
         private static DiagnosticResult GetCA1001CSharpResultAt(int line, int column, string objectName, string disposableFields)
-        {
-            return GetCSharpResultAt(line, column, CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.RuleId,
-                string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.TypesThatOwnDisposableFieldsShouldBeDisposableMessageNonBreaking, objectName, disposableFields));
-        }
+            => new DiagnosticResult(CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.TypesThatOwnDisposableFieldsShouldBeDisposableMessageNonBreaking, objectName, disposableFields));
 
         private static DiagnosticResult GetCA1001BasicResultAt(int line, int column, string objectName, string disposableFields)
-        {
-            return GetBasicResultAt(line, column, BasicTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.RuleId,
-                string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.TypesThatOwnDisposableFieldsShouldBeDisposableMessageNonBreaking, objectName, disposableFields));
-        }
+            => new DiagnosticResult(CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.TypesThatOwnDisposableFieldsShouldBeDisposableMessageNonBreaking, objectName, disposableFields));
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriParametersShouldNotBeStringsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriParametersShouldNotBeStringsTests.cs
@@ -1,28 +1,24 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UriParametersShouldNotBeStringsAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UriParametersShouldNotBeStringsFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UriParametersShouldNotBeStringsAnalyzer,
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UriParametersShouldNotBeStringsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class UriParametersShouldNotBeStringsTests : DiagnosticAnalyzerTestBase
+    public class UriParametersShouldNotBeStringsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UriParametersShouldNotBeStringsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UriParametersShouldNotBeStringsAnalyzer();
-        }
-
         [Fact]
-        public void CA1054NoWarningWithUrlNotStringType()
+        public async Task CA1054NoWarningWithUrlNotStringType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -33,9 +29,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1054WarningWithUrl()
+        public async Task CA1054WarningWithUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -46,9 +42,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1054NoWarningWithUrlWithOverload()
+        public async Task CA1054NoWarningWithUrlWithOverload()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -60,9 +56,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1495, "https://github.com/dotnet/roslyn-analyzers/issues/1495")]
-        public void CA1054NoWarningWithUrlWithOverload_IdenticalTypeParameters()
+        public async Task CA1054NoWarningWithUrlWithOverload_IdenticalTypeParameters()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -85,9 +81,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1495, "https://github.com/dotnet/roslyn-analyzers/issues/1495")]
-        public void CA1054WarningWithUrlWithOverload_DifferingTypeParameters()
+        public async Task CA1054WarningWithUrlWithOverload_DifferingTypeParameters()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -105,15 +101,15 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
     public class C<T> { }
 ",
             // Test0.cs(7,51): warning CA1054: Change the type of parameter url of method A.Method1<T1, T2>(string, T1) from string to System.Uri, or provide an overload to A.Method1<T1, T2>(string, T1) that allows url to be passed as a System.Uri object.
-            GetCSharpResultAt(7, 51, UriParametersShouldNotBeStringsAnalyzer.Rule, "url", "A.Method1<T1, T2>(string, T1)"),
+            GetCA1054CSharpResultAt(7, 51, "url", "A.Method1<T1, T2>(string, T1)"),
             // Test0.cs(11,46): warning CA1054: Change the type of parameter url of method A.Method2<T>(string, B<T>) from string to System.Uri, or provide an overload to A.Method2<T>(string, B<T>) that allows url to be passed as a System.Uri object.
-            GetCSharpResultAt(11, 46, UriParametersShouldNotBeStringsAnalyzer.Rule, "url", "A.Method2<T>(string, B<T>)"));
+            GetCA1054CSharpResultAt(11, 46, "url", "A.Method2<T>(string, B<T>)"));
         }
 
         [Fact]
-        public void CA1054MultipleWarningWithUrl()
+        public async Task CA1054MultipleWarningWithUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -125,9 +121,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1054NoMultipleWarningWithUrlWithOverload()
+        public async Task CA1054NoMultipleWarningWithUrlWithOverload()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -141,10 +137,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1054MultipleWarningWithUrlWithOverload()
+        public async Task CA1054MultipleWarningWithUrlWithOverload()
         {
             // Following original FxCop implementation. but this seems strange.
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -158,9 +154,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1054NoWarningNotPublic()
+        public async Task CA1054NoWarningNotPublic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     internal class A
@@ -171,9 +167,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1054NoWarningDerivedFromAttribute()
+        public async Task CA1054NoWarningDerivedFromAttribute()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     internal class A : Attribute
@@ -184,10 +180,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1054WarningVB()
+        public async Task CA1054WarningVB()
         {
             // C# and VB shares same implementation. so just one vb test
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Imports System
     
     Public Module A
@@ -198,13 +194,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCA1054CSharpResultAt(int line, int column, params string[] args)
-        {
-            return GetCSharpResultAt(line, column, UriParametersShouldNotBeStringsAnalyzer.Rule, args);
-        }
+            => new DiagnosticResult(UriParametersShouldNotBeStringsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(args);
 
         private static DiagnosticResult GetCA1054BasicResultAt(int line, int column, params string[] args)
-        {
-            return GetBasicResultAt(line, column, UriParametersShouldNotBeStringsAnalyzer.Rule, args);
-        }
+            => new DiagnosticResult(UriParametersShouldNotBeStringsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(args);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriPropertiesShouldNotBeStringsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriPropertiesShouldNotBeStringsTests.cs
@@ -1,28 +1,23 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UriPropertiesShouldNotBeStringsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UriPropertiesShouldNotBeStringsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class UriPropertiesShouldNotBeStringsTests : DiagnosticAnalyzerTestBase
+    public class UriPropertiesShouldNotBeStringsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UriPropertiesShouldNotBeStringsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UriPropertiesShouldNotBeStringsAnalyzer();
-        }
-
         [Fact]
-        public void CA1056NoWarningWithUrl()
+        public async Task CA1056NoWarningWithUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -33,9 +28,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1056NoWarningWithUrlNotStringType()
+        public async Task CA1056NoWarningWithUrlNotStringType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -46,9 +41,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1056WarningWithUrl()
+        public async Task CA1056WarningWithUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -59,9 +54,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1056NoWarningWithNoUrl()
+        public async Task CA1056NoWarningWithNoUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -72,9 +67,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1056NoWarningNotPublic()
+        public async Task CA1056NoWarningNotPublic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -87,9 +82,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1056NoWarningDerivedFromAttribute()
+        public async Task CA1056NoWarningDerivedFromAttribute()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A : Attribute
@@ -100,10 +95,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1056NoWarningOverride()
+        public async Task CA1056NoWarningOverride()
         {
             // warning is from base type not overriden one
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class Base
@@ -119,10 +114,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1056WarningVB()
+        public async Task CA1056WarningVB()
         {
             // C# and VB shares same implementation. so just one vb test
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Imports System
     
     Public Module A
@@ -136,13 +131,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCA1056CSharpResultAt(int line, int column, params string[] args)
-        {
-            return GetCSharpResultAt(line, column, UriPropertiesShouldNotBeStringsAnalyzer.Rule, args);
-        }
+            => new DiagnosticResult(UriPropertiesShouldNotBeStringsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(args);
 
         private static DiagnosticResult GetCA1056BasicResultAt(int line, int column, params string[] args)
-        {
-            return GetBasicResultAt(line, column, UriPropertiesShouldNotBeStringsAnalyzer.Rule, args);
-        }
+            => new DiagnosticResult(UriPropertiesShouldNotBeStringsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(args);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriReturnValuesShouldNotBeStringsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriReturnValuesShouldNotBeStringsTests.cs
@@ -1,28 +1,23 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UriReturnValuesShouldNotBeStringsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UriReturnValuesShouldNotBeStringsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class UriReturnValuesShouldNotBeStringsTests : DiagnosticAnalyzerTestBase
+    public class UriReturnValuesShouldNotBeStringsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UriReturnValuesShouldNotBeStringsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UriReturnValuesShouldNotBeStringsAnalyzer();
-        }
-
         [Fact]
-        public void CA1055NoWarningWithUrl()
+        public async Task CA1055NoWarningWithUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -33,9 +28,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1055NoWarningWithUrlNotStringType()
+        public async Task CA1055NoWarningWithUrlNotStringType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -46,9 +41,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1055WarningWithUrl()
+        public async Task CA1055WarningWithUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -59,9 +54,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1055NoWarningWithNoUrl()
+        public async Task CA1055NoWarningWithNoUrl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -72,9 +67,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1055NoWarningNotPublic()
+        public async Task CA1055NoWarningNotPublic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -85,9 +80,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1055NoWarningWithUrlParameter()
+        public async Task CA1055NoWarningWithUrlParameter()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class A
@@ -98,10 +93,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1055NoWarningOverride()
+        public async Task CA1055NoWarningOverride()
         {
             // warning is from base type not overriden one
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public class Base
@@ -117,10 +112,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1055WarningVB()
+        public async Task CA1055WarningVB()
         {
             // C# and VB shares same implementation. so just one vb test
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Imports System
     
     Public Module A
@@ -131,13 +126,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCA1055CSharpResultAt(int line, int column, params string[] args)
-        {
-            return GetCSharpResultAt(line, column, UriReturnValuesShouldNotBeStringsAnalyzer.Rule, args);
-        }
+            => new DiagnosticResult(UriReturnValuesShouldNotBeStringsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(args);
 
         private static DiagnosticResult GetCA1055BasicResultAt(int line, int column, params string[] args)
-        {
-            return GetBasicResultAt(line, column, UriReturnValuesShouldNotBeStringsAnalyzer.Rule, args);
-        }
+            => new DiagnosticResult(UriReturnValuesShouldNotBeStringsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(args);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseEventsWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseEventsWhereAppropriateTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -12,25 +14,15 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class UseEventsWhereAppropriateTests : DiagnosticAnalyzerTestBase
+    public class UseEventsWhereAppropriateTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseEventsWhereAppropriateAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseEventsWhereAppropriateAnalyzer();
-        }
-
         #region No Diagnostic Tests
 
         [WorkItem(380, "https://github.com/dotnet/roslyn-analyzers/issues/380")]
         [Fact]
-        public void NoDiagnostic_NamingCases()
+        public async Task NoDiagnostic_NamingCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class EventsClass1
@@ -57,7 +49,7 @@ public class EventsClass1
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class EventsClass1
@@ -86,9 +78,9 @@ End Class
 
         [WorkItem(380, "https://github.com/dotnet/roslyn-analyzers/issues/380")]
         [Fact]
-        public void NoDiagnostic_InterfaceMemberImplementation()
+        public async Task NoDiagnostic_InterfaceMemberImplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class InterfaceImplementation : I
@@ -116,7 +108,7 @@ public interface I
 #pragma warning restore CA1030
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class InterfaceImplementation
@@ -144,9 +136,9 @@ End Interface
 
         [WorkItem(380, "https://github.com/dotnet/roslyn-analyzers/issues/380")]
         [Fact]
-        public void NoDiagnostic_UnflaggedMethodKinds()
+        public async Task NoDiagnostic_UnflaggedMethodKinds()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class FireOnSomethingDerivedClass : BaseClass
@@ -201,7 +193,7 @@ public abstract class BaseClass
 #pragma warning restore CA1030
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class FireOnSomethingDerivedClass
@@ -255,9 +247,9 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void NoDiagnostic_FlaggedMethodKinds_NotExternallyVisible()
+        public async Task NoDiagnostic_FlaggedMethodKinds_NotExternallyVisible()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 internal interface InterfaceWithViolations
@@ -304,7 +296,7 @@ public abstract class ClassWithViolations
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface InterfaceWithViolations
     ' Interface methods.
     Sub FireOnSomething_InterfaceMethod1()
@@ -349,9 +341,9 @@ End Class
 
         [WorkItem(380, "https://github.com/dotnet/roslyn-analyzers/issues/380")]
         [Fact]
-        public void Diagnostic_FlaggedMethodKinds()
+        public async Task Diagnostic_FlaggedMethodKinds()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface InterfaceWithViolations
@@ -403,7 +395,7 @@ public abstract class ClassWithViolations
       // Test0.cs(33,26): warning CA1030: Consider making 'RemoveOnSomething_AbstractMethod' an event.
       GetCSharpResultAt(33, 26, UseEventsWhereAppropriateAnalyzer.Rule, "RemoveOnSomething_AbstractMethod"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface InterfaceWithViolations
 	' Interface methods - Rule fires.
 	Sub FireOnSomething_InterfaceMethod1()
@@ -452,9 +444,9 @@ End Class
 
         [WorkItem(380, "https://github.com/dotnet/roslyn-analyzers/issues/380")]
         [Fact]
-        public void Diagnostic_PascalCasedMethodNames()
+        public async Task Diagnostic_PascalCasedMethodNames()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class EventsClassPascalCased
 {
     public void Fire() { }
@@ -491,7 +483,7 @@ public class EventsClassPascalCased
       // Test0.cs(18,17): warning CA1030: Consider making 'Remove_OnFileEvent' an event.
       GetCSharpResultAt(18, 17, UseEventsWhereAppropriateAnalyzer.Rule, "Remove_OnFileEvent"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class EventsClassPascalCased
 	Public Sub Fire()
 	End Sub
@@ -539,9 +531,9 @@ End Class
 
         [WorkItem(380, "https://github.com/dotnet/roslyn-analyzers/issues/380")]
         [Fact]
-        public void Diagnostic_LowerCaseMethodNames()
+        public async Task Diagnostic_LowerCaseMethodNames()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class EventsClassLowercase
 {
     public void fire() { }
@@ -578,7 +570,7 @@ public class EventsClassLowercase
       // Test0.cs(18,17): warning CA1030: Consider making 'remove_onFileEvent' an event.
       GetCSharpResultAt(18, 17, UseEventsWhereAppropriateAnalyzer.Rule, "remove_onFileEvent"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class EventsClassLowercase
 	Public Sub fire()
 	End Sub
@@ -625,5 +617,15 @@ End Class
         }
 
         #endregion
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseGenericEventHandlerInstancesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseGenericEventHandlerInstancesTests.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpUseGenericEventHandlerInstancesAnalyzer,
@@ -14,22 +13,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class UseGenericEventHandlerTests : DiagnosticAnalyzerTestBase
+    public class UseGenericEventHandlerTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicUseGenericEventHandlerInstancesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpUseGenericEventHandlerInstancesAnalyzer();
-        }
-
         [Fact]
-        public void TestAlreadyUsingGenericEventHandlerCSharp()
+        public async Task TestAlreadyUsingGenericEventHandlerCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public event System.EventHandler<System.EventArgs> E1;
@@ -39,9 +28,9 @@ public class C
         }
 
         [Fact]
-        public void TestAlreadyUsingGenericEventHandlerBasic()
+        public async Task TestAlreadyUsingGenericEventHandlerBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Event E1 As System.EventHandler(Of System.EventArgs)
     Public Event E2 As System.EventHandler
@@ -50,9 +39,9 @@ End Class
         }
 
         [Fact]
-        public void TestUsingStructAsEventArgsForOptimizationCSharp()
+        public async Task TestUsingStructAsEventArgsForOptimizationCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct SpecialCaseStructEventArgs
 {
 }
@@ -72,9 +61,9 @@ public class C
         }
 
         [Fact]
-        public void TestUsingStructAsEventArgsForOptimizationBasic()
+        public async Task TestUsingStructAsEventArgsForOptimizationBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure SpecialCaseStructEventArgs
 End Structure
 
@@ -91,9 +80,9 @@ End Class
         }
 
         [Fact]
-        public void TestGeneratedEventHandlersBasic()
+        public async Task TestGeneratedEventHandlersBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Event E1()
     Public Event E2(args As System.EventArgs)
@@ -112,9 +101,9 @@ End Class
         }
 
         [Fact]
-        public void TestNonPublicEventAndNonPublicDelegate()
+        public async Task TestNonPublicEventAndNonPublicDelegate()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal delegate void BadEventHandler(object senderId, System.EventArgs e);
 
 public class EventsClass
@@ -125,9 +114,9 @@ public class EventsClass
         }
 
         [Fact]
-        public void TestNonPublicEventButPublicDelegate()
+        public async Task TestNonPublicEventButPublicDelegate()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public delegate void BadEventHandler(object senderId, System.EventArgs e);
 
 public class EventsClass
@@ -140,9 +129,9 @@ public class EventsClass
         }
 
         [Fact]
-        public void TestNonPublicEventAndPublicInvalidDelegate()
+        public async Task TestNonPublicEventAndPublicInvalidDelegate()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public delegate void BadEventHandler(object senderId);
 
 public class EventsClass
@@ -153,9 +142,9 @@ public class EventsClass
         }
 
         [Fact]
-        public void TestIgnoreEventsThatAreInterfaceImplementations()
+        public async Task TestIgnoreEventsThatAreInterfaceImplementations()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public delegate void BadEventHandler(object senderId, EventArgs e);
@@ -188,9 +177,9 @@ public class EventsClassExplicit : ITest
         }
 
         [Fact]
-        public void TestOverrideEvent()
+        public async Task TestOverrideEvent()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public delegate void BadHandler();
 
 public class C
@@ -208,9 +197,9 @@ public class D : C
         }
 
         [Fact]
-        public void TestComSourceInterfaceEvent()
+        public async Task TestComSourceInterfaceEvent()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public delegate void BadHandler();
 
 [System.Runtime.InteropServices.ComSourceInterfaces(""C"")]
@@ -222,9 +211,9 @@ public class C
         }
 
         [Fact]
-        public void TestViolatingEventsCSharp()
+        public async Task TestViolatingEventsCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public delegate void BadHandler1();
@@ -258,9 +247,9 @@ public class C
         }
 
         [Fact]
-        public void TestViolatingEventsBasic()
+        public async Task TestViolatingEventsBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Delegate Sub BadHandler(sender As Object, args As System.EventArgs)
 
 Public Class C
@@ -279,5 +268,15 @@ End Structure
             // Test0.vb(7,18): warning CA1003: Change the event 'E3' to use a generic EventHandler by defining the event type explicitly, for e.g. Event MyEvent As EventHandler(Of MyEventArgs).
             GetBasicResultAt(7, 18, UseGenericEventHandlerInstancesAnalyzer.RuleForEvents2, "E3"));
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexersTests.cs
@@ -1,28 +1,24 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UseIntegralOrStringArgumentForIndexersAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UseIntegralOrStringArgumentForIndexersAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class UseIntegralOrStringArgumentForIndexersTests : DiagnosticAnalyzerTestBase
+    public class UseIntegralOrStringArgumentForIndexersTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseIntegralOrStringArgumentForIndexersAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseIntegralOrStringArgumentForIndexersAnalyzer();
-        }
-
         [Fact]
-        public void TestBasicUseIntegralOrStringArgumentForIndexersWarning1()
+        public async Task TestBasicUseIntegralOrStringArgumentForIndexersWarning1()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Imports System
 
     Public Class Months
@@ -37,9 +33,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestBasicUseIntegralOrStringArgumentForIndexersNoWarning_Internal()
+        public async Task TestBasicUseIntegralOrStringArgumentForIndexersNoWarning_Internal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Imports System
 
     Friend Class Months
@@ -63,9 +59,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void TestBasicUseIntegralOrStringArgumentForIndexersNoWarning1()
+        public async Task TestBasicUseIntegralOrStringArgumentForIndexersNoWarning1()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Public Class Months
         Private month() As String = {""Jan"", ""Feb"", ""...""}
         Default ReadOnly Property Item(index As String) As String
@@ -78,9 +74,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void TestCSharpUseIntegralOrStringArgumentForIndexersWarning1()
+        public async Task TestCSharpUseIntegralOrStringArgumentForIndexersWarning1()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     public class Months
     {
         string[] month = new string[] {""Jan"", ""Feb"", ""...""};
@@ -95,9 +91,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestCSharpUseIntegralOrStringArgumentForIndexersNoWarning_Internal()
+        public async Task TestCSharpUseIntegralOrStringArgumentForIndexersNoWarning_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     internal class Months
     {
         string[] month = new string[] {""Jan"", ""Feb"", ""...""};
@@ -124,9 +120,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void TestCSharpUseIntegralOrStringArgumentForIndexersNoWarning1()
+        public async Task TestCSharpUseIntegralOrStringArgumentForIndexersNoWarning1()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     public class Months
     {
         string[] month = new string[] {""Jan"", ""Feb"", ""...""};
@@ -141,9 +137,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void TestCSharpGenericIndexer()
+        public async Task TestCSharpGenericIndexer()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     public class Months<T>
     {
         public string this[T index]
@@ -157,9 +153,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void TestBasicGenericIndexer()
+        public async Task TestBasicGenericIndexer()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Public Class Months(Of T)
         Default Public ReadOnly Property Item(index As T)
             Get
@@ -170,9 +166,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void TestCSharpEnumIndexer()
+        public async Task TestCSharpEnumIndexer()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     public class Months<T>
     {
         public enum Foo { }
@@ -188,9 +184,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void TestBasicEnumIndexer()
+        public async Task TestBasicEnumIndexer()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
     Public Class Months(Of T)
         Public Enum Foo
             Val1
@@ -205,13 +201,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult CreateCSharpResult(int line, int col)
-        {
-            return GetCSharpResultAt(line, col, UseIntegralOrStringArgumentForIndexersAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.UseIntegralOrStringArgumentForIndexersMessage);
-        }
+            => new DiagnosticResult(UseIntegralOrStringArgumentForIndexersAnalyzer.Rule)
+                .WithLocation(line, col)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.UseIntegralOrStringArgumentForIndexersMessage);
 
         private static DiagnosticResult CreateBasicResult(int line, int col)
-        {
-            return GetBasicResultAt(line, col, UseIntegralOrStringArgumentForIndexersAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.UseIntegralOrStringArgumentForIndexersMessage);
-        }
+            => new DiagnosticResult(UseIntegralOrStringArgumentForIndexersAnalyzer.Rule)
+                .WithLocation(line, col)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.UseIntegralOrStringArgumentForIndexersMessage);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -14,22 +14,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public partial class UsePropertiesWhereAppropriateTests : DiagnosticAnalyzerTestBase
+    public class UsePropertiesWhereAppropriateTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UsePropertiesWhereAppropriateAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UsePropertiesWhereAppropriateAnalyzer();
-        }
-
         [Fact]
-        public void CSharp_CA1024NoDiagnosticCases()
+        public async Task CSharp_CA1024NoDiagnosticCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 
@@ -157,9 +147,9 @@ public class Class1 : Base
         }
 
         [Fact]
-        public void CSharp_CA1024DiagnosticCases()
+        public async Task CSharp_CA1024DiagnosticCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class
 {
     private string fileName = ""data.txt"";
@@ -192,9 +182,9 @@ public class Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_CA1024NoDiagnosticCases_Internal()
+        public async Task CSharp_CA1024NoDiagnosticCases_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class
 {
     private string fileName = ""data.txt"";
@@ -223,9 +213,9 @@ public class Class
         }
 
         [Fact]
-        public void VisualBasic_CA1024NoDiagnosticCases()
+        public async Task VisualBasic_CA1024NoDiagnosticCases()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Collections
 
 Public Class Base
@@ -325,9 +315,9 @@ End Class
         }
 
         [Fact]
-        public void CSharp_CA1024NoDiagnosticOnUnboundMethodCaller()
+        public async Task CSharp_CA1024NoDiagnosticOnUnboundMethodCaller()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class class1
@@ -342,22 +332,22 @@ public class class1
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7222")]
-        public void VisualBasic_CA1024NoDiagnosticOnUnboundMethodCaller()
+        public async Task VisualBasic_CA1024NoDiagnosticOnUnboundMethodCaller()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class class1
     Public Function GetSomethingWithUnboundInvocation() As Integer
         Console.WriteLine(Me)
         Return 0
     End Function
 End Class
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void VisualBasic_CA1024DiagnosticCases()
+        public async Task VisualBasic_CA1024DiagnosticCases()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
     Private fileName As String
 
@@ -385,9 +375,9 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void VisualBasic_CA1024NoDiagnosticCases_Internal()
+        public async Task VisualBasic_CA1024NoDiagnosticCases_Internal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
     Private fileName As String
 
@@ -449,15 +439,13 @@ public class Foo : IFoo
         }
 
         private static DiagnosticResult GetCA1024CSharpResultAt(int line, int column, string methodName)
-        {
-            return GetCSharpResultAt(line, column, UsePropertiesWhereAppropriateAnalyzer.RuleId,
-                string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UsePropertiesWhereAppropriateMessage, methodName));
-        }
+            => new DiagnosticResult(UsePropertiesWhereAppropriateAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UsePropertiesWhereAppropriateMessage, methodName));
 
         private static DiagnosticResult GetCA1024BasicResultAt(int line, int column, string methodName)
-        {
-            return GetBasicResultAt(line, column, UsePropertiesWhereAppropriateAnalyzer.RuleId,
-                string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UsePropertiesWhereAppropriateMessage, methodName));
-        }
+            => new DiagnosticResult(UsePropertiesWhereAppropriateAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UsePropertiesWhereAppropriateMessage, methodName));
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -403,7 +403,7 @@ End Class
         [Fact, WorkItem(1551, "https://github.com/dotnet/roslyn-analyzers/issues/1551")]
         public void CA1024_ExplicitInterfaceImplementation_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            VerifyCS.VerifyAnalyzerAsync(@"
 public interface IFoo
 {
     object GetContent();
@@ -422,7 +422,7 @@ public class Foo : IFoo
         [Fact, WorkItem(1551, "https://github.com/dotnet/roslyn-analyzers/issues/1551")]
         public void CA1024_ImplicitInterfaceImplementation_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            VerifyCS.VerifyAnalyzerAsync(@"
 public interface IFoo
 {
     object GetContent();

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Documentation/AvoidUsingCrefTagsWithAPrefixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Documentation/AvoidUsingCrefTagsWithAPrefixTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.Documentation;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.Documentation;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.CSharp.Analyzers.Documentation.CSharpAvoidUsingCrefTagsWithAPrefixAnalyzer,
@@ -15,24 +12,14 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.Documentation.UnitTests
 {
-    public class AvoidUsingCrefTagsWithAPrefixTests : DiagnosticAnalyzerTestBase
+    public class AvoidUsingCrefTagsWithAPrefixTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicAvoidUsingCrefTagsWithAPrefixAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpAvoidUsingCrefTagsWithAPrefixAnalyzer();
-        }
-
         #region No Diagnostic Tests
 
         [Fact]
-        public void NoDiagnosticCases()
+        public async Task NoDiagnosticCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 /// <summary>
 /// Type <see cref=""C"" /> contains method <see cref=""C.F"" />
 /// This one is a dummy cref without kind prefix <see cref="":C.F"" />, <see cref=""T : C.F"" />
@@ -43,7 +30,7 @@ class C
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 ''' <summary>
 ''' Type <see cref=""C""/> contains method <see cref=""C.F"" />
 ''' This one is a dummy cref without kind prefix <see cref="":C.F"" />, <see cref=""T : C.F"" />
@@ -60,9 +47,9 @@ End Class
         #region Diagnostic Tests
 
         [Fact]
-        public void DiagnosticCases()
+        public async Task DiagnosticCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 /// <summary>
 /// Type <see cref=""T:C""/> contains method <see cref=""M:C.F"" />
 /// </summary>
@@ -76,7 +63,7 @@ class C
     // Test0.cs(3,55): warning RS0010: Avoid using cref tags with a prefix
     GetCSharpResultAt(3, 55));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 ''' <summary>
 ''' Type <see cref=""T:C""/> contains method <see cref=""M:C.F"" />
 ''' </summary>
@@ -94,13 +81,13 @@ End Class
         #endregion
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, AvoidUsingCrefTagsWithAPrefixAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.AvoidUsingCrefTagsWithAPrefixMessage);
-        }
+            => new DiagnosticResult(AvoidUsingCrefTagsWithAPrefixAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.AvoidUsingCrefTagsWithAPrefixMessage);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, AvoidUsingCrefTagsWithAPrefixAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.AvoidUsingCrefTagsWithAPrefixMessage);
-        }
+            => new DiagnosticResult(AvoidUsingCrefTagsWithAPrefixAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.AvoidUsingCrefTagsWithAPrefixMessage);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.VisualBasic;
 using Test.Utilities;
 
 using Xunit;
@@ -13,60 +17,60 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 {
-    public class AvoidUninstantiatedInternalClassesTests : DiagnosticAnalyzerTestBase
+    public class AvoidUninstantiatedInternalClassesTests
     {
         [Fact]
-        public void CA1812_CSharp_Diagnostic_UninstantiatedInternalClass()
+        public async Task CA1812_CSharp_Diagnostic_UninstantiatedInternalClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal class C { }
 ",
                 GetCSharpResultAt(1, 16, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C"));
         }
 
         [Fact]
-        public void CA1812_Basic_Diagnostic_UninstantiatedInternalClass()
+        public async Task CA1812_Basic_Diagnostic_UninstantiatedInternalClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Class C
 End Class",
                 GetBasicResultAt(1, 14, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C"));
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_UninstantiatedInternalStruct()
+        public async Task CA1812_CSharp_NoDiagnostic_UninstantiatedInternalStruct()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal struct CInternal { }");
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_UninstantiatedInternalStruct()
+        public async Task CA1812_Basic_NoDiagnostic_UninstantiatedInternalStruct()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Structure CInternal
 End Structure");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_UninstantiatedPublicClass()
+        public async Task CA1812_CSharp_NoDiagnostic_UninstantiatedPublicClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class C { }");
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_UninstantiatedPublicClass()
+        public async Task CA1812_Basic_NoDiagnostic_UninstantiatedPublicClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class C
 End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_InstantiatedInternalClass()
+        public async Task CA1812_CSharp_NoDiagnostic_InstantiatedInternalClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal class C { }
 
 public class D
@@ -76,9 +80,9 @@ public class D
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_InstantiatedInternalClass()
+        public async Task CA1812_Basic_NoDiagnostic_InstantiatedInternalClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Class C
 End Class
 
@@ -88,9 +92,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_Diagnostic_UninstantiatedInternalClassNestedInPublicClass()
+        public async Task CA1812_CSharp_Diagnostic_UninstantiatedInternalClassNestedInPublicClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class C
 {
     internal class D { }
@@ -99,9 +103,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_Basic_Diagnostic_UninstantiatedInternalClassNestedInPublicClass()
+        public async Task CA1812_Basic_Diagnostic_UninstantiatedInternalClassNestedInPublicClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class C
     Friend Class D
     End Class
@@ -110,9 +114,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_InstantiatedInternalClassNestedInPublicClass()
+        public async Task CA1812_CSharp_NoDiagnostic_InstantiatedInternalClassNestedInPublicClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"public class C
 {
     private readonly D _d = new D();
@@ -122,9 +126,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_InstantiatedInternalClassNestedInPublicClass()
+        public async Task CA1812_Basic_NoDiagnostic_InstantiatedInternalClassNestedInPublicClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Public Class C
     Private ReadOnly _d = New D
 
@@ -134,33 +138,33 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_InternalModule()
+        public async Task CA1812_Basic_NoDiagnostic_InternalModule()
         {
             // No static classes in VB.
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Module M
 End Module");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_InternalAbstractClass()
+        public async Task CA1812_CSharp_NoDiagnostic_InternalAbstractClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal abstract class A { }");
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_InternalAbstractClass()
+        public async Task CA1812_Basic_NoDiagnostic_InternalAbstractClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend MustInherit Class A
 End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_InternalDelegate()
+        public async Task CA1812_CSharp_NoDiagnostic_InternalDelegate()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace N
 {
     internal delegate void Del();
@@ -168,18 +172,18 @@ namespace N
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_InternalDelegate()
+        public async Task CA1812_Basic_NoDiagnostic_InternalDelegate()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Namespace N
     Friend Delegate Sub Del()
 End Namespace");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_InternalEnum()
+        public async Task CA1812_CSharp_NoDiagnostic_InternalEnum()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"namespace N
 {
     internal enum E {}  // C# enums don't care if there are any members.
@@ -187,9 +191,9 @@ End Namespace");
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_InternalEnum()
+        public async Task CA1812_Basic_NoDiagnostic_InternalEnum()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Namespace N
     Friend Enum E
         None            ' VB enums require at least one member.
@@ -198,9 +202,9 @@ End Namespace");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_AttributeClass()
+        public async Task CA1812_CSharp_NoDiagnostic_AttributeClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 
 internal class MyAttribute: Attribute {}
@@ -208,9 +212,9 @@ internal class MyOtherAttribute: MyAttribute {}");
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_AttributeClass()
+        public async Task CA1812_Basic_NoDiagnostic_AttributeClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 
 Friend Class MyAttribute
@@ -223,80 +227,116 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningVoid()
+        public async Task CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningVoid()
         {
-            VerifyCSharp(
+            await new VerifyCS.Test
+            {
+                TestCode =
 @"internal class C
 {
     private static void Main() {}
 }",
-            compilationOptions: s_CSharpDefaultOptions.WithOutputKind(CodeAnalysis.OutputKind.ConsoleApplication));
+                SolutionTransforms =
+                {
+                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.ConsoleApplication))
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_TypeContainingAssemblyEntryPointReturningVoid()
+        public async Task CA1812_Basic_NoDiagnostic_TypeContainingAssemblyEntryPointReturningVoid()
         {
-            VerifyBasic(
+            await new VerifyVB.Test
+            {
+                TestCode =
 @"Friend Class C
     Public Shared Sub Main()
     End Sub
 End Class",
-            compilationOptions: s_visualBasicDefaultOptions.WithOutputKind(CodeAnalysis.OutputKind.ConsoleApplication));
-        }
+                SolutionTransforms =
+                    {
+                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
+                    }
+            }.RunAsync();
+    }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningInt()
+        public async Task CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningInt()
         {
-            VerifyCSharp(
+            await new VerifyCS.Test
+            {
+                TestCode =
 @"internal class C
 {
     private static int Main() { return 1; }
 }",
-            compilationOptions: s_CSharpDefaultOptions.WithOutputKind(CodeAnalysis.OutputKind.ConsoleApplication));
+                SolutionTransforms =
+                {
+                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.ConsoleApplication))
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_TypeContainingAssemblyEntryPointReturningInt()
+        public async Task CA1812_Basic_NoDiagnostic_TypeContainingAssemblyEntryPointReturningInt()
         {
-            VerifyBasic(
+            await new VerifyVB.Test
+            {
+                TestCode =
 @"Friend Class C
     Public Shared Function Main() As Integer
         Return 1
     End Function
 End Class",
-            compilationOptions: s_visualBasicDefaultOptions.WithOutputKind(CodeAnalysis.OutputKind.ConsoleApplication));
+                SolutionTransforms =
+                {
+                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningTask()
+        public async Task CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningTask()
         {
-            VerifyCSharp(
+            await new VerifyCS.Test
+            {
+                TestCode =
 @" using System.Threading.Tasks;
 internal static class C
 {
     private static async Task Main() { await Task.Delay(1); }
 }",
-                parseOptions: CodeAnalysis.CSharp.CSharpParseOptions.Default.WithLanguageVersion(CodeAnalysis.CSharp.LanguageVersion.CSharp7_1),
-                compilationOptions: s_CSharpDefaultOptions.WithOutputKind(CodeAnalysis.OutputKind.ConsoleApplication));
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp7_1,
+                SolutionTransforms =
+                {
+                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.ConsoleApplication))
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningTaskInt()
+        public async Task CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningTaskInt()
         {
-            VerifyCSharp(
+            await new VerifyCS.Test
+            {
+                TestCode =
 @" using System.Threading.Tasks;
 internal static class C
 {
     private static async Task<int> Main() { await Task.Delay(1); return 1; }
 }",
-                parseOptions: CodeAnalysis.CSharp.CSharpParseOptions.Default.WithLanguageVersion(CodeAnalysis.CSharp.LanguageVersion.CSharp7_1),
-                compilationOptions: s_CSharpDefaultOptions.WithOutputKind(CodeAnalysis.OutputKind.ConsoleApplication));
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp7_1,
+                SolutionTransforms =
+                {
+                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.ConsoleApplication))
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1812_CSharp_Diagnostic_MainMethodIsNotStatic()
+        public async Task CA1812_CSharp_Diagnostic_MainMethodIsNotStatic()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal class C
 {
     private void Main() {}
@@ -305,9 +345,9 @@ internal static class C
         }
 
         [Fact]
-        public void CA1812_Basic_Diagnostic_MainMethodIsNotStatic()
+        public async Task CA1812_Basic_Diagnostic_MainMethodIsNotStatic()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Class C
     Private Sub Main()
     End Sub
@@ -316,23 +356,29 @@ End Class",
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_MainMethodIsDifferentlyCased()
+        public async Task CA1812_Basic_NoDiagnostic_MainMethodIsDifferentlyCased()
         {
-            VerifyBasic(
+            await new VerifyVB.Test
+            {
+                TestCode =
 @"Friend Class C
     Private Shared Sub mAiN()
     End Sub
 End Class",
-            validationMode: TestValidationMode.AllowCompileErrors, // No Main method
-            compilationOptions: s_visualBasicDefaultOptions.WithOutputKind(CodeAnalysis.OutputKind.ConsoleApplication));
+                CompilerDiagnostics = CompilerDiagnostics.None, // No Main method
+                SolutionTransforms =
+                {
+                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
+                }
+            }.RunAsync();
         }
 
         // The following tests are just to ensure that the messages are formatted properly
         // for types within namespaces.
         [Fact]
-        public void CA1812_CSharp_Diagnostic_UninstantiatedInternalClassInNamespace()
+        public async Task CA1812_CSharp_Diagnostic_UninstantiatedInternalClassInNamespace()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"namespace N
 {
     internal class C { }
@@ -341,9 +387,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1812_Basic_Diagnostic_UninstantiatedInternalClassInNamespace()
+        public async Task CA1812_Basic_Diagnostic_UninstantiatedInternalClassInNamespace()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Namespace N
     Friend Class C
     End Class
@@ -352,9 +398,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA1812_CSharp_Diagnostic_UninstantiatedInternalClassNestedInPublicClassInNamespace()
+        public async Task CA1812_CSharp_Diagnostic_UninstantiatedInternalClassNestedInPublicClassInNamespace()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"namespace N
 {
     public class C
@@ -366,9 +412,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA1812_Basic_Diagnostic_UninstantiatedInternalClassNestedInPublicClassInNamespace()
+        public async Task CA1812_Basic_Diagnostic_UninstantiatedInternalClassNestedInPublicClassInNamespace()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Namespace N
     Public Class C
         Friend Class D
@@ -379,9 +425,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_UninstantiatedInternalMef1ExportedClass()
+        public async Task CA1812_CSharp_NoDiagnostic_UninstantiatedInternalMef1ExportedClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.ComponentModel.Composition;
 
@@ -399,9 +445,9 @@ internal class C
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_UninstantiatedInternalMef1ExportedClass()
+        public async Task CA1812_Basic_NoDiagnostic_UninstantiatedInternalMef1ExportedClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 Imports System.ComponentModel.Composition
 
@@ -417,9 +463,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_UninstantiatedInternalMef2ExportedClass()
+        public async Task CA1812_CSharp_NoDiagnostic_UninstantiatedInternalMef2ExportedClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.ComponentModel.Composition;
 
@@ -437,9 +483,9 @@ internal class C
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_UninstantiatedInternalMef2ExportedClass()
+        public async Task CA1812_Basic_NoDiagnostic_UninstantiatedInternalMef2ExportedClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 Imports System.ComponentModel.Composition
 
@@ -455,9 +501,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_ImplementsIConfigurationSectionHandler()
+        public async Task CA1812_CSharp_NoDiagnostic_ImplementsIConfigurationSectionHandler()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Configuration;
 using System.Xml;
 
@@ -471,9 +517,9 @@ internal class C : IConfigurationSectionHandler
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_ImplementsIConfigurationSectionHandler()
+        public async Task CA1812_Basic_NoDiagnostic_ImplementsIConfigurationSectionHandler()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Configuration
 Imports System.Xml
 
@@ -486,9 +532,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_DerivesFromConfigurationSection()
+        public async Task CA1812_CSharp_NoDiagnostic_DerivesFromConfigurationSection()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Configuration;
 
 namespace System.Configuration
@@ -504,9 +550,9 @@ internal class C : ConfigurationSection
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_DerivesFromConfigurationSection()
+        public async Task CA1812_Basic_NoDiagnostic_DerivesFromConfigurationSection()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Configuration
 
 Namespace System.Configuration
@@ -520,9 +566,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_DerivesFromSafeHandle()
+        public async Task CA1812_CSharp_NoDiagnostic_DerivesFromSafeHandle()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System;
 using System.Runtime.InteropServices;
 
@@ -543,9 +589,9 @@ internal class MySafeHandle : SafeHandle
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_DerivesFromSafeHandle()
+        public async Task CA1812_Basic_NoDiagnostic_DerivesFromSafeHandle()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System
 Imports System.Runtime.InteropServices
 
@@ -569,9 +615,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_DerivesFromTraceListener()
+        public async Task CA1812_CSharp_NoDiagnostic_DerivesFromTraceListener()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Diagnostics;
 
 internal class MyTraceListener : TraceListener
@@ -582,9 +628,9 @@ internal class MyTraceListener : TraceListener
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_DerivesFromTraceListener()
+        public async Task CA1812_Basic_NoDiagnostic_DerivesFromTraceListener()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Diagnostics
 
 Friend Class MyTraceListener
@@ -599,9 +645,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_InternalNestedTypeIsInstantiated()
+        public async Task CA1812_CSharp_NoDiagnostic_InternalNestedTypeIsInstantiated()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal class C
 {
     internal class C2
@@ -617,9 +663,9 @@ public class D
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_InternalNestedTypeIsInstantiated()
+        public async Task CA1812_Basic_NoDiagnostic_InternalNestedTypeIsInstantiated()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Class C
     Friend Class C2
     End Class
@@ -631,9 +677,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_CSharp_Diagnostic_InternalNestedTypeIsNotInstantiated()
+        public async Task CA1812_CSharp_Diagnostic_InternalNestedTypeIsNotInstantiated()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal class C
 {
     internal class C2
@@ -647,9 +693,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1812_Basic_Diagnostic_InternalNestedTypeIsNotInstantiated()
+        public async Task CA1812_Basic_Diagnostic_InternalNestedTypeIsNotInstantiated()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Class C
     Friend Class C2
     End Class
@@ -661,9 +707,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1812_CSharp_Diagnostic_PrivateNestedTypeIsInstantiated()
+        public async Task CA1812_CSharp_Diagnostic_PrivateNestedTypeIsInstantiated()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal class C
 {
     private readonly C2 _c2 = new C2();
@@ -678,9 +724,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1812_Basic_Diagnostic_PrivateNestedTypeIsInstantiated()
+        public async Task CA1812_Basic_Diagnostic_PrivateNestedTypeIsInstantiated()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Class C
     Private _c2 As New C2
     
@@ -694,9 +740,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_StaticHolderClass()
+        public async Task CA1812_CSharp_NoDiagnostic_StaticHolderClass()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal static class C
 {
     internal static void F() { }
@@ -704,9 +750,9 @@ End Class",
         }
 
         [Fact, WorkItem(1370, "https://github.com/dotnet/roslyn-analyzers/issues/1370")]
-        public void CA1812_CSharp_NoDiagnostic_ImplicitlyInstantiatedFromSubTypeConstructor()
+        public async Task CA1812_CSharp_NoDiagnostic_ImplicitlyInstantiatedFromSubTypeConstructor()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 internal class A
 {
@@ -737,9 +783,9 @@ internal class D : C<int>
         }
 
         [Fact, WorkItem(1370, "https://github.com/dotnet/roslyn-analyzers/issues/1370")]
-        public void CA1812_CSharp_NoDiagnostic_ExplicitlyInstantiatedFromSubTypeConstructor()
+        public async Task CA1812_CSharp_NoDiagnostic_ExplicitlyInstantiatedFromSubTypeConstructor()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"
 internal class A
 {
@@ -774,9 +820,9 @@ internal class D : C<int>
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_StaticHolderClass()
+        public async Task CA1812_Basic_NoDiagnostic_StaticHolderClass()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Module C
     Friend Sub F()
     End Sub
@@ -784,11 +830,11 @@ End Module");
         }
 
         [Fact]
-        public void CA1812_CSharp_Diagnostic_EmptyInternalStaticClass()
+        public async Task CA1812_CSharp_Diagnostic_EmptyInternalStaticClass()
         {
             // Note that this is not considered a "static holder class"
             // because it doesn't actually have any static members.
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"internal static class S { }",
 
                 GetCSharpResultAt(
@@ -798,9 +844,9 @@ End Module");
         }
 
         [Fact]
-        public void CA1812_CSharp_NoDiagnostic_UninstantiatedInternalClassInFriendlyAssembly()
+        public async Task CA1812_CSharp_NoDiagnostic_UninstantiatedInternalClassInFriendlyAssembly()
         {
-            VerifyCSharp(
+            await VerifyCS.VerifyAnalyzerAsync(
 @"using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo(""TestProject"")]
@@ -810,9 +856,9 @@ internal class C { }"
         }
 
         [Fact]
-        public void CA1812_Basic_NoDiagnostic_UninstantiatedInternalClassInFriendlyAssembly()
+        public async Task CA1812_Basic_NoDiagnostic_UninstantiatedInternalClassInFriendlyAssembly()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"Imports System.Runtime.CompilerServices
 
 <Assembly: InternalsVisibleToAttribute(""TestProject"")>
@@ -823,9 +869,9 @@ End Class"
         }
 
         [Fact, WorkItem(1370, "https://github.com/dotnet/roslyn-analyzers/issues/1370")]
-        public void CA1812_Basic_NoDiagnostic_ImplicitlyInstantiatedFromSubTypeConstructor()
+        public async Task CA1812_Basic_NoDiagnostic_ImplicitlyInstantiatedFromSubTypeConstructor()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"
 Friend Class A
     Public Sub New()
@@ -851,9 +897,9 @@ End Class");
         }
 
         [Fact, WorkItem(1370, "https://github.com/dotnet/roslyn-analyzers/issues/1370")]
-        public void CA1812_Basic_NoDiagnostic_ExplicitlyInstantiatedFromSubTypeConstructor()
+        public async Task CA1812_Basic_NoDiagnostic_ExplicitlyInstantiatedFromSubTypeConstructor()
         {
-            VerifyBasic(
+            await VerifyVB.VerifyAnalyzerAsync(
 @"
 Friend Class A
     Public Sub New(ByVal x As Integer)
@@ -885,9 +931,9 @@ End Class");
         }
 
         [Fact, WorkItem(1154, "https://github.com/dotnet/roslyn-analyzers/issues/1154")]
-        public void CA1812_CSharp_GenericInternalClass_InstanciatedNoDiagnostic()
+        public async Task CA1812_CSharp_GenericInternalClass_InstanciatedNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -923,9 +969,9 @@ public static class X
         }
 
         [Fact, WorkItem(1154, "https://github.com/dotnet/roslyn-analyzers/issues/1154")]
-        public void CA1812_Basic_GenericInternalClass_InstanciatedNoDiagnostic()
+        public async Task CA1812_Basic_GenericInternalClass_InstanciatedNoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Collections.Generic
 Imports System.Linq
@@ -960,9 +1006,9 @@ End Module
         }
 
         [Fact, WorkItem(1158, "https://github.com/dotnet/roslyn-analyzers/issues/1158")]
-        public void CA1812_CSharp_NoDiagnostic_GenericMethodWithNewConstraint()
+        public async Task CA1812_CSharp_NoDiagnostic_GenericMethodWithNewConstraint()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 internal class InstantiatedType
@@ -988,9 +1034,9 @@ internal class Program
         }
 
         [Fact, WorkItem(1447, "https://github.com/dotnet/roslyn-analyzers/issues/1447")]
-        public void CA1812_CSharp_NoDiagnostic_GenericMethodWithNewConstraintInvokedFromGenericMethod()
+        public async Task CA1812_CSharp_NoDiagnostic_GenericMethodWithNewConstraintInvokedFromGenericMethod()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class InstantiatedClass
 {
     public InstantiatedClass()
@@ -1051,9 +1097,9 @@ internal static class C
         }
 
         [Fact, WorkItem(1158, "https://github.com/dotnet/roslyn-analyzers/issues/1158")]
-        public void CA1812_Basic_NoDiagnostic_GenericMethodWithNewConstraint()
+        public async Task CA1812_Basic_NoDiagnostic_GenericMethodWithNewConstraint()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Module Module1
@@ -1071,9 +1117,9 @@ End Module");
         }
 
         [Fact, WorkItem(1158, "https://github.com/dotnet/roslyn-analyzers/issues/1158")]
-        public void CA1812_CSharp_NoDiagnostic_GenericTypeWithNewConstraint()
+        public async Task CA1812_CSharp_NoDiagnostic_GenericTypeWithNewConstraint()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class InstantiatedType
 {
 }
@@ -1092,9 +1138,9 @@ internal class Program
         }
 
         [Fact, WorkItem(1158, "https://github.com/dotnet/roslyn-analyzers/issues/1158")]
-        public void CA1812_Basic_NoDiagnostic_GenericTypeWithNewConstraint()
+        public async Task CA1812_Basic_NoDiagnostic_GenericTypeWithNewConstraint()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Module Module1
@@ -1111,9 +1157,9 @@ End Module");
         }
 
         [Fact, WorkItem(1158, "https://github.com/dotnet/roslyn-analyzers/issues/1158")]
-        public void CA1812_CSharp_Diagnostic_NestedGenericTypeWithNoNewConstraint()
+        public async Task CA1812_CSharp_Diagnostic_NestedGenericTypeWithNoNewConstraint()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 
 internal class InstantiatedType
@@ -1142,9 +1188,9 @@ internal class Program
         }
 
         [Fact, WorkItem(1158, "https://github.com/dotnet/roslyn-analyzers/issues/1158")]
-        public void CA1812_Basic_Diagnostic_NestedGenericTypeWithNoNewConstraint()
+        public async Task CA1812_Basic_Diagnostic_NestedGenericTypeWithNoNewConstraint()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Collections.Generic
 
 Module Library
@@ -1169,9 +1215,9 @@ End Module",
         }
 
         [Fact, WorkItem(1158, "https://github.com/dotnet/roslyn-analyzers/issues/1158")]
-        public void CA1812_CSharp_NoDiagnostic_NestedGenericTypeWithNewConstraint()
+        public async Task CA1812_CSharp_NoDiagnostic_NestedGenericTypeWithNewConstraint()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 
 internal class InstantiatedType
@@ -1196,9 +1242,9 @@ internal class Program
         }
 
         [Fact, WorkItem(1158, "https://github.com/dotnet/roslyn-analyzers/issues/1158")]
-        public void CA1812_Basic_NoDiagnostic_NestedGenericTypeWithNewConstraint()
+        public async Task CA1812_Basic_NoDiagnostic_NestedGenericTypeWithNewConstraint()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Collections.Generic
 
 Module Library
@@ -1218,9 +1264,9 @@ End Module");
         }
 
         [Fact, WorkItem(1739, "https://github.com/dotnet/roslyn-analyzers/issues/1739")]
-        public void CA1812_CSharp_NoDiagnostic_GenericTypeWithRecursiveConstraint()
+        public async Task CA1812_CSharp_NoDiagnostic_GenericTypeWithRecursiveConstraint()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public abstract class JobStateBase<TState>
     where TState : JobStateBase<TState>, new()
 {
@@ -1238,9 +1284,9 @@ public class JobStateChangeHandler<TState>
         }
 
         [Fact, WorkItem(2751, "https://github.com/dotnet/roslyn-analyzers/issues/2751")]
-        public void CA1812_CSharp_NoDiagnostic_TypeDeclaredInCoClassAttribute()
+        public async Task CA1812_CSharp_NoDiagnostic_TypeDeclaredInCoClassAttribute()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 [CoClass(typeof(CFoo))]
@@ -1251,9 +1297,9 @@ internal class CFoo {}
         }
 
         [Fact, WorkItem(2751, "https://github.com/dotnet/roslyn-analyzers/issues/2751")]
-        public void CA1812_CSharp_DontFailOnInvalidCoClassUsages()
+        public async Task CA1812_CSharp_DontFailOnInvalidCoClassUsages()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 [CoClass]
@@ -1270,18 +1316,18 @@ internal interface IFoo4 {}
 
 internal class CFoo {}
 ",
-                TestValidationMode.AllowCompileErrors, // Invalid syntaxes around CoClass
+                CompilerDiagnostics.None, // Invalid syntaxes around CoClass
                 GetCSharpResultAt(16, 16, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "CFoo"));
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new AvoidUninstantiatedInternalClassesAnalyzer();
-        }
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new AvoidUninstantiatedInternalClassesAnalyzer();
-        }
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -2,9 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.VisualBasic;
 using Test.Utilities;
 
 using Xunit;
@@ -238,7 +236,11 @@ End Class");
 }",
                 SolutionTransforms =
                 {
-                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.ConsoleApplication))
+                    (solution, projectId) =>
+                    {
+                      var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                      return solution.WithProjectCompilationOptions(projectId, compilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+                    }
                 }
             }.RunAsync();
         }
@@ -254,9 +256,13 @@ End Class");
     End Sub
 End Class",
                 SolutionTransforms =
+                {
+                    (solution, projectId) =>
                     {
-                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
+                      var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                      return solution.WithProjectCompilationOptions(projectId, compilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
                     }
+                }
             }.RunAsync();
         }
 
@@ -272,7 +278,11 @@ End Class",
 }",
                 SolutionTransforms =
                 {
-                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.ConsoleApplication))
+                    (solution, projectId) =>
+                    {
+                      var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                      return solution.WithProjectCompilationOptions(projectId, compilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+                    }
                 }
             }.RunAsync();
         }
@@ -290,7 +300,11 @@ End Class",
 End Class",
                 SolutionTransforms =
                 {
-                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
+                    (solution, projectId) =>
+                    {
+                      var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                      return solution.WithProjectCompilationOptions(projectId, compilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+                    }
                 }
             }.RunAsync();
         }
@@ -309,7 +323,11 @@ internal static class C
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp7_1,
                 SolutionTransforms =
                 {
-                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.ConsoleApplication))
+                    (solution, projectId) =>
+                    {
+                      var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                      return solution.WithProjectCompilationOptions(projectId, compilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+                    }
                 }
             }.RunAsync();
         }
@@ -328,7 +346,11 @@ internal static class C
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp7_1,
                 SolutionTransforms =
                 {
-                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.ConsoleApplication))
+                    (solution, projectId) =>
+                    {
+                      var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                      return solution.WithProjectCompilationOptions(projectId, compilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+                    }
                 }
             }.RunAsync();
         }
@@ -368,7 +390,11 @@ End Class",
                 CompilerDiagnostics = CompilerDiagnostics.None, // No Main method
                 SolutionTransforms =
                 {
-                    (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
+                    (solution, projectId) =>
+                    {
+                      var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                      return solution.WithProjectCompilationOptions(projectId, compilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+                    }
                 }
             }.RunAsync();
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -258,7 +258,7 @@ End Class",
                     (solution, projectId) => solution.WithProjectCompilationOptions(projectId, new VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
                     }
             }.RunAsync();
-    }
+        }
 
         [Fact]
         public async Task CA1812_CSharp_NoDiagnostic_TypeContainingAssemblyEntryPointReturningInt()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -1,22 +1,28 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.Maintainability.ReviewUnusedParametersAnalyzer,
+    Microsoft.CodeQuality.CSharp.Analyzers.Maintainability.CSharpReviewUnusedParametersFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.Maintainability.ReviewUnusedParametersAnalyzer,
+    Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability.BasicReviewUnusedParametersFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 {
-    public class ReviewUnusedParametersTests : DiagnosticAnalyzerTestBase
+    public class ReviewUnusedParametersTests
     {
         #region Unit tests for no analyzer diagnostic
 
         [Fact]
         [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
-        public void NoDiagnosticSimpleCasesTest()
+        public async Task NoDiagnosticSimpleCasesTest()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class NeatCode
@@ -40,7 +46,7 @@ public class NeatCode
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class NeatCode
@@ -63,9 +69,9 @@ End Class
 
         [Fact]
         [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
-        public void NoDiagnosticDelegateTest()
+        public async Task NoDiagnosticDelegateTest()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class NeatCode
@@ -90,7 +96,7 @@ public class NeatCode
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class NeatCode
@@ -112,9 +118,9 @@ End Class
 
         [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
-        public void NoDiagnosticDelegateTest2_CSharp()
+        public async Task NoDiagnosticDelegateTest2_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class NeatCode
@@ -132,9 +138,9 @@ public class NeatCode
 
         [Fact]
         [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
-        public void NoDiagnosticDelegateTest2_VB()
+        public async Task NoDiagnosticDelegateTest2_VB()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class NeatCode
@@ -150,9 +156,9 @@ End Class
 
         [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
-        public void NoDiagnosticUsingTest_CSharp()
+        public async Task NoDiagnosticUsingTest_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class C
@@ -170,9 +176,9 @@ class C
 
         [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
-        public void NoDiagnosticUsingTest_VB()
+        public async Task NoDiagnosticUsingTest_VB()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class C
@@ -187,9 +193,9 @@ End Class
 
         [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
-        public void NoDiagnosticLinqTest_CSharp()
+        public async Task NoDiagnosticLinqTest_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Linq;
 using System.Reflection;
@@ -209,9 +215,9 @@ class C
 
         [Fact]
         [WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
-        public void NoDiagnosticLinqTest_VB()
+        public async Task NoDiagnosticLinqTest_VB()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Linq
 Imports System.Reflection
@@ -227,9 +233,9 @@ End Class
 
         [Fact]
         [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
-        public void NoDiagnosticSpecialCasesTest()
+        public async Task NoDiagnosticSpecialCasesTest()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -288,7 +294,7 @@ public class ClassWithExtern
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Runtime.InteropServices
 
@@ -345,9 +351,9 @@ End Class
 
         [Fact]
         [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
-        public void NoDiagnosticForMethodsWithSpecialAttributesTest()
+        public async Task NoDiagnosticForMethodsWithSpecialAttributesTest()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 #define CONDITION_1
 
 using System;
@@ -397,7 +403,7 @@ public class SerializableMethodsClass
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 #Const CONDITION_1 = 5
 
 Imports System
@@ -441,9 +447,9 @@ End Class
         }
 
         [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
-        public void NoDiagnosticForMethodsUsedAsDelegatesCSharp()
+        public async Task NoDiagnosticForMethodsUsedAsDelegatesCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C1
@@ -493,9 +499,9 @@ public class C3
         }
 
         [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
-        public void NoDiagnosticForMethodsUsedAsDelegatesBasic()
+        public async Task NoDiagnosticForMethodsUsedAsDelegatesBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Public Class C1
     Private _handler As Action(Of Object)
@@ -535,9 +541,9 @@ End Class
         }
 
         [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
-        public void NoDiagnosticForObsoleteMethods()
+        public async Task NoDiagnosticForObsoleteMethods()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C1
@@ -548,7 +554,7 @@ public class C1
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C1
@@ -559,9 +565,9 @@ End Class");
         }
 
         [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
-        public void NoDiagnosticMethodJustThrowsNotImplemented()
+        public async Task NoDiagnosticMethodJustThrowsNotImplemented()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class MyAttribute: Attribute
@@ -601,7 +607,7 @@ public class C1
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C1
@@ -621,9 +627,9 @@ End Class");
         }
 
         [Fact, WorkItem(1218, "https://github.com/dotnet/roslyn-analyzers/issues/1218")]
-        public void NoDiagnosticMethodJustThrowsNotSupported()
+        public async Task NoDiagnosticMethodJustThrowsNotSupported()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C1
@@ -648,7 +654,7 @@ public class C1
     public void Method2(object o1) => throw new NotSupportedException();
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C1
@@ -668,9 +674,9 @@ End Class");
         }
 
         [Fact]
-        public void NoDiagnosticsForIndexer()
+        public async Task NoDiagnosticsForIndexer()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public int this[int i]
@@ -681,7 +687,7 @@ class C
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Property Item(i As Integer) As Integer
         Get
@@ -696,9 +702,9 @@ End Class
         }
 
         [Fact]
-        public void NoDiagnosticsForPropertySetter()
+        public async Task NoDiagnosticsForPropertySetter()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public int Property
@@ -709,7 +715,7 @@ class C
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Property Property1 As Integer
         Get
@@ -723,9 +729,9 @@ End Class
 ");
         }
         [Fact]
-        public void NoDiagnosticsForFirstParameterOfExtensionMethod()
+        public async Task NoDiagnosticsForFirstParameterOfExtensionMethod()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 static class C
 {
     static void ExtensionMethod(this int i) { }
@@ -735,9 +741,9 @@ static class C
         }
 
         [Fact]
-        public void NoDiagnosticsForSingleStatementMethodsWithDefaultParameters()
+        public async Task NoDiagnosticsForSingleStatementMethodsWithDefaultParameters()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -749,7 +755,7 @@ public class C
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Public Class C
     Public Sub Test(bar As String, Optional baz As String = Nothing)
@@ -761,9 +767,9 @@ End Class");
         [Fact]
         [WorkItem(2589, "https://github.com/dotnet/roslyn-analyzers/issues/2589")]
         [WorkItem(2593, "https://github.com/dotnet/roslyn-analyzers/issues/2593")]
-        public void NoDiagnosticDiscardParameterNames()
+        public async Task NoDiagnosticDiscardParameterNames()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -774,7 +780,7 @@ public class C
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -787,9 +793,9 @@ End Class
 
         [Fact]
         [WorkItem(2466, "https://github.com/dotnet/roslyn-analyzers/issues/2466")]
-        public void NoDiagnosticUsedLocalFunctionParameters()
+        public async Task NoDiagnosticUsedLocalFunctionParameters()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -817,23 +823,23 @@ public class C
         [InlineData("public", "dotnet_code_quality.Usage.api_surface = internal, private")]
         [InlineData("public", @"dotnet_code_quality.api_surface = all
                                 dotnet_code_quality.CA1801.api_surface = private")]
-        public void EditorConfigConfiguration_ApiSurfaceOption(string accessibility, string editorConfigText)
+        public async Task EditorConfigConfiguration_ApiSurfaceOption(string accessibility, string editorConfigText)
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync($@"
 public class C
 {{
     {accessibility} void M(int unused)
     {{
     }}
 }}",
-                GetEditorConfigAdditionalFile(editorConfigText));
+                editorConfigText);
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync($@"
 Public Class C
     {accessibility} Sub M(unused As Integer)
     End Sub
 End Class",
-                GetEditorConfigAdditionalFile(editorConfigText));
+                editorConfigText);
         }
 
         #endregion
@@ -842,9 +848,9 @@ End Class",
 
         [Fact]
         [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
-        public void CSharp_DiagnosticForSimpleCasesTest()
+        public async Task CSharp_DiagnosticForSimpleCasesTest()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class C
@@ -881,7 +887,7 @@ class C
     {
     }
 }
-", TestValidationMode.AllowCompileErrors,
+", CompilerDiagnostics.None,
           // Test0.cs(6,18): warning CA1801: Parameter param of method .ctor is never used. Remove the parameter or use it in the method body.
           GetCSharpUnusedParameterResultAt(6, 18, "param", ".ctor"),
           // Test0.cs(10,39): warning CA1801: Parameter param of method UnusedParamMethod is never used. Remove the parameter or use it in the method body.
@@ -904,9 +910,9 @@ class C
 
         [Fact]
         [WorkItem(459, "https://github.com/dotnet/roslyn-analyzers/issues/459")]
-        public void Basic_DiagnosticForSimpleCasesTest()
+        public async Task Basic_DiagnosticForSimpleCasesTest()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Sub New(param As Integer)
     End Sub
@@ -932,7 +938,7 @@ Class C
     Public Sub UnusedErrorTypeParamMethod(param1 As UndefinedType) ' error BC30002: Type 'UndefinedType' is not defined.
     End Sub
 End Class
-", TestValidationMode.AllowCompileErrors,
+", CompilerDiagnostics.None,
       // Test0.vb(3,20): warning CA1801: Parameter param of method .ctor is never used. Remove the parameter or use it in the method body.
       GetBasicUnusedParameterResultAt(3, 20, "param", ".ctor"),
       // Test0.vb(6,34): warning CA1801: Parameter param of method UnusedParamMethod is never used. Remove the parameter or use it in the method body.
@@ -954,9 +960,9 @@ End Class
         }
 
         [Fact]
-        public void DiagnosticsForNonFirstParameterOfExtensionMethod()
+        public async Task DiagnosticsForNonFirstParameterOfExtensionMethod()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 static class C
 {
     static void ExtensionMethod(this int i, int anotherParam) { }
@@ -968,9 +974,9 @@ static class C
 
         [Fact]
         [WorkItem(2466, "https://github.com/dotnet/roslyn-analyzers/issues/2466")]
-        public void DiagnosticForUnusedLocalFunctionParameters_01()
+        public async Task DiagnosticForUnusedLocalFunctionParameters_01()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -991,9 +997,9 @@ public class C
 
         [Fact]
         [WorkItem(2466, "https://github.com/dotnet/roslyn-analyzers/issues/2466")]
-        public void DiagnosticForUnusedLocalFunctionParameters_02()
+        public async Task DiagnosticForUnusedLocalFunctionParameters_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -1014,27 +1020,15 @@ public class C
 
         #region Helpers
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new ReviewUnusedParametersAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new ReviewUnusedParametersAnalyzer();
-        }
-
         private static DiagnosticResult GetCSharpUnusedParameterResultAt(int line, int column, string parameterName, string methodName)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ReviewUnusedParametersMessage, parameterName, methodName);
-            return GetCSharpResultAt(line, column, ReviewUnusedParametersAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(ReviewUnusedParametersAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ReviewUnusedParametersMessage, parameterName, methodName));
 
         private static DiagnosticResult GetBasicUnusedParameterResultAt(int line, int column, string parameterName, string methodName)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ReviewUnusedParametersMessage, parameterName, methodName);
-            return GetBasicResultAt(line, column, ReviewUnusedParametersAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(ReviewUnusedParametersAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ReviewUnusedParametersMessage, parameterName, methodName));
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -791,7 +791,7 @@ End Class
 ");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/2996")]
         [WorkItem(2466, "https://github.com/dotnet/roslyn-analyzers/issues/2466")]
         public async Task NoDiagnosticUsedLocalFunctionParameters()
         {
@@ -990,7 +990,7 @@ static class C
     GetCSharpUnusedParameterResultAt(4, 49, "anotherParam", "ExtensionMethod"));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/2996")]
         [WorkItem(2466, "https://github.com/dotnet/roslyn-analyzers/issues/2466")]
         public async Task DiagnosticForUnusedLocalFunctionParameters_01()
         {
@@ -1013,7 +1013,7 @@ public class C
             GetCSharpUnusedParameterResultAt(11, 32, "x", "LocalFunction"));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/2996")]
         [WorkItem(2466, "https://github.com/dotnet/roslyn-analyzers/issues/2466")]
         public async Task DiagnosticForUnusedLocalFunctionParameters_02()
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -344,7 +344,7 @@ Public Class ClassWithExtern
     Public Shared Sub DllImportMethod(param As Integer)
     End Sub
 
-    Public Declare Function DeclareFunction Lib ""Dependency.dll"" (param As Integer) As Integer    
+    Public Declare Function DeclareFunction Lib ""Dependency.dll"" (param As Integer) As Integer
 End Class
 ");
         }
@@ -825,21 +825,39 @@ public class C
                                 dotnet_code_quality.CA1801.api_surface = private")]
         public async Task EditorConfigConfiguration_ApiSurfaceOption(string accessibility, string editorConfigText)
         {
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync($@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 public class C
 {{
     {accessibility} void M(int unused)
     {{
     }}
-}}",
-                editorConfigText);
+}}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
 
-            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync($@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 Public Class C
     {accessibility} Sub M(unused As Integer)
     End Sub
-End Class",
-                editorConfigText);
+End Class"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         #endregion

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -3,23 +3,28 @@
 using System.Globalization;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeQuality.CSharp.Analyzers.Maintainability;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.CSharp.Analyzers.Maintainability.CSharpUseNameofInPlaceOfStringAnalyzer,
+    Microsoft.CodeQuality.CSharp.Analyzers.Maintainability.CSharpUseNameofInPlaceOfStringFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability.BasicUseNameofInPlaceOfStringAnalyzer,
+    Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability.BasicUseNameofInPlaceOfStringFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 {
-    public class UseNameofInPlaceOfStringTests : DiagnosticAnalyzerTestBase
+    public class UseNameofInPlaceOfStringTests
     {
         #region Unit tests for no analyzer diagnostic
 
         [Fact]
-        public void NoDiagnostic_NoArguments()
+        public async Task NoDiagnostic_NoArguments()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -31,9 +36,9 @@ class C
         }
 
         [Fact]
-        public void NoDiagnostic_NullLiteral()
+        public async Task NoDiagnostic_NullLiteral()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -45,9 +50,9 @@ class C
         }
 
         [Fact]
-        public void NoDiagnostic_StringIsAReservedWord()
+        public async Task NoDiagnostic_StringIsAReservedWord()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -59,9 +64,9 @@ class C
         }
 
         [Fact]
-        public void NoDiagnostic_NoMatchingParametersInScope()
+        public async Task NoDiagnostic_NoMatchingParametersInScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -73,9 +78,9 @@ class C
         }
 
         [Fact]
-        public void NoDiagnostic_NameColonOtherParameterName()
+        public async Task NoDiagnostic_NameColonOtherParameterName()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -87,9 +92,9 @@ class C
         }
 
         [Fact]
-        public void NoDiagnostic_NotStringLiteral()
+        public async Task NoDiagnostic_NotStringLiteral()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -102,9 +107,9 @@ class C
         }
 
         [Fact]
-        public void NoDiagnostic_NotValidIdentifier()
+        public async Task NoDiagnostic_NotValidIdentifier()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -116,9 +121,9 @@ class C
         }
 
         [Fact]
-        public void NoDiagnostic_NoArgumentList()
+        public async Task NoDiagnostic_NoArgumentList()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -126,13 +131,13 @@ class C
     {
         throw new ArgumentNullException(
     }
-}", TestValidationMode.AllowCompileErrors);
+}", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void NoDiagnostic_NoMatchingParameter()
+        public async Task NoDiagnostic_NoMatchingParameter()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -140,13 +145,13 @@ class C
     {
         throw new ArgumentNullException(""test"", ""test2"", ""test3"");
     }
-}", TestValidationMode.AllowCompileErrors);
+}", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void NoDiagnostic_MatchesParameterButNotCalledParamName()
+        public async Task NoDiagnostic_MatchesParameterButNotCalledParamName()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -158,9 +163,9 @@ class C
         }
 
         [Fact]
-        public void NoDiagnostic_MatchesPropertyButNotCalledPropertyName()
+        public async Task NoDiagnostic_MatchesPropertyButNotCalledPropertyName()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.ComponentModel;
 
@@ -190,9 +195,9 @@ public class Person : INotifyPropertyChanged
         }
 
         [Fact]
-        public void NoDiagnostic_PositionalArgumentOtherParameterName()
+        public async Task NoDiagnostic_PositionalArgumentOtherParameterName()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -205,9 +210,9 @@ class C
 
         [WorkItem(1426, "https://github.com/dotnet/roslyn-analyzers/issues/1426")]
         [Fact]
-        public void NoDiagnostic_1426()
+        public async Task NoDiagnostic_1426()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.CompilerServices;
 
 public class C
@@ -229,9 +234,11 @@ public class C
 
         [WorkItem(1524, "https://github.com/dotnet/roslyn-analyzers/issues/1524")]
         [Fact]
-        public void NoDiagnostic_CSharp5()
+        public async Task NoDiagnostic_CSharp5()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 using System;
 class C
 {
@@ -239,14 +246,18 @@ class C
     {
         throw new ArgumentNullException(""x"");
     }
-}", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(CodeAnalysis.CSharp.LanguageVersion.CSharp5));
+}",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp5
+            }.RunAsync();
         }
 
         [WorkItem(1524, "https://github.com/dotnet/roslyn-analyzers/issues/1524")]
         [Fact]
-        public void Diagnostic_CSharp6()
+        public async Task Diagnostic_CSharp6()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 using System;
 class C
 {
@@ -254,35 +265,53 @@ class C
     {
         throw new ArgumentNullException(""x"");
     }
-}", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(CodeAnalysis.CSharp.LanguageVersion.CSharp6), expected: GetCSharpNameofResultAt(7, 41, "x"));
+}",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp6,
+                ExpectedDiagnostics =
+                {
+                    GetCSharpNameofResultAt(7, 41, "x")
+                }
+            }.RunAsync();
         }
 
         [WorkItem(1524, "https://github.com/dotnet/roslyn-analyzers/issues/1524")]
         [Fact]
-        public void NoDiagnostic_VB12()
+        public async Task NoDiagnostic_VB12()
         {
-            VerifyBasic(@"
+            await new VerifyVB.Test
+            {
+                TestCode = @"
 Imports System
 
 Module Mod1
     Sub f(s As String)
         Throw New ArgumentNullException(""s"")
     End Sub
-End Module", parseOptions: VisualBasicParseOptions.Default.WithLanguageVersion(CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic12));
+End Module",
+                LanguageVersion = LanguageVersion.VisualBasic12
+            }.RunAsync();
         }
 
         [WorkItem(1524, "https://github.com/dotnet/roslyn-analyzers/issues/1524")]
         [Fact]
-        public void Diagnostic_VB14()
+        public async Task Diagnostic_VB14()
         {
-            VerifyBasic(@"
+            await new VerifyVB.Test
+            {
+                TestCode = @"
 Imports System
 
 Module Mod1
     Sub f(s As String)
         Throw New ArgumentNullException(""s"")
     End Sub
-End Module", parseOptions: VisualBasicParseOptions.Default.WithLanguageVersion(CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic14), expected: GetBasicNameofResultAt(6, 41, "s"));
+End Module",
+                LanguageVersion = LanguageVersion.VisualBasic14,
+                ExpectedDiagnostics =
+                {
+                    GetBasicNameofResultAt(6, 41, "s")
+                }
+            }.RunAsync();
         }
 
         #endregion
@@ -291,9 +320,9 @@ End Module", parseOptions: VisualBasicParseOptions.Default.WithLanguageVersion(C
         #region Unit tests for analyzer diagnostic(s)
 
         [Fact]
-        public void Diagnostic_ArgumentMatchesAParameterInScope()
+        public async Task Diagnostic_ArgumentMatchesAParameterInScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -306,9 +335,9 @@ class C
         }
 
         [Fact]
-        public void Diagnostic_VB_ArgumentMatchesAParameterInScope()
+        public async Task Diagnostic_VB_ArgumentMatchesAParameterInScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Module Mod1
@@ -320,9 +349,9 @@ End Module",
         }
 
         [Fact]
-        public void Diagnostic_ArgumentMatchesAPropertyInScope()
+        public async Task Diagnostic_ArgumentMatchesAPropertyInScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class Person : INotifyPropertyChanged
@@ -352,9 +381,9 @@ public class Person : INotifyPropertyChanged
         }
 
         [Fact]
-        public void Diagnostic_ArgumentMatchesAPropertyInScope2()
+        public async Task Diagnostic_ArgumentMatchesAPropertyInScope2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class Person : INotifyPropertyChanged
@@ -395,9 +424,9 @@ public class Person : INotifyPropertyChanged
         }
 
         [Fact]
-        public void Diagnostic_ArgumentNameColonParamName()
+        public async Task Diagnostic_ArgumentNameColonParamName()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 class C
 {
@@ -410,9 +439,9 @@ class C
         }
 
         [Fact]
-        public void Diagnostic_ArgumentNameColonPropertyName()
+        public async Task Diagnostic_ArgumentNameColonPropertyName()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class Person : INotifyPropertyChanged
@@ -443,9 +472,9 @@ public class Person : INotifyPropertyChanged
 
 
         [Fact]
-        public void Diagnostic_AnonymousFunctionMultiline1()
+        public async Task Diagnostic_AnonymousFunctionMultiline1()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Test
@@ -462,9 +491,9 @@ class Test
         }
 
         [Fact]
-        public void Diagnostic_AnonymousFunctionMultiLine2()
+        public async Task Diagnostic_AnonymousFunctionMultiLine2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Test
@@ -481,9 +510,9 @@ class Test
         }
 
         [Fact]
-        public void Diagnostic_AnonymousFunctionSingleLine1()
+        public async Task Diagnostic_AnonymousFunctionSingleLine1()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Test
@@ -497,9 +526,9 @@ class Test
         }
 
         [Fact]
-        public void Diagnostic_AnonymousFunctionSingleLine2()
+        public async Task Diagnostic_AnonymousFunctionSingleLine2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Test
@@ -513,9 +542,9 @@ class Test
         }
 
         [Fact]
-        public void Diagnostic_AnonymousFunctionMultipleParameters()
+        public async Task Diagnostic_AnonymousFunctionMultipleParameters()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Test
@@ -529,9 +558,9 @@ class Test
         }
 
         [Fact]
-        public void Diagnostic_LocalFunction1()
+        public async Task Diagnostic_LocalFunction1()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Test
@@ -548,9 +577,9 @@ class Test
         }
 
         [Fact]
-        public void Diagnostic_LocalFunction2()
+        public async Task Diagnostic_LocalFunction2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Test
@@ -567,9 +596,9 @@ class Test
         }
 
         [Fact]
-        public void Diagnostic_Delegate()
+        public async Task Diagnostic_Delegate()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 namespace ConsoleApp14
@@ -591,25 +620,13 @@ namespace ConsoleApp14
         #endregion
 
         private DiagnosticResult GetBasicNameofResultAt(int line, int column, string name)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UseNameOfInPlaceOfStringMessage, name);
-            return GetBasicResultAt(line, column, UseNameofInPlaceOfStringAnalyzer.RuleId, message);
-        }
+            => new DiagnosticResult(UseNameofInPlaceOfStringAnalyzer.RuleWithSuggestion)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UseNameOfInPlaceOfStringMessage, name));
 
         private DiagnosticResult GetCSharpNameofResultAt(int line, int column, string name)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UseNameOfInPlaceOfStringMessage, name);
-            return GetCSharpResultAt(line, column, UseNameofInPlaceOfStringAnalyzer.RuleId, message);
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicUseNameofInPlaceOfStringAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpUseNameofInPlaceOfStringAnalyzer();
-        }
+            => new DiagnosticResult(UseNameofInPlaceOfStringAnalyzer.RuleWithSuggestion)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UseNameOfInPlaceOfStringMessage, name));
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.VisualBasic;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -288,7 +285,7 @@ Module Mod1
         Throw New ArgumentNullException(""s"")
     End Sub
 End Module",
-                LanguageVersion = LanguageVersion.VisualBasic12
+                LanguageVersion = CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic12
             }.RunAsync();
         }
 
@@ -306,7 +303,7 @@ Module Mod1
         Throw New ArgumentNullException(""s"")
     End Sub
 End Module",
-                LanguageVersion = LanguageVersion.VisualBasic14,
+                LanguageVersion = CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic14,
                 ExpectedDiagnostics =
                 {
                     GetBasicNameofResultAt(6, 41, "s")
@@ -406,7 +403,7 @@ public class Person : INotifyPropertyChanged
         get { return name; }
         set
         {
-            name = value; 
+            name = value;
             OnPropertyChanged(nameof(PersonName2));
         }
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
@@ -1,28 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.Analyzers.QualityGuidelines;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.AssigningSymbolAndItsMemberInSameStatement,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.UnitTests.QualityGuidelines
 {
-    public partial class AssigningSymbolAndItsMemberInSameStatementTests : DiagnosticAnalyzerTestBase
+    public class AssigningSymbolAndItsMemberInSameStatementTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new AssigningSymbolAndItsMemberInSameStatement();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new AssigningSymbolAndItsMemberInSameStatement();
-        }
-
         [Fact]
-        public void CSharpReassignLocalVariableAndReferToItsField()
+        public async Task CSharpReassignLocalVariableAndReferToItsField()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Field;
@@ -37,13 +31,13 @@ public class Test
     }
 }
 ",
-            GetCSharpResultAt(12, 9, AssigningSymbolAndItsMemberInSameStatement.Rule, "a", "Field"));
+            GetCSharpResultAt(12, 9, "a", "Field"));
         }
 
         [Fact]
-        public void CSharpReassignLocalVariableAndReferToItsProperty()
+        public async Task CSharpReassignLocalVariableAndReferToItsProperty()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -58,13 +52,13 @@ public class Test
     }
 }
 ",
-            GetCSharpResultAt(12, 9, AssigningSymbolAndItsMemberInSameStatement.Rule, "a", "Property"));
+            GetCSharpResultAt(12, 9, "a", "Property"));
         }
 
         [Fact]
-        public void CSharpReassignLocalVariablesPropertyAndReferToItsProperty()
+        public async Task CSharpReassignLocalVariablesPropertyAndReferToItsProperty()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -79,13 +73,13 @@ public class Test
     }
 }
 ",
-            GetCSharpResultAt(12, 9, AssigningSymbolAndItsMemberInSameStatement.Rule, "a.Property", "Property"));
+            GetCSharpResultAt(12, 9, "a.Property", "Property"));
         }
 
         [Fact]
-        public void CSharpReassignLocalVariableAndItsPropertyAndReferToItsProperty()
+        public async Task CSharpReassignLocalVariableAndItsPropertyAndReferToItsProperty()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -100,14 +94,14 @@ public class Test
     }
 }
 ",
-            GetCSharpResultAt(12, 9, AssigningSymbolAndItsMemberInSameStatement.Rule, "a.Property", "Property"),
-            GetCSharpResultAt(12, 31, AssigningSymbolAndItsMemberInSameStatement.Rule, "a", "Property"));
+            GetCSharpResultAt(12, 9, "a.Property", "Property"),
+            GetCSharpResultAt(12, 31, "a", "Property"));
         }
 
         [Fact]
-        public void CSharpReferToFieldOfReferenceTypeLocalVariableAfterItsReassignment()
+        public async Task CSharpReferToFieldOfReferenceTypeLocalVariableAfterItsReassignment()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Field;
@@ -123,13 +117,13 @@ public class Test
     }
 }
 ",
-            GetCSharpResultAt(13, 9, AssigningSymbolAndItsMemberInSameStatement.Rule, "x", "Field"));
+            GetCSharpResultAt(13, 9, "x", "Field"));
         }
 
         [Fact]
-        public void CSharpReassignGlobalVariableAndReferToItsField()
+        public async Task CSharpReassignGlobalVariableAndReferToItsField()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -145,13 +139,13 @@ public class Test
     }
 }
 ",
-            GetCSharpResultAt(13, 9, AssigningSymbolAndItsMemberInSameStatement.Rule, "x.Property", "Property"));
+            GetCSharpResultAt(13, 9, "x.Property", "Property"));
         }
 
         [Fact]
-        public void CSharpReassignGlobalVariableAndItsPropertyAndReferToItsProperty()
+        public async Task CSharpReassignGlobalVariableAndItsPropertyAndReferToItsProperty()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -167,15 +161,15 @@ public class Test
     }
 }
 ",
-            GetCSharpResultAt(13, 9, AssigningSymbolAndItsMemberInSameStatement.Rule, "x.Property", "Property"),
-            GetCSharpResultAt(13, 31, AssigningSymbolAndItsMemberInSameStatement.Rule, "x", "Property"));
+            GetCSharpResultAt(13, 9, "x.Property", "Property"),
+            GetCSharpResultAt(13, 31, "x", "Property"));
         }
 
 
         [Fact]
-        public void CSharpReassignGlobalPropertyAndItsPropertyAndReferToItsProperty()
+        public async Task CSharpReassignGlobalPropertyAndItsPropertyAndReferToItsProperty()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -192,14 +186,14 @@ public class Test
     }
 }
 ",
-            GetCSharpResultAt(14, 9, AssigningSymbolAndItsMemberInSameStatement.Rule, "x.Property", "Property"),
-            GetCSharpResultAt(14, 31, AssigningSymbolAndItsMemberInSameStatement.Rule, "x", "Property"));
+            GetCSharpResultAt(14, 9, "x.Property", "Property"),
+            GetCSharpResultAt(14, 31, "x", "Property"));
         }
 
         [Fact]
-        public void CSharpReassignSecondLocalVariableAndReferToItsPropertyOfFirstVariable()
+        public async Task CSharpReassignSecondLocalVariableAndReferToItsPropertyOfFirstVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -217,9 +211,9 @@ public class Test
         }
 
         [Fact]
-        public void CSharpReassignPropertyOfFirstLocalVariableWithSecondAndReferToPropertyOfSecondVariable()
+        public async Task CSharpReassignPropertyOfFirstLocalVariableWithSecondAndReferToPropertyOfSecondVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -237,9 +231,9 @@ public class Test
         }
 
         [Fact]
-        public void CSharpReassignPropertyOfFirstLocalVariableWithThirdAndReferToPropertyOfSecondVariable()
+        public async Task CSharpReassignPropertyOfFirstLocalVariableWithThirdAndReferToPropertyOfSecondVariable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -257,9 +251,9 @@ public class Test
         }
 
         [Fact]
-        public void CSharpReassignMethodParameterAndReferToItsProperty()
+        public async Task CSharpReassignMethodParameterAndReferToItsProperty()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public C Property { get; set; }
@@ -274,13 +268,13 @@ public class Test
     }
 }
 ",
-            GetCSharpResultAt(12, 9, AssigningSymbolAndItsMemberInSameStatement.Rule, "b", "Property"));
+            GetCSharpResultAt(12, 9, "b", "Property"));
         }
 
         [Fact]
-        public void CSharpReassignLocalValueTypeVariableAndReferToItsField()
+        public async Task CSharpReassignLocalValueTypeVariableAndReferToItsField()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
     public S Field;
@@ -294,13 +288,13 @@ public class Test
         a.Field = a = b;
     }
 }
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CSharpReassignLocalValueTypeVariableAndReferToItsProperty()
+        public async Task CSharpReassignLocalValueTypeVariableAndReferToItsProperty()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
     public S Property { get; set; }
@@ -314,13 +308,13 @@ public class Test
         a.Property = c = a = b;
     }
 }
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CSharpAssignmentInCodeWithOperationNone()
+        public async Task CSharpAssignmentInCodeWithOperationNone()
         {
-            VerifyCSharpUnsafeCode(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct Test
 {
     public System.IntPtr PtrField;
@@ -334,9 +328,9 @@ public struct Test
 
         [Fact]
         [WorkItem(2889, "https://github.com/dotnet/roslyn-analyzers/issues/2889")]
-        public void CSharpAssignmentLocalReferenceOperation()
+        public async Task CSharpAssignmentLocalReferenceOperation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public static class Class1
 {
     public static void Foo()
@@ -347,5 +341,10 @@ public static class Class1
 }
 ");
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => new DiagnosticResult(AssigningSymbolAndItsMemberInSameStatement.Rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidDuplicateElementInitializationTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidDuplicateElementInitializationTests.cs
@@ -1,29 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidDuplicateElementInitialization,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
-    public partial class AvoidDuplicateElementInitializationTests : DiagnosticAnalyzerTestBase
+    public class AvoidDuplicateElementInitializationTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return null;
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new AvoidDuplicateElementInitialization();
-        }
-
         [Fact]
-        public void NoInitializer()
+        public async Task NoInitializer()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -35,9 +26,9 @@ class C
         }
 
         [Fact]
-        public void LiteralIntIndex()
+        public async Task LiteralIntIndex()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -55,9 +46,9 @@ class C
         }
 
         [Fact]
-        public void CalculatedIntIndex()
+        public async Task CalculatedIntIndex()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -75,9 +66,9 @@ class C
         }
 
         [Fact]
-        public void LiteralStringIndex()
+        public async Task LiteralStringIndex()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -95,9 +86,9 @@ class C
         }
 
         [Fact]
-        public void ConcatenatedStringIndex()
+        public async Task ConcatenatedStringIndex()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -115,9 +106,9 @@ class C
         }
 
         [Fact]
-        public void EnumIndex()
+        public async Task EnumIndex()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -136,9 +127,9 @@ class C
         }
 
         [Fact]
-        public void MultipleIndexerArguments()
+        public async Task MultipleIndexerArguments()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -166,9 +157,9 @@ class D
         }
 
         [Fact]
-        public void MultipleIndexerArgumentsNamed()
+        public async Task MultipleIndexerArgumentsNamed()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -196,9 +187,9 @@ class D
         }
 
         [Fact]
-        public void MultipleIndexerArgumentsNamedWithAtPrefix()
+        public async Task MultipleIndexerArgumentsNamedWithAtPrefix()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -226,9 +217,9 @@ class D
         }
 
         [Fact]
-        public void MultipleArgumentsWithOmittedDefault()
+        public async Task MultipleArgumentsWithOmittedDefault()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -258,9 +249,9 @@ class D
         }
 
         [Fact]
-        public void NonConstantArguments()
+        public async Task NonConstantArguments()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -278,9 +269,9 @@ class C
         }
 
         [Fact]
-        public void MatchingNonConstantArguments()
+        public async Task MatchingNonConstantArguments()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -298,9 +289,9 @@ class C
         }
 
         [Fact]
-        public void ConstantMatchingNonConstantArgument()
+        public async Task ConstantMatchingNonConstantArgument()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo()
@@ -317,9 +308,9 @@ class C
         }
 
         [Fact]
-        public void AllNonConstantArguments()
+        public async Task AllNonConstantArguments()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Foo(string a)
@@ -337,8 +328,8 @@ class C
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
-        {
-            return GetCSharpResultAt(line, column, AvoidDuplicateElementInitialization.Rule, symbolName);
-        }
+            => new DiagnosticResult(AvoidDuplicateElementInitialization.Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
@@ -1,29 +1,24 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.Analyzers.QualityGuidelines;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidPropertySelfAssignment,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidPropertySelfAssignment,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.UnitTests.QualityGuidelines
 {
-    public partial class AvoidPropertySelfAssignmentTests : DiagnosticAnalyzerTestBase
+    public class AvoidPropertySelfAssignmentTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new AvoidPropertySelfAssignment();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new AvoidPropertySelfAssignment();
-        }
-
         [Fact]
-        public void CSharpAssignmentInConstructorWithNoArguments()
+        public async Task CSharpAssignmentInConstructorWithNoArguments()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private string P { get; set; }
@@ -37,9 +32,9 @@ class C
         }
 
         [Fact]
-        public void CSharpAssignmentInConstructorUsingThisWithNoArguments()
+        public async Task CSharpAssignmentInConstructorUsingThisWithNoArguments()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private string P { get; set; }
@@ -54,9 +49,9 @@ class C
 
 
         [Fact]
-        public void CSharpAssignmentInConstructorWithSimilarArgument()
+        public async Task CSharpAssignmentInConstructorWithSimilarArgument()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private string P { get; set; }
@@ -70,9 +65,9 @@ class C
         }
 
         [Fact]
-        public void CSharpAssignmentInMethodWithoutArguments()
+        public async Task CSharpAssignmentInMethodWithoutArguments()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private string P { get; set; }
@@ -86,9 +81,9 @@ class C
         }
 
         [Fact]
-        public void CSharpAssignmentInMethodWithSimilarArgumentName()
+        public async Task CSharpAssignmentInMethodWithSimilarArgumentName()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private string P { get; set; }
@@ -102,9 +97,9 @@ class C
         }
 
         [Fact]
-        public void CSharpAdditionAssignmentOperatorDoesNotCauseDiagnosticToAppear()
+        public async Task CSharpAdditionAssignmentOperatorDoesNotCauseDiagnosticToAppear()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private int Property { get; set; }
@@ -117,9 +112,9 @@ class C
         }
 
         [Fact]
-        public void CSharpNormalPropertyAssignmentDoesNotCauseDiagnosticToAppear()
+        public async Task CSharpNormalPropertyAssignmentDoesNotCauseDiagnosticToAppear()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private string P { get; set; }
@@ -132,9 +127,9 @@ class C
         }
 
         [Fact]
-        public void CSharpNormalAssignmentOfTwoDifferentPropertiesDoesNotCauseDiagnosticToAppear()
+        public async Task CSharpNormalAssignmentOfTwoDifferentPropertiesDoesNotCauseDiagnosticToAppear()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private string FirstP { get; set; }
@@ -148,9 +143,9 @@ class C
         }
 
         [Fact]
-        public void CSharpNormalVariableAssignmentDoesNotCauseDiagnosticToAppear()
+        public async Task CSharpNormalVariableAssignmentDoesNotCauseDiagnosticToAppear()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private string P { get; set; }
@@ -163,9 +158,9 @@ class C
         }
 
         [Fact]
-        public void CSharpNormalAssignmentWithTwoDifferentInstancesDoesNotCauseDiagnosticToAppear()
+        public async Task CSharpNormalAssignmentWithTwoDifferentInstancesDoesNotCauseDiagnosticToAppear()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class A
 {
     public string P { get; set; } = ""value"";
@@ -184,9 +179,9 @@ class C
         }
 
         [Fact]
-        public void CSharpIndexerAssignmentDoesNotCauseDiagnosticToAppear()
+        public async Task CSharpIndexerAssignmentDoesNotCauseDiagnosticToAppear()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class A
 {
     private int[] _a;
@@ -203,9 +198,9 @@ internal class A
         }
 
         [Fact]
-        public void CSharpIndexerAssignmentWithSameConstantIndexCausesDiagnosticToAppear()
+        public async Task CSharpIndexerAssignmentWithSameConstantIndexCausesDiagnosticToAppear()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class A
 {
     private int[] _a;
@@ -221,9 +216,9 @@ internal class A
         }
 
         [Fact]
-        public void CSharpIndexerAssignmentWithSameLocalReferenceIndexCausesDiagnosticToAppear()
+        public async Task CSharpIndexerAssignmentWithSameLocalReferenceIndexCausesDiagnosticToAppear()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class A
 {
     private int[] _a;
@@ -240,9 +235,9 @@ internal class A
         }
 
         [Fact]
-        public void CSharpIndexerAssignmentWithSameParameterReferenceIndexCausesDiagnosticToAppear()
+        public async Task CSharpIndexerAssignmentWithSameParameterReferenceIndexCausesDiagnosticToAppear()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal class A
 {
     private int[] _a;
@@ -258,9 +253,9 @@ internal class A
         }
 
         [Fact]
-        public void VbAssignmentInConstructorWithNoArguments()
+        public async Task VbAssignmentInConstructorWithNoArguments()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Private Property [P] As String
 
@@ -273,9 +268,9 @@ End Class
         }
 
         [Fact]
-        public void VbAssignmentInConstructorUsingThisWithNoArguments()
+        public async Task VbAssignmentInConstructorUsingThisWithNoArguments()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Private Property [P] As String
 
@@ -289,9 +284,9 @@ End Class
 
 
         [Fact]
-        public void VbAssignmentInConstructorWithSimilarArgument()
+        public async Task VbAssignmentInConstructorWithSimilarArgument()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Private Property [P] As String
 
@@ -304,9 +299,9 @@ End Class
         }
 
         [Fact]
-        public void VbAssignmentInMethodWithoutArguments()
+        public async Task VbAssignmentInMethodWithoutArguments()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Private Property [P] As String
 
@@ -319,9 +314,9 @@ End Class
         }
 
         [Fact]
-        public void VbAssignmentInMethodWithSimilarArgumentName()
+        public async Task VbAssignmentInMethodWithSimilarArgumentName()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Private Property [P] As String
 
@@ -334,9 +329,9 @@ End Class
         }
 
         [Fact]
-        public void VbAdditionAssignmentOperatorDoesNotCauseDiagnosticToAppear()
+        public async Task VbAdditionAssignmentOperatorDoesNotCauseDiagnosticToAppear()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Private Property [P] As Integer
 
@@ -348,9 +343,9 @@ End Class
         }
 
         [Fact]
-        public void VbNormalPropertyAssignmentDoesNotCauseDiagnosticToAppear()
+        public async Task VbNormalPropertyAssignmentDoesNotCauseDiagnosticToAppear()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Private Property [P] As String
 
@@ -362,9 +357,9 @@ End Class
         }
 
         [Fact]
-        public void VbNormalAssignmentOfTwoDifferentPropertiesDoesNotCauseDiagnosticToAppear()
+        public async Task VbNormalAssignmentOfTwoDifferentPropertiesDoesNotCauseDiagnosticToAppear()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Private Property FirstP As String
     Private Property SecondP As String
@@ -377,9 +372,9 @@ End Class
         }
 
         [Fact]
-        public void VbNormalVariableAssignmentDoesNotCauseDiagnosticToAppear()
+        public async Task VbNormalVariableAssignmentDoesNotCauseDiagnosticToAppear()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Private Property [P] As String
 
@@ -391,9 +386,9 @@ End Class
         }
 
         [Fact]
-        public void VbNormalAssignmentWithTwoDifferentInstancesDoesNotCauseDiagnosticToAppear()
+        public async Task VbNormalAssignmentWithTwoDifferentInstancesDoesNotCauseDiagnosticToAppear()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Class A
     Public Property [P] As String = ""value""
 End Class
@@ -409,13 +404,13 @@ End Class
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
-        {
-            return GetCSharpResultAt(line, column, AvoidPropertySelfAssignment.Rule, symbolName);
-        }
+            => new DiagnosticResult(AvoidPropertySelfAssignment.Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
 
         private DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
-        {
-            return GetBasicResultAt(line, column, AvoidPropertySelfAssignment.Rule, symbolName);
-        }
+            => new DiagnosticResult(AvoidPropertySelfAssignment.Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotCallOverridableMethodsInConstructorsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotCallOverridableMethodsInConstructorsTests.cs
@@ -1,11 +1,18 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.DoNotCallOverridableMethodsInConstructorsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.DoNotCallOverridableMethodsInConstructorsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
@@ -22,9 +29,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2214VirtualMethodCSharp()
+        public async Task CA2214VirtualMethodCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     C()
@@ -55,9 +62,9 @@ class C
         }
 
         [Fact]
-        public void CA2214VirtualMethodBasic()
+        public async Task CA2214VirtualMethodBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Sub New()
         Foo()
@@ -84,9 +91,9 @@ End Class
         }
 
         [Fact]
-        public void CA2214AbstractMethodCSharp()
+        public async Task CA2214AbstractMethodCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 abstract class C
 {
     C()
@@ -101,9 +108,9 @@ abstract class C
         }
 
         [Fact]
-        public void CA2214AbstractMethodBasic()
+        public async Task CA2214AbstractMethodBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 MustInherit Class C
     Public Sub New()
         Foo()
@@ -115,9 +122,9 @@ End Class
         }
 
         [Fact]
-        public void CA2214MultipleInstancesCSharp()
+        public async Task CA2214MultipleInstancesCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 abstract class C
 {
     C()
@@ -135,9 +142,9 @@ abstract class C
         }
 
         [Fact]
-        public void CA2214MultipleInstancesBasic()
+        public async Task CA2214MultipleInstancesBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 MustInherit Class C
     Public Sub New()
         Foo()
@@ -153,9 +160,9 @@ End Class
         }
 
         [Fact]
-        public void CA2214NotTopLevelCSharp()
+        public async Task CA2214NotTopLevelCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 abstract class C
 {
     C()
@@ -179,9 +186,9 @@ abstract class C
         }
 
         [Fact]
-        public void CA2214NotTopLevelBasic()
+        public async Task CA2214NotTopLevelBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 MustInherit Class C
     Public Sub New()
         If True Then
@@ -200,9 +207,9 @@ End Class
         }
 
         [Fact]
-        public void CA2214NoDiagnosticsOutsideConstructorCSharp()
+        public async Task CA2214NoDiagnosticsOutsideConstructorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 abstract class C
 {
     protected abstract void Foo();
@@ -216,9 +223,9 @@ abstract class C
         }
 
         [Fact]
-        public void CA2214NoDiagnosticsOutsideConstructorBasic()
+        public async Task CA2214NoDiagnosticsOutsideConstructorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 MustInherit Class C
     MustOverride Sub Foo()
 
@@ -230,7 +237,7 @@ End Class
         }
 
         [Fact]
-        public void CA2214SpecialInheritanceCSharp()
+        public async Task CA2214SpecialInheritanceCSharp()
         {
             var source = @"
 abstract class C : System.Web.UI.Control
@@ -288,7 +295,7 @@ abstract class F : System.ComponentModel.Component
         }
 
         [Fact]
-        public void CA2214SpecialInheritanceBasic()
+        public async Task CA2214SpecialInheritanceBasic()
         {
             var source = @"
 MustInherit Class C
@@ -339,9 +346,9 @@ End Class
         }
 
         [Fact]
-        public void CA2214VirtualOnOtherClassesCSharp()
+        public async Task CA2214VirtualOnOtherClassesCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class D
 {
     public virtual void Foo() {}
@@ -361,9 +368,9 @@ class C
         }
 
         [Fact]
-        public void CA2214VirtualOnOtherClassesBasic()
+        public async Task CA2214VirtualOnOtherClassesBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class D
     Public Overridable Sub Foo()
     End Sub
@@ -380,9 +387,9 @@ End Class
         }
 
         [Fact, WorkItem(1652, "https://github.com/dotnet/roslyn-analyzers/issues/1652")]
-        public void CA2214VirtualInvocationsInLambdaCSharp()
+        public async Task CA2214VirtualInvocationsInLambdaCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 internal abstract class A
@@ -399,9 +406,9 @@ internal abstract class A
         }
 
         [Fact, WorkItem(1652, "https://github.com/dotnet/roslyn-analyzers/issues/1652")]
-        public void CA2214VirtualInvocationsInLambdaBasic()
+        public async Task CA2214VirtualInvocationsInLambdaBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Friend MustInherit Class A
@@ -417,13 +424,13 @@ End Class
         }
 
         private static DiagnosticResult GetCA2214CSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, DoNotCallOverridableMethodsInConstructorsAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.DoNotCallOverridableMethodsInConstructors);
-        }
+            => new DiagnosticResult(DoNotCallOverridableMethodsInConstructorsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DoNotCallOverridableMethodsInConstructors);
 
         private static DiagnosticResult GetCA2214BasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, DoNotCallOverridableMethodsInConstructorsAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.DoNotCallOverridableMethodsInConstructors);
-        }
+            => new DiagnosticResult(DoNotCallOverridableMethodsInConstructorsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DoNotCallOverridableMethodsInConstructors);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotCallOverridableMethodsInConstructorsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotCallOverridableMethodsInConstructorsTests.cs
@@ -237,7 +237,7 @@ End Class
         }
 
         [Fact]
-        public async Task CA2214SpecialInheritanceCSharp()
+        public void CA2214SpecialInheritanceCSharp()
         {
             var source = @"
 abstract class C : System.Web.UI.Control
@@ -295,7 +295,7 @@ abstract class F : System.ComponentModel.Component
         }
 
         [Fact]
-        public async Task CA2214SpecialInheritanceBasic()
+        public void CA2214SpecialInheritanceBasic()
         {
             var source = @"
 MustInherit Class C

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotRaiseExceptionsInExceptionClausesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotRaiseExceptionsInExceptionClausesTests.cs
@@ -1,25 +1,21 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.DoNotRaiseExceptionsInExceptionClausesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.DoNotRaiseExceptionsInExceptionClausesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
-    public class DoNotRaiseExceptionsInExceptionClausesTests : DiagnosticAnalyzerTestBase
+    public class DoNotRaiseExceptionsInExceptionClausesTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotRaiseExceptionsInExceptionClausesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotRaiseExceptionsInExceptionClausesAnalyzer();
-        }
-
         [Fact]
-        public void CSharpSimpleCase()
+        public async Task CSharpSimpleCase()
         {
             var code = @"
 using System;
@@ -44,16 +40,15 @@ public class Test
         {
             throw new Exception();
         }
-    
     }
 }
 ";
-            VerifyCSharp(code,
-                GetCSharpResultAt(22, 13, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                GetCSharpResultAt(22, 13));
         }
 
         [Fact]
-        public void BasicSimpleCase()
+        public async Task BasicSimpleCase()
         {
             var code = @"
 Imports System
@@ -68,16 +63,16 @@ Public Class Test
             Throw New Exception()
         Finally
             Throw New Exception()
-        End Try    
+        End Try
     End Sub
 End Class
 ";
-            VerifyBasic(code,
-                GetBasicResultAt(13, 13, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule));
+            await VerifyVB.VerifyAnalyzerAsync(code,
+                GetBasicResultAt(13, 13));
         }
 
         [Fact]
-        public void CSharpNestedFinally()
+        public async Task CSharpNestedFinally()
         {
             var code = @"
 using System;
@@ -108,15 +103,15 @@ public class Test
     }
 }
 ";
-            VerifyCSharp(code,
-                GetCSharpResultAt(15, 17, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule),
-                GetCSharpResultAt(19, 17, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule),
-                GetCSharpResultAt(23, 17, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule),
-                GetCSharpResultAt(25, 13, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                GetCSharpResultAt(15, 17),
+                GetCSharpResultAt(19, 17),
+                GetCSharpResultAt(23, 17),
+                GetCSharpResultAt(25, 13));
         }
 
         [Fact]
-        public void BasicNestedFinally()
+        public async Task BasicNestedFinally()
         {
             var code = @"
 Imports System
@@ -137,11 +132,19 @@ Public Class Test
     End Sub
 End Class
 ";
-            VerifyBasic(code,
-                GetBasicResultAt(9, 17, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule),
-                GetBasicResultAt(11, 17, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule),
-                GetBasicResultAt(13, 17, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule),
-                GetBasicResultAt(15, 13, DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule));
+            await VerifyVB.VerifyAnalyzerAsync(code,
+                GetBasicResultAt(9, 17),
+                GetBasicResultAt(11, 17),
+                GetBasicResultAt(13, 17),
+                GetBasicResultAt(15, 13));
         }
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
+            => new DiagnosticResult(DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule)
+                .WithLocation(line, column);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
+            => new DiagnosticResult(DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule)
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/PreferJaggedArraysOverMultidimensionalTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/PreferJaggedArraysOverMultidimensionalTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.QualityGuidelines.PreferJaggedArraysOverMultidimensionalAnalyzer,
@@ -13,22 +12,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
-    public class PreferJaggedArraysOverMultidimensionalTests : DiagnosticAnalyzerTestBase
+    public class PreferJaggedArraysOverMultidimensionalTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new PreferJaggedArraysOverMultidimensionalAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new PreferJaggedArraysOverMultidimensionalAnalyzer();
-        }
-
         [Fact]
-        public void CSharpSimpleMembers()
+        public async Task CSharpSimpleMembers()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     public int[,] MultidimensionalArrayField;
@@ -70,9 +59,9 @@ public interface IInterface
         }
 
         [Fact]
-        public void BasicSimpleMembers()
+        public async Task BasicSimpleMembers()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
     Public MultidimensionalArrayField As Integer(,)
 
@@ -112,9 +101,9 @@ End Interface
         }
 
         [Fact]
-        public void CSharpNoDiagostics()
+        public async Task CSharpNoDiagostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     public int[][] JaggedArrayField;
@@ -135,9 +124,9 @@ public class Class1
         }
 
         [Fact]
-        public void BasicNoDiangnostics()
+        public async Task BasicNoDiangnostics()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
     Public JaggedArrayField As Integer()()
 
@@ -158,9 +147,9 @@ End Class
         }
 
         [Fact]
-        public void CSharpOverridenMembers()
+        public async Task CSharpOverridenMembers()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     public virtual int[,] MultidimensionalArrayProperty
@@ -192,9 +181,9 @@ public class Class2 : Class1
         }
 
         [Fact]
-        public void BasicOverriddenMembers()
+        public async Task BasicOverriddenMembers()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
     Public Overridable ReadOnly Property MultidimensionalArrayProperty As Integer(,)
         Get
@@ -226,30 +215,42 @@ End Class
 
         private DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)
         {
-            return GetCSharpResultAt(line, column, PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule, symbolName);
+            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
         }
 
         private DiagnosticResult GetCSharpReturnResultAt(int line, int column, string symbolName, string typeName)
         {
-            return GetCSharpResultAt(line, column, PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule, symbolName, typeName);
+            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, typeName);
         }
         private DiagnosticResult GetCSharpBodyResultAt(int line, int column, string symbolName, string typeName)
         {
-            return GetCSharpResultAt(line, column, PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule, symbolName, typeName);
+            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, typeName);
         }
 
         private DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName)
         {
-            return GetBasicResultAt(line, column, PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule, symbolName);
+            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
         }
 
         private DiagnosticResult GetBasicReturnResultAt(int line, int column, string symbolName, string typeName)
         {
-            return GetBasicResultAt(line, column, PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule, symbolName, typeName);
+            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, typeName);
         }
         private DiagnosticResult GetBasicBodyResultAt(int line, int column, string symbolName, string typeName)
         {
-            return GetBasicResultAt(line, column, PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule, symbolName, typeName);
+            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, typeName);
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
@@ -1,11 +1,18 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines;
 using Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines.CSharpRemoveEmptyFinalizersAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines.BasicRemoveEmptyFinalizersAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
@@ -22,9 +29,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1821CSharpTestNoWarning()
+        public async Task CA1821CSharpTestNoWarning()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Diagnostics;
 
 public class Class1
@@ -152,9 +159,9 @@ public class Class2
         }
 
         [Fact]
-        public void CA1821CSharpTestRemoveEmptyFinalizersWithDebugFail()
+        public async Task CA1821CSharpTestRemoveEmptyFinalizersWithDebugFail()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Diagnostics;
 
 public class Class1
@@ -193,9 +200,9 @@ public class Class1
         }
 
         [Fact]
-        public void CA1821CSharpTestRemoveEmptyFinalizersWithDebugFailAndDirective()
+        public async Task CA1821CSharpTestRemoveEmptyFinalizersWithDebugFailAndDirective()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
 #if DEBUG
@@ -246,9 +253,9 @@ public class Class2
 
         [WorkItem(820941, "DevDiv")]
         [Fact]
-        public void CA1821CSharpTestRemoveEmptyFinalizersWithNonInvocationBody()
+        public async Task CA1821CSharpTestRemoveEmptyFinalizersWithNonInvocationBody()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     ~Class1()
@@ -265,9 +272,9 @@ public class Class2
         }
 
         [Fact]
-        public void CA1821BasicTestNoWarning()
+        public async Task CA1821BasicTestNoWarning()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Diagnostics
 
 Public Class Class1
@@ -438,9 +445,9 @@ End Class
         }
 
         [Fact, WorkItem(1211, "https://github.com/dotnet/roslyn-analyzers/issues/1211")]
-        public void CA1821CSharpRemoveEmptyFinalizersInvalidInvocationExpression()
+        public async Task CA1821CSharpRemoveEmptyFinalizersInvalidInvocationExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C1
 {
     ~C1()
@@ -449,39 +456,39 @@ public class C1
     }
 }
 ",
-                TestValidationMode.AllowCompileErrors);
+                CompilerDiagnostics.None);
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]
-        public void CA1821CSharpRemoveEmptyFinalizers_ErrorCodeWithBothBlockAndExpressionBody()
+        public async Task CA1821CSharpRemoveEmptyFinalizers_ErrorCodeWithBothBlockAndExpressionBody()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C1
 {
     ~C1() { }
     => ;
 }
 ",
-                TestValidationMode.AllowCompileErrors);
+                CompilerDiagnostics.None);
         }
 
         [Fact, WorkItem(1211, "https://github.com/dotnet/roslyn-analyzers/issues/1211")]
-        public void CA1821BasicRemoveEmptyFinalizersInvalidInvocationExpression()
+        public async Task CA1821BasicRemoveEmptyFinalizersInvalidInvocationExpression()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
     Protected Overrides Sub Finalize()
         a
     End Sub
 End Class
 ",
-                TestValidationMode.AllowCompileErrors);
+                CompilerDiagnostics.None);
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]
-        public void CA1821CSharpRemoveEmptyFinalizers_ExpressionBodiedImpl()
+        public async Task CA1821CSharpRemoveEmptyFinalizers_ExpressionBodiedImpl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 
@@ -508,13 +515,13 @@ public class SomeTestClass : IDisposable
         }
 
         private static DiagnosticResult GetCA1821CSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, AbstractRemoveEmptyFinalizersAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.RemoveEmptyFinalizers);
-        }
+            => new DiagnosticResult(AbstractRemoveEmptyFinalizersAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.RemoveEmptyFinalizers);
 
         private static DiagnosticResult GetCA1821BasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, AbstractRemoveEmptyFinalizersAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.RemoveEmptyFinalizers);
-        }
+            => new DiagnosticResult(AbstractRemoveEmptyFinalizersAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.RemoveEmptyFinalizers);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -1,11 +1,18 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines;
 using Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines.CSharpRethrowToPreserveStackDetailsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines.BasicRethrowToPreserveStackDetailsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
@@ -22,9 +29,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2200_NoDiagnosticsForRethrow()
+        public async Task CA2200_NoDiagnosticsForRethrow()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -43,7 +50,7 @@ class Program
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrowExplicitly()
@@ -58,9 +65,9 @@ End Class
         }
 
         [Fact]
-        public void CA2200_NoDiagnosticsForThrowAnotherException()
+        public async Task CA2200_NoDiagnosticsForThrowAnotherException()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -81,7 +88,7 @@ class Program
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrowExplicitly()
@@ -98,9 +105,9 @@ End Class
         }
 
         [Fact]
-        public void CA2200_DiagnosticForThrowCaughtException()
+        public async Task CA2200_DiagnosticForThrowCaughtException()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -125,7 +132,7 @@ class Program
 ",
            GetCA2200CSharpResultAt(14, 13));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrowExplicitly()
@@ -142,9 +149,9 @@ End Class
         }
 
         [Fact]
-        public void CA2200_NoDiagnosticsForThrowCaughtReassignedException()
+        public async Task CA2200_NoDiagnosticsForThrowCaughtReassignedException()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -168,7 +175,7 @@ class Program
     }
 }
 ");
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrowExplicitly()
@@ -185,9 +192,9 @@ End Class
         }
 
         [Fact]
-        public void CA2200_NoDiagnosticsForEmptyBlock()
+        public async Task CA2200_NoDiagnosticsForEmptyBlock()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -210,7 +217,7 @@ class Program
     }
 }
 ");
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrowExplicitly()
@@ -275,9 +282,9 @@ End Class
         }
 
         [Fact]
-        public void CA2200_MultipleDiagnosticsForThrowCaughtExceptionAtMultiplePlaces()
+        public async Task CA2200_MultipleDiagnosticsForThrowCaughtExceptionAtMultiplePlaces()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -307,7 +314,7 @@ class Program
             GetCA2200CSharpResultAt(14, 13),
             GetCA2200CSharpResultAt(18, 13));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrowExplicitly()
@@ -327,9 +334,9 @@ End Class
         }
 
         [Fact]
-        public void CA2200_DiagnosticForThrowOuterCaughtException()
+        public async Task CA2200_DiagnosticForThrowOuterCaughtException()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -356,7 +363,7 @@ class Program
 ",
             GetCA2200CSharpResultAt(20, 17));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrowExplicitly()
@@ -377,9 +384,9 @@ End Class
         }
 
         [Fact]
-        public void CA2200_NoDiagnosticsForNestingWithCompileErrors()
+        public async Task CA2200_NoDiagnosticsForNestingWithCompileErrors()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -414,9 +421,9 @@ class Program
         }
     }
 }
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrowExplicitly()
@@ -437,13 +444,13 @@ Class Program
         End Try
     End Sub
 End Class
-", TestValidationMode.AllowCompileErrors);
+", CompilerDiagnostics.None);
         }
 
         [Fact]
-        public void CA2200_NoDiagnosticsForCatchWithoutIdentifier()
+        public async Task CA2200_NoDiagnosticsForCatchWithoutIdentifier()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -465,9 +472,9 @@ class Program
 
         [Fact]
         [WorkItem(2167, "https://github.com/dotnet/roslyn-analyzers/issues/2167")]
-        public void CA2200_NoDiagnosticsForCatchWithoutArgument()
+        public async Task CA2200_NoDiagnosticsForCatchWithoutArgument()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -486,7 +493,7 @@ class Program
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrow(exception As Exception)
@@ -502,13 +509,13 @@ End Class
         }
 
         private static DiagnosticResult GetCA2200BasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, RethrowToPreserveStackDetailsAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.RethrowToPreserveStackDetailsMessage);
-        }
+            => new DiagnosticResult(RethrowToPreserveStackDetailsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.RethrowToPreserveStackDetailsMessage);
 
         private static DiagnosticResult GetCA2200CSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, RethrowToPreserveStackDetailsAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.RethrowToPreserveStackDetailsMessage);
-        }
+            => new DiagnosticResult(RethrowToPreserveStackDetailsAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftCodeQualityAnalyzersResources.RethrowToPreserveStackDetailsMessage);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
@@ -1,27 +1,23 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.SealMethodsThatSatisfyPrivateInterfacesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.SealMethodsThatSatisfyPrivateInterfacesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
-    public class SealMethodsThatSatisfyPrivateInterfacesTests : DiagnosticAnalyzerTestBase
+    public class SealMethodsThatSatisfyPrivateInterfacesTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new SealMethodsThatSatisfyPrivateInterfacesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new SealMethodsThatSatisfyPrivateInterfacesAnalyzer();
-        }
-
         [Fact]
-        public void TestCSharp_ClassesThatCannotBeSubClassedOutsideThisAssembly_HasNoDiagnostic()
+        public async Task TestCSharp_ClassesThatCannotBeSubClassedOutsideThisAssembly_HasNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface IFace
 {
     void M();
@@ -50,9 +46,9 @@ public class D : IFace
         }
 
         [Fact]
-        public void TestCSharp_VirtualImplicit_HasDiagnostic()
+        public async Task TestCSharp_VirtualImplicit_HasDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface IFace
 {
     void M();
@@ -64,13 +60,13 @@ public class C : IFace
     {
     }
 }
-", GetCSharpResultAt(9, 25, SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule));
+", GetCSharpResultAt(9, 25));
         }
 
         [Fact]
-        public void TestCSharp_AbstractImplicit_HasDiagnostic()
+        public async Task TestCSharp_AbstractImplicit_HasDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface IFace
 {
     void M();
@@ -80,13 +76,13 @@ public abstract class C : IFace
 {
     public abstract void M();
 }
-", GetCSharpResultAt(9, 26, SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule));
+", GetCSharpResultAt(9, 26));
         }
 
         [Fact]
-        public void TestCSharp_Explicit_NoDiagnostic()
+        public async Task TestCSharp_Explicit_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface IFace
 {
     void M();
@@ -102,9 +98,9 @@ public class C : IFace
         }
 
         [Fact]
-        public void TestCSharp_NoInterface_NoDiagnostic()
+        public async Task TestCSharp_NoInterface_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void M()
@@ -115,9 +111,9 @@ public class C
         }
 
         [Fact]
-        public void TestCSharp_StructImplicit_NoDiagnostic()
+        public async Task TestCSharp_StructImplicit_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface IFace
 {
     void M();
@@ -133,9 +129,9 @@ public class C : IFace
         }
 
         [Fact]
-        public void TestCSharp_PublicInterface_NoDiagnostic()
+        public async Task TestCSharp_PublicInterface_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface IFace
 {
     void M();
@@ -151,9 +147,9 @@ public class C : IFace
         }
 
         [Fact]
-        public void TestCSharp_OverriddenFromBase_HasDiagnostic()
+        public async Task TestCSharp_OverriddenFromBase_HasDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface IFace
 {
     void M();
@@ -170,13 +166,13 @@ public class C : B, IFace
     {
     }
 }
-", GetCSharpResultAt(14, 26, SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule));
+", GetCSharpResultAt(14, 26));
         }
 
         [Fact]
-        public void TestCSharp_OverriddenFromBaseButMethodIsSealed_NoDiagnostic()
+        public async Task TestCSharp_OverriddenFromBaseButMethodIsSealed_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface IFace
 {
     void M();
@@ -197,9 +193,9 @@ public class C : B, IFace
         }
 
         [Fact]
-        public void TestCSharp_OverriddenFromBaseButClassIsSealed_NoDiagnostic()
+        public async Task TestCSharp_OverriddenFromBaseButClassIsSealed_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface IFace
 {
     void M();
@@ -220,9 +216,9 @@ public sealed class C : B, IFace
         }
 
         [Fact]
-        public void TestCSharp_ImplicitlyImplementedFromBaseMember_HasDiagnostic()
+        public async Task TestCSharp_ImplicitlyImplementedFromBaseMember_HasDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface IFace
 {
     void M();
@@ -238,13 +234,13 @@ public class B
 public class C : B, IFace
 {
 }
-", GetCSharpResultAt(14, 14, SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule));
+", GetCSharpResultAt(14, 14));
         }
 
         [Fact]
-        public void TestCSharp_ImplicitlyImplementedFromBaseMember_Public_NoDiagnostic()
+        public async Task TestCSharp_ImplicitlyImplementedFromBaseMember_Public_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface IFace
 {
     void M();
@@ -264,9 +260,9 @@ class C : B, IFace
         }
 
         [Fact]
-        public void TestVB_Overridable_HasDiagnostic()
+        public async Task TestVB_Overridable_HasDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface IFace
     Sub M()
 End Interface
@@ -277,13 +273,13 @@ Public Class C
     Public Overridable Sub M() Implements IFace.M
     End Sub
 End Class
-", GetBasicResultAt(9, 28, SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule));
+", GetBasicResultAt(9, 28));
         }
 
         [Fact]
-        public void TestVB_MustOverride_HasDiagnostic()
+        public async Task TestVB_MustOverride_HasDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface IFace
     Sub M()
 End Interface
@@ -293,13 +289,13 @@ Public MustInherit Class C
 
     Public MustOverride Sub M() Implements IFace.M
 End Class
-", GetBasicResultAt(9, 29, SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule));
+", GetBasicResultAt(9, 29));
         }
 
         [Fact]
-        public void TestVB_OverridenFromBase_HasDiagnostic()
+        public async Task TestVB_OverridenFromBase_HasDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface IFace
     Sub M()
 End Interface
@@ -315,13 +311,13 @@ Public Class C
     Public Overrides Sub M() Implements IFace.M
     End Sub
 End Class
-", GetBasicResultAt(14, 26, SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule));
+", GetBasicResultAt(14, 26));
         }
 
         [Fact]
-        public void TestVB_OverridenFromBaseButNotOverridable_NoDiagnostic()
+        public async Task TestVB_OverridenFromBaseButNotOverridable_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface IFace
     Sub M()
 End Interface
@@ -341,9 +337,9 @@ End Class
         }
 
         [Fact]
-        public void TestVB_NotExplicit_NoDiagnostic()
+        public async Task TestVB_NotExplicit_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface IFace
     Sub M()
 End Interface
@@ -360,9 +356,9 @@ End Class
         }
 
         [Fact]
-        public void TestVB_PrivateMethod_NoDiagnostic()
+        public async Task TestVB_PrivateMethod_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface IFace
     Sub M()
 End Interface
@@ -377,9 +373,9 @@ End Class
         }
 
         [Fact]
-        public void TestVB_PublicMethod_NoDiagnostic()
+        public async Task TestVB_PublicMethod_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface IFace
     Sub M()
 End Interface
@@ -394,9 +390,9 @@ End Class
         }
 
         [Fact]
-        public void TestVB_FriendMethod_NoDiagnostic()
+        public async Task TestVB_FriendMethod_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface IFace
     Sub M()
 End Interface
@@ -411,9 +407,9 @@ End Class
         }
 
         [Fact]
-        public void TestVB_PublicInterface_NoDiagnostic()
+        public async Task TestVB_PublicInterface_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface IFace
     Sub M()
 End Interface
@@ -430,5 +426,13 @@ End Class
         // TODO:
 
         // sealed overrides - no diagnostic
+
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
+            => new DiagnosticResult(SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule)
+                .WithLocation(line, column);
+
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
+            => new DiagnosticResult(SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule)
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
@@ -1,29 +1,25 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.UseLiteralsWhereAppropriateAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.UseLiteralsWhereAppropriateAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
-    public class UseLiteralsWhereAppropriateTests : DiagnosticAnalyzerTestBase
+    public class UseLiteralsWhereAppropriateTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseLiteralsWhereAppropriateAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseLiteralsWhereAppropriateAnalyzer();
-        }
-
         [Fact]
-        public void CA1802_Diagnostics_CSharp()
+        public async Task CA1802_Diagnostics_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     static readonly string f1 = """";
@@ -43,9 +39,9 @@ public class Class1
         }
 
         [Fact]
-        public void CA1802_NoDiagnostics_CSharp()
+        public async Task CA1802_NoDiagnostics_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     public static readonly string f1 = """"; // Not private or Internal
@@ -64,9 +60,9 @@ public class Class1
         }
 
         [Fact]
-        public void CA1802_Diagnostics_VisualBasic()
+        public async Task CA1802_Diagnostics_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
     Shared ReadOnly f1 As String = """"
     Shared ReadOnly f2 As String = ""Nothing""
@@ -85,9 +81,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1802_NoDiagnostics_VisualBasic()
+        public async Task CA1802_NoDiagnostics_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
     ' Not Private or Friend
     Public Shared ReadOnly f1 As String = """"
@@ -115,7 +111,7 @@ End Class");
         [InlineData("dotnet_code_quality.required_modifiers = static", false)]
         [InlineData("dotnet_code_quality.required_modifiers = none", true)]
         [InlineData("dotnet_code_quality." + UseLiteralsWhereAppropriateAnalyzer.RuleId + ".required_modifiers = none", true)]
-        public void EditorConfigConfiguration_RequiredModifiersOption(string editorConfigText, bool reportDiagnostic)
+        public async Task EditorConfigConfiguration_RequiredModifiersOption(string editorConfigText, bool reportDiagnostic)
         {
             var expected = Array.Empty<DiagnosticResult>();
             if (reportDiagnostic)
@@ -126,12 +122,12 @@ End Class");
                 };
             }
 
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
 public class Test
 {
     private readonly int field = 0;
 }
-", GetEditorConfigAdditionalFile(editorConfigText), expected);
+", editorConfigText, expected);
 
             expected = Array.Empty<DiagnosticResult>();
             if (reportDiagnostic)
@@ -142,31 +138,31 @@ public class Test
                 };
             }
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
 Public Class Test
     Private ReadOnly field As Integer = 0
 End Class
-", GetEditorConfigAdditionalFile(editorConfigText), expected);
+", editorConfigText, expected);
         }
 
         private DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)
-        {
-            return GetCSharpResultAt(line, column, UseLiteralsWhereAppropriateAnalyzer.DefaultRule, symbolName);
-        }
+            => new DiagnosticResult(UseLiteralsWhereAppropriateAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
 
         private DiagnosticResult GetCSharpEmptyStringResultAt(int line, int column, string symbolName)
-        {
-            return GetCSharpResultAt(line, column, UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule, symbolName);
-        }
+            => new DiagnosticResult(UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
 
         private DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName)
-        {
-            return GetBasicResultAt(line, column, UseLiteralsWhereAppropriateAnalyzer.DefaultRule, symbolName);
-        }
+            => new DiagnosticResult(UseLiteralsWhereAppropriateAnalyzer.DefaultRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
 
         private DiagnosticResult GetBasicEmptyStringResultAt(int line, int column, string symbolName)
-        {
-            return GetBasicResultAt(line, column, UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule, symbolName);
-        }
+            => new DiagnosticResult(UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
@@ -122,12 +122,24 @@ End Class");
                 };
             }
 
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
+            var csTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 public class Test
 {
     private readonly int field = 0;
 }
-", editorConfigText, expected);
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                },
+            };
+            csTest.ExpectedDiagnostics.AddRange(expected);
+            await csTest.RunAsync();
 
             expected = Array.Empty<DiagnosticResult>();
             if (reportDiagnostic)
@@ -138,11 +150,23 @@ public class Test
                 };
             }
 
-            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
+            var vbTest = new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Public Class Test
     Private ReadOnly field As Integer = 0
 End Class
-", editorConfigText, expected);
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+            vbTest.ExpectedDiagnostics.AddRange(expected);
+            await vbTest.RunAsync();
         }
 
         private DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -1862,7 +1862,13 @@ End Class
                       dotnet_code_quality.max_interprocedural_method_call_chain = 0")]
         public async Task HazardousUsageInInvokedMethod_PrivateMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
         {
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 public class C
 {
     public int X;
@@ -1885,9 +1891,19 @@ public class Test
         var x = c.X;
     }
 }
-", editorConfigText);
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
 
-            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Public Class C
     Public X As Integer
 End Class
@@ -1905,7 +1921,11 @@ Public Class Test
         Dim x = c.X
     End Sub
 End Class
-", editorConfigText);
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         [Theory, WorkItem(2525, "https://github.com/dotnet/roslyn-analyzers/issues/2525")]
@@ -1915,7 +1935,13 @@ End Class
                       dotnet_code_quality.max_interprocedural_method_call_chain = 0")]
         public async Task ValidatedNotNullAttributeInInvokedMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
         {
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 public class ValidatedNotNullAttribute : System.Attribute
 {
 }
@@ -1939,9 +1965,16 @@ public class C
     {
     }
 }
-", editorConfigText,
-            // Test0.cs(14,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-            GetCSharpResultAt(14, 13, "void C.M1(C c1, C c2)", "c2"));
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                },
+                ExpectedDiagnostics =
+                {
+                    // Test0.cs(14,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+                    GetCSharpResultAt(14, 13, "void C.M1(C c1, C c2)", "c2")
+                }
+            }.RunAsync();
         }
 
         [Fact, WorkItem(2525, "https://github.com/dotnet/roslyn-analyzers/issues/2525")]
@@ -2047,7 +2080,13 @@ public static class Issue2578Test
                       dotnet_code_quality.null_check_validation_methods = M:C.Validate(C)|M:Helper`1.Validate(C)|M:Helper`1.Validate``1(C,``0)")]
         public async Task NullCheckValidationMethod_ConfiguredInEditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
         {
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 public class C
 {
     public void M1(C c1, C c2, C c3, C c4, C c5, C c6)
@@ -2098,13 +2137,20 @@ internal static class Helper<T>
     {
     }
 }
-", editorConfigText,
-            // Test0.cs(16,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c4' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-            GetCSharpResultAt(16, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c4"),
-            // Test0.cs(19,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c5' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-            GetCSharpResultAt(19, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c5"),
-            // Test0.cs(22,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c6' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-            GetCSharpResultAt(22, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c6"));
+"
+},
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                },
+                ExpectedDiagnostics =
+                {
+                    // Test0.cs(16,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c4' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+                    GetCSharpResultAt(16, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c4"),
+                    // Test0.cs(19,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c5' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+                    GetCSharpResultAt(19, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c5"),
+                    // Test0.cs(22,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c6' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+                    GetCSharpResultAt(22, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c6")
+                }
+            }.RunAsync();
         }
 
         [Fact, WorkItem(1707, "https://github.com/dotnet/roslyn-analyzers/issues/1707")]
@@ -6018,7 +6064,13 @@ public class Class1
                 };
             }
 
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
+            var csTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 public class Test
 {
     public void M1(string str)
@@ -6026,7 +6078,14 @@ public class Test
         var x = str.ToString();
     }
 }
-", editorConfigText, expected);
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                },
+            };
+            csTest.ExpectedDiagnostics.AddRange(expected);
+            await csTest.RunAsync();
+
 
             expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length == 0)
@@ -6038,13 +6097,25 @@ public class Test
                 };
             }
 
-            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
+            var vbTest = new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Public Class Test
     Public Sub M1(str As String)
         Dim x = str.ToString()
     End Sub
 End Class
-", editorConfigText, expected);
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+            vbTest.ExpectedDiagnostics.AddRange(expected);
+            await vbTest.RunAsync();
         }
 
         [Theory]
@@ -6065,7 +6136,13 @@ End Class
                 };
             }
 
-            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
+            var csTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 public static class Test
 {
     public static void M1(this string str)
@@ -6073,7 +6150,13 @@ public static class Test
         var x = str.ToString();
     }
 }
-", editorConfigText, expected);
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                },
+            };
+            csTest.ExpectedDiagnostics.AddRange(expected);
+            await csTest.RunAsync();
 
             expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length == 0)
@@ -6085,7 +6168,13 @@ public static class Test
                 };
             }
 
-            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
+            var vbTest = new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Imports System.Runtime.CompilerServices
 
 Public Module Test
@@ -6093,7 +6182,13 @@ Public Module Test
     Public Sub M1(str As String)
         Dim x = str.ToString()
     End Sub
-End Module", editorConfigText, expected);
+End Module"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+            vbTest.ExpectedDiagnostics.AddRange(expected);
+            await vbTest.RunAsync();
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3660,7 +3660,11 @@ namespace Blah
         {
             await new VerifyCS.Test
             {
-                TestCode = @"
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 using System.Xml.Linq;
  namespace Blah
@@ -3747,10 +3751,9 @@ using System.Xml.Linq;
             return part.Definition.Name + ""-"" + (versioned ? ""VersionInfoset"" : ""Infoset"");
         }
     }
-}",
-                SolutionTransforms =
-                {
-                    (solution, projectId) => solution.AddMetadataReference(projectId, AdditionalMetadataReferences.SystemXmlLinq)
+}"
+                    },
+                    AdditionalReferences = {  AdditionalMetadataReferences.SystemXmlLinq }
                 },
                 ExpectedDiagnostics =
                 {
@@ -3890,7 +3893,11 @@ public class C2
         {
             await new VerifyCS.Test
             {
-                TestCode = @"
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 using System.IO;
 using System.Threading;
@@ -4051,10 +4058,9 @@ public class Class1
         }
         return true;
     }
-}",
-                SolutionTransforms =
-                {
-                    (solution, projectId) => solution.AddMetadataReference(projectId, AdditionalMetadataReferences.SystemWeb)
+}"
+                    },
+                    AdditionalReferences = { AdditionalMetadataReferences.SystemWeb }
                 },
                 ExpectedDiagnostics =
                 {
@@ -5393,7 +5399,11 @@ public enum Kind
         {
             await new VerifyCS.Test
             {
-                TestCode = @"
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System.IO;
 using System.Web;
 
@@ -5452,10 +5462,9 @@ namespace MyComments
         }
     }
 }
-",
-                SolutionTransforms =
-                {
-                    (solution, projectId) => solution.AddMetadataReference(projectId, AdditionalMetadataReferences.SystemWeb)
+"
+                    },
+                    AdditionalReferences = { AdditionalMetadataReferences.SystemWeb }
                 }
             }.RunAsync();
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -26,14 +26,14 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new ValidateArgumentsOfPublicMethods();
 
         private static new DiagnosticResult GetCSharpResultAt(int line, int column, string methodSignature, string parameterName)
-            =>  new DiagnosticResult(ValidateArgumentsOfPublicMethods.Rule)
-            .WithLocation(line, column)
-            .WithArguments(methodSignature, parameterName);
+            => new DiagnosticResult(ValidateArgumentsOfPublicMethods.Rule)
+                .WithLocation(line, column)
+                .WithArguments(methodSignature, parameterName);
 
         private static new DiagnosticResult GetBasicResultAt(int line, int column, string methodSignature, string parameterName)
             => new DiagnosticResult(ValidateArgumentsOfPublicMethods.Rule)
-            .WithLocation(line, column)
-            .WithArguments(methodSignature, parameterName);
+                .WithLocation(line, column)
+                .WithArguments(methodSignature, parameterName);
 
         [Fact]
         public async Task ValueTypeParameter_NoDiagnostic()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -1,10 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.ValidateArgumentsOfPublicMethods,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.QualityGuidelines.ValidateArgumentsOfPublicMethods,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
@@ -18,16 +25,20 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new ValidateArgumentsOfPublicMethods();
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new ValidateArgumentsOfPublicMethods();
 
-        private new DiagnosticResult GetCSharpResultAt(int line, int column, string methodSignature, string parameterName) =>
-            GetCSharpResultAt(line, column, ValidateArgumentsOfPublicMethods.Rule, methodSignature, parameterName);
+        private static new DiagnosticResult GetCSharpResultAt(int line, int column, string methodSignature, string parameterName)
+            =>  new DiagnosticResult(ValidateArgumentsOfPublicMethods.Rule)
+            .WithLocation(line, column)
+            .WithArguments(methodSignature, parameterName);
 
-        private new DiagnosticResult GetBasicResultAt(int line, int column, string methodSignature, string parameterName) =>
-            GetBasicResultAt(line, column, ValidateArgumentsOfPublicMethods.Rule, methodSignature, parameterName);
+        private static new DiagnosticResult GetBasicResultAt(int line, int column, string methodSignature, string parameterName)
+            => new DiagnosticResult(ValidateArgumentsOfPublicMethods.Rule)
+            .WithLocation(line, column)
+            .WithArguments(methodSignature, parameterName);
 
         [Fact]
-        public void ValueTypeParameter_NoDiagnostic()
+        public async Task ValueTypeParameter_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct C
 {
     public int X;
@@ -42,7 +53,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure C
     Public X As Integer
 End Structure
@@ -55,9 +66,9 @@ End Class");
         }
 
         [Fact]
-        public void ReferenceTypeParameter_NoUsages_NoDiagnostic()
+        public async Task ReferenceTypeParameter_NoUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Test
 {
     public void M1(string str)
@@ -66,7 +77,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Test
     Public Sub M1(str As String)
     End Sub
@@ -74,9 +85,9 @@ End Class");
         }
 
         [Fact]
-        public void ReferenceTypeParameter_NoHazardousUsages_NoDiagnostic()
+        public async Task ReferenceTypeParameter_NoHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Test
 {
     public void M1(string str)
@@ -91,7 +102,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Test
     Public Sub M1(str As String)
         Dim x = str
@@ -104,9 +115,9 @@ End Class");
         }
 
         [Fact]
-        public void NonExternallyVisibleMethod_NoDiagnostic()
+        public async Task NonExternallyVisibleMethod_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -144,7 +155,7 @@ internal class Test2
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -175,9 +186,9 @@ End Class");
         }
 
         [Fact]
-        public void HazardousUsage_MethodReference_Diagnostic()
+        public async Task HazardousUsage_MethodReference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Test
 {
     public void M1(string str)
@@ -189,7 +200,7 @@ public class Test
             // Test0.cs(6,17): warning CA1062: In externally visible method 'void Test.M1(string str)', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(6, 17, "void Test.M1(string str)", "str"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Test
     Public Sub M1(str As String)
         Dim x = str.ToString()
@@ -201,9 +212,9 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsage_FieldReference_Diagnostic()
+        public async Task HazardousUsage_FieldReference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -220,7 +231,7 @@ public class Test
             // Test0.cs(11,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(11, 17, "void Test.M1(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -236,9 +247,9 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsage_PropertyReference_Diagnostic()
+        public async Task HazardousUsage_PropertyReference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X { get; }
@@ -255,7 +266,7 @@ public class Test
             // Test0.cs(11,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(11, 17, "void Test.M1(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public ReadOnly Property X As Integer
 End Class
@@ -271,9 +282,9 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsage_EventReference_Diagnostic()
+        public async Task HazardousUsage_EventReference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public delegate void MyDelegate();
@@ -295,7 +306,7 @@ public class Test
             // Test0.cs(12,9): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(12, 9, "void Test.M1(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Event X()
 End Class
@@ -314,9 +325,9 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsage_ArrayElementReference_Diagnostic()
+        public async Task HazardousUsage_ArrayElementReference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Test
 {
     public void M1(Test[] tArray)
@@ -328,7 +339,7 @@ public class Test
             // Test0.cs(6,17): warning CA1062: In externally visible method 'void Test.M1(Test[] tArray)', validate parameter 'tArray' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(6, 17, "void Test.M1(Test[] tArray)", "tArray"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Test
     Public Sub M1(tArray As Test())
         Dim x = tArray(0)
@@ -340,9 +351,9 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsage_ReferenceInConditiona_Diagnostic()
+        public async Task HazardousUsage_ReferenceInConditiona_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public bool X;
@@ -361,7 +372,7 @@ public class Test
             // Test0.cs(11,13): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(11, 13, "void Test.M1(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Boolean
 End Class
@@ -378,9 +389,9 @@ End Class
         }
 
         [Fact]
-        public void MultipleHazardousUsages_OneReportPerParameter_Diagnostic()
+        public async Task MultipleHazardousUsages_OneReportPerParameter_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -406,7 +417,7 @@ public class Test
         // Test0.cs(16,18): warning CA1062: In externally visible method 'void Test.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
         GetCSharpResultAt(16, 18, "void Test.M1(C c1, C c2)", "c2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
     Public Y As Integer
@@ -432,9 +443,9 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsage_OptionalParameter_Diagnostic()
+        public async Task HazardousUsage_OptionalParameter_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Test
 {
     private const string _constStr = """";
@@ -447,7 +458,7 @@ public class Test
             // Test0.cs(7,17): warning CA1062: In externally visible method 'void Test.M1(string str = "")', validate parameter 'str' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(7, 17, @"void Test.M1(string str = """")", "str"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Test
     Private Const _constStr As String = """"
     Public Sub M1(Optional str As String = _constStr)
@@ -460,9 +471,9 @@ End Class
         }
 
         [Fact]
-        public void ConditionalAccessUsages_NoDiagnostic()
+        public async Task ConditionalAccessUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -480,7 +491,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -496,9 +507,9 @@ End Class");
         }
 
         [Fact]
-        public void ValidatedNonNullAttribute_PossibleNullRefUsage_NoDiagnostic()
+        public async Task ValidatedNonNullAttribute_PossibleNullRefUsage_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class ValidatedNotNullAttribute : System.Attribute
 {
 }
@@ -512,7 +523,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class ValidatedNotNullAttribute
     Inherits System.Attribute
 End Class
@@ -526,9 +537,9 @@ End Class
         }
 
         [Fact]
-        public void ValidatedNonNullAttribute_PossibleNullRefUsageOnDifferentParam_Diagnostic()
+        public async Task ValidatedNonNullAttribute_PossibleNullRefUsageOnDifferentParam_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class ValidatedNotNullAttribute : System.Attribute
 {
 }
@@ -544,7 +555,7 @@ public class Test
             // Test0.cs(10,34): warning CA1062: In externally visible method 'void Test.M1(string str, string str2)', validate parameter 'str2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(10, 34, "void Test.M1(string str, string str2)", "str2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class ValidatedNotNullAttribute
     Inherits System.Attribute
 End Class
@@ -560,9 +571,9 @@ End Class
         }
 
         [Fact]
-        public void DefiniteSimpleAssignment_BeforeHazardousUsages_NoDiagnostic()
+        public async Task DefiniteSimpleAssignment_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -582,7 +593,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -600,9 +611,9 @@ End Class");
         }
 
         [Fact]
-        public void AssignedToFieldAndValidated_BeforeHazardousUsages_NoDiagnostic()
+        public async Task AssignedToFieldAndValidated_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -628,7 +639,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -651,9 +662,9 @@ End Class");
         }
 
         [Fact]
-        public void AssignedToFieldAndNotValidated_BeforeHazardousUsages_Diagnostic()
+        public async Task AssignedToFieldAndNotValidated_BeforeHazardousUsages_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -692,7 +703,7 @@ public class Test
             // Test0.cs(27,17): warning CA1062: In externally visible method 'void Test.M2(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(27, 17, "void Test.M2(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -726,9 +737,9 @@ End Class",
         }
 
         [Fact]
-        public void MayBeAssigned_BeforeHazardousUsages_Diagnostic()
+        public async Task MayBeAssigned_BeforeHazardousUsages_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -756,7 +767,7 @@ public class Test
             // Test0.cs(20,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c, bool flag)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(20, 17, "void Test.M1(string str, C c, bool flag)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -769,7 +780,7 @@ Public Class Test
             x = ""newString""
             c = New C()
         End If
-        
+
         ' Below may or may not cause null refs
         Dim y = x.ToString()
         Dim z = c.X
@@ -901,9 +912,9 @@ End Class", GetEditorConfigToEnableCopyAnalysis());
         }
 
         [Fact]
-        public void ThrowOnNull_BeforeHazardousUsages_NoDiagnostic()
+        public async Task ThrowOnNull_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -944,7 +955,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -979,9 +990,9 @@ End Class");
         }
 
         [Fact]
-        public void ThrowOnNullForSomeParameter_HazardousUsageForDifferentParameter_Diagnostic()
+        public async Task ThrowOnNullForSomeParameter_HazardousUsageForDifferentParameter_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -1026,7 +1037,7 @@ public class Test
             // Test0.cs(37,17): warning CA1062: In externally visible method 'void Test.M2(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(37, 17, "void Test.M2(string str, C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -1066,9 +1077,9 @@ End Class
         }
 
         [Fact]
-        public void ThrowOnNull_AfterHazardousUsages_Diagnostic()
+        public async Task ThrowOnNull_AfterHazardousUsages_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -1089,7 +1100,7 @@ public class Test
             // Test0.cs(11,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(11, 17, "void Test.M1(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -1108,9 +1119,9 @@ End Class
         }
 
         [Fact]
-        public void NullCoalescingThrowExpressionOnNull_BeforeHazardousUsages_NoDiagnostic()
+        public async Task NullCoalescingThrowExpressionOnNull_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -1134,9 +1145,9 @@ public class Test
         }
 
         [Fact]
-        public void ThrowOnNull_UncommonNullCheckSyntax_BeforeHazardousUsages_NoDiagnostic()
+        public async Task ThrowOnNull_UncommonNullCheckSyntax_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -1195,7 +1206,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -1335,9 +1346,9 @@ End Class
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void ContractCheck_Diagnostic()
+        public async Task ContractCheck_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -1387,7 +1398,7 @@ public class Test
             // Test0.cs(30,17): warning CA1062: In externally visible method 'void Test.M3(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(30, 17, "void Test.M3(C c1, C c2)", "c2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
 
     Public X As Integer
@@ -1435,9 +1446,9 @@ End Class",
         }
 
         [Fact]
-        public void ReturnOnNull_BeforeHazardousUsages_NoDiagnostic()
+        public async Task ReturnOnNull_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -1493,7 +1504,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -1540,9 +1551,9 @@ End Class
         }
 
         [Fact]
-        public void ReturnOnNullForSomeParameter_HazardousUsageForDifferentParameter_Diagnostic()
+        public async Task ReturnOnNullForSomeParameter_HazardousUsageForDifferentParameter_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -1587,7 +1598,7 @@ public class Test
             // Test0.cs(37,17): warning CA1062: In externally visible method 'void Test.M2(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(37, 17, "void Test.M2(string str, C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -1627,9 +1638,9 @@ End Class
         }
 
         [Fact]
-        public void StringIsNullCheck_BeforeHazardousUsages_NoDiagnostic()
+        public async Task StringIsNullCheck_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Test
 {
     public void M1(string str)
@@ -1642,7 +1653,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Test
     Public Sub M1(ByVal str As String)
         If Not String.IsNullOrEmpty(str) Then
@@ -1653,9 +1664,9 @@ End Class");
         }
 
         [Fact]
-        public void StringIsNullCheck_WithCopyAnalysis_BeforeHazardousUsages_NoDiagnostic()
+        public async Task StringIsNullCheck_WithCopyAnalysis_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Test
 {
     public void M1(string str)
@@ -1669,7 +1680,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Test
     Public Sub M1(ByVal str As String)
         Dim x = str
@@ -1681,9 +1692,9 @@ End Class");
         }
 
         [Fact]
-        public void SpecialCase_ExceptionGetObjectData_NoDiagnostic()
+        public async Task SpecialCase_ExceptionGetObjectData_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.Serialization;
 
@@ -1718,7 +1729,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Runtime.Serialization
 
@@ -1749,9 +1760,9 @@ End Class
         }
 
         [Fact]
-        public void NullCheckWithNegationBasedCondition_BeforeHazardousUsages_NoDiagnostic()
+        public async Task NullCheckWithNegationBasedCondition_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -1773,7 +1784,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -1792,9 +1803,9 @@ End Class");
         }
 
         [Fact]
-        public void HazardousUsageInInvokedMethod_PrivateMethod_Diagnostic()
+        public async Task HazardousUsageInInvokedMethod_PrivateMethod_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -1821,7 +1832,7 @@ public class Test
             // Test0.cs(12,12): warning CA1062: In externally visible method 'void Test.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(12, 12, "void Test.M1(C c1, C c2)", "c2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -1849,9 +1860,9 @@ End Class
         [InlineData(@"dotnet_code_quality.max_interprocedural_method_call_chain = 0")]
         [InlineData(@"dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive
                       dotnet_code_quality.max_interprocedural_method_call_chain = 0")]
-        public void HazardousUsageInInvokedMethod_PrivateMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
+        public async Task HazardousUsageInInvokedMethod_PrivateMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
 public class C
 {
     public int X;
@@ -1874,9 +1885,9 @@ public class Test
         var x = c.X;
     }
 }
-", GetEditorConfigAdditionalFile(editorConfigText));
+", editorConfigText);
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -1894,7 +1905,7 @@ Public Class Test
         Dim x = c.X
     End Sub
 End Class
-", GetEditorConfigAdditionalFile(editorConfigText));
+", editorConfigText);
         }
 
         [Theory, WorkItem(2525, "https://github.com/dotnet/roslyn-analyzers/issues/2525")]
@@ -1902,9 +1913,9 @@ End Class
         [InlineData(@"dotnet_code_quality.max_interprocedural_method_call_chain = 0")]
         [InlineData(@"dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive
                       dotnet_code_quality.max_interprocedural_method_call_chain = 0")]
-        public void ValidatedNotNullAttributeInInvokedMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
+        public async Task ValidatedNotNullAttributeInInvokedMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
 public class ValidatedNotNullAttribute : System.Attribute
 {
 }
@@ -1928,15 +1939,15 @@ public class C
     {
     }
 }
-", GetEditorConfigAdditionalFile(editorConfigText),
+", editorConfigText,
             // Test0.cs(14,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(14, 13, "void C.M1(C c1, C c2)", "c2"));
         }
 
         [Fact, WorkItem(2525, "https://github.com/dotnet/roslyn-analyzers/issues/2525")]
-        public void ValidatedNotNullAttributeInInvokedMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic_02()
+        public async Task ValidatedNotNullAttributeInInvokedMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1975,9 +1986,9 @@ public static class Issue2578Test
         }
 
         [Fact, WorkItem(2525, "https://github.com/dotnet/roslyn-analyzers/issues/2525")]
-        public void ValidatedNotNullAttributeInInvokedMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic_03()
+        public async Task ValidatedNotNullAttributeInInvokedMethod_EditorConfig_NoInterproceduralAnalysis_NoDiagnostic_03()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -2034,9 +2045,9 @@ public static class Issue2578Test
         // Match multiple methods by method documentation ID with "M:" prefix
         [InlineData(@"dotnet_code_quality.interprocedural_analysis_kind = None
                       dotnet_code_quality.null_check_validation_methods = M:C.Validate(C)|M:Helper`1.Validate(C)|M:Helper`1.Validate``1(C,``0)")]
-        public void NullCheckValidationMethod_ConfiguredInEditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
+        public async Task NullCheckValidationMethod_ConfiguredInEditorConfig_NoInterproceduralAnalysis_NoDiagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
 public class C
 {
     public void M1(C c1, C c2, C c3, C c4, C c5, C c6)
@@ -2087,7 +2098,7 @@ internal static class Helper<T>
     {
     }
 }
-", GetEditorConfigAdditionalFile(editorConfigText),
+", editorConfigText,
             // Test0.cs(16,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c4' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(16, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c4"),
             // Test0.cs(19,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c5' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
@@ -2097,9 +2108,9 @@ internal static class Helper<T>
         }
 
         [Fact, WorkItem(1707, "https://github.com/dotnet/roslyn-analyzers/issues/1707")]
-        public void HazardousUsageInInvokedMethod_PrivateMethod_Generic_Diagnostic()
+        public async Task HazardousUsageInInvokedMethod_PrivateMethod_Generic_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2126,7 +2137,7 @@ public class Test
             // Test0.cs(12,12): warning CA1062: In externally visible method 'void Test.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(12, 12, "void Test.M1(C c1, C c2)", "c2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -2150,9 +2161,9 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsageInInvokedMethod_PublicMethod_Diagnostic()
+        public async Task HazardousUsageInInvokedMethod_PublicMethod_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2179,7 +2190,7 @@ public class Test
             // Test0.cs(21,17): warning CA1062: In externally visible method 'void Test.M3(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(21, 17, "void Test.M3(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -2203,9 +2214,9 @@ End Class
         }
 
         [Fact, WorkItem(1707, "https://github.com/dotnet/roslyn-analyzers/issues/1707")]
-        public void HazardousUsageInInvokedMethod_PublicMethod_Generic_Diagnostic()
+        public async Task HazardousUsageInInvokedMethod_PublicMethod_Generic_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2232,7 +2243,7 @@ public class Test
             // Test0.cs(21,17): warning CA1062: In externally visible method 'void Test.M3<T>(T c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(21, 17, "void Test.M3<T>(T c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -2256,9 +2267,9 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsageInInvokedMethod_PrivateMethod_MultipleLevelsDown_NoDiagnostic()
+        public async Task HazardousUsageInInvokedMethod_PrivateMethod_MultipleLevelsDown_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2283,7 +2294,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -2305,10 +2316,10 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsageInInvokedMethod_WithInvocationCycles_Diagnostic()
+        public async Task HazardousUsageInInvokedMethod_WithInvocationCycles_Diagnostic()
         {
             // Code with cyclic call graph to verify we don't analyze indefinitely.
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2337,7 +2348,7 @@ public class Test
             // Test0.cs(12,12): warning CA1062: In externally visible method 'void Test.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(12, 12, "void Test.M1(C c1, C c2)", "c2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -2361,9 +2372,9 @@ End Class
         }
 
         [Fact]
-        public void HazardousUsageInInvokedMethod_InvokedAfterValidation_NoDiagnostic()
+        public async Task HazardousUsageInInvokedMethod_InvokedAfterValidation_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2386,7 +2397,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -2406,9 +2417,9 @@ End Class
         }
 
         [Fact]
-        public void ValidatedInInvokedMethod_NoDiagnostic()
+        public async Task ValidatedInInvokedMethod_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -2434,7 +2445,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2456,9 +2467,9 @@ End Class");
         }
 
         [Fact, WorkItem(1707, "https://github.com/dotnet/roslyn-analyzers/issues/1707")]
-        public void ValidatedInInvokedMethod_Generic_NoDiagnostic()
+        public async Task ValidatedInInvokedMethod_Generic_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -2484,7 +2495,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2506,9 +2517,9 @@ End Class");
         }
 
         [Fact, WorkItem(2504, "https://github.com/dotnet/roslyn-analyzers/issues/2504")]
-        public void ValidatedInInvokedMethod_Generic_02_NoDiagnostic()
+        public async Task ValidatedInInvokedMethod_Generic_02_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -2538,9 +2549,9 @@ public class Test
         }
 
         [Fact]
-        public void MaybeValidatedInInvokedMethod_Diagnostic()
+        public async Task MaybeValidatedInInvokedMethod_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -2570,7 +2581,7 @@ public class Test
             // Test0.cs(16,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(16, 17, "void Test.M1(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2596,9 +2607,9 @@ End Class",
         }
 
         [Fact]
-        public void ValidatedButNoExceptionThrownInInvokedMethod_Diagnostic()
+        public async Task ValidatedButNoExceptionThrownInInvokedMethod_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -2628,7 +2639,7 @@ public class Test
             // Test0.cs(14,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(14, 17, "void Test.M1(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2654,9 +2665,9 @@ End Class",
         }
 
         [Fact]
-        public void ValidatedInInvokedMethod_AfterHazardousUsage_Diagnostic()
+        public async Task ValidatedInInvokedMethod_AfterHazardousUsage_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -2684,7 +2695,7 @@ public class Test
             // Test0.cs(13,17): warning CA1062: In externally visible method 'void Test.M1(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(13, 17, "void Test.M1(C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2708,9 +2719,9 @@ End Class",
         }
 
         [Fact]
-        public void WhileLoop_NullCheckInCondition_NoDiagnostic()
+        public async Task WhileLoop_NullCheckInCondition_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2730,7 +2741,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -2747,9 +2758,9 @@ End Class");
         }
 
         [Fact]
-        public void WhileLoop_NullCheckInCondition_HazardousUsageOnExit_Diagnostic()
+        public async Task WhileLoop_NullCheckInCondition_HazardousUsageOnExit_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2776,7 +2787,7 @@ public class Test
             // Test0.cs(19,18): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(19, 18, "void Test.M1(string str, C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -2800,9 +2811,9 @@ End Class",
         }
 
         [Fact]
-        public void ForLoop_NullCheckInCondition_NoDiagnostic()
+        public async Task ForLoop_NullCheckInCondition_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2823,9 +2834,9 @@ public class Test
         }
 
         [Fact]
-        public void ForLoop_NullCheckInCondition_HazardousUsageOnExit_Diagnostic()
+        public async Task ForLoop_NullCheckInCondition_HazardousUsageOnExit_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2853,9 +2864,9 @@ public class Test
         }
 
         [Fact]
-        public void LocalFunctionInvocation_EmptyBody_Diagnostic()
+        public async Task LocalFunctionInvocation_EmptyBody_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2886,9 +2897,9 @@ public class Test
         }
 
         [Fact]
-        public void LocalFunction_HazardousUsagesInBody_Diagnostic()
+        public async Task LocalFunction_HazardousUsagesInBody_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2921,9 +2932,9 @@ public class Test
         }
 
         [Fact]
-        public void LambdaInvocation_EmptyBody_Diagnostic()
+        public async Task LambdaInvocation_EmptyBody_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -2950,7 +2961,7 @@ public class Test
             // Test0.cs(19,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(19, 17, "void Test.M1(string str, C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -2974,9 +2985,9 @@ End Class",
         }
 
         [Fact]
-        public void Lambda_HazardousUsagesInBody_Diagnostic()
+        public async Task Lambda_HazardousUsagesInBody_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -3005,7 +3016,7 @@ public class Test
             // Test0.cs(17,21): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(17, 21, "void Test.M1(string str, C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -3031,9 +3042,9 @@ End Class",
         }
 
         [Fact]
-        public void DelegateInvocation_ValidatedArguments_NoDiagnostic()
+        public async Task DelegateInvocation_ValidatedArguments_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -3069,7 +3080,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -3100,9 +3111,9 @@ End Class");
         }
 
         [Fact]
-        public void DelegateInvocation_EmptyBody_Diagnostic()
+        public async Task DelegateInvocation_EmptyBody_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -3131,7 +3142,7 @@ public class Test
             // Test0.cs(17,17): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(17, 17, "void Test.M1(string str, C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -3157,9 +3168,9 @@ End Class",
         }
 
         [Fact]
-        public void DelegateInvocation_HazardousUsagesInBody_Diagnostic()
+        public async Task DelegateInvocation_HazardousUsagesInBody_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -3187,7 +3198,7 @@ public class Test
             // Test0.cs(14,23): warning CA1062: In externally visible method 'void Test.M1(string str, C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(14, 23, "void Test.M1(string str, C c)", "c"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -3212,9 +3223,9 @@ End Class",
         }
 
         [Fact]
-        public void TryCast_NoDiagnostic()
+        public async Task TryCast_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
 }
@@ -3240,7 +3251,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class A
 End Class
 
@@ -3258,9 +3269,9 @@ End Class");
         }
 
         [Fact]
-        public void DirectCastToObject_BeforeNullCheck_NoDiagnostic()
+        public async Task DirectCastToObject_BeforeNullCheck_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -3280,7 +3291,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -3297,9 +3308,9 @@ End Class");
         }
 
         [Fact]
-        public void StaticObjectReferenceEquals_BeforeHazardousUsages_NoDiagnostic()
+        public async Task StaticObjectReferenceEquals_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -3319,7 +3330,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -3336,9 +3347,9 @@ End Class");
         }
 
         [Fact]
-        public void StaticObjectEquals_BeforeHazardousUsages_NoDiagnostic()
+        public async Task StaticObjectEquals_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -3358,7 +3369,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -3375,9 +3386,9 @@ End Class");
         }
 
         [Fact]
-        public void ObjectEquals_BeforeHazardousUsages_NoDiagnostic()
+        public async Task ObjectEquals_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -3397,7 +3408,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 End Class
@@ -3414,9 +3425,9 @@ End Class");
         }
 
         [Fact]
-        public void ObjectEqualsOverride_BeforeHazardousUsages_NoDiagnostic()
+        public async Task ObjectEqualsOverride_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public int X;
@@ -3438,7 +3449,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public X As Integer
 
@@ -3459,9 +3470,9 @@ End Class");
         }
 
         [Fact]
-        public void IEquatableEquals_ExplicitImplementation_BeforeHazardousUsages_NoDiagnostic()
+        public async Task IEquatableEquals_ExplicitImplementation_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IEquatable<C>
@@ -3485,7 +3496,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -3509,9 +3520,9 @@ End Class");
         }
 
         [Fact]
-        public void IEquatableEquals_ImplicitImplementation_BeforeHazardousUsages_NoDiagnostic()
+        public async Task IEquatableEquals_ImplicitImplementation_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IEquatable<C>
@@ -3537,9 +3548,9 @@ public class Test
         }
 
         [Fact]
-        public void IEquatableEquals_Override_BeforeHazardousUsages_NoDiagnostic()
+        public async Task IEquatableEquals_Override_BeforeHazardousUsages_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public abstract class MyEquatable<T> : IEquatable<T>
@@ -3569,9 +3580,9 @@ public class Test
         }
 
         [Fact, WorkItem(1852, "https://github.com/dotnet/roslyn-analyzers/issues/1852")]
-        public void Issue1852()
+        public async Task Issue1852()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -3599,9 +3610,11 @@ namespace Blah
         }
 
         [Fact, WorkItem(1856, "https://github.com/dotnet/roslyn-analyzers/issues/1856")]
-        public void PointsToDataFlowOperationVisitor_VisitInstanceReference_Assert()
+        public async Task PointsToDataFlowOperationVisitor_VisitInstanceReference_Assert()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 using System;
 using System.Xml.Linq;
  namespace Blah
@@ -3689,14 +3702,22 @@ using System.Xml.Linq;
         }
     }
 }",
-            // Test0.cs(77,21): warning CA1062: In externally visible method 'void Idk<TContent>.ExportInfo(TContent part, ContentContext context)', validate parameter 'context' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-            GetCSharpResultAt(77, 21, "void Idk<TContent>.ExportInfo(TContent part, ContentContext context)", "context"));
+                SolutionTransforms =
+                {
+                    (solution, projectId) => solution.AddMetadataReference(projectId, AdditionalMetadataReferences.SystemXmlLinq)
+                },
+                ExpectedDiagnostics =
+                {
+                    // Test0.cs(77,21): warning CA1062: In externally visible method 'void Idk<TContent>.ExportInfo(TContent part, ContentContext context)', validate parameter 'context' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+                    GetCSharpResultAt(77, 21, "void Idk<TContent>.ExportInfo(TContent part, ContentContext context)", "context")
+                }
+            }.RunAsync();
         }
 
         [Fact, WorkItem(1856, "https://github.com/dotnet/roslyn-analyzers/issues/1856")]
-        public void InvocationThroughAnUninitializedLocalInstance()
+        public async Task InvocationThroughAnUninitializedLocalInstance()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     private int _field;
@@ -3711,15 +3732,15 @@ public class C
         var x = c._field;
     }
 }
-", validationMode: TestValidationMode.AllowCompileErrors, expected:
+", CompilerDiagnostics.None,
             // Test0.cs(8,15): warning CA1062: In externally visible method 'void C.M(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(8, 15, "void C.M(C c)", "c"));
         }
 
         [Fact, WorkItem(1870, "https://github.com/dotnet/roslyn-analyzers/issues/1870")]
-        public void Issue1870()
+        public async Task Issue1870()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
@@ -3764,9 +3785,9 @@ using System.Reflection;
         }
 
         [Fact, WorkItem(1870, "https://github.com/dotnet/roslyn-analyzers/issues/1870")]
-        public void Issue1870_02()
+        public async Task Issue1870_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -3790,9 +3811,9 @@ namespace ANamespace
         }
 
         [Fact, WorkItem(1886, "https://github.com/dotnet/roslyn-analyzers/issues/1886")]
-        public void Issue1886()
+        public async Task Issue1886()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public enum Status
 {
     Status1,
@@ -3819,9 +3840,11 @@ public class C2
         }
 
         [Fact, WorkItem(1891, "https://github.com/dotnet/roslyn-analyzers/issues/1891")]
-        public void Issue1891()
+        public async Task Issue1891()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 using System;
 using System.IO;
 using System.Threading;
@@ -3983,16 +4006,24 @@ public class Class1
         return true;
     }
 }",
-            // Test0.cs(115,28): warning CA1062: In externally visible method 'void Class1.Method(IContext aContext)', validate parameter 'aContext' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-            GetCSharpResultAt(115, 28, "void Class1.Method(IContext aContext)", "aContext"),
-            // Test0.cs(156,13): warning CA1062: In externally visible method 'bool Class1.HasUrl(IContext filterContext)', validate parameter 'filterContext' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-            GetCSharpResultAt(156, 13, "bool Class1.HasUrl(IContext filterContext)", "filterContext"));
+                SolutionTransforms =
+                {
+                    (solution, projectId) => solution.AddMetadataReference(projectId, AdditionalMetadataReferences.SystemWeb)
+                },
+                ExpectedDiagnostics =
+                {
+                    // Test0.cs(115,28): warning CA1062: In externally visible method 'void Class1.Method(IContext aContext)', validate parameter 'aContext' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+                    GetCSharpResultAt(115, 28, "void Class1.Method(IContext aContext)", "aContext"),
+                    // Test0.cs(156,13): warning CA1062: In externally visible method 'bool Class1.HasUrl(IContext filterContext)', validate parameter 'filterContext' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
+                    GetCSharpResultAt(156, 13, "bool Class1.HasUrl(IContext filterContext)", "filterContext")
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void MakeNullAndMakeMayBeNullAssert()
+        public async Task MakeNullAndMakeMayBeNullAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -4050,9 +4081,9 @@ public class Class1
         }
 
         [Fact]
-        public void OutParameterAssert()
+        public async Task OutParameterAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void M(string s, bool b)
@@ -4084,9 +4115,9 @@ internal class C2
         }
 
         [Fact]
-        public void OutParameterAssert_02()
+        public async Task OutParameterAssert_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -4126,9 +4157,9 @@ internal static class EncodingExtensions
         }
 
         [Fact]
-        public void GetValueOrDefaultAssert()
+        public async Task GetValueOrDefaultAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
     public bool Flag;
@@ -4150,9 +4181,9 @@ public struct S
         }
 
         [Fact]
-        public void GetValueOrDefaultAssert_02()
+        public async Task GetValueOrDefaultAssert_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
     public object Node;
@@ -4188,9 +4219,9 @@ public struct S2
         }
 
         [Fact]
-        public void GetValueAssert()
+        public async Task GetValueAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
     public int Major { get; }
@@ -4226,9 +4257,9 @@ public struct S2
         }
 
         [Fact]
-        public void SameFlowCaptureIdAcrossInterproceduralMethod()
+        public async Task SameFlowCaptureIdAcrossInterproceduralMethod()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public bool Flag;
@@ -4250,9 +4281,9 @@ public class C
         }
 
         [Fact]
-        public void HashCodeClashForUnequalPointsToAbstractValues()
+        public async Task HashCodeClashForUnequalPointsToAbstractValues()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Diagnostics;
 
 internal static class FileUtilities
@@ -4320,9 +4351,9 @@ public class C
         }
 
         [Fact]
-        public void AssignmentInTry_CatchWithThrow()
+        public async Task AssignmentInTry_CatchWithThrow()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 
@@ -4356,9 +4387,9 @@ public class C2
         }
 
         [Fact]
-        public void AnalysisEntityWithIndexAssert()
+        public async Task AnalysisEntityWithIndexAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct C1
 {
     public void M1(int index, C2 c2)
@@ -4387,9 +4418,9 @@ public struct S { }
         }
 
         [Fact]
-        public void NonMonotonicMergeAssert_FieldAllocatedInCallee()
+        public async Task NonMonotonicMergeAssert_FieldAllocatedInCallee()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -4457,9 +4488,9 @@ public struct S { }
         }
 
         [Fact]
-        public void NonMonotonicMergeAssert_LValueFlowCatpure_ResetAcrossInterproceduralCall()
+        public async Task NonMonotonicMergeAssert_LValueFlowCatpure_ResetAcrossInterproceduralCall()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Threading;
 
 public class C<T> where T : class
@@ -4487,9 +4518,9 @@ public class C<T> where T : class
         }
 
         [Fact]
-        public void YieldReturn_WithinLoop()
+        public async Task YieldReturn_WithinLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 
 public class C
@@ -4534,9 +4565,9 @@ public class E : C
         }
 
         [Fact]
-        public void NonMonotonicMergeAssert_UnknownValueMerge()
+        public async Task NonMonotonicMergeAssert_UnknownValueMerge()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 using System.IO;
 
@@ -4573,9 +4604,9 @@ public class C
         }
 
         [Fact]
-        public void NonMonotonicMergeAssert_DefaultEntityEntryMissing()
+        public async Task NonMonotonicMergeAssert_DefaultEntityEntryMissing()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 
 public class C
@@ -4622,9 +4653,9 @@ internal static class FileUtilities
         }
 
         [Fact]
-        public void NonMonotonicMergeAssert_DefaultEntityEntryMissing_02()
+        public async Task NonMonotonicMergeAssert_DefaultEntityEntryMissing_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -4659,9 +4690,9 @@ public class GreenNode { }
         }
 
         [Fact]
-        public void ComparisonOfValueTypeCastToObjectWithNull()
+        public async Task ComparisonOfValueTypeCastToObjectWithNull()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void M(object p)
@@ -4678,9 +4709,9 @@ public struct S { }",
         }
 
         [Fact]
-        public void InvalidParentInstanceAssertForAnalysisEntity()
+        public async Task InvalidParentInstanceAssertForAnalysisEntity()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Threading;
 
 public struct S
@@ -4705,9 +4736,9 @@ public class C
         }
 
         [Fact]
-        public void InvalidParentInstanceAssertForAnalysisEntity_02()
+        public async Task InvalidParentInstanceAssertForAnalysisEntity_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Threading;
 
 public struct S
@@ -4732,9 +4763,9 @@ internal static class C
         }
 
         [Fact]
-        public void IndexedEntityInstanceLocationMergeAssert()
+        public async Task IndexedEntityInstanceLocationMergeAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 using System.Threading;
 
@@ -4844,9 +4875,9 @@ public class C
         }
 
         [Fact]
-        public void CopyValueMergeAssert()
+        public async Task CopyValueMergeAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void M(object obj, ref int index)
@@ -4873,9 +4904,9 @@ public class C
         }
 
         [Fact]
-        public void CopyValueInvalidResetDataAssert()
+        public async Task CopyValueInvalidResetDataAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -4911,9 +4942,9 @@ public class C
         }
 
         [Fact]
-        public void CopyValueAddressSharedEntityAssert()
+        public async Task CopyValueAddressSharedEntityAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -4935,9 +4966,9 @@ public class C
         }
 
         [Fact]
-        public void CopyValueAddressSharedEntityAssert_RecursiveInvocations()
+        public async Task CopyValueAddressSharedEntityAssert_RecursiveInvocations()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -4966,9 +4997,9 @@ public class C
         }
 
         [Fact]
-        public void CopyValueTrackingEntityWithUnknownInstanceLocationAssert()
+        public async Task CopyValueTrackingEntityWithUnknownInstanceLocationAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -5005,9 +5036,9 @@ public class C
         }
 
         [Fact]
-        public void RecursiveLocalFunctionInvocation()
+        public async Task RecursiveLocalFunctionInvocation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -5035,9 +5066,9 @@ public class C
         }
 
         [Fact]
-        public void MultiChainedLocalFunctionInvocations()
+        public async Task MultiChainedLocalFunctionInvocations()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -5073,9 +5104,9 @@ public class C
         }
 
         [Fact]
-        public void MultiChainedLambdaInvocations()
+        public async Task MultiChainedLambdaInvocations()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -5104,9 +5135,9 @@ public class C
         }
 
         [Fact]
-        public void IsPatterExpression_UndefinedValueAssert()
+        public async Task IsPatterExpression_UndefinedValueAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 public class C
 {
@@ -5129,9 +5160,9 @@ public class D : C { }
 
         [WorkItem(1939, "https://github.com/dotnet/roslyn-analyzers/issues/1939")]
         [Fact]
-        public void Issue1939()
+        public async Task Issue1939()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class Test
@@ -5154,9 +5185,9 @@ public class Test
         }
 
         [Fact]
-        public void CopyAnalysisGetTrimmedDataAssert()
+        public async Task CopyAnalysisGetTrimmedDataAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -5179,9 +5210,9 @@ public class C
         }
 
         [Fact]
-        public void CopyAnalysisGetTrimmedDataAssert_02()
+        public async Task CopyAnalysisGetTrimmedDataAssert_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Text;
@@ -5218,9 +5249,9 @@ public class C
         }
 
         [Fact]
-        public void CopyAnalysisFlowCaptureReturnValueAssert()
+        public async Task CopyAnalysisFlowCaptureReturnValueAssert()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -5264,9 +5295,9 @@ public enum Kind
         }
 
         [Fact]
-        public void CopyAnalysisFlowCaptureReturnValueAssert_02()
+        public async Task CopyAnalysisFlowCaptureReturnValueAssert_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -5312,9 +5343,11 @@ public enum Kind
 
         [WorkItem(1943, "https://github.com/dotnet/roslyn-analyzers/issues/1943")]
         [Fact]
-        public void Issue1943()
+        public async Task Issue1943()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 using System.IO;
 using System.Web;
 
@@ -5373,15 +5406,20 @@ namespace MyComments
         }
     }
 }
-");
+",
+                SolutionTransforms =
+                {
+                    (solution, projectId) => solution.AddMetadataReference(projectId, AdditionalMetadataReferences.SystemWeb)
+                }
+            }.RunAsync();
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void CopyAnalysisAssert_AddressSharedOutParam()
+        public async Task CopyAnalysisAssert_AddressSharedOutParam()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void M(C c)
@@ -5403,9 +5441,9 @@ public class C
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void CopyAnalysisAssert_ApplyInterproceduralResult()
+        public async Task CopyAnalysisAssert_ApplyInterproceduralResult()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class SyntaxNode
 {
     public SyntaxNode Parent { get; }
@@ -5492,9 +5530,9 @@ public class CSharpSyntaxNode : SyntaxNode
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2339, "https://github.com/dotnet/roslyn-analyzers/issues/2339")]
-        public void ParameterReassignedAfterNullCheck()
+        public async Task ParameterReassignedAfterNullCheck()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public static class C
@@ -5518,9 +5556,9 @@ public static class C
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2327, "https://github.com/dotnet/roslyn-analyzers/issues/2327")]
-        public void ForEachLoopsAfterNullCheck()
+        public async Task ForEachLoopsAfterNullCheck()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.ObjectModel;
 
@@ -5555,9 +5593,9 @@ public class Model
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2280, "https://github.com/dotnet/roslyn-analyzers/issues/2280")]
-        public void ConditionalAssignmentAfterNullCheck()
+        public async Task ConditionalAssignmentAfterNullCheck()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class Node
@@ -5576,9 +5614,9 @@ public class Node
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2276, "https://github.com/dotnet/roslyn-analyzers/issues/2276")]
-        public void AssignedArrayEmptyOnNullPath()
+        public async Task AssignedArrayEmptyOnNullPath()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data.Common;
 
@@ -5606,9 +5644,9 @@ public class TableSet
         [Theory, WorkItem(2275, "https://github.com/dotnet/roslyn-analyzers/issues/2275")]
         [InlineData("IsNullOrWhiteSpace")]
         [InlineData("IsNullOrEmpty")]
-        public void StringNullCheckApis(string apiName)
+        public async Task StringNullCheckApis(string apiName)
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 using System.Globalization;
 
 public class C
@@ -5644,9 +5682,9 @@ public class C
         [Theory, WorkItem(2369, "https://github.com/dotnet/roslyn-analyzers/issues/2369")]
         [InlineData("IsNullOrWhiteSpace")]
         [InlineData("IsNullOrEmpty")]
-        public void StringNullCheckApis_02(string apiName)
+        public async Task StringNullCheckApis_02(string apiName)
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 using System;
 
 public class C
@@ -5672,9 +5710,9 @@ public class C
         [Theory, WorkItem(2369, "https://github.com/dotnet/roslyn-analyzers/issues/2369")]
         [InlineData("IsNullOrWhiteSpace")]
         [InlineData("IsNullOrEmpty")]
-        public void StringNullCheckApis_03(string apiName)
+        public async Task StringNullCheckApis_03(string apiName)
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 using System;
 
 public class C
@@ -5696,9 +5734,9 @@ public class C
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2582, "https://github.com/dotnet/roslyn-analyzers/issues/2582")]
-        public void StringEmptyFieldIsNonNull()
+        public async Task StringEmptyFieldIsNonNull()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 using System;
 
 public class Class1
@@ -5714,9 +5752,9 @@ public class Class1
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2582, "https://github.com/dotnet/roslyn-analyzers/issues/2582")]
-        public void ArrayEmptyMethodIsNonNull()
+        public async Task ArrayEmptyMethodIsNonNull()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 using System;
 
 public class Class1
@@ -5732,9 +5770,9 @@ public class Class1
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2582, "https://github.com/dotnet/roslyn-analyzers/issues/2582")]
-        public void ImmutableCreationMethodIsNonNull()
+        public async Task ImmutableCreationMethodIsNonNull()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 using System.Collections.Immutable;
 
 public class Class1
@@ -5755,9 +5793,9 @@ public class Class1
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact]
-        public void NamedArgumentInDifferentOrder()
+        public async Task NamedArgumentInDifferentOrder()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void M(C c1, C c2)
@@ -5785,9 +5823,9 @@ public class C
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2528, "https://github.com/dotnet/roslyn-analyzers/issues/2528")]
-        public void ParamArrayIsNotFlagged()
+        public async Task ParamArrayIsNotFlagged()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void M(params int[] p)
@@ -5796,7 +5834,7 @@ public class C
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Sub M(ParamArray p As Integer())
         Dim x = p.Length
@@ -5807,9 +5845,9 @@ End Class
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2269, "https://github.com/dotnet/roslyn-analyzers/issues/2269")]
-        public void ProtectedMemberOfSealedClassNotFlagged()
+        public async Task ProtectedMemberOfSealedClassNotFlagged()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public abstract class A
@@ -5827,9 +5865,9 @@ public sealed class B : A
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2526, "https://github.com/dotnet/roslyn-analyzers/issues/2526")]
-        public void CheckedWithConditionalAccess_01()
+        public async Task CheckedWithConditionalAccess_01()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 
 public class C
@@ -5847,9 +5885,9 @@ public class C
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2526, "https://github.com/dotnet/roslyn-analyzers/issues/2526")]
-        public void CheckedWithConditionalAccess_02()
+        public async Task CheckedWithConditionalAccess_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 
 public class C
@@ -5863,9 +5901,9 @@ public class C
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2586, "https://github.com/dotnet/roslyn-analyzers/issues/2586")]
-        public void CheckedWithConditionalAccess_03()
+        public async Task CheckedWithConditionalAccess_03()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 
 public class C
@@ -5888,9 +5926,9 @@ public class C
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2630, "https://github.com/dotnet/roslyn-analyzers/issues/2630")]
-        public void IsPatternInConditionalExpression_01_NoDiagnostic()
+        public async Task IsPatternInConditionalExpression_01_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     public static void DoSomething(object input)
@@ -5912,9 +5950,9 @@ public class Class1
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2630, "https://github.com/dotnet/roslyn-analyzers/issues/2630")]
-        public void IsPatternInConditionalExpression_01_Diagnostic()
+        public async Task IsPatternInConditionalExpression_01_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     public static void DoSomething(object input)
@@ -5942,9 +5980,9 @@ public class Class1
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Fact, WorkItem(2630, "https://github.com/dotnet/roslyn-analyzers/issues/2630")]
-        public void IsPatternInConditionalExpression_02_NoDiagnostic()
+        public async Task IsPatternInConditionalExpression_02_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     public static void DoSomething(object input)
@@ -5968,7 +6006,7 @@ public class Class1
         [InlineData("dotnet_code_quality.excluded_symbol_names = M1")]
         [InlineData("dotnet_code_quality." + ValidateArgumentsOfPublicMethods.RuleId + ".excluded_symbol_names = M1")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = M1")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
             var expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length == 0)
@@ -5980,7 +6018,7 @@ public class Class1
                 };
             }
 
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
 public class Test
 {
     public void M1(string str)
@@ -5988,7 +6026,7 @@ public class Test
         var x = str.ToString();
     }
 }
-", GetEditorConfigAdditionalFile(editorConfigText), expected);
+", editorConfigText, expected);
 
             expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length == 0)
@@ -6000,13 +6038,13 @@ public class Test
                 };
             }
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
 Public Class Test
     Public Sub M1(str As String)
         Dim x = str.ToString()
     End Sub
 End Class
-", GetEditorConfigAdditionalFile(editorConfigText), expected);
+", editorConfigText, expected);
         }
 
         [Theory]
@@ -6015,7 +6053,7 @@ End Class
         [InlineData("dotnet_code_quality.exclude_extension_method_this_parameter = true")]
         [InlineData("dotnet_code_quality." + ValidateArgumentsOfPublicMethods.RuleId + ".exclude_extension_method_this_parameter = true")]
         [InlineData("dotnet_code_quality.dataflow.exclude_extension_method_this_parameter = true")]
-        public void EditorConfigConfiguration_ExcludeExtensionMethodThisParameterOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludeExtensionMethodThisParameterOption(string editorConfigText)
         {
             var expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length == 0)
@@ -6027,7 +6065,7 @@ End Class
                 };
             }
 
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerWithEditorConfigAsync(@"
 public static class Test
 {
     public static void M1(this string str)
@@ -6035,7 +6073,7 @@ public static class Test
         var x = str.ToString();
     }
 }
-", GetEditorConfigAdditionalFile(editorConfigText), expected);
+", editorConfigText, expected);
 
             expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length == 0)
@@ -6047,7 +6085,7 @@ public static class Test
                 };
             }
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerWithEditorConfigAsync(@"
 Imports System.Runtime.CompilerServices
 
 Public Module Test
@@ -6055,7 +6093,7 @@ Public Module Test
     Public Sub M1(str As String)
         Dim x = str.ToString()
     End Sub
-End Module", GetEditorConfigAdditionalFile(editorConfigText), expected);
+End Module", editorConfigText, expected);
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/CallGCSuppressFinalizeCorrectlyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/CallGCSuppressFinalizeCorrectlyTests.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
-using Xunit.Abstractions;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.CallGCSuppressFinalizeCorrectlyAnalyzer,
     Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpCallGCSuppressFinalizeCorrectlyFixer>;
@@ -15,40 +13,25 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class CallGCSuppressFinalizeCorrectlyTests : DiagnosticAnalyzerTestBase
+    public class CallGCSuppressFinalizeCorrectlyTests
     {
         private const string GCSuppressFinalizeMethodSignature_CSharp = "GC.SuppressFinalize(object)";
         private const string GCSuppressFinalizeMethodSignature_Basic = "GC.SuppressFinalize(Object)";
 
         private static DiagnosticResult GetCA1816CSharpResultAt(int line, int column, DiagnosticDescriptor rule, string containingMethodName, string gcSuppressFinalizeMethodName)
-        {
-            return GetCSharpResultAt(line, column, rule, containingMethodName, gcSuppressFinalizeMethodName);
-        }
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(containingMethodName, gcSuppressFinalizeMethodName);
 
         private static DiagnosticResult GetCA1816BasicResultAt(int line, int column, DiagnosticDescriptor rule, string containingMethodName, string gcSuppressFinalizeMethodName)
-        {
-            return GetBasicResultAt(line, column, rule, containingMethodName, gcSuppressFinalizeMethodName);
-        }
-
-        public CallGCSuppressFinalizeCorrectlyTests(ITestOutputHelper output)
-            : base(output)
-        {
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new CallGCSuppressFinalizeCorrectlyAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CallGCSuppressFinalizeCorrectlyAnalyzer();
-        }
+            => new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(containingMethodName, gcSuppressFinalizeMethodName);
 
         #region NoDiagnosticCases
 
         [Fact]
-        public void DisposableWithoutFinalizer_CSharp_NoDiagnostic()
+        public async Task DisposableWithoutFinalizer_CSharp_NoDiagnostic()
         {
             var code = @"
 using System;
@@ -68,11 +51,11 @@ public class DisposableWithoutFinalizer : IDisposable
         Console.WriteLine(disposing);
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void DisposableWithoutFinalizer_Basic_NoDiagnostic()
+        public async Task DisposableWithoutFinalizer_Basic_NoDiagnostic()
         {
             var code = @"
 Imports System
@@ -90,11 +73,11 @@ Public Class DisposableWithoutFinalizer
 		Console.WriteLine(disposing)
 	End Sub
 End Class";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void DisposableWithFinalizer_CSharp_NoDiagnostic()
+        public async Task DisposableWithFinalizer_CSharp_NoDiagnostic()
         {
             var code = @"
 using System;
@@ -119,11 +102,11 @@ public class DisposableWithFinalizer : IDisposable
         Console.WriteLine(disposing);
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void DisposableWithFinalizer_Basic_NoDiagnostic()
+        public async Task DisposableWithFinalizer_Basic_NoDiagnostic()
         {
             var code = @"
 Imports System
@@ -149,11 +132,11 @@ Public Class DisposableWithFinalizer
 		Console.WriteLine(disposing)
 	End Sub
 End Class";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void SealedDisposableWithoutFinalizer_CSharp_NoDiagnostic()
+        public async Task SealedDisposableWithoutFinalizer_CSharp_NoDiagnostic()
         {
 
             var code = @"
@@ -174,11 +157,11 @@ public sealed class SealedDisposableWithoutFinalizer : IDisposable
         Console.WriteLine(disposing);
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void SealedDisposableWithoutFinalizer_Basic_NoDiagnostic()
+        public async Task SealedDisposableWithoutFinalizer_Basic_NoDiagnostic()
         {
             var code = @"
 Imports System
@@ -196,11 +179,11 @@ Public NotInheritable Class SealedDisposableWithoutFinalizer
 		Console.WriteLine(disposing)
 	End Sub
 End Class";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void SealedDisposableWithFinalizer_CSharp_NoDiagnostic()
+        public async Task SealedDisposableWithFinalizer_CSharp_NoDiagnostic()
         {
             var code = @"
 using System;
@@ -225,11 +208,11 @@ public sealed class SealedDisposableWithFinalizer : IDisposable
         Console.WriteLine(disposing);
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void SealedDisposableWithFinalizer_Basic_NoDiagnostic()
+        public async Task SealedDisposableWithFinalizer_Basic_NoDiagnostic()
         {
             var code = @"
 Imports System
@@ -255,11 +238,11 @@ Public NotInheritable Class SealedDisposableWithFinalizer
 		Console.WriteLine(disposing)
 	End Sub
 End Class";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void InternalDisposableWithoutFinalizer_CSharp_NoDiagnostic()
+        public async Task InternalDisposableWithoutFinalizer_CSharp_NoDiagnostic()
         {
             var code = @"
 using System;
@@ -279,11 +262,11 @@ internal class InternalDisposableWithoutFinalizer : IDisposable
         Console.WriteLine(disposing);
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void InternalDisposableWithoutFinalizer_Basic_NoDiagnostic()
+        public async Task InternalDisposableWithoutFinalizer_Basic_NoDiagnostic()
         {
             var code = @"
 Imports System
@@ -301,11 +284,11 @@ Friend Class InternalDisposableWithoutFinalizer
 		Console.WriteLine(disposing)
 	End Sub
 End Class";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void PrivateDisposableWithoutFinalizer_CSharp_NoDiagnostic()
+        public async Task PrivateDisposableWithoutFinalizer_CSharp_NoDiagnostic()
         {
             var code = @"
 using System;
@@ -328,11 +311,11 @@ public static class NestedClassHolder
         }
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void PrivateDisposableWithoutFinalizer_Basic_NoDiagnostic()
+        public async Task PrivateDisposableWithoutFinalizer_Basic_NoDiagnostic()
         {
             var code = @"
 Imports System
@@ -354,11 +337,11 @@ Public NotInheritable Class NestedClassHolder
 		End Sub
 	End Class
 End Class";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void SealedDisposableWithoutFinalizerAndWithoutCallingSuppressFinalize_CSharp_NoDiagnostic()
+        public async Task SealedDisposableWithoutFinalizerAndWithoutCallingSuppressFinalize_CSharp_NoDiagnostic()
         {
             var code = @"
 using System;
@@ -377,11 +360,11 @@ public sealed class SealedDisposableWithoutFinalizerAndWithoutCallingSuppressFin
         Console.WriteLine(disposing);
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void SealedDisposableWithoutFinalizerAndWithoutCallingSuppressFinalize_Basic_NoDiagnostic()
+        public async Task SealedDisposableWithoutFinalizerAndWithoutCallingSuppressFinalize_Basic_NoDiagnostic()
         {
             var code = @"
 Imports System
@@ -398,11 +381,11 @@ Public NotInheritable Class SealedDisposableWithoutFinalizerAndWithoutCallingSup
 		Console.WriteLine(disposing)
 	End Sub
 End Class";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void DisposableStruct_CSharp_NoDiagnostic()
+        public async Task DisposableStruct_CSharp_NoDiagnostic()
         {
             var code = @"
 using System;
@@ -421,11 +404,11 @@ public struct DisposableStruct : IDisposable
         Console.WriteLine(disposing);
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void DisposableStruct_Basic_NoDiagnostic()
+        public async Task DisposableStruct_Basic_NoDiagnostic()
         {
             var code = @"
 Imports System
@@ -442,11 +425,11 @@ Public Structure DisposableStruct
 		Console.WriteLine(disposing)
 	End Sub
 End Structure";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void SealedDisposableCallingGCSuppressFinalizeInConstructor_CSharp_NoDiagnostic()
+        public async Task SealedDisposableCallingGCSuppressFinalizeInConstructor_CSharp_NoDiagnostic()
         {
             var code = @"
 using System;
@@ -461,11 +444,11 @@ public sealed class SealedDisposableCallingGCSuppressFinalizeInConstructor : Com
         GC.SuppressFinalize(this);
     }
 }";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void SealedDisposableCallingGCSuppressFinalizeInConstructor_Basic_NoDiagnostic()
+        public async Task SealedDisposableCallingGCSuppressFinalizeInConstructor_Basic_NoDiagnostic()
         {
             var code = @"
 Imports System
@@ -479,11 +462,11 @@ Public NotInheritable Class SealedDisposableCallingGCSuppressFinalizeInConstruct
 		GC.SuppressFinalize(Me)
 	End Sub
 End Class";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void Disposable_ImplementedExplicitly_NoDiagnostic()
+        public async Task Disposable_ImplementedExplicitly_NoDiagnostic()
         {
             var csharpCode = @"
 using System;
@@ -500,7 +483,7 @@ public class ImplementsDisposableExplicitly : IDisposable
     {
     }
 }";
-            VerifyCSharp(csharpCode);
+            await VerifyCS.VerifyAnalyzerAsync(csharpCode);
 
             var vbCode = @"
 Imports System
@@ -516,7 +499,7 @@ Public Class C
     Public Sub Dispose(disposing As Boolean)
     End Sub
 End Class";
-            VerifyBasic(vbCode);
+            await VerifyVB.VerifyAnalyzerAsync(vbCode);
         }
 
         #endregion
@@ -524,7 +507,7 @@ End Class";
         #region DiagnosticCases
 
         [Fact]
-        public void SealedDisposableWithFinalizer_CSharp_Diagnostic()
+        public async Task SealedDisposableWithFinalizer_CSharp_Diagnostic()
         {
             var code = @"
 using System;
@@ -561,11 +544,11 @@ using System.ComponentModel;
                 containingMethodName: "SealedDisposableWithFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_CSharp);
 
-            VerifyCSharp(code, diagnosticResult);
+            await VerifyCS.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void SealedDisposableWithFinalizer_Basic_Diagnostic()
+        public async Task SealedDisposableWithFinalizer_Basic_Diagnostic()
         {
             var code = @"
 Imports System
@@ -603,11 +586,11 @@ End Class";
                 containingMethodName: "SealedDisposableWithFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_Basic);
 
-            VerifyBasic(code, diagnosticResult);
+            await VerifyVB.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void DisposableWithFinalizer_CSharp_Diagnostic()
+        public async Task DisposableWithFinalizer_CSharp_Diagnostic()
         {
             var code = @"
 using System;
@@ -639,11 +622,11 @@ public class DisposableWithFinalizer : IDisposable
                 containingMethodName: "DisposableWithFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_CSharp);
 
-            VerifyCSharp(code, diagnosticResult);
+            await VerifyCS.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void DisposableWithFinalizer_Basic_Diagnostic()
+        public async Task DisposableWithFinalizer_Basic_Diagnostic()
         {
             var code = @"
 Imports System
@@ -677,11 +660,11 @@ End Class";
                 containingMethodName: "DisposableWithFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_Basic);
 
-            VerifyBasic(code, diagnosticResult);
+            await VerifyVB.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void InternalDisposableWithFinalizer_CSharp_Diagnostic()
+        public async Task InternalDisposableWithFinalizer_CSharp_Diagnostic()
         {
             var code = @"
 using System;
@@ -713,11 +696,11 @@ internal class InternalDisposableWithFinalizer : IDisposable
                 containingMethodName: "InternalDisposableWithFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_CSharp);
 
-            VerifyCSharp(code, diagnosticResult);
+            await VerifyCS.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void InternalDisposableWithFinalizer_Basic_Diagnostic()
+        public async Task InternalDisposableWithFinalizer_Basic_Diagnostic()
         {
             var code = @"
 Imports System
@@ -751,11 +734,11 @@ End Class";
                 containingMethodName: "InternalDisposableWithFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_Basic);
 
-            VerifyBasic(code, diagnosticResult);
+            await VerifyVB.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void PrivateDisposableWithFinalizer_CSharp_Diagnostic()
+        public async Task PrivateDisposableWithFinalizer_CSharp_Diagnostic()
         {
             var code = @"
 using System;
@@ -790,11 +773,11 @@ public static class NestedClassHolder
                 containingMethodName: "NestedClassHolder.PrivateDisposableWithFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_CSharp);
 
-            VerifyCSharp(code, diagnosticResult);
+            await VerifyCS.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void PrivateDisposableWithFinalizer_Basic_Diagnostic()
+        public async Task PrivateDisposableWithFinalizer_Basic_Diagnostic()
         {
             var code = @"
 Imports System
@@ -832,11 +815,11 @@ End Class";
                 containingMethodName: "NestedClassHolder.PrivateDisposableWithFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_Basic);
 
-            VerifyBasic(code, diagnosticResult);
+            await VerifyVB.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void DisposableWithoutFinalizer_CSharp_Diagnostic()
+        public async Task DisposableWithoutFinalizer_CSharp_Diagnostic()
         {
             var code = @"
 using System;
@@ -863,11 +846,11 @@ public class DisposableWithoutFinalizer : IDisposable
                 containingMethodName: "DisposableWithoutFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_CSharp);
 
-            VerifyCSharp(code, diagnosticResult);
+            await VerifyCS.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void DisposableWithoutFinalizer_Basic_Diagnostic()
+        public async Task DisposableWithoutFinalizer_Basic_Diagnostic()
         {
             var code = @"
 Imports System
@@ -893,11 +876,11 @@ End Class";
                 containingMethodName: "DisposableWithoutFinalizer.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_Basic);
 
-            VerifyBasic(code, diagnosticResult);
+            await VerifyVB.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void DisposableComponent_CSharp_Diagnostic()
+        public async Task DisposableComponent_CSharp_Diagnostic()
         {
             var code = @"
 using System;
@@ -918,11 +901,11 @@ public class DisposableComponent : Component, IDisposable
                 containingMethodName: "DisposableComponent.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_CSharp);
 
-            VerifyCSharp(code, diagnosticResult);
+            await VerifyCS.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void DisposableComponent_Basic_Diagnostic()
+        public async Task DisposableComponent_Basic_Diagnostic()
         {
             var code = @"
 Imports System
@@ -947,11 +930,11 @@ End Class";
                 containingMethodName: "DisposableComponent.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_Basic);
 
-            VerifyBasic(code, diagnosticResult);
+            await VerifyVB.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void NotADisposableClass_CSharp_Diagnostic()
+        public async Task NotADisposableClass_CSharp_Diagnostic()
         {
             var code = @"
 using System;
@@ -971,11 +954,11 @@ public class NotADisposableClass
                 containingMethodName: "NotADisposableClass.NotADisposableClass()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_CSharp);
 
-            VerifyCSharp(code, diagnosticResult);
+            await VerifyCS.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void NotADisposableClass_Basic_Diagnostic()
+        public async Task NotADisposableClass_Basic_Diagnostic()
         {
             var code = @"
 Imports System
@@ -994,11 +977,11 @@ End Class";
                 containingMethodName: "NotADisposableClass.New()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_Basic);
 
-            VerifyBasic(code, diagnosticResult);
+            await VerifyVB.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void DisposableClassThatCallsGCSuppressFinalizeInTheWrongPlaces_CSharp_Diagnostic()
+        public async Task DisposableClassThatCallsGCSuppressFinalizeInTheWrongPlaces_CSharp_Diagnostic()
         {
             var code = @"
 using System;
@@ -1056,11 +1039,11 @@ public class DisposableClassThatCallsGCSuppressFinalizeInTheWrongPlaces : IDispo
                 containingMethodName: "DisposableClassThatCallsGCSuppressFinalizeInTheWrongPlaces.Dispose(bool)",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_CSharp);
 
-            VerifyCSharp(code, diagnosticResult1, diagnosticResult2, diagnosticResult3, diagnosticResult4);
+            await VerifyCS.VerifyAnalyzerAsync(code, diagnosticResult1, diagnosticResult2, diagnosticResult3, diagnosticResult4);
         }
 
         [Fact]
-        public void DisposableClassThatCallsGCSuppressFinalizeInTheWrongPlaces_Basic_Diagnostic()
+        public async Task DisposableClassThatCallsGCSuppressFinalizeInTheWrongPlaces_Basic_Diagnostic()
         {
             var code = @"
 Imports System
@@ -1114,11 +1097,11 @@ End Class";
                 containingMethodName: "DisposableClassThatCallsGCSuppressFinalizeInTheWrongPlaces.Dispose(Boolean)",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_Basic);
 
-            VerifyBasic(code, diagnosticResult1, diagnosticResult2, diagnosticResult3, diagnosticResult4);
+            await VerifyVB.VerifyAnalyzerAsync(code, diagnosticResult1, diagnosticResult2, diagnosticResult3, diagnosticResult4);
         }
 
         [Fact]
-        public void DisposableClassThatCallsGCSuppressFinalizeWithTheWrongArguments_CSharp_Diagnostic()
+        public async Task DisposableClassThatCallsGCSuppressFinalizeWithTheWrongArguments_CSharp_Diagnostic()
         {
             var code = @"
 using System;
@@ -1151,11 +1134,11 @@ public class DisposableClassThatCallsGCSuppressFinalizeWithTheWrongArguments : I
                 containingMethodName: "DisposableClassThatCallsGCSuppressFinalizeWithTheWrongArguments.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_CSharp);
 
-            VerifyCSharp(code, diagnosticResult);
+            await VerifyCS.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         [Fact]
-        public void DisposableClassThatCallsGCSuppressFinalizeWithTheWrongArguments_Basic_Diagnostic()
+        public async Task DisposableClassThatCallsGCSuppressFinalizeWithTheWrongArguments_Basic_Diagnostic()
         {
             var code = @"
 Imports System
@@ -1184,7 +1167,7 @@ End Class";
                 containingMethodName: "DisposableClassThatCallsGCSuppressFinalizeWithTheWrongArguments.Dispose()",
                 gcSuppressFinalizeMethodName: GCSuppressFinalizeMethodSignature_Basic);
 
-            VerifyBasic(code, diagnosticResult);
+            await VerifyVB.VerifyAnalyzerAsync(code, diagnosticResult);
         }
 
         #endregion

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposableTypesShouldDeclareFinalizerTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposableTypesShouldDeclareFinalizerTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.DisposableTypesShouldDeclareFinalizerAnalyzer,
@@ -14,10 +12,10 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class DisposableTypesShouldDeclareFinalizerTests : DiagnosticAnalyzerTestBase
+    public class DisposableTypesShouldDeclareFinalizerTests
     {
         [Fact]
-        public void CSharpDiagnosticIfIntPtrFieldIsAssignedFromNativeCodeAndNoFinalizerExists()
+        public async Task CSharpDiagnosticIfIntPtrFieldIsAssignedFromNativeCodeAndNoFinalizerExists()
         {
             var code = @"
 using System;
@@ -43,12 +41,12 @@ public class A : IDisposable
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                 GetCSharpDiagnostic(11, 14));
         }
 
         [Fact]
-        public void BasicDiagnosticIfIntPtrFieldIsAssignedFromNativeCodeAndNoFinalizerExists()
+        public async Task BasicDiagnosticIfIntPtrFieldIsAssignedFromNativeCodeAndNoFinalizerExists()
         {
             var code = @"
 Imports System
@@ -73,12 +71,12 @@ Public Class A
     End Sub
 End Class
 ";
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                 GetBasicDiagnostic(11, 14));
         }
 
         [Fact]
-        public void CSharpNoDiagnosticIfIntPtrFieldIsAssignedFromNativeCodeAndFinalizerExists()
+        public async Task CSharpNoDiagnosticIfIntPtrFieldIsAssignedFromNativeCodeAndFinalizerExists()
         {
             var code = @"
 using System;
@@ -108,11 +106,11 @@ public class A : IDisposable
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticIfIntPtrFieldIsAssignedFromNativeCodeAndFinalizerExists()
+        public async Task BasicNoDiagnosticIfIntPtrFieldIsAssignedFromNativeCodeAndFinalizerExists()
         {
             var code = @"
 Imports System
@@ -140,11 +138,11 @@ Public Class A
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticIfIntPtrFieldInValueTypeIsAssignedFromNativeCode()
+        public async Task CSharpNoDiagnosticIfIntPtrFieldInValueTypeIsAssignedFromNativeCode()
         {
             var code = @"
 using System;
@@ -170,11 +168,11 @@ public struct A : IDisposable // Although disposable structs are evil
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticIfIntPtrFieldInValueTypeIsAssignedFromNativeCode()
+        public async Task BasicNoDiagnosticIfIntPtrFieldInValueTypeIsAssignedFromNativeCode()
         {
             var code = @"
 Imports System
@@ -199,11 +197,11 @@ Public Structure A
     End Sub
 End Structure
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticIfIntPtrFieldInNonDisposableTypeIsAssignedFromNativeCode()
+        public async Task CSharpNoDiagnosticIfIntPtrFieldInNonDisposableTypeIsAssignedFromNativeCode()
         {
             var code = @"
 using System;
@@ -225,11 +223,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticIfIntPtrFieldInNonDisposableTypeIsAssignedFromNativeCode()
+        public async Task BasicNoDiagnosticIfIntPtrFieldInNonDisposableTypeIsAssignedFromNativeCode()
         {
             var code = @"
 Imports System
@@ -252,11 +250,11 @@ Public Class A
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticIfIntPtrFieldIsAssignedFromManagedCode()
+        public async Task CSharpNoDiagnosticIfIntPtrFieldIsAssignedFromManagedCode()
         {
             var code = @"
 using System;
@@ -283,11 +281,11 @@ public class A : IDisposable
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticIfIntPtrFieldIsAssignedFromManagedCode()
+        public async Task BasicNoDiagnosticIfIntPtrFieldIsAssignedFromManagedCode()
         {
             var code = @"
 Imports System
@@ -311,11 +309,11 @@ Public Class A
     End Sub
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpDiagnosticIfUIntPtrFieldIsAssignedFromNativeCode()
+        public async Task CSharpDiagnosticIfUIntPtrFieldIsAssignedFromNativeCode()
         {
             var code = @"
 using System;
@@ -341,12 +339,12 @@ public class A : IDisposable
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                 GetCSharpDiagnostic(11, 14));
         }
 
         [Fact]
-        public void BasicDiagnosticIfUIntPtrFieldIsAssignedFromNativeCode()
+        public async Task BasicDiagnosticIfUIntPtrFieldIsAssignedFromNativeCode()
         {
             var code = @"
 Imports System
@@ -371,12 +369,12 @@ Public Class A
     End Sub
 End Class
 ";
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                 GetBasicDiagnostic(11, 14));
         }
 
         [Fact]
-        public void CSharpDiagnosticIfHandleRefFieldIsAssignedFromNativeCode()
+        public async Task CSharpDiagnosticIfHandleRefFieldIsAssignedFromNativeCode()
         {
             var code = @"
 using System;
@@ -402,12 +400,12 @@ public class A : IDisposable
     }
 }
 ";
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                 GetCSharpDiagnostic(11, 14));
         }
 
         [Fact]
-        public void BasicDiagnosticIfHandleRefFieldIsAssignedFromNativeCode()
+        public async Task BasicDiagnosticIfHandleRefFieldIsAssignedFromNativeCode()
         {
             var code = @"
 Imports System
@@ -432,12 +430,12 @@ Public Class A
     End Sub
 End Class
 ";
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                 GetBasicDiagnostic(11, 14));
         }
 
         [Fact]
-        public void CSharpNoDiagnosticIfNonNativeResourceFieldIsAssignedFromNativeCode()
+        public async Task CSharpNoDiagnosticIfNonNativeResourceFieldIsAssignedFromNativeCode()
         {
             var code = @"
 using System;
@@ -463,11 +461,11 @@ public class A : IDisposable
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticIfNonNativeResourceFieldIsAssignedFromNativeCode()
+        public async Task BasicNoDiagnosticIfNonNativeResourceFieldIsAssignedFromNativeCode()
         {
             var code = @"
 Imports System
@@ -492,17 +490,7 @@ Public Class A
     End Sub
 End Class
 ";
-            VerifyBasic(code);
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DisposableTypesShouldDeclareFinalizerAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DisposableTypesShouldDeclareFinalizerAnalyzer();
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         private static DiagnosticResult GetCSharpDiagnostic(int line, int column)

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/InitializeStaticFieldsInlineTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/InitializeStaticFieldsInlineTests.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.NetCore.CSharp.Analyzers.Runtime;
-using Microsoft.NetCore.VisualBasic.Analyzers.Runtime;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpInitializeStaticFieldsInlineAnalyzer,
@@ -16,14 +14,14 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class InitializeStaticFieldsInlineTests : DiagnosticAnalyzerTestBase
+    public class InitializeStaticFieldsInlineTests
     {
         #region Unit tests for no analyzer diagnostic
 
         [Fact]
-        public void CA1810_EmptyStaticConstructor()
+        public async Task CA1810_EmptyStaticConstructor()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     private readonly static int field = 1;
@@ -32,7 +30,7 @@ public class Class1
     }
 }
 ");
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
 	Private Shared ReadOnly field As Integer = 1
 	Shared Sub New() ' Empty
@@ -42,9 +40,9 @@ End Class
         }
 
         [Fact]
-        public void CA2207_EmptyStaticConstructor()
+        public async Task CA2207_EmptyStaticConstructor()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct Struct1
 {
     private readonly static int field = 1;
@@ -53,7 +51,7 @@ public struct Struct1
     }
 }
 ");
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure Struct1
 	Private Shared ReadOnly field As Integer = 1
 	Shared Sub New() ' Empty
@@ -63,9 +61,9 @@ End Structure
         }
 
         [Fact]
-        public void CA1810_NoStaticFieldInitializedInStaticConstructor()
+        public async Task CA1810_NoStaticFieldInitializedInStaticConstructor()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     private readonly static int field = 1;
@@ -78,7 +76,7 @@ public class Class1
     private static void Class1_Method() { throw new System.NotImplementedException(); }
 }
 ");
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
 	Private Shared ReadOnly field As Integer = 1
 	Shared Sub New() ' No static field initalization
@@ -94,9 +92,9 @@ End Class
         }
 
         [Fact]
-        public void CA1810_StaticPropertyInStaticConstructor()
+        public async Task CA1810_StaticPropertyInStaticConstructor()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     private static int Property { get; set; }
@@ -108,7 +106,7 @@ public class Class1
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
 	Private Shared Property [Property]() As Integer
 		Get
@@ -127,9 +125,9 @@ End Class
         }
 
         [Fact]
-        public void CA1810_InitializionInNonStaticConstructor()
+        public async Task CA1810_InitializionInNonStaticConstructor()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     private static int field = 1;
@@ -144,7 +142,7 @@ public class Class1
     }
 }
 ");
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
 	Private Shared field As Integer = 1
 	Public Sub New() ' Non static constructor
@@ -163,9 +161,9 @@ End Class
         #region Unit tests for analyzer diagnostic(s)
 
         [Fact]
-        public void CA1810_InitializationInStaticConstructor()
+        public async Task CA1810_InitializationInStaticConstructor()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     private readonly static int field;
@@ -177,7 +175,7 @@ public class Class1
 ",
     GetCA1810CSharpDefaultResultAt(5, 12, "Class1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
 	Private Shared ReadOnly field As Integer
 	Shared Sub New()
@@ -190,9 +188,9 @@ End Class
         }
 
         [Fact]
-        public void CA2207_InitializationInStaticConstructor()
+        public async Task CA2207_InitializationInStaticConstructor()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct Struct1
 {
     private readonly static int field;
@@ -204,7 +202,7 @@ public struct Struct1
 ",
     GetCA2207CSharpDefaultResultAt(5, 12, "Struct1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure Struct1
 	Private Shared ReadOnly field As Integer
 	Shared Sub New()
@@ -217,9 +215,9 @@ End Structure
         }
 
         [Fact]
-        public void CA1810_NoDuplicateDiagnostics()
+        public async Task CA1810_NoDuplicateDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     private readonly static int field, field2;
@@ -232,7 +230,7 @@ public class Class1
 ",
     GetCA1810CSharpDefaultResultAt(5, 12, "Class1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
 	Private Shared ReadOnly field As Integer, field2 As Integer
 	Shared Sub New()
@@ -245,9 +243,9 @@ End Class",
         }
 
         [Fact]
-        public void CA2207_NoDuplicateDiagnostics()
+        public async Task CA2207_NoDuplicateDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct Struct1
 {
     private readonly static int field, field2;
@@ -260,7 +258,7 @@ public struct Struct1
 ",
     GetCA2207CSharpDefaultResultAt(5, 12, "Struct1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure Struct1
 	Private Shared ReadOnly field As Integer, field2 As Integer
 	Shared Sub New()
@@ -276,38 +274,36 @@ End Structure",
 
         #region Helpers
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicInitializeStaticFieldsInlineAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpInitializeStaticFieldsInlineAnalyzer();
-        }
-
         private static DiagnosticResult GetCA1810CSharpDefaultResultAt(int line, int column, string typeName)
         {
             string message = string.Format(CultureInfo.CurrentCulture, MicrosoftNetCoreAnalyzersResources.InitializeStaticFieldsInlineMessage, typeName);
-            return GetCSharpResultAt(line, column, CSharpInitializeStaticFieldsInlineAnalyzer.CA1810RuleId, message);
+            return new DiagnosticResult(CSharpInitializeStaticFieldsInlineAnalyzer.CA1810Rule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetCA1810BasicDefaultResultAt(int line, int column, string typeName)
         {
             string message = string.Format(CultureInfo.CurrentCulture, MicrosoftNetCoreAnalyzersResources.InitializeStaticFieldsInlineMessage, typeName);
-            return GetBasicResultAt(line, column, BasicInitializeStaticFieldsInlineAnalyzer.CA1810RuleId, message);
+            return new DiagnosticResult(CSharpInitializeStaticFieldsInlineAnalyzer.CA1810Rule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetCA2207CSharpDefaultResultAt(int line, int column, string typeName)
         {
             string message = string.Format(CultureInfo.CurrentCulture, MicrosoftNetCoreAnalyzersResources.InitializeStaticFieldsInlineMessage, typeName);
-            return GetCSharpResultAt(line, column, CSharpInitializeStaticFieldsInlineAnalyzer.CA2207RuleId, message);
+            return new DiagnosticResult(CSharpInitializeStaticFieldsInlineAnalyzer.CA2207Rule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetCA2207BasicDefaultResultAt(int line, int column, string typeName)
         {
             string message = string.Format(CultureInfo.CurrentCulture, MicrosoftNetCoreAnalyzersResources.InitializeStaticFieldsInlineMessage, typeName);
-            return GetBasicResultAt(line, column, BasicInitializeStaticFieldsInlineAnalyzer.CA2207RuleId, message);
+            return new DiagnosticResult(CSharpInitializeStaticFieldsInlineAnalyzer.CA2207Rule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         #endregion

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -14,26 +14,16 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class InstantiateArgumentExceptionsCorrectlyTests : DiagnosticAnalyzerTestBase
+    public class InstantiateArgumentExceptionsCorrectlyTests
     {
         private static readonly string s_noArguments = MicrosoftNetCoreAnalyzersResources.InstantiateArgumentExceptionsCorrectlyMessageNoArguments;
         private static readonly string s_incorrectMessage = MicrosoftNetCoreAnalyzersResources.InstantiateArgumentExceptionsCorrectlyMessageIncorrectMessage;
         private static readonly string s_incorrectParameterName = MicrosoftNetCoreAnalyzersResources.InstantiateArgumentExceptionsCorrectlyMessageIncorrectParameterName;
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new InstantiateArgumentExceptionsCorrectlyAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new InstantiateArgumentExceptionsCorrectlyAnalyzer();
-        }
-
         [Fact]
-        public void ArgumentException_NoArguments_Warns()
+        public async Task ArgumentException_NoArguments_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -43,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(6, 31, s_noArguments, "ArgumentException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentException()
@@ -53,9 +43,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentException_EmptyParameterNameArgument_Warns()
+        public async Task ArgumentException_EmptyParameterNameArgument_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -65,7 +55,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "", "paramName", "ArgumentNullException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentNullException("""")
@@ -75,9 +65,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentNullException_SpaceParameterArgument_Warns()
+        public async Task ArgumentNullException_SpaceParameterArgument_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -87,7 +77,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", " ", "paramName", "ArgumentNullException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentNullException("" "")
@@ -97,9 +87,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentNullException_NameofNonParameter_Warns()
+        public async Task ArgumentNullException_NameofNonParameter_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -110,7 +100,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(7, 31, s_incorrectParameterName, "Test", "foo", "paramName", "ArgumentNullException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Dim foo As New Object()
@@ -121,9 +111,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentException_ParameterNameAsMessage_Warns()
+        public async Task ArgumentException_ParameterNameAsMessage_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -133,7 +123,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(6, 31, s_incorrectMessage, "Test", "first", "message", "ArgumentException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentException(""first"")
@@ -143,9 +133,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentException_ReversedArguments_Warns()
+        public async Task ArgumentException_ReversedArguments_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -156,7 +146,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectMessage, "Test", "first", "message", "ArgumentException"),
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "first is incorrect", "paramName", "ArgumentException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentException(""first"", ""first is incorrect"")
@@ -167,9 +157,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentNullException_NoArguments_Warns()
+        public async Task ArgumentNullException_NoArguments_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -179,7 +169,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(6, 31, s_noArguments, "ArgumentNullException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentNullException()
@@ -189,9 +179,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentNullException_MessageAsParameterName_Warns()
+        public async Task ArgumentNullException_MessageAsParameterName_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -203,9 +193,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentNullException_ReversedArguments_Warns()
+        public async Task ArgumentNullException_ReversedArguments_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -216,7 +206,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "first is null", "paramName", "ArgumentNullException"),
                 GetCSharpExpectedResult(6, 31, s_incorrectMessage, "Test", "first", "message", "ArgumentNullException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentNullException(""first is null"", ""first"")
@@ -227,9 +217,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentOutOfRangeException_NoArguments_Warns()
+        public async Task ArgumentOutOfRangeException_NoArguments_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -239,7 +229,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(6, 31, s_noArguments, "ArgumentOutOfRangeException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentOutOfRangeException()
@@ -249,9 +239,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentOutOfRangeException_MessageAsParameterName_Warns()
+        public async Task ArgumentOutOfRangeException_MessageAsParameterName_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -261,7 +251,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "first is out of range", "paramName", "ArgumentOutOfRangeException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentOutOfRangeException(""first is out of range"")
@@ -271,9 +261,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentOutOfRangeException_ReversedArguments_Warns()
+        public async Task ArgumentOutOfRangeException_ReversedArguments_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -284,7 +274,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "first is out of range", "paramName", "ArgumentOutOfRangeException"),
                 GetCSharpExpectedResult(6, 31, s_incorrectMessage, "Test", "first", "message", "ArgumentOutOfRangeException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentOutOfRangeException(""first is out of range"", ""first"")
@@ -295,9 +285,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void DuplicateWaitObjectException_NoArguments_Warns()
+        public async Task DuplicateWaitObjectException_NoArguments_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -307,7 +297,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(6, 31, s_noArguments, "DuplicateWaitObjectException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.DuplicateWaitObjectException()
@@ -317,9 +307,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void DuplicateWaitObjectException_MessageAsParameterName_Warns()
+        public async Task DuplicateWaitObjectException_MessageAsParameterName_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -329,7 +319,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }",
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "first is duplicate", "parameterName", "DuplicateWaitObjectException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.DuplicateWaitObjectException(""first is duplicate"")
@@ -339,9 +329,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void DuplicateWaitObjectException_ReversedArguments_Warns()
+        public async Task DuplicateWaitObjectException_ReversedArguments_Warns()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -352,7 +342,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 GetCSharpExpectedResult(6, 31, s_incorrectParameterName, "Test", "first is duplicate", "parameterName", "DuplicateWaitObjectException"),
                 GetCSharpExpectedResult(6, 31, s_incorrectMessage, "Test", "first", "message", "DuplicateWaitObjectException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.DuplicateWaitObjectException(""first is duplicate"", ""first"")
@@ -364,9 +354,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
 
         [Fact]
-        public void ArgumentException_CorrectMessage_DoesNotWarn()
+        public async Task ArgumentException_CorrectMessage_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -375,7 +365,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                Public Class [MyClass]
                    Public Sub Test(first As String)
                        Throw New System.ArgumentException(""first is incorrect"")
@@ -384,9 +374,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentException_CorrectMessageAndParameterName_DoesNotWarn()
+        public async Task ArgumentException_CorrectMessageAndParameterName_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -395,7 +385,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                Public Class [MyClass]
                    Public Sub Test(first As String)
                        Throw New System.ArgumentException(""first is incorrect"", ""first"")
@@ -404,9 +394,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentNullException_CorrectParameterName_DoesNotWarn()
+        public async Task ArgumentNullException_CorrectParameterName_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -415,7 +405,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                Public Class [MyClass]
                    Public Sub Test(first As String)
                        Throw New System.ArgumentNullException(""first"")
@@ -426,9 +416,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
         [Fact]
 
-        public void ArgumentNullException_NameofParameter_DoesNotWarn()
+        public async Task ArgumentNullException_NameofParameter_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -437,7 +427,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                 Public Class [MyClass]
                     Public Sub Test(first As String)
                         Throw New System.ArgumentNullException(NameOf(first))
@@ -446,9 +436,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentNull_CorrectParameterNameAndMessage_DoesNotWarn()
+        public async Task ArgumentNull_CorrectParameterNameAndMessage_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -457,7 +447,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                Public Class [MyClass]
                    Public Sub Test(first As String)
                        Throw New System.ArgumentNullException(""first"", ""first is null"")
@@ -466,9 +456,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentOutOfRangeException_CorrectParameterName_DoesNotWarn()
+        public async Task ArgumentOutOfRangeException_CorrectParameterName_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -477,7 +467,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                Public Class [MyClass]
                    Public Sub Test(first As String)
                        Throw New System.ArgumentOutOfRangeException(""first"")
@@ -486,9 +476,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void ArgumentOutOfRangeException_CorrectParameterNameAndMessage_DoesNotWarn()
+        public async Task ArgumentOutOfRangeException_CorrectParameterNameAndMessage_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -497,7 +487,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                Public Class [MyClass]
                    Public Sub Test(first As String)
                        Throw New System.DuplicateWaitObjectException(""first"", ""first is out of range"")
@@ -506,9 +496,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void DuplicateWaitObjectException_CorrectParameterName_DoesNotWarn()
+        public async Task DuplicateWaitObjectException_CorrectParameterName_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -517,7 +507,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                Public Class [MyClass]
                    Public Sub Test(first As String)
                        Throw New System.DuplicateWaitObjectException(""first"")
@@ -526,9 +516,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void DuplicateWaitObjectException_CorrectParameterNameAndMessage_DoesNotWarn()
+        public async Task DuplicateWaitObjectException_CorrectParameterNameAndMessage_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test(string first)
@@ -537,7 +527,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
                Public Class [MyClass]
                    Public Sub Test(first As String)
                        Throw New System.DuplicateWaitObjectException(""first"", ""first is duplicate"")
@@ -546,9 +536,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact, WorkItem(1824, "https://github.com/dotnet/roslyn-analyzers/issues/1824")]
-        public void ArgumentNullException_LocalFunctionParameter_DoesNotWarn()
+        public async Task ArgumentNullException_LocalFunctionParameter_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test()
@@ -562,9 +552,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact, WorkItem(1824, "https://github.com/dotnet/roslyn-analyzers/issues/1824")]
-        public void ArgumentNullException_NestedLocalFunctionParameter_DoesNotWarn()
+        public async Task ArgumentNullException_NestedLocalFunctionParameter_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test()
@@ -581,9 +571,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact, WorkItem(1824, "https://github.com/dotnet/roslyn-analyzers/issues/1824")]
-        public void ArgumentNullException_LambdaParameter_DoesNotWarn()
+        public async Task ArgumentNullException_LambdaParameter_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 public class Class
                 {
                     public void Test()
@@ -597,9 +587,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact, WorkItem(1561, "https://github.com/dotnet/roslyn-analyzers/issues/1561")]
-        public void ArgumentOutOfRangeException_PropertyName_DoesNotWarn()
+        public async Task ArgumentOutOfRangeException_PropertyName_DoesNotWarn()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
                 using System;
 
                 public class Class1
@@ -624,13 +614,17 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         private static DiagnosticResult GetCSharpExpectedResult(int line, int column, string format, params string[] args)
         {
             string message = string.Format(CultureInfo.CurrentCulture, format, args);
-            return GetCSharpResultAt(line, column, InstantiateArgumentExceptionsCorrectlyAnalyzer.RuleId, message);
+            return new DiagnosticResult(InstantiateArgumentExceptionsCorrectlyAnalyzer.Descriptor)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetBasicExpectedResult(int line, int column, string format, params string[] args)
         {
             string message = string.Format(CultureInfo.CurrentCulture, format, args);
-            return GetBasicResultAt(line, column, InstantiateArgumentExceptionsCorrectlyAnalyzer.RuleId, message);
+            return new DiagnosticResult(InstantiateArgumentExceptionsCorrectlyAnalyzer.Descriptor)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/NormalizeStringsToUppercaseTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/NormalizeStringsToUppercaseTests.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.NormalizeStringsToUppercaseAnalyzer,
@@ -14,24 +13,14 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class NormalizeStringsToUppercaseTests : DiagnosticAnalyzerTestBase
+    public class NormalizeStringsToUppercaseTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new NormalizeStringsToUppercaseAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new NormalizeStringsToUppercaseAnalyzer();
-        }
-
         #region No Diagnostic Tests
 
         [Fact]
-        public void NoDiagnostic_ToUpperCases()
+        public async Task NoDiagnostic_ToUpperCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -65,7 +54,7 @@ public class NormalizeStringsTesterClass
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -95,9 +84,9 @@ End Class
         }
 
         [Fact]
-        public void NoDiagnostic_ToLowerCases()
+        public async Task NoDiagnostic_ToLowerCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -131,7 +120,7 @@ public class NormalizeStringsTesterClass
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -161,9 +150,9 @@ End Class
         }
 
         [Fact]
-        public void NoDiagnostic_ToUpperInvariantCases()
+        public async Task NoDiagnostic_ToUpperInvariantCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -176,7 +165,7 @@ public class NormalizeStringsTesterClass
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -193,9 +182,9 @@ End Class
         #region Diagnostic Tests
 
         [Fact]
-        public void Diagnostic_ToLowerCases()
+        public async Task Diagnostic_ToLowerCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -209,7 +198,7 @@ public class NormalizeStringsTesterClass
 ",
             GetCSharpDefaultResultAt(9, 27, "TestMethod", "ToLower", "ToUpperInvariant"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -223,9 +212,9 @@ End Class
         }
 
         [Fact]
-        public void Diagnostic_ToLowerInvariantCases()
+        public async Task Diagnostic_ToLowerInvariantCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -239,7 +228,7 @@ public class NormalizeStringsTesterClass
 ",
             GetCSharpDefaultResultAt(9, 27, "TestMethod", "ToLowerInvariant", "ToUpperInvariant"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -260,14 +249,18 @@ End Class
         {
             // In method '{0}', replace the call to '{1}' with '{2}'.
             string message = string.Format(CultureInfo.CurrentCulture, NormalizeStringsToUppercaseAnalyzer.ToUpperRule.MessageFormat.ToString(CultureInfo.CurrentCulture), containingMethod, invokedMethod, suggestedMethod);
-            return GetCSharpResultAt(line, column, NormalizeStringsToUppercaseAnalyzer.RuleId, message);
+            return new DiagnosticResult(NormalizeStringsToUppercaseAnalyzer.ToUpperRule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         private static DiagnosticResult GetBasicDefaultResultAt(int line, int column, string containingMethod, string invokedMethod, string suggestedMethod)
         {
             // In method '{0}', replace the call to '{1}' with '{2}'.
             string message = string.Format(CultureInfo.CurrentCulture, NormalizeStringsToUppercaseAnalyzer.ToUpperRule.MessageFormat.ToString(CultureInfo.CurrentCulture), containingMethod, invokedMethod, suggestedMethod);
-            return GetBasicResultAt(line, column, NormalizeStringsToUppercaseAnalyzer.RuleId, message);
+            return new DiagnosticResult(NormalizeStringsToUppercaseAnalyzer.ToUpperRule)
+                .WithLocation(line, column)
+                .WithMessage(message);
         }
 
         #endregion

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyCultureInfoTests.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.SpecifyCultureInfoAnalyzer,
@@ -12,22 +13,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class SpecifyCultureInfoTests : DiagnosticAnalyzerTestBase
+    public class SpecifyCultureInfoTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new SpecifyCultureInfoAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new SpecifyCultureInfoAnalyzer();
-        }
-
         [Fact]
-        public void CA1304_PlainString_CSharp()
+        public async Task CA1304_PlainString_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -42,9 +33,9 @@ public class CultureInfoTestClass0
         }
 
         [Fact]
-        public void CA1304_VariableStringInsideDifferentContainingSymbols_CSharp()
+        public async Task CA1304_VariableStringInsideDifferentContainingSymbols_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -85,9 +76,9 @@ public class CultureInfoTestClass1
         }
 
         [Fact]
-        public void CA1304_MethodOverloadHasCultureInfoAsFirstArgument_CSharp()
+        public async Task CA1304_MethodOverloadHasCultureInfoAsFirstArgument_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -112,9 +103,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_MethodOverloadHasCultureInfoAsFirstAndSecondArgument_CSharp()
+        public async Task CA1304_MethodOverloadHasCultureInfoAsFirstAndSecondArgument_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -139,9 +130,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_MethodOverloadHasCultureInfoAsFirstArgument_RefKindRef_CSharp()
+        public async Task CA1304_MethodOverloadHasCultureInfoAsFirstArgument_RefKindRef_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -166,9 +157,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_MethodOverloadHasCultureInfoAsLastArgument_CSharp()
+        public async Task CA1304_MethodOverloadHasCultureInfoAsLastArgument_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -198,9 +189,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_MethodOverloadHasCultureInfoAsLastArgument_RefKindOut_CSharp()
+        public async Task CA1304_MethodOverloadHasCultureInfoAsLastArgument_RefKindOut_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -226,9 +217,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_MethodOverloadHasJustCultureInfo_CSharp()
+        public async Task CA1304_MethodOverloadHasJustCultureInfo_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -253,9 +244,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_DoesNotRecommendObsoleteOverload_CSharp()
+        public async Task CA1304_DoesNotRecommendObsoleteOverload_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -280,9 +271,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_TargetMethodIsGenericsAndNonGenerics_CSharp()
+        public async Task CA1304_TargetMethodIsGenericsAndNonGenerics_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -314,9 +305,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_MethodOverloadIncludeNonCandidates_CSharp()
+        public async Task CA1304_MethodOverloadIncludeNonCandidates_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -344,9 +335,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_MethodOverloadWithJustCultureInfoAsExtraParameter_CSharp()
+        public async Task CA1304_MethodOverloadWithJustCultureInfoAsExtraParameter_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -371,9 +362,9 @@ public class CultureInfoTestClass2
         }
 
         [Fact]
-        public void CA1304_NoDiagnostics_CSharp()
+        public async Task CA1304_NoDiagnostics_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -442,9 +433,9 @@ public class DerivedCultureInfo : CultureInfo
         }
 
         [Fact]
-        public void CA1304_PlainString_VisualBasic()
+        public async Task CA1304_PlainString_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -457,9 +448,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1304_VariableStringInsideDifferentContainingSymbols_VisualBasic()
+        public async Task CA1304_VariableStringInsideDifferentContainingSymbols_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -491,9 +482,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1304_MethodOverloadHasCultureInfoAsFirstArgument_VisualBasic()
+        public async Task CA1304_MethodOverloadHasCultureInfoAsFirstArgument_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -514,9 +505,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1304_MethodOverloadHasCultureInfoAsLastArgument_VisualBasic()
+        public async Task CA1304_MethodOverloadHasCultureInfoAsLastArgument_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -541,9 +532,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1304_MethodOverloadHasJustCultureInfo_VisualBasic()
+        public async Task CA1304_MethodOverloadHasJustCultureInfo_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -564,9 +555,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1304_MethodOverloadIncludeNonCandidates_VisualBasic()
+        public async Task CA1304_MethodOverloadIncludeNonCandidates_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -590,9 +581,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1304_MethodOverloadWithJustCultureInfoAsExtraParameter_VisualBasic()
+        public async Task CA1304_MethodOverloadWithJustCultureInfoAsExtraParameter_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -613,9 +604,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1304_NoDiagnostics_VisualBasic()
+        public async Task CA1304_NoDiagnostics_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -661,5 +652,15 @@ Public Class DerivedCultureInfo
     End Sub
 End Class");
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2, string arg3) =>
+            new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2, string arg3) =>
+            new DiagnosticResult(rule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyIFormatProviderTests.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -13,22 +13,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class SpecifyIFormatProviderTests : DiagnosticAnalyzerTestBase
+    public class SpecifyIFormatProviderTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new SpecifyIFormatProviderAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new SpecifyIFormatProviderAnalyzer();
-        }
-
         [Fact]
-        public void CA1305_StringReturningStringFormatOverloads_CSharp()
+        public async Task CA1305_StringReturningStringFormatOverloads_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 using System.Threading;
@@ -70,9 +60,9 @@ GetIFormatProviderAlternateStringRuleCSharpResultAt(25, 16, "string.Format(strin
         }
 
         [Fact]
-        public void CA1305_StringReturningUserMethodOverloads_CSharp()
+        public async Task CA1305_StringReturningUserMethodOverloads_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 using System.Threading;
@@ -136,9 +126,9 @@ GetIFormatProviderAlternateStringRuleCSharpResultAt(12, 9, "IFormatProviderOverl
         }
 
         [Fact]
-        public void CA1305_StringReturningNoDiagnostics_CSharp()
+        public async Task CA1305_StringReturningNoDiagnostics_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 using System.Threading;
@@ -210,9 +200,9 @@ public class DerivedClass : IFormatProvider
         }
 
         [Fact]
-        public void CA1305_NonStringReturningStringFormatOverloads_CSharp()
+        public async Task CA1305_NonStringReturningStringFormatOverloads_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -264,9 +254,9 @@ GetIFormatProviderAlternateRuleCSharpResultAt(12, 9, "IFormatProviderOverloads.T
         }
 
         [Fact]
-        public void CA1305_NonStringReturningStringFormatOverloads_TargetMethodNoGenerics_CSharp()
+        public async Task CA1305_NonStringReturningStringFormatOverloads_TargetMethodNoGenerics_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public static class IFormatProviderStringTest
@@ -302,9 +292,9 @@ GetIFormatProviderAlternateRuleCSharpResultAt(8, 9, "IFormatProviderOverloads.Ta
         }
 
         [Fact]
-        public void CA1305_StringReturningUICultureIFormatProvider_CSharp()
+        public async Task CA1305_StringReturningUICultureIFormatProvider_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 using System.Threading;
@@ -359,9 +349,9 @@ GetIFormatProviderUICultureStringRuleCSharpResultAt(13, 9, "UICultureAsIFormatPr
         }
 
         [Fact]
-        public void CA1305_NonStringReturningUICultureIFormatProvider_CSharp()
+        public async Task CA1305_NonStringReturningUICultureIFormatProvider_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 using System.Threading;
@@ -415,9 +405,9 @@ GetIFormatProviderUICultureRuleCSharpResultAt(13, 9, "UICultureAsIFormatProvider
 
 
         [Fact]
-        public void CA1305_AcceptNullForIFormatProvider_CSharp()
+        public async Task CA1305_AcceptNullForIFormatProvider_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 using System.Threading;
@@ -440,9 +430,9 @@ internal static class IFormatProviderOverloads
         }
 
         [Fact]
-        public void CA1305_DoesNotRecommendObsoleteOverload_CSharp()
+        public async Task CA1305_DoesNotRecommendObsoleteOverload_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 using System.Threading;
@@ -471,9 +461,9 @@ internal static class IFormatProviderOverloads
         }
 
         [Fact]
-        public void CA1305_RuleException_NoDiagnostics_CSharp()
+        public async Task CA1305_RuleException_NoDiagnostics_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 using System.Threading;
@@ -494,9 +484,9 @@ public static class IFormatProviderStringTest
         }
 
         [Fact]
-        public void CA1305_StringReturningStringFormatOverloads_VisualBasic()
+        public async Task CA1305_StringReturningStringFormatOverloads_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -536,9 +526,9 @@ GetIFormatProviderAlternateStringRuleBasicResultAt(23, 16, "String.Format(String
         }
 
         [Fact]
-        public void CA1305_StringReturningUserMethodOverloads_VisualBasic()
+        public async Task CA1305_StringReturningUserMethodOverloads_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -596,9 +586,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1305_StringReturningNoDiagnostics_VisualBasic()
+        public async Task CA1305_StringReturningNoDiagnostics_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -646,9 +636,9 @@ End Class");
         }
 
         [Fact]
-        public void CA1305_NonStringReturningStringFormatOverloads_VisualBasic()
+        public async Task CA1305_NonStringReturningStringFormatOverloads_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -698,9 +688,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1305_StringReturningUICultureIFormatProvider_VisualBasic()
+        public async Task CA1305_StringReturningUICultureIFormatProvider_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -754,9 +744,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1305_NonStringReturningUICultureIFormatProvider_VisualBasic()
+        public async Task CA1305_NonStringReturningUICultureIFormatProvider_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -808,9 +798,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1305_NonStringReturningComputerInfoInstalledUICultureIFormatProvider_VisualBasic()
+        public async Task CA1305_NonStringReturningComputerInfoInstalledUICultureIFormatProvider_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -837,9 +827,9 @@ GetIFormatProviderUICultureRuleBasicResultAt(12, 9, "UICultureAsIFormatProviderR
         }
 
         [Fact]
-        public void CA1305_RuleException_NoDiagnostics_VisualBasic()
+        public async Task CA1305_RuleException_NoDiagnostics_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 Imports System.Threading
@@ -861,9 +851,9 @@ End Class");
 
         [Fact]
         [WorkItem(2394, "https://github.com/dotnet/roslyn-analyzers/issues/2394")]
-        public void CA1305_BoolToString_NoDiagnostics()
+        public async Task CA1305_BoolToString_NoDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Foo
 {
     public string Bar(bool b1, System.Boolean b2)
@@ -872,7 +862,7 @@ public class Foo
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Foo
     Public Function Bar(ByVal b As Boolean) As String
         Return b.ToString()
@@ -883,9 +873,9 @@ End Class
 
         [Fact]
         [WorkItem(2394, "https://github.com/dotnet/roslyn-analyzers/issues/2394")]
-        public void CA1305_CharToString_NoDiagnostics()
+        public async Task CA1305_CharToString_NoDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Foo
 {
     public string Bar(char c1, System.Char c2)
@@ -894,7 +884,7 @@ public class Foo
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Foo
     Public Function Bar(ByVal c As Char) As String
         Return c.ToString()
@@ -905,9 +895,9 @@ End Class
 
         [Fact]
         [WorkItem(2394, "https://github.com/dotnet/roslyn-analyzers/issues/2394")]
-        public void CA1305_StringToString_NoDiagnostics()
+        public async Task CA1305_StringToString_NoDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Foo
 {
     public string Bar(string s1, System.String s2)
@@ -916,7 +906,7 @@ public class Foo
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Foo
     Public Function Bar(ByVal s As String) As String
         Return s.ToString()
@@ -927,42 +917,58 @@ End Class
 
         private DiagnosticResult GetIFormatProviderAlternateStringRuleCSharpResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetCSharpResultAt(line, column, SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateStringRule, arg1, arg2, arg3);
+            return new DiagnosticResult(SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateStringRule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
 
         private DiagnosticResult GetIFormatProviderAlternateRuleCSharpResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetCSharpResultAt(line, column, SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateRule, arg1, arg2, arg3);
+            return new DiagnosticResult(SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateRule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
 
         private DiagnosticResult GetIFormatProviderUICultureStringRuleCSharpResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetCSharpResultAt(line, column, SpecifyIFormatProviderAnalyzer.UICultureStringRule, arg1, arg2, arg3);
+            return new DiagnosticResult(SpecifyIFormatProviderAnalyzer.UICultureStringRule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
 
         private DiagnosticResult GetIFormatProviderUICultureRuleCSharpResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetCSharpResultAt(line, column, SpecifyIFormatProviderAnalyzer.UICultureRule, arg1, arg2, arg3);
+            return new DiagnosticResult(SpecifyIFormatProviderAnalyzer.UICultureRule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
 
         private DiagnosticResult GetIFormatProviderAlternateStringRuleBasicResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetBasicResultAt(line, column, SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateStringRule, arg1, arg2, arg3);
+            return new DiagnosticResult(SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateStringRule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
 
         private DiagnosticResult GetIFormatProviderAlternateRuleBasicResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetBasicResultAt(line, column, SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateRule, arg1, arg2, arg3);
+            return new DiagnosticResult(SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateRule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
 
         private DiagnosticResult GetIFormatProviderUICultureStringRuleBasicResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetBasicResultAt(line, column, SpecifyIFormatProviderAnalyzer.UICultureStringRule, arg1, arg2, arg3);
+            return new DiagnosticResult(SpecifyIFormatProviderAnalyzer.UICultureStringRule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
 
         private DiagnosticResult GetIFormatProviderUICultureRuleBasicResultAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetBasicResultAt(line, column, SpecifyIFormatProviderAnalyzer.UICultureRule, arg1, arg2, arg3);
+            return new DiagnosticResult(SpecifyIFormatProviderAnalyzer.UICultureRule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyStringComparisonTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyStringComparisonTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.SpecifyStringComparisonAnalyzer,
@@ -13,22 +12,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class SpecifyStringComparisonTests : DiagnosticAnalyzerTestBase
+    public class SpecifyStringComparisonTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new SpecifyStringComparisonAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new SpecifyStringComparisonAnalyzer();
-        }
-
         [Fact]
-        public void CA1307_StringCompareTests_CSharp()
+        public async Task CA1307_StringCompareTests_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -60,9 +49,9 @@ GetCA1307CSharpResultsAt(14, 18, "string.Compare(string, int, string, int, int, 
         }
 
         [Fact]
-        public void CA1307_StringWithTests_CSharp()
+        public async Task CA1307_StringWithTests_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -85,9 +74,9 @@ GetCA1307CSharpResultsAt(12, 16, "string.StartsWith(string)",
         }
 
         [Fact]
-        public void CA1307_StringIndexOfTests_CSharp()
+        public async Task CA1307_StringIndexOfTests_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -113,9 +102,9 @@ GetCA1307CSharpResultsAt(12, 16, "string.IndexOf(string, int, int)",
         }
 
         [Fact]
-        public void CA1307_StringCompareToTests_CSharp()
+        public async Task CA1307_StringCompareToTests_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -138,9 +127,9 @@ GetCA1307CSharpResultsAt(12, 20, "string.CompareTo(object)",
         }
 
         [Fact]
-        public void CA1307_OverloadTests_CSharp()
+        public async Task CA1307_OverloadTests_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -170,9 +159,9 @@ GetCA1307CSharpResultsAt(9, 9, "StringComparisonTests.DoNothing(string)",
         }
 
         [Fact]
-        public void CA1307_OverloadWithMismatchRefKind_CSharp()
+        public async Task CA1307_OverloadWithMismatchRefKind_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -204,9 +193,9 @@ public class StringComparisonTests
         }
 
         [Fact]
-        public void CA1307_StringCompareTests_VisualBasic()
+        public async Task CA1307_StringCompareTests_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -236,9 +225,9 @@ GetCA1307BasicResultsAt(12, 18, "String.Compare(String, Integer, String, Integer
         }
 
         [Fact]
-        public void CA1307_StringWithTests_VisualBasic()
+        public async Task CA1307_StringWithTests_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -259,9 +248,9 @@ GetCA1307BasicResultsAt(10, 16, "String.StartsWith(String)",
         }
 
         [Fact]
-        public void CA1307_StringIndexOfTests_VisualBasic()
+        public async Task CA1307_StringIndexOfTests_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -285,9 +274,9 @@ GetCA1307BasicResultsAt(10, 16, "String.IndexOf(String, Integer, Integer)",
         }
 
         [Fact]
-        public void CA1307_StringCompareToTests_VisualBasic()
+        public async Task CA1307_StringCompareToTests_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -308,9 +297,9 @@ GetCA1307BasicResultsAt(10, 16, "String.CompareTo(Object)",
         }
 
         [Fact]
-        public void CA1307_OverloadTests_VisualBasic()
+        public async Task CA1307_OverloadTests_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -337,24 +326,16 @@ GetCA1307BasicResultsAt(7, 9, "StringComparisonTests.DoNothing(String)",
 
         private DiagnosticResult GetCA1307CSharpResultsAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetCSharpResultAt(
-                line,
-                column,
-                SpecifyStringComparisonAnalyzer.Rule,
-                arg1,
-                arg2,
-                arg3);
+            return new DiagnosticResult(SpecifyStringComparisonAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
 
         private DiagnosticResult GetCA1307BasicResultsAt(int line, int column, string arg1, string arg2, string arg3)
         {
-            return GetBasicResultAt(
-                line,
-                column,
-                SpecifyStringComparisonAnalyzer.Rule,
-                arg1,
-                arg2,
-                arg3);
+            return new DiagnosticResult(SpecifyStringComparisonAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithArguments(arg1, arg2, arg3);
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCreateTasksWithoutPassingATaskSchedulerTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCreateTasksWithoutPassingATaskSchedulerTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Tasks.DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer,
@@ -13,24 +12,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
 {
-    public class DoNotCreateTasksWithoutPassingATaskSchedulerTests : DiagnosticAnalyzerTestBase
+    public class DoNotCreateTasksWithoutPassingATaskSchedulerTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer();
-        }
-
-        #region No Diagnostic Tests
-
         [Fact]
-        public void NoDiagnosticCases()
+        public async Task NoDiagnosticCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -70,7 +57,7 @@ class C
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading
 Imports System.Threading.Tasks
@@ -104,14 +91,10 @@ End Class
 ");
         }
 
-        #endregion
-
-        #region Diagnostic Tests
-
         [Fact]
-        public void DiagnosticCases()
+        public async Task DiagnosticCases()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -181,7 +164,7 @@ class C
     // Test0.cs(22,9): warning RS0018: Do not create tasks without passing a TaskScheduler
     GetCSharpResultAt(22, 9));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading
 Imports System.Threading.Tasks
@@ -245,16 +228,14 @@ End Class
     GetBasicResultAt(20, 3));
         }
 
-        #endregion
-
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.DoNotCreateTasksWithoutPassingATaskSchedulerMessage);
-        }
+            => new DiagnosticResult(DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftNetCoreAnalyzersResources.DoNotCreateTasksWithoutPassingATaskSchedulerMessage);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.DoNotCreateTasksWithoutPassingATaskSchedulerMessage);
-        }
+            => new DiagnosticResult(DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer.Rule)
+                .WithLocation(line, column)
+                .WithMessage(MicrosoftNetCoreAnalyzersResources.DoNotCreateTasksWithoutPassingATaskSchedulerMessage);
     }
 }

--- a/src/Test.Utilities/AdditionalMetadataReferences.cs
+++ b/src/Test.Utilities/AdditionalMetadataReferences.cs
@@ -26,11 +26,12 @@ namespace Test.Utilities
         internal static readonly MetadataReference SystemDataReference = MetadataReference.CreateFromFile(typeof(System.Data.DataSet).Assembly.Location);
         internal static readonly MetadataReference SystemWebReference = MetadataReference.CreateFromFile(typeof(System.Web.HttpRequest).Assembly.Location);
         internal static readonly MetadataReference SystemRuntimeSerialization = MetadataReference.CreateFromFile(typeof(System.Runtime.Serialization.NetDataContractSerializer).Assembly.Location);
-        internal static readonly MetadataReference SystemXmlLinq = MetadataReference.CreateFromFile(typeof(System.Xml.Linq.XAttribute).Assembly.Location);
+        public static readonly MetadataReference SystemXmlLinq = MetadataReference.CreateFromFile(typeof(System.Xml.Linq.XAttribute).Assembly.Location);
         internal static readonly MetadataReference TestReferenceAssembly = MetadataReference.CreateFromFile(typeof(OtherDll.OtherDllStaticMethods).Assembly.Location);
         internal static readonly MetadataReference SystemDirectoryServices = MetadataReference.CreateFromFile(typeof(System.DirectoryServices.DirectoryEntry).Assembly.Location);
         internal static readonly MetadataReference SystemXaml = MetadataReference.CreateFromFile(typeof(System.Xaml.XamlReader).Assembly.Location);
         internal static readonly MetadataReference PresentationFramework = MetadataReference.CreateFromFile(typeof(System.Windows.Markup.XamlReader).Assembly.Location);
+        public static readonly MetadataReference SystemWeb = MetadataReference.CreateFromFile(typeof(System.Web.HttpRequest).Assembly.Location);
         internal static readonly MetadataReference SystemWebExtensions = MetadataReference.CreateFromFile(typeof(System.Web.Script.Serialization.JavaScriptSerializer).Assembly.Location);
         private static MetadataReference s_systemRuntimeFacadeRef;
         public static MetadataReference SystemRuntimeFacadeRef

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Test.Utilities
 {
@@ -25,16 +24,9 @@ namespace Test.Utilities
             => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
 
         public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
-            => VerifyAnalyzerAsync(source, expectedDiagnostics: expected);
+            => VerifyAnalyzerAsync(source, CompilerDiagnostics.Errors, expected);
 
-        public static Task VerifyAnalyzerAsync(string source, CompilerDiagnostics compilerDiagnostics, params DiagnosticResult[] expected)
-            => VerifyAnalyzerAsync(source, expected, compilerDiagnostics);
-
-        public static Task VerifyAnalyzerWithEditorConfigAsync(string source, string editorConfigSource, params DiagnosticResult[] expected)
-            => VerifyAnalyzerAsync(source, expected, additionalFiles: new SourceFileCollection { (".editorconfig", SourceText.From(editorConfigSource)) });
-
-        public static async Task VerifyAnalyzerAsync(string source, DiagnosticResult[] expectedDiagnostics,
-            CompilerDiagnostics compilerDiagnostics = CompilerDiagnostics.Errors, SourceFileCollection additionalFiles = null)
+        public static async Task VerifyAnalyzerAsync(string source, CompilerDiagnostics compilerDiagnostics, params DiagnosticResult[] expected)
         {
             var test = new Test
             {
@@ -42,11 +34,7 @@ namespace Test.Utilities
                 CompilerDiagnostics = compilerDiagnostics
             };
 
-            if (additionalFiles?.Count > 0)
-            {
-                test.TestState.AdditionalFiles.AddRange(additionalFiles);
-            }
-            test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
+            test.ExpectedDiagnostics.AddRange(expected);
             await test.RunAsync();
         }
 

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
@@ -23,8 +23,8 @@ namespace Test.Utilities
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
             => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
 
-        public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
-            => VerifyAnalyzerAsync(source, CompilerDiagnostics.Errors, expected);
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+            => await VerifyAnalyzerAsync(source, CompilerDiagnostics.Errors, expected);
 
         public static async Task VerifyAnalyzerAsync(string source, CompilerDiagnostics compilerDiagnostics, params DiagnosticResult[] expected)
         {
@@ -38,11 +38,11 @@ namespace Test.Utilities
             await test.RunAsync();
         }
 
-        public static Task VerifyCodeFixAsync(string source, string fixedSource)
-            => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
-        public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
-            => VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
 
         public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
         {

--- a/src/Test.Utilities/VisualBasicCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/VisualBasicCodeFixVerifier`2.cs
@@ -23,8 +23,8 @@ namespace Test.Utilities
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
             => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
 
-        public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
-            => VerifyAnalyzerAsync(source, CompilerDiagnostics.Errors, expected);
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+            => await VerifyAnalyzerAsync(source, CompilerDiagnostics.Errors, expected);
 
         public static async Task VerifyAnalyzerAsync(string source, CompilerDiagnostics compilerDiagnostics, params DiagnosticResult[] expected)
         {
@@ -38,11 +38,11 @@ namespace Test.Utilities
             await test.RunAsync();
         }
 
-        public static Task VerifyCodeFixAsync(string source, string fixedSource)
-            => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
-        public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
-            => VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
 
         public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
         {

--- a/src/Test.Utilities/VisualBasicCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/VisualBasicCodeFixVerifier`2.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic.Testing;
 
 namespace Test.Utilities
@@ -25,16 +24,9 @@ namespace Test.Utilities
             => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
 
         public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
-            => VerifyAnalyzerAsync(source, expectedDiagnostics: expected);
+            => VerifyAnalyzerAsync(source, CompilerDiagnostics.Errors, expected);
 
-        public static Task VerifyAnalyzerAsync(string source, CompilerDiagnostics compilerDiagnostics, params DiagnosticResult[] expected)
-            => VerifyAnalyzerAsync(source, expected, compilerDiagnostics);
-
-        public static Task VerifyAnalyzerWithEditorConfigAsync(string source, string editorConfigSource, params DiagnosticResult[] expected)
-            => VerifyAnalyzerAsync(source, expected, additionalFiles: new SourceFileCollection { (".editorconfig", SourceText.From(editorConfigSource)) });
-
-        public static async Task VerifyAnalyzerAsync(string source, DiagnosticResult[] expectedDiagnostics,
-            CompilerDiagnostics compilerDiagnostics = CompilerDiagnostics.Errors, SourceFileCollection additionalFiles = null)
+        public static async Task VerifyAnalyzerAsync(string source, CompilerDiagnostics compilerDiagnostics, params DiagnosticResult[] expected)
         {
             var test = new Test
             {
@@ -42,11 +34,7 @@ namespace Test.Utilities
                 CompilerDiagnostics = compilerDiagnostics
             };
 
-            if (additionalFiles?.Count > 0)
-            {
-                test.TestState.AdditionalFiles.AddRange(additionalFiles);
-            }
-            test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
+            test.ExpectedDiagnostics.AddRange(expected);
             await test.RunAsync();
         }
 

--- a/src/Test.Utilities/VisualBasicCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/VisualBasicCodeFixVerifier`2.cs
@@ -3,10 +3,11 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.VisualBasic.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
 
 namespace Test.Utilities
 {
@@ -23,14 +24,29 @@ namespace Test.Utilities
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
             => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
 
-        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+            => VerifyAnalyzerAsync(source, expectedDiagnostics: expected);
+
+        public static Task VerifyAnalyzerAsync(string source, CompilerDiagnostics compilerDiagnostics, params DiagnosticResult[] expected)
+            => VerifyAnalyzerAsync(source, expected, compilerDiagnostics);
+
+        public static Task VerifyAnalyzerWithEditorConfigAsync(string source, string editorConfigSource, params DiagnosticResult[] expected)
+            => VerifyAnalyzerAsync(source, expected, additionalFiles: new SourceFileCollection { (".editorconfig", SourceText.From(editorConfigSource)) });
+
+        public static async Task VerifyAnalyzerAsync(string source, DiagnosticResult[] expectedDiagnostics,
+            CompilerDiagnostics compilerDiagnostics = CompilerDiagnostics.Errors, SourceFileCollection additionalFiles = null)
         {
             var test = new Test
             {
                 TestCode = source,
+                CompilerDiagnostics = compilerDiagnostics
             };
 
-            test.ExpectedDiagnostics.AddRange(expected);
+            if (additionalFiles?.Count > 0)
+            {
+                test.TestState.AdditionalFiles.AddRange(additionalFiles);
+            }
+            test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
             await test.RunAsync();
         }
 


### PR DESCRIPTION
## Motivation

In one of the PR review, @sharwell said that inheriting from `DiagnosticAnalyzerTestBase` was the old (obsolete?) way of doing tests. Some preparation for the migration was already done by adding the static usings for C# and VB.NET.

This PR tries to replace most of the old usages with the new recommended.

## What's left

There is still some work left but I am not sure whether this shall be done within this PR or into some other. Also, I need some input from you to move forward on some points.

### Non migrated tests

Some tests are not migrated because:

- usage of the scope notation doesn't seem to be working properly. I didn't spend time to do investigate what was the issue. I will try to do so later on.

- some tests explicitly force the parse option to `null`, although I think I might have found a way to do the same thing with the new syntax, I am not sure about it.

- ~~something wasn't working properly when multiple "files" were given~~

- I missed some test classes

### AD0001

The following tests from `ReviewUnusedParametersTests.cs`:

- `public async Task DiagnosticForUnusedLocalFunctionParameters_01()`

- `public async Task DiagnosticForUnusedLocalFunctionParameters_02()`

- `public async Task NoDiagnosticUsedLocalFunctionParameters()`

are failing with the following error: `error AD0001: Analyzer 'Microsoft.CodeQuality.Analyzers.Maintainability.ReviewUnusedParametersAnalyzer' threw an exception of type 'System.ArgumentException' with message 'The key already existed in the dictionary.'.`

~~I will create a ticket to handle this issue but I am not sure whether to revert the failing tests to the old way or to skip them for the time being. WDYT?~~

### Miscellaneous

- In some tests the callers always provide the same rule, it could be move directly to the get diagnostic result method.

- Some tests need to be updated to use the descriptor instead of the ID.

- I am not sure whether tests shall be using `new DiagnosticResult()` or `VerifyCS.Diagnostic()`

Hope this PR is going the right direction and helps you!