### PR TITLE
Couple of small changes post migration to new test framework

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -17,14 +16,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
     public class CollectionPropertiesShouldBeReadOnlyTests
     {
         private DiagnosticResult GetBasicResultAt(int line, int column, string propertyName)
-            => new DiagnosticResult(CollectionPropertiesShouldBeReadOnlyAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.CollectionPropertiesShouldBeReadOnlyMessage, propertyName));
+                .WithArguments(propertyName);
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string propertyName)
-            => new DiagnosticResult(CollectionPropertiesShouldBeReadOnlyAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.CollectionPropertiesShouldBeReadOnlyMessage, propertyName));
+                .WithArguments(propertyName);
 
         [Fact]
         public async Task CSharp_CA2227_Test()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
     public class CollectionsShouldImplementGenericInterfaceTests
     {
-        private static readonly string CA1010Message = MicrosoftCodeQualityAnalyzersResources.CollectionsShouldImplementGenericInterfaceMessage;
-
         private DiagnosticResult GetCA1010CSharpResultAt(int line, int column, string typeName, string interfaceName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -19,14 +18,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         private static readonly string CA1010Message = MicrosoftCodeQualityAnalyzersResources.CollectionsShouldImplementGenericInterfaceMessage;
 
         private DiagnosticResult GetCA1010CSharpResultAt(int line, int column, string typeName, string interfaceName)
-            => new DiagnosticResult(CollectionsShouldImplementGenericInterfaceAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1010Message, typeName, interfaceName, $"{interfaceName}<T>"));
+                .WithArguments(typeName, interfaceName, $"{interfaceName}<T>");
 
         private DiagnosticResult GetCA1010BasicResultAt(int line, int column, string typeName, string interfaceName)
-            => new DiagnosticResult(CollectionsShouldImplementGenericInterfaceAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1010Message, typeName, interfaceName, $"{interfaceName}(Of T)"));
+                .WithArguments(typeName, interfaceName, $"{interfaceName}(Of T)");
 
         [Fact]
         public async Task Test_WithCollectionBase()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumWithFlagsAttributeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumWithFlagsAttributeTests.cs
@@ -578,23 +578,23 @@ End Enum
         }
 
         private static DiagnosticResult GetCA1027CSharpResultAt(int line, int column, string enumTypeName)
-            => new DiagnosticResult(EnumWithFlagsAttributeAnalyzer.Rule1027)
+            => VerifyCS.Diagnostic(EnumWithFlagsAttributeAnalyzer.Rule1027)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkEnumsWithFlagsMessage, enumTypeName));
+                .WithArguments(enumTypeName);
 
         private static DiagnosticResult GetCA1027BasicResultAt(int line, int column, string enumTypeName)
-            => new DiagnosticResult(EnumWithFlagsAttributeAnalyzer.Rule1027)
+            => VerifyVB.Diagnostic(EnumWithFlagsAttributeAnalyzer.Rule1027)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkEnumsWithFlagsMessage, enumTypeName));
+                .WithArguments(enumTypeName);
 
         private static DiagnosticResult GetCA2217CSharpResultAt(int line, int column, string enumTypeName, string missingValuesString)
-            => new DiagnosticResult(EnumWithFlagsAttributeAnalyzer.Rule2217)
+            => VerifyCS.Diagnostic(EnumWithFlagsAttributeAnalyzer.Rule2217)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotMarkEnumsWithFlagsMessage, enumTypeName, missingValuesString));
+                .WithArguments(enumTypeName, missingValuesString);
 
         private static DiagnosticResult GetCA2217BasicResultAt(int line, int column, string enumTypeName, string missingValuesString)
-            => new DiagnosticResult(EnumWithFlagsAttributeAnalyzer.Rule2217)
+            => VerifyVB.Diagnostic(EnumWithFlagsAttributeAnalyzer.Rule2217)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotMarkEnumsWithFlagsMessage, enumTypeName, missingValuesString));
+                .WithArguments(enumTypeName, missingValuesString);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNamesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNamesTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -453,9 +452,9 @@ public sealed class SomeEqualityComparer : IEqualityComparer<string>, IEqualityC
         #region Helpers
 
         private static DiagnosticResult GetCA1720CSharpResultAt(int line, int column, string identifierName)
-            => new DiagnosticResult(IdentifiersShouldNotContainTypeNames.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldNotContainTypeNamesMessage, identifierName));
+                .WithArguments(identifierName);
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementStandardExceptionConstructorsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementStandardExceptionConstructorsTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -337,14 +336,14 @@ End Class
         #region Helpers
 
         private static DiagnosticResult GetCA1032CSharpMissingConstructorResultAt(int line, int column, string typeName, string constructor)
-            => new DiagnosticResult(ImplementStandardExceptionConstructorsAnalyzer.MissingConstructorRule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementStandardExceptionConstructorsMessageMissingConstructor, typeName, constructor));
+                .WithArguments(typeName, constructor);
 
         private static DiagnosticResult GetCA1032BasicMissingConstructorResultAt(int line, int column, string typeName, string constructor)
-            => new DiagnosticResult(ImplementStandardExceptionConstructorsAnalyzer.MissingConstructorRule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementStandardExceptionConstructorsMessageMissingConstructor, typeName, constructor));
+                .WithArguments(typeName, constructor);
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAssembliesWithComVisibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAssembliesWithComVisibleTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -109,15 +108,11 @@ internal class C
         }
 
         private static DiagnosticResult GetExposeIndividualTypesResult()
-        {
-            return new DiagnosticResult(MarkAssembliesWithComVisibleAnalyzer.RuleA)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ChangeAssemblyLevelComVisibleToFalse, "TestProject"));
-        }
+            => VerifyCS.Diagnostic(MarkAssembliesWithComVisibleAnalyzer.RuleA)
+                .WithArguments("TestProject");
 
         private static DiagnosticResult GetAddComVisibleFalseResult()
-        {
-            return new DiagnosticResult(MarkAssembliesWithComVisibleAnalyzer.RuleB)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.AddAssemblyLevelComVisibleFalse, "TestProject"));
-        }
+            => VerifyCS.Diagnostic(MarkAssembliesWithComVisibleAnalyzer.RuleB)
+                .WithArguments("TestProject");
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAttributesWithAttributeUsageTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAttributesWithAttributeUsageTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -97,13 +96,13 @@ End Class
         }
 
         private static DiagnosticResult GetCA1018CSharpResultAt(int line, int column, string objectName)
-            => new DiagnosticResult(MarkAttributesWithAttributeUsageAnalyzer.Rule)
+            => VerifyCS.Diagnostic(MarkAttributesWithAttributeUsageAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkAttributesWithAttributeUsageMessageDefault, objectName));
+                .WithArguments(objectName);
 
         private static DiagnosticResult GetCA1018BasicResultAt(int line, int column, string objectName)
-            => new DiagnosticResult(MarkAttributesWithAttributeUsageAnalyzer.Rule)
+            => VerifyVB.Diagnostic(MarkAttributesWithAttributeUsageAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.MarkAttributesWithAttributeUsageMessageDefault, objectName));
+                .WithArguments(objectName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
@@ -30,14 +29,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult CSharpResult(int line, int column)
-            => new DiagnosticResult(MovePInvokesToNativeMethodsClassAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MovePInvokesToNativeMethodsClassAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+            => VerifyCS.Diagnostic().WithLocation(line, column);
 
         private static DiagnosticResult BasicResult(int line, int column)
-            => new DiagnosticResult(MovePInvokesToNativeMethodsClassAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MovePInvokesToNativeMethodsClassAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+            => VerifyVB.Diagnostic().WithLocation(line, column);
 
         #endregion
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NonConstantFieldsShouldNotBeVisibleTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -133,7 +132,7 @@ End Class");
             await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
-    public const string field = ""X""; 
+    public const string field = ""X"";
 }");
         }
 
@@ -147,13 +146,9 @@ End Class");
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-            => new DiagnosticResult(NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+            => VerifyCS.Diagnostic().WithLocation(line, column);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column)
-            => new DiagnosticResult(NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(NonConstantFieldsShouldNotBeVisibleAnalyzer.Rule.MessageFormat.ToString(CultureInfo.CurrentCulture));
+            => VerifyVB.Diagnostic().WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -19,29 +18,29 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         #region Boilerplate
 
         private static DiagnosticResult GetCA2225CSharpDefaultResultAt(int line, int column, string alternateName, string operatorName)
-            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.DefaultRule)
+            => VerifyCS.Diagnostic(OperatorOverloadsHaveNamedAlternatesAnalyzer.DefaultRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageDefault, alternateName, operatorName));
+                .WithArguments(alternateName, operatorName);
 
         private static DiagnosticResult GetCA2225CSharpPropertyResultAt(int line, int column, string alternateName, string operatorName)
-            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.PropertyRule)
+            => VerifyCS.Diagnostic(OperatorOverloadsHaveNamedAlternatesAnalyzer.PropertyRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageProperty, alternateName, operatorName));
+                .WithArguments(alternateName, operatorName);
 
         private static DiagnosticResult GetCA2225CSharpMultipleResultAt(int line, int column, string alternateName1, string alternateName2, string operatorName)
-            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.MultipleRule)
+            => VerifyCS.Diagnostic(OperatorOverloadsHaveNamedAlternatesAnalyzer.MultipleRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageMultiple, alternateName1, alternateName2, operatorName));
+                .WithArguments(alternateName1, alternateName2, operatorName);
 
         private static DiagnosticResult GetCA2225CSharpVisibilityResultAt(int line, int column, string alternateName, string operatorName)
-            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.VisibilityRule)
+            => VerifyCS.Diagnostic(OperatorOverloadsHaveNamedAlternatesAnalyzer.VisibilityRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageVisibility, alternateName, operatorName));
+                .WithArguments(alternateName, operatorName);
 
         private static DiagnosticResult GetCA2225BasicDefaultResultAt(int line, int column, string alternateName, string operatorName)
-            => new DiagnosticResult(OperatorOverloadsHaveNamedAlternatesAnalyzer.DefaultRule)
+            => VerifyVB.Diagnostic(OperatorOverloadsHaveNamedAlternatesAnalyzer.DefaultRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OperatorOverloadsHaveNamedAlternatesMessageDefault, alternateName, operatorName));
+                .WithArguments(alternateName, operatorName);
 
         #endregion
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -19,14 +18,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         #region Verifiers
 
         private static DiagnosticResult CSharpResult(int line, int column, string objectName)
-            => new DiagnosticResult(StaticHolderTypesAnalyzer.Rule)
+            => VerifyCS.Diagnostic(StaticHolderTypesAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.StaticHolderTypeIsNotStatic, objectName));
+                .WithArguments(objectName);
 
         private static DiagnosticResult BasicResult(int line, int column, string objectName)
-            => new DiagnosticResult(StaticHolderTypesAnalyzer.Rule)
+            => VerifyVB.Diagnostic(StaticHolderTypesAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.StaticHolderTypeIsNotStatic, objectName));
+                .WithArguments(objectName);
 
         #endregion
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
@@ -470,13 +469,13 @@ End Namespace
         }
 
         private static DiagnosticResult GetCA1001CSharpResultAt(int line, int column, string objectName, string disposableFields)
-            => new DiagnosticResult(CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Rule)
+            => VerifyCS.Diagnostic(CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.TypesThatOwnDisposableFieldsShouldBeDisposableMessageNonBreaking, objectName, disposableFields));
+                .WithArguments(objectName, disposableFields);
 
         private static DiagnosticResult GetCA1001BasicResultAt(int line, int column, string objectName, string disposableFields)
-            => new DiagnosticResult(CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Rule)
+            => VerifyVB.Diagnostic(CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.TypesThatOwnDisposableFieldsShouldBeDisposableMessageNonBreaking, objectName, disposableFields));
+                .WithArguments(objectName, disposableFields);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -439,13 +438,13 @@ public class Foo : IFoo
         }
 
         private static DiagnosticResult GetCA1024CSharpResultAt(int line, int column, string methodName)
-            => new DiagnosticResult(UsePropertiesWhereAppropriateAnalyzer.Rule)
+            => VerifyCS.Diagnostic(UsePropertiesWhereAppropriateAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UsePropertiesWhereAppropriateMessage, methodName));
+                .WithArguments(methodName);
 
         private static DiagnosticResult GetCA1024BasicResultAt(int line, int column, string methodName)
-            => new DiagnosticResult(UsePropertiesWhereAppropriateAnalyzer.Rule)
+            => VerifyVB.Diagnostic(UsePropertiesWhereAppropriateAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UsePropertiesWhereAppropriateMessage, methodName));
+                .WithArguments(methodName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -400,9 +400,9 @@ End Class
         }
 
         [Fact, WorkItem(1551, "https://github.com/dotnet/roslyn-analyzers/issues/1551")]
-        public void CA1024_ExplicitInterfaceImplementation_NoDiagnostic()
+        public async Task CA1024_ExplicitInterfaceImplementation_NoDiagnostic()
         {
-            VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface IFoo
 {
     object GetContent();
@@ -419,9 +419,9 @@ public class Foo : IFoo
         }
 
         [Fact, WorkItem(1551, "https://github.com/dotnet/roslyn-analyzers/issues/1551")]
-        public void CA1024_ImplicitInterfaceImplementation_NoDiagnostic()
+        public async Task CA1024_ImplicitInterfaceImplementation_NoDiagnostic()
         {
-            VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface IFoo
 {
     object GetContent();

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -413,13 +412,13 @@ End Class
         }
 
         private static DiagnosticResult GetCA1823CSharpResultAt(int line, int column, string fieldName)
-            => new DiagnosticResult(AvoidUnusedPrivateFieldsAnalyzer.Rule)
+            => VerifyCS.Diagnostic(AvoidUnusedPrivateFieldsAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.AvoidUnusedPrivateFieldsMessage, fieldName));
+                .WithArguments(fieldName);
 
         private static DiagnosticResult GetCA1823BasicResultAt(int line, int column, string fieldName)
-            => new DiagnosticResult(AvoidUnusedPrivateFieldsAnalyzer.Rule)
+            => VerifyVB.Diagnostic(AvoidUnusedPrivateFieldsAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.AvoidUnusedPrivateFieldsMessage, fieldName));
+                .WithArguments(fieldName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -653,49 +650,49 @@ End Class", MSTestAttributes.VisualBasic
         #region Helpers
 
         private static DiagnosticResult GetCSharpStringCreationResultAt(int line, int column, string containingMethodName, string invokedMethodName)
-            => new DiagnosticResult(DoNotIgnoreMethodResultsAnalyzer.StringCreationRule)
+            => VerifyCS.Diagnostic(DoNotIgnoreMethodResultsAnalyzer.StringCreationRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotIgnoreMethodResultsMessageStringCreation, containingMethodName, invokedMethodName));
+                .WithArguments(containingMethodName, invokedMethodName);
 
         private static DiagnosticResult GetBasicStringCreationResultAt(int line, int column, string containingMethodName, string invokedMethodName)
-            => new DiagnosticResult(DoNotIgnoreMethodResultsAnalyzer.StringCreationRule)
+            => VerifyVB.Diagnostic(DoNotIgnoreMethodResultsAnalyzer.StringCreationRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotIgnoreMethodResultsMessageStringCreation, containingMethodName, invokedMethodName));
+                .WithArguments(containingMethodName, invokedMethodName);
 
         private static DiagnosticResult GetCSharpObjectCreationResultAt(int line, int column, string containingMethodName, string invokedMethodName)
-            => new DiagnosticResult(DoNotIgnoreMethodResultsAnalyzer.ObjectCreationRule)
+            => VerifyCS.Diagnostic(DoNotIgnoreMethodResultsAnalyzer.ObjectCreationRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotIgnoreMethodResultsMessageObjectCreation, containingMethodName, invokedMethodName));
+                .WithArguments(containingMethodName, invokedMethodName);
 
         private static DiagnosticResult GetCSharpTryParseResultAt(int line, int column, string containingMethodName, string invokedMethodName)
-            => new DiagnosticResult(DoNotIgnoreMethodResultsAnalyzer.TryParseRule)
+            => VerifyCS.Diagnostic(DoNotIgnoreMethodResultsAnalyzer.TryParseRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotIgnoreMethodResultsMessageTryParse, containingMethodName, invokedMethodName));
+                .WithArguments(containingMethodName, invokedMethodName);
 
         private static DiagnosticResult GetBasicTryParseResultAt(int line, int column, string containingMethodName, string invokedMethodName)
-            => new DiagnosticResult(DoNotIgnoreMethodResultsAnalyzer.TryParseRule)
+            => VerifyVB.Diagnostic(DoNotIgnoreMethodResultsAnalyzer.TryParseRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotIgnoreMethodResultsMessageTryParse, containingMethodName, invokedMethodName));
+                .WithArguments(containingMethodName, invokedMethodName);
 
         private static DiagnosticResult GetCSharpHResultOrErrorCodeResultAt(int line, int column, string containingMethodName, string invokedMethodName)
-            => new DiagnosticResult(DoNotIgnoreMethodResultsAnalyzer.HResultOrErrorCodeRule)
+            => VerifyCS.Diagnostic(DoNotIgnoreMethodResultsAnalyzer.HResultOrErrorCodeRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotIgnoreMethodResultsMessageHResultOrErrorCode, containingMethodName, invokedMethodName));
+                .WithArguments(containingMethodName, invokedMethodName);
 
         private static DiagnosticResult GetBasicHResultOrErrorCodeResultAt(int line, int column, string containingMethodName, string invokedMethodName)
-            => new DiagnosticResult(DoNotIgnoreMethodResultsAnalyzer.HResultOrErrorCodeRule)
+            => VerifyVB.Diagnostic(DoNotIgnoreMethodResultsAnalyzer.HResultOrErrorCodeRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotIgnoreMethodResultsMessageHResultOrErrorCode, containingMethodName, invokedMethodName));
+                .WithArguments(containingMethodName, invokedMethodName);
 
         private static DiagnosticResult GetCSharpPureMethodResultAt(int line, int column, string containingMethodName, string invokedMethodName)
-            => new DiagnosticResult(DoNotIgnoreMethodResultsAnalyzer.PureMethodRule)
+            => VerifyCS.Diagnostic(DoNotIgnoreMethodResultsAnalyzer.PureMethodRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotIgnoreMethodResultsMessagePureMethod, containingMethodName, invokedMethodName));
+                .WithArguments(containingMethodName, invokedMethodName);
 
         private static DiagnosticResult GetBasicPureMethodResultAt(int line, int column, string containingMethodName, string invokedMethodName)
-            => new DiagnosticResult(DoNotIgnoreMethodResultsAnalyzer.PureMethodRule)
+            => VerifyVB.Diagnostic(DoNotIgnoreMethodResultsAnalyzer.PureMethodRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.DoNotIgnoreMethodResultsMessagePureMethod, containingMethodName, invokedMethodName));
+                .WithArguments(containingMethodName, invokedMethodName);
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -1039,14 +1038,14 @@ public class C
         #region Helpers
 
         private static DiagnosticResult GetCSharpUnusedParameterResultAt(int line, int column, string parameterName, string methodName)
-            => new DiagnosticResult(ReviewUnusedParametersAnalyzer.Rule)
+            => VerifyCS.Diagnostic(ReviewUnusedParametersAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ReviewUnusedParametersMessage, parameterName, methodName));
+                .WithArguments(parameterName, methodName);
 
         private static DiagnosticResult GetBasicUnusedParameterResultAt(int line, int column, string parameterName, string methodName)
-            => new DiagnosticResult(ReviewUnusedParametersAnalyzer.Rule)
+            => VerifyVB.Diagnostic(ReviewUnusedParametersAnalyzer.Rule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ReviewUnusedParametersMessage, parameterName, methodName));
+                .WithArguments(parameterName, methodName);
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -617,13 +616,13 @@ namespace ConsoleApp14
         #endregion
 
         private DiagnosticResult GetBasicNameofResultAt(int line, int column, string name)
-            => new DiagnosticResult(UseNameofInPlaceOfStringAnalyzer.RuleWithSuggestion)
+            => VerifyVB.Diagnostic(UseNameofInPlaceOfStringAnalyzer.RuleWithSuggestion)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UseNameOfInPlaceOfStringMessage, name));
+                .WithArguments(name);
 
         private DiagnosticResult GetCSharpNameofResultAt(int line, int column, string name)
-            => new DiagnosticResult(UseNameofInPlaceOfStringAnalyzer.RuleWithSuggestion)
+            => VerifyCS.Diagnostic(UseNameofInPlaceOfStringAnalyzer.RuleWithSuggestion)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.UseNameOfInPlaceOfStringMessage, name));
+                .WithArguments(name);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/NormalizeStringsToUppercaseTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/NormalizeStringsToUppercaseTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -246,22 +245,14 @@ End Class
         #region Helpers
 
         private static DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string containingMethod, string invokedMethod, string suggestedMethod)
-        {
-            // In method '{0}', replace the call to '{1}' with '{2}'.
-            string message = string.Format(CultureInfo.CurrentCulture, NormalizeStringsToUppercaseAnalyzer.ToUpperRule.MessageFormat.ToString(CultureInfo.CurrentCulture), containingMethod, invokedMethod, suggestedMethod);
-            return new DiagnosticResult(NormalizeStringsToUppercaseAnalyzer.ToUpperRule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(containingMethod, invokedMethod, suggestedMethod);
 
         private static DiagnosticResult GetBasicDefaultResultAt(int line, int column, string containingMethod, string invokedMethod, string suggestedMethod)
-        {
-            // In method '{0}', replace the call to '{1}' with '{2}'.
-            string message = string.Format(CultureInfo.CurrentCulture, NormalizeStringsToUppercaseAnalyzer.ToUpperRule.MessageFormat.ToString(CultureInfo.CurrentCulture), containingMethod, invokedMethod, suggestedMethod);
-            return new DiagnosticResult(NormalizeStringsToUppercaseAnalyzer.ToUpperRule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(containingMethod, invokedMethod, suggestedMethod);
 
         #endregion
     }


### PR DESCRIPTION
- Simplify cases where `MessageFormat.ToString` was used

- Simplify cases where `.WithMessage(string.Format` was used

- Add missing await for a couple of tests

Relates to #2988 