### PR TITLE
Convert the CallSiteImplicitAllocationAnalyzer to use IOperation

### DIFF
--- a/src/PerformanceSensitiveAnalyzers/CSharp/CallSiteImplicitAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/CallSiteImplicitAllocationAnalyzer.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers;
 
 namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     internal sealed class CallSiteImplicitAllocationAnalyzer : AbstractAllocationAnalyzer
     {
         public const string ParamsParameterRuleId = "HAA0101";

--- a/src/PerformanceSensitiveAnalyzers/CSharp/CallSiteImplicitAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/CallSiteImplicitAllocationAnalyzer.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers;
 
 namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal sealed class CallSiteImplicitAllocationAnalyzer : AbstractAllocationAnalyzer
     {
         public const string ParamsParameterRuleId = "HAA0101";
@@ -61,12 +61,12 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
                 }
             }
 
-            if (invocation.Arguments.Length > 0)
+            for (int i = invocation.Arguments.Length - 1; i >= 0; i--)
             {
-                var lastArgument = invocation.Arguments[invocation.Arguments.Length - 1];
-                if (lastArgument.ArgumentKind == ArgumentKind.ParamArray && lastArgument.IsImplicit)
+                if (invocation.Arguments[i].ArgumentKind == ArgumentKind.ParamArray && invocation.Arguments[i].IsImplicit)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(ParamsParameterRule, invocation.Syntax.GetLocation(), EmptyMessageArgs));
+                    return;
                 }
             }
         }

--- a/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
+++ b/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
@@ -8,7 +8,7 @@ using VerifyCS = Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.UnitTests.
     Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CallSiteImplicitAllocationAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
-namespace Microsoft.CodeAnalysisPerformanceSensitiveAnalyzers.UnitTests
+namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.UnitTests
 {
     public class CallSiteImplicitAllocationAnalyzerTests
     {
@@ -27,8 +27,8 @@ public class MyClass
 
         Params();
         Params(1, 2);
-        Params(new [] { 1, 2}); // explicit, so no warning
-        ParamsWithObjects(new [] { 1, 2}); // explicit, but converted to objects, so stil la warning?!
+        Params(new [] { 1, 2 }); // explicit, so no warning
+        ParamsWithObjects(new [] { 1, 2 }); // explicit, but converted to object[]
 
         // Only 4 args and above use the params overload of String.Format
         var test = String.Format(""Testing {0}, {1}, {2}, {3}"", 1, ""blah"", 2.0m, 'c');


### PR DESCRIPTION
This PR converts CallSiteImplicitAllocationAnalyzer to use IOperation instead of syntax.

One thing I did not like with the old code and still do not like with the new is that the code:

`FunctionCall(new [] { 1, 2 });`

reports (if FunctionCall has params object[])

> This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter

While technically true, the message is confusing. It is not obvious that the `int[]` is converted into a `object[] `. I have tried to differentiate between this case and the others, but have not been able to find a correct way of doing it. 

Could possibly mitigate by altering the message to something like:

> Function call to a function with a 'params {0}' parameter. This will result in an array allocation.

Where {0} is the params type.