### PR TITLE
[WIP] Convert remanining tests to the new test framework

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
@@ -216,10 +216,8 @@ class C1 : CodeFixProvider
                 // Test0.cs(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
                 GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1"),
                 false,
-                // Test0.cs(21,40): error CS1501: No overload for method 'Create' takes 1 arguments
-                DiagnosticResult.CompilerError("CS1501").WithLocation(21, 40),
-                // Test0.cs(22,40): error CS7036: There is no argument given that corresponds to the required formal parameter 'title' of 'CodeAction.Create(string, Func<CancellationToken, Task<Document>>, string)'
-                DiagnosticResult.CompilerError("CS7036").WithLocation(22, 40));
+                DiagnosticResult.CompilerError("CS1501").WithLocation(21, 40).WithMessage("No overload for method 'Create' takes 1 arguments"),
+                DiagnosticResult.CompilerError("CS7036").WithLocation(22, 40).WithMessage("There is no argument given that corresponds to the required formal parameter 'title' of 'CodeAction.Create(string, Func<CancellationToken, Task<Document>>, string)'"));
         }
 
         [Fact]
@@ -569,10 +567,12 @@ Class C1
                 // Test0.vb(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
                 GetBasicOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1"),
                 false,
-                // Test0.vb(18) : error BC30516: Overload resolution failed because no accessible 'Create' accepts this number of arguments.
-                DiagnosticResult.CompilerError("BC30516").WithLocation(18, 34),
-                // Test0.vb(19) : error BC30518: Overload resolution failed because no accessible 'Create' can be called with these arguments:
-                DiagnosticResult.CompilerError("BC30518").WithLocation(19, 34));
+                DiagnosticResult.CompilerError("BC30516").WithLocation(18, 34).WithMessage("Overload resolution failed because no accessible 'Create' accepts this number of arguments."),
+                DiagnosticResult.CompilerError("BC30518").WithLocation(19, 34).WithMessage(@"Overload resolution failed because no accessible 'Create' can be called with these arguments:
+    'Public Shared Overloads Function Create(title As String, createChangedDocument As Func(Of CancellationToken, Task(Of Document)), [equivalenceKey As String = Nothing]) As CodeAction': Argument not specified for parameter 'title'.
+    'Public Shared Overloads Function Create(title As String, createChangedSolution As Func(Of CancellationToken, Task(Of Solution)), [equivalenceKey As String = Nothing]) As CodeAction': 'createChangedDocument' is not a method parameter.
+    'Public Shared Overloads Function Create(title As String, createChangedSolution As Func(Of CancellationToken, Task(Of Solution)), [equivalenceKey As String = Nothing]) As CodeAction': Argument not specified for parameter 'title'.
+    'Public Shared Overloads Function Create(title As String, createChangedSolution As Func(Of CancellationToken, Task(Of Solution)), [equivalenceKey As String = Nothing]) As CodeAction': Argument not specified for parameter 'createChangedSolution'."));
         }
 
         [Fact]

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
@@ -217,9 +217,9 @@ class C1 : CodeFixProvider
                 GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1"),
                 false,
                 // Test0.cs(21,40): error CS1501: No overload for method 'Create' takes 1 arguments
-                new DiagnosticResult("CS1501", DiagnosticSeverity.Error).WithLocation(21, 40),
+                DiagnosticResult.CompilerError("CS1501").WithLocation(21, 40),
                 // Test0.cs(22,40): error CS7036: There is no argument given that corresponds to the required formal parameter 'title' of 'CodeAction.Create(string, Func<CancellationToken, Task<Document>>, string)'
-                new DiagnosticResult("CS7036", DiagnosticSeverity.Error).WithLocation(22, 40));
+                DiagnosticResult.CompilerError("CS7036").WithLocation(22, 40));
         }
 
         [Fact]
@@ -570,9 +570,9 @@ Class C1
                 GetBasicOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1"),
                 false,
                 // Test0.vb(18) : error BC30516: Overload resolution failed because no accessible 'Create' accepts this number of arguments.
-                new DiagnosticResult("BC30516", DiagnosticSeverity.Error).WithLocation(18, 34),
+                DiagnosticResult.CompilerError("BC30516").WithLocation(18, 34),
                 // Test0.vb(19) : error BC30518: Overload resolution failed because no accessible 'Create' can be called with these arguments:
-                new DiagnosticResult("BC30518", DiagnosticSeverity.Error).WithLocation(19, 34));
+                DiagnosticResult.CompilerError("BC30518").WithLocation(19, 34));
         }
 
         [Fact]

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
@@ -262,7 +262,7 @@ Class C2
 End Class";
 
             await VerifyBasicAsync(apiProviderSource, apiConsumerSource,
-                new DiagnosticResult("BC30389", DiagnosticSeverity.Error)
+                DiagnosticResult.CompilerError("BC30389")
                     .WithLocation("Test0.vb", new LinePosition(2, 23), DiagnosticLocationOptions.IgnoreAdditionalLocations)
                     .WithMessage("'N1.C1' is not accessible in this context because it is 'Friend'."));
         }

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
@@ -3,11 +3,9 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers;
 using Test.Utilities;
 using Xunit;
 
@@ -24,18 +22,14 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers.UnitTests
     public class RestrictedInternalsVisibleToAnalyzerTests
     {
         private static DiagnosticResult GetCSharpResultAt(int line, int column, string bannedSymbolName, string restrictedNamespaces)
-        {
-            return new DiagnosticResult(CSharpRestrictedInternalsVisibleToAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(bannedSymbolName, ApiProviderProjectName, restrictedNamespaces);
-        }
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, string bannedSymbolName, string restrictedNamespaces)
-        {
-            return new DiagnosticResult(BasicRestrictedInternalsVisibleToAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(bannedSymbolName, ApiProviderProjectName, restrictedNamespaces);
-        }
 
         private const string ApiProviderProjectName = nameof(ApiProviderProjectName);
         private const string ApiConsumerProjectName = nameof(ApiConsumerProjectName);

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -19,18 +19,14 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers.UnitTests
     public class SymbolIsBannedAnalyzerTests
     {
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor descriptor, string v3, string v4)
-        {
-            return new DiagnosticResult(descriptor)
+            => VerifyCS.Diagnostic(descriptor)
                 .WithLocation(line, column)
                 .WithArguments(v3, v4);
-        }
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor descriptor, string v3, string v4)
-        {
-            return new DiagnosticResult(descriptor)
+            => VerifyVB.Diagnostic(descriptor)
                 .WithLocation(line, column)
                 .WithArguments(v3, v4);
-        }
 
         private static async Task VerifyBasicAsync(string source, string bannedApiText, params DiagnosticResult[] expected)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructorsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AbstractTypesShouldNotHaveConstructorsTests.cs
@@ -181,12 +181,12 @@ End Class
         }
 
         private static DiagnosticResult GetCA1012CSharpResultAt(int line, int column, string objectName)
-            => new DiagnosticResult(AbstractTypesShouldNotHaveConstructorsAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(objectName);
 
         private static DiagnosticResult GetCA1012BasicResultAt(int line, int column, string objectName)
-            => new DiagnosticResult(AbstractTypesShouldNotHaveConstructorsAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(objectName);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
@@ -161,7 +161,7 @@ public class C
                 },
                 ExpectedDiagnostics =
                 {
-                    CreateCSharpResult(4, 16 + accessibility.Length)
+                    CreateCSharpResult(4, 16 + accessibility.Length),
                 }
             }.RunAsync();
         }
@@ -209,7 +209,7 @@ End Class"
                 },
                 ExpectedDiagnostics =
                 {
-                    CreateBasicResult(3, 16 + accessibility.Length)
+                    CreateBasicResult(3, 16 + accessibility.Length),
                 }
             }.RunAsync();
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
@@ -265,13 +265,11 @@ End Class"
         }
 
         private static DiagnosticResult CreateCSharpResult(int line, int col)
-            => new DiagnosticResult(AvoidEmptyInterfacesAnalyzer.Rule)
-                .WithLocation(line, col)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.AvoidEmptyInterfacesMessage);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, col);
 
         private static DiagnosticResult CreateBasicResult(int line, int col)
-            => new DiagnosticResult(AvoidEmptyInterfacesAnalyzer.Rule)
-                .WithLocation(line, col)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.AvoidEmptyInterfacesMessage);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, col);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
     public class CollectionPropertiesShouldBeReadOnlyTests
     {
-        private DiagnosticResult GetBasicResultAt(int line, int column, string propertyName)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, string propertyName)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(propertyName);
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string propertyName)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string propertyName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(propertyName);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
     public class CollectionsShouldImplementGenericInterfaceTests
     {
-        private DiagnosticResult GetCA1010CSharpResultAt(int line, int column, string typeName, string interfaceName)
+        private static DiagnosticResult GetCA1010CSharpResultAt(int line, int column, string typeName, string interfaceName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(typeName, interfaceName, $"{interfaceName}<T>");
 
-        private DiagnosticResult GetCA1010BasicResultAt(int line, int column, string typeName, string interfaceName)
+        private static DiagnosticResult GetCA1010BasicResultAt(int line, int column, string typeName, string interfaceName)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(typeName, interfaceName, $"{interfaceName}(Of T)");

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DeclareTypesInNamespacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DeclareTypesInNamespacesTests.cs
@@ -85,13 +85,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCSharpExpectedResult(int line, int column)
-            => new DiagnosticResult(DeclareTypesInNamespacesAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DeclareTypesInNamespacesMessage);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetBasicExpectedResult(int line, int column)
-            => new DiagnosticResult(DeclareTypesInNamespacesAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DeclareTypesInNamespacesMessage);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotCatchGeneralExceptionTypesTests.cs
@@ -744,12 +744,12 @@ End Class"
         }
 
         private static DiagnosticResult GetCA1031CSharpResultAt(int line, int column, string signature)
-            => VerifyCS.Diagnostic(DoNotCatchGeneralExceptionTypesAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(signature);
 
         private static DiagnosticResult GetCA1031BasicResultAt(int line, int column, string signature)
-            => VerifyVB.Diagnostic(DoNotCatchGeneralExceptionTypesAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(signature);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
@@ -140,7 +140,7 @@ public class SomeAwaiter : INotifyCompletion
 }
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
-                new DiagnosticResult("CS1525", DiagnosticSeverity.Error).WithLocation(16, 14));
+                DiagnosticResult.CompilerError("CS1525").WithLocation(16, 14));
         }
 
         [Fact]
@@ -185,7 +185,7 @@ Public Class SomeAwaiter
 End Class
 ";
             await VerifyVB.VerifyAnalyzerAsync(code,
-                new DiagnosticResult("BC30201", DiagnosticSeverity.Error).WithLocation(14, 15));
+                DiagnosticResult.CompilerError("BC30201").WithLocation(14, 15));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
@@ -422,11 +422,11 @@ public class C
             await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(11, 19));
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column)
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
@@ -425,13 +425,11 @@ public class C
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column)
-            => new DiagnosticResult(DoNotDirectlyAwaitATaskAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DoNotDirectlyAwaitATaskMessage);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
         private DiagnosticResult GetBasicResultAt(int line, int column)
-            => new DiagnosticResult(DoNotDirectlyAwaitATaskAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DoNotDirectlyAwaitATaskMessage);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
@@ -114,7 +114,7 @@ public class C
         SomeAwaitable s = null;
         await s;
 
-        await; // No Argument
+        await; // Test0.cs(16,14): error CS1525: Invalid expression term ';'
     }
 }
 
@@ -139,7 +139,8 @@ public class SomeAwaiter : INotifyCompletion
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                new DiagnosticResult("CS1525", DiagnosticSeverity.Error).WithLocation(16, 14));
         }
 
         [Fact]
@@ -158,7 +159,7 @@ Public Class C
         Dim s As SomeAwaitable = Nothing
         Await s
 
-        Await 'No Argument
+        Await ' Test0.vb(14) : error BC30201: Expression expected.
     End Function
 End Class
 
@@ -183,7 +184,8 @@ Public Class SomeAwaiter
     End Sub
 End Class
 ";
-            await VerifyVB.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyVB.VerifyAnalyzerAsync(code,
+                new DiagnosticResult("BC30201", DiagnosticSeverity.Error).WithLocation(14, 15));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -487,12 +487,12 @@ End Class
 ");
         }
 
-        private DiagnosticResult GetCA1061CSharpResultAt(int line, int column, string derivedMethod, string baseMethod)
+        private static DiagnosticResult GetCA1061CSharpResultAt(int line, int column, string derivedMethod, string baseMethod)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(derivedMethod, baseMethod);
 
-        private DiagnosticResult GetCA1061BasicResultAt(int line, int column, string derivedMethod, string baseMethod)
+        private static DiagnosticResult GetCA1061BasicResultAt(int line, int column, string derivedMethod, string baseMethod)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(derivedMethod, baseMethod);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -198,8 +198,7 @@ class Derived : IFace
     {
     }
 }",
-            // Test0.cs(7,17): error CS0535: 'Derived' does not implement interface member 'IFace.Method(string)'
-            DiagnosticResult.CompilerError("CS0535").WithLocation(7, 17));
+            DiagnosticResult.CompilerError("CS0535").WithLocation(7, 17).WithMessage("'Derived' does not implement interface member 'IFace.Method(string)'"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Interface IFace
@@ -212,10 +211,8 @@ Class Derived
     Public Sub Method(input As Object) Implements IFace.Method
     End Sub
 End Class",
-                // Test0.vb(7) : error BC30149: Class 'Derived' must implement 'Sub Method(input As String)' for interface 'IFace'.
-                DiagnosticResult.CompilerError("BC30149").WithLocation(7, 16),
-                // Test0.vb(9) : error BC30401: 'Method' cannot implement 'Method' because there is no matching sub on interface 'IFace'.
-                DiagnosticResult.CompilerError("BC30401").WithLocation(9, 51));
+                DiagnosticResult.CompilerError("BC30149").WithLocation(7, 16).WithMessage("Class 'Derived' must implement 'Sub Method(input As String)' for interface 'IFace'."),
+                DiagnosticResult.CompilerError("BC30401").WithLocation(9, 51).WithMessage("'Method' cannot implement 'Method' because there is no matching sub on interface 'IFace'."));
         }
 
         [Fact]
@@ -233,10 +230,8 @@ class Derived : Base
     {
     }
 }",
-            // Test0.cs(4,25): error CS0501: 'Base.Method(string)' must declare a body because it is not marked abstract, extern, or partial
-            DiagnosticResult.CompilerError("CS0501").WithLocation(4, 25),
-            // Test0.cs(9,26): error CS0115: 'Derived.Method(object)': no suitable method found to override
-            DiagnosticResult.CompilerError("CS0115").WithLocation(9, 26));
+            DiagnosticResult.CompilerError("CS0501").WithLocation(4, 25).WithMessage("'Base.Method(string)' must declare a body because it is not marked abstract, extern, or partial"),
+            DiagnosticResult.CompilerError("CS0115").WithLocation(9, 26).WithMessage("'Derived.Method(object)': no suitable method found to override"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
@@ -250,8 +245,7 @@ Class Derived
     Public Overrides Sub Method(input As Object)
     End Sub
 End Class",
-                // Test0.vb(10) : error BC30284: sub 'Method' cannot be declared 'Overrides' because it does not override a sub in a base class.
-                DiagnosticResult.CompilerError("BC30284").WithLocation(10, 26));
+                DiagnosticResult.CompilerError("BC30284").WithLocation(10, 26).WithMessage("sub 'Method' cannot be declared 'Overrides' because it does not override a sub in a base class."));
         }
 
 
@@ -270,10 +264,8 @@ class Derived : Base
     {
     }
 }",
-            // Test0.cs(7,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Method(string)'
-            DiagnosticResult.CompilerError("CS0534").WithLocation(7, 7),
-            // Test0.cs(9,26): error CS0115: 'Derived.Method(object)': no suitable method found to override
-            DiagnosticResult.CompilerError("CS0115").WithLocation(9, 26));
+            DiagnosticResult.CompilerError("CS0534").WithLocation(7, 7).WithMessage("'Derived' does not implement inherited abstract member 'Base.Method(string)'"),
+            DiagnosticResult.CompilerError("CS0115").WithLocation(9, 26).WithMessage("'Derived.Method(object)': no suitable method found to override"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 MustInherit Class Base
@@ -287,12 +279,10 @@ Class Derived
     Public Overrides Sub Method(input As Object)
     End Sub
 End Class",
-                // Test0.vb(4) : error BC30429: 'End Sub' must be preceded by a matching 'Sub'.
-                DiagnosticResult.CompilerError("BC30429").WithLocation(4, 5),
-                // Test0.vb(7) : error BC30610: Class 'Derived' must either be declared 'MustInherit' or override the following inherited 'MustOverride' member(s):
-                DiagnosticResult.CompilerError("BC30610").WithLocation(7, 7),
-                // Test0.vb(10) : error BC30284: sub 'Method' cannot be declared 'Overrides' because it does not override a sub in a base class.
-                DiagnosticResult.CompilerError("BC30284").WithLocation(10, 26));
+                DiagnosticResult.CompilerError("BC30429").WithLocation(4, 5).WithMessage("'End Sub' must be preceded by a matching 'Sub'."),
+                DiagnosticResult.CompilerError("BC30610").WithLocation(7, 7).WithMessage(@"Class 'Derived' must either be declared 'MustInherit' or override the following inherited 'MustOverride' member(s): 
+    Base: Public MustOverride Sub Method(input As String)."),
+                DiagnosticResult.CompilerError("BC30284").WithLocation(10, 26).WithMessage("sub 'Method' cannot be declared 'Overrides' because it does not override a sub in a base class."));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -489,27 +488,13 @@ End Class
         }
 
         private DiagnosticResult GetCA1061CSharpResultAt(int line, int column, string derivedMethod, string baseMethod)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture,
-                MicrosoftCodeQualityAnalyzersResources.DoNotHideBaseClassMethodsMessage,
-                derivedMethod,
-                baseMethod);
-
-            return new DiagnosticResult(DoNotHideBaseClassMethodsAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(derivedMethod, baseMethod);
 
         private DiagnosticResult GetCA1061BasicResultAt(int line, int column, string derivedMethod, string baseMethod)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture,
-                MicrosoftCodeQualityAnalyzersResources.DoNotHideBaseClassMethodsMessage,
-                derivedMethod,
-                baseMethod);
-
-            return new DiagnosticResult(DoNotHideBaseClassMethodsAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(derivedMethod, baseMethod);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -199,7 +199,7 @@ class Derived : IFace
     }
 }",
             // Test0.cs(7,17): error CS0535: 'Derived' does not implement interface member 'IFace.Method(string)'
-            new DiagnosticResult("CS0535", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 17));
+            DiagnosticResult.CompilerError("CS0535").WithLocation(7, 17));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Interface IFace
@@ -213,9 +213,9 @@ Class Derived
     End Sub
 End Class",
                 // Test0.vb(7) : error BC30149: Class 'Derived' must implement 'Sub Method(input As String)' for interface 'IFace'.
-                new DiagnosticResult("BC30149", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 16),
+                DiagnosticResult.CompilerError("BC30149").WithLocation(7, 16),
                 // Test0.vb(9) : error BC30401: 'Method' cannot implement 'Method' because there is no matching sub on interface 'IFace'.
-                new DiagnosticResult("BC30401", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(9, 51));
+                DiagnosticResult.CompilerError("BC30401").WithLocation(9, 51));
         }
 
         [Fact]
@@ -234,9 +234,9 @@ class Derived : Base
     }
 }",
             // Test0.cs(4,25): error CS0501: 'Base.Method(string)' must declare a body because it is not marked abstract, extern, or partial
-            new DiagnosticResult("CS0501", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 25),
+            DiagnosticResult.CompilerError("CS0501").WithLocation(4, 25),
             // Test0.cs(9,26): error CS0115: 'Derived.Method(object)': no suitable method found to override
-            new DiagnosticResult("CS0115", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(9, 26));
+            DiagnosticResult.CompilerError("CS0115").WithLocation(9, 26));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
@@ -251,7 +251,7 @@ Class Derived
     End Sub
 End Class",
                 // Test0.vb(10) : error BC30284: sub 'Method' cannot be declared 'Overrides' because it does not override a sub in a base class.
-                new DiagnosticResult("BC30284", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(10, 26));
+                DiagnosticResult.CompilerError("BC30284").WithLocation(10, 26));
         }
 
 
@@ -271,9 +271,9 @@ class Derived : Base
     }
 }",
             // Test0.cs(7,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Method(string)'
-            new DiagnosticResult("CS0534", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 7),
+            DiagnosticResult.CompilerError("CS0534").WithLocation(7, 7),
             // Test0.cs(9,26): error CS0115: 'Derived.Method(object)': no suitable method found to override
-            new DiagnosticResult("CS0115", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(9, 26));
+            DiagnosticResult.CompilerError("CS0115").WithLocation(9, 26));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 MustInherit Class Base
@@ -288,11 +288,11 @@ Class Derived
     End Sub
 End Class",
                 // Test0.vb(4) : error BC30429: 'End Sub' must be preceded by a matching 'Sub'.
-                new DiagnosticResult("BC30429", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 5),
+                DiagnosticResult.CompilerError("BC30429").WithLocation(4, 5),
                 // Test0.vb(7) : error BC30610: Class 'Derived' must either be declared 'MustInherit' or override the following inherited 'MustOverride' member(s):
-                new DiagnosticResult("BC30610", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 7),
+                DiagnosticResult.CompilerError("BC30610").WithLocation(7, 7),
                 // Test0.vb(10) : error BC30284: sub 'Method' cannot be declared 'Overrides' because it does not override a sub in a base class.
-                new DiagnosticResult("BC30284", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(10, 26));
+                DiagnosticResult.CompilerError("BC30284").WithLocation(10, 26));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -198,7 +198,8 @@ class Derived : IFace
     {
     }
 }",
-                CompilerDiagnostics.None);
+            // Test0.cs(7,17): error CS0535: 'Derived' does not implement interface member 'IFace.Method(string)'
+            new DiagnosticResult("CS0535", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 17));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Interface IFace
@@ -211,7 +212,10 @@ Class Derived
     Public Sub Method(input As Object) Implements IFace.Method
     End Sub
 End Class",
-                CompilerDiagnostics.None);
+                // Test0.vb(7) : error BC30149: Class 'Derived' must implement 'Sub Method(input As String)' for interface 'IFace'.
+                new DiagnosticResult("BC30149", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 16),
+                // Test0.vb(9) : error BC30401: 'Method' cannot implement 'Method' because there is no matching sub on interface 'IFace'.
+                new DiagnosticResult("BC30401", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(9, 51));
         }
 
         [Fact]
@@ -229,7 +233,10 @@ class Derived : Base
     {
     }
 }",
-                CompilerDiagnostics.None);
+            // Test0.cs(4,25): error CS0501: 'Base.Method(string)' must declare a body because it is not marked abstract, extern, or partial
+            new DiagnosticResult("CS0501", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 25),
+            // Test0.cs(9,26): error CS0115: 'Derived.Method(object)': no suitable method found to override
+            new DiagnosticResult("CS0115", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(9, 26));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Class Base
@@ -243,7 +250,8 @@ Class Derived
     Public Overrides Sub Method(input As Object)
     End Sub
 End Class",
-                CompilerDiagnostics.None);
+                // Test0.vb(10) : error BC30284: sub 'Method' cannot be declared 'Overrides' because it does not override a sub in a base class.
+                new DiagnosticResult("BC30284", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(10, 26));
         }
 
 
@@ -262,7 +270,10 @@ class Derived : Base
     {
     }
 }",
-                CompilerDiagnostics.None);
+            // Test0.cs(7,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Method(string)'
+            new DiagnosticResult("CS0534", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 7),
+            // Test0.cs(9,26): error CS0115: 'Derived.Method(object)': no suitable method found to override
+            new DiagnosticResult("CS0115", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(9, 26));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 MustInherit Class Base
@@ -276,7 +287,12 @@ Class Derived
     Public Overrides Sub Method(input As Object)
     End Sub
 End Class",
-                CompilerDiagnostics.None);
+                // Test0.vb(4) : error BC30429: 'End Sub' must be preceded by a matching 'Sub'.
+                new DiagnosticResult("BC30429", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 5),
+                // Test0.vb(7) : error BC30610: Class 'Derived' must either be declared 'MustInherit' or override the following inherited 'MustOverride' member(s):
+                new DiagnosticResult("BC30610", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 7),
+                // Test0.vb(10) : error BC30284: sub 'Method' cannot be declared 'Overrides' because it does not override a sub in a base class.
+                new DiagnosticResult("BC30284", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(10, 26));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotPrefixEnumValuesWithTypeNameTests.cs
@@ -2,7 +2,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotPrefixEnumValuesWithTypeNameAnalyzer,
@@ -140,12 +139,12 @@ namespace Microsoft.CodeQuality.Analyzers.UnitTests.ApiDesignGuidelines
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
-            => new DiagnosticResult(DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
-            => new DiagnosticResult(DoNotPrefixEnumValuesWithTypeNameAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocationsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocationsTests.cs
@@ -692,12 +692,12 @@ End Class
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocationsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocationsTests.cs
@@ -665,28 +665,28 @@ End Class
         }
         #endregion
 
-        private DiagnosticResult GetCSharpPropertyResultAt(int line, int column, string methodName, string exceptionName)
+        private static DiagnosticResult GetCSharpPropertyResultAt(int line, int column, string methodName, string exceptionName)
         {
             return GetCSharpResultAt(line, column, DoNotRaiseExceptionsInUnexpectedLocationsAnalyzer.PropertyGetterRule, methodName, exceptionName);
         }
-        private DiagnosticResult GetCSharpAllowedExceptionsResultAt(int line, int column, string methodName, string exceptionName)
+        private static DiagnosticResult GetCSharpAllowedExceptionsResultAt(int line, int column, string methodName, string exceptionName)
         {
             return GetCSharpResultAt(line, column, DoNotRaiseExceptionsInUnexpectedLocationsAnalyzer.HasAllowedExceptionsRule, methodName, exceptionName);
         }
-        private DiagnosticResult GetCSharpNoExceptionsResultAt(int line, int column, string methodName, string exceptionName)
+        private static DiagnosticResult GetCSharpNoExceptionsResultAt(int line, int column, string methodName, string exceptionName)
         {
             return GetCSharpResultAt(line, column, DoNotRaiseExceptionsInUnexpectedLocationsAnalyzer.NoAllowedExceptionsRule, methodName, exceptionName);
         }
 
-        private DiagnosticResult GetBasicPropertyResultAt(int line, int column, string methodName, string exceptionName)
+        private static DiagnosticResult GetBasicPropertyResultAt(int line, int column, string methodName, string exceptionName)
         {
             return GetBasicResultAt(line, column, DoNotRaiseExceptionsInUnexpectedLocationsAnalyzer.PropertyGetterRule, methodName, exceptionName);
         }
-        private DiagnosticResult GetBasicAllowedExceptionsResultAt(int line, int column, string methodName, string exceptionName)
+        private static DiagnosticResult GetBasicAllowedExceptionsResultAt(int line, int column, string methodName, string exceptionName)
         {
             return GetBasicResultAt(line, column, DoNotRaiseExceptionsInUnexpectedLocationsAnalyzer.HasAllowedExceptionsRule, methodName, exceptionName);
         }
-        private DiagnosticResult GetBasicNoExceptionsResultAt(int line, int column, string methodName, string exceptionName)
+        private static DiagnosticResult GetBasicNoExceptionsResultAt(int line, int column, string methodName, string exceptionName)
         {
             return GetBasicResultAt(line, column, DoNotRaiseExceptionsInUnexpectedLocationsAnalyzer.NoAllowedExceptionsRule, methodName, exceptionName);
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumStorageShouldBeInt32Tests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumStorageShouldBeInt32Tests.cs
@@ -189,12 +189,12 @@ End Module
         #endregion
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumWithFlagsAttributeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumWithFlagsAttributeTests.cs
@@ -2,7 +2,6 @@
 
 using System.Globalization;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -15,18 +14,8 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class EnumWithFlagsAttributeTests : DiagnosticAnalyzerTestBase
+    public class EnumWithFlagsAttributeTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new EnumWithFlagsAttributeAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new EnumWithFlagsAttributeAnalyzer();
-        }
-
         private static string GetCSharpCode_EnumWithFlagsAttributes(string code, bool hasFlags)
         {
             string stringToReplace = hasFlags ? "[System.Flags]" : "";
@@ -105,7 +94,7 @@ internal class OuterClass
         }
 
         [Fact]
-        public void CSharp_EnumWithFlagsAttributes_SimpleCaseWithScope()
+        public async Task CSharp_EnumWithFlagsAttributes_SimpleCaseWithScope()
         {
             var code = @"{0}
 public enum SimpleFlagsEnumClass
@@ -117,18 +106,18 @@ public enum SimpleFlagsEnumClass
 }}
 
 {0}
-[|public enum HexFlagsEnumClass
+public enum {{|CA1027:HexFlagsEnumClass|}}
 {{
     One = 0x1,
     Two = 0x2,
     Four = 0x4,
     All = 0x7
-}}|]";
+}}";
 
             // Verify CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetCSharpCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyCSharp(codeWithoutFlags,
-                GetCA1027CSharpResultAt(11, 13, "HexFlagsEnumClass"));
+            await VerifyCS.VerifyAnalyzerAsync(codeWithoutFlags,
+                GetCA1027CSharpResultAt(2, 13, "HexFlagsEnumClass"));
         }
 
         [Fact]
@@ -192,7 +181,7 @@ End Class";
         }
 
         [Fact]
-        public void VisualBasic_EnumWithFlagsAttributes_SimpleCaseWithScope()
+        public async Task VisualBasic_EnumWithFlagsAttributes_SimpleCaseWithScope()
         {
             var code = @"{0}
 Public Enum SimpleFlagsEnumClass
@@ -203,17 +192,17 @@ Public Enum SimpleFlagsEnumClass
 End Enum
 
 {0}
-[|Public Enum HexFlagsEnumClass
+Public Enum {{|CA1027:HexFlagsEnumClass|}}
     One = &H1
     Two = &H2
     Four = &H4
     All = &H7
-End Enum|]";
+End Enum";
 
             // Verify CA1027: Mark enums with FlagsAttribute
             string codeWithoutFlags = GetBasicCode_EnumWithFlagsAttributes(code, hasFlags: false);
-            VerifyBasic(codeWithoutFlags,
-                GetCA1027BasicResultAt(10, 13, "HexFlagsEnumClass"));
+            await VerifyVB.VerifyAnalyzerAsync(codeWithoutFlags,
+                GetCA1027BasicResultAt(2, 13, "HexFlagsEnumClass"));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
@@ -555,23 +555,19 @@ End Class
         }
 
         private static DiagnosticResult GetCSharpPluralResultAt(int line, int column)
-            => new DiagnosticResult(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.FlagsEnumsShouldHavePluralNamesMessage);
+            => VerifyCS.Diagnostic(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714)
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetBasicPluralResultAt(int line, int column)
-            => new DiagnosticResult(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.FlagsEnumsShouldHavePluralNamesMessage);
+            => VerifyVB.Diagnostic(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1714)
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetCSharpNoPluralResultAt(int line, int column)
-            => new DiagnosticResult(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.OnlyFlagsEnumsShouldHavePluralNamesMessage);
+            => VerifyCS.Diagnostic(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717)
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetBasicNoPluralResultAt(int line, int column)
-            => new DiagnosticResult(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.OnlyFlagsEnumsShouldHavePluralNamesMessage);
+            => VerifyVB.Diagnostic(EnumsShouldHavePluralNamesAnalyzer.Rule_CA1717)
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
@@ -218,7 +218,7 @@ class C : IEquatable<C>
                 new DiagnosticResult("CS1001", DiagnosticSeverity.Error).WithLocation(6, 25));
         }
 
-    [Fact]
+        [Fact]
         public async Task NoDiagnosticForClassWithIEquatableImplementationWithWrongReturnTypeAndNoEqualsOverride()
         {
             var code = @"

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
@@ -121,7 +121,15 @@ class C : IEquatable<C>
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
+                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                // Test0.cs(6,17): error CS0548: 'C.Equals': property or indexer must have at least one accessor
+                new DiagnosticResult("CS0548", DiagnosticSeverity.Error).WithLocation(6, 17),
+                // Test0.cs(8,9): error CS1014: A get or set accessor expected
+                new DiagnosticResult("CS1014", DiagnosticSeverity.Error).WithLocation(8, 9),
+                // Test0.cs(8,20): error CS1014: A get or set accessor expected
+                new DiagnosticResult("CS1014", DiagnosticSeverity.Error).WithLocation(8, 20));
         }
 
         [Fact]
@@ -138,7 +146,11 @@ class C : IEquatable<C>
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
+                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                // Test0.cs(6,24): error CS1026: ) expected
+                new DiagnosticResult("CS1026", DiagnosticSeverity.Error).WithLocation(6, 24));
         }
 
         [Fact]
@@ -155,7 +167,13 @@ class C : IEquatable<C>
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
+                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                // Test0.cs(6,23): error CS1003: Syntax error, ',' expected
+                new DiagnosticResult("CS1003", DiagnosticSeverity.Error).WithLocation(6, 23),
+                // Test0.cs(10,1): error CS1022: Type or namespace definition, or end-of-file expected
+                new DiagnosticResult("CS1022", DiagnosticSeverity.Error).WithLocation(10, 1));
         }
 
         [Fact]
@@ -172,7 +190,9 @@ class C : IEquatable<C>
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                    // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
+                    new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11));
         }
 
         [Fact]
@@ -189,10 +209,16 @@ class C : IEquatable<C>
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                // Test0.cs(4, 11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
+                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                // Test0.cs(6,24): error CS0246: The type or namespace name 'x' could not be found (are you missing a using directive or an assembly reference?)
+                new DiagnosticResult("CS0246", DiagnosticSeverity.Error).WithLocation(6, 24),
+                // Test0.cs(6,25): error CS1001: Identifier expected
+                new DiagnosticResult("CS1001", DiagnosticSeverity.Error).WithLocation(6, 25));
         }
 
-        [Fact]
+    [Fact]
         public async Task NoDiagnosticForClassWithIEquatableImplementationWithWrongReturnTypeAndNoEqualsOverride()
         {
             var code = @"
@@ -206,7 +232,9 @@ class C : IEquatable<C>
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                // Test0.cs(4,11): error CS0738: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'. 'C.Equals(C)' cannot implement 'IEquatable<C>.Equals(C)' because it does not have the matching return type of 'bool'.
+                new DiagnosticResult("CS0738", DiagnosticSeverity.Error).WithLocation(4, 11));
         }
 
         [Fact]
@@ -221,8 +249,13 @@ class C : IEquatable<C>
 }
 ";
             string expectedMessage = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideObjectEqualsMessage, "C");
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None,
-                GetCSharpResultAt(4, 7, EquatableAnalyzer.OverridesObjectEqualsDescriptor, expectedMessage));
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                // Test0.cs(4,7): warning CA1067: Type C should override Equals because it implements IEquatable<T>
+                GetCSharpResultAt(4, 7, EquatableAnalyzer.OverridesObjectEqualsDescriptor, expectedMessage),
+                // Test0.cs(6,17): error CS0501: 'C.Equals(C)' must declare a body because it is not marked abstract, extern, or partial
+                new DiagnosticResult("CS0501", DiagnosticSeverity.Error).WithLocation(6, 17),
+                // Test0.cs(6,32): error CS1002: ; expected
+                new DiagnosticResult("CS1002", DiagnosticSeverity.Error).WithLocation(6, 32));
         }
 
         [Fact]
@@ -239,7 +272,13 @@ class C : IEquatable<C>
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
+                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                // Test0.cs(6,12): error CS1520: Method must have a return type
+                new DiagnosticResult("CS1520", DiagnosticSeverity.Error).WithLocation(6, 12),
+                // Test0.cs(8,9): error CS0127: Since 'C.C(C)' returns void, a return keyword must not be followed by an object expression
+                new DiagnosticResult("CS0127", DiagnosticSeverity.Error).WithLocation(8, 9));
         }
 
         [Fact]
@@ -256,7 +295,9 @@ class C
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                    // Test0.cs(6,26): error CS0115: 'C.Equals(object, int)': no suitable method found to override
+                    new DiagnosticResult("CS0115", DiagnosticSeverity.Error).WithLocation(6, 26));
         }
 
         [Fact]
@@ -302,9 +343,13 @@ struct C : B
 ";
             string expectedMessage1 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsMessage, "B");
             string expectedMessage2 = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIEquatableWhenOverridingObjectEqualsMessage, "C");
-            await VerifyCS.VerifyAnalyzerAsync(code, CompilerDiagnostics.None,
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                // Test0.cs(4,8): warning CA1066: Implement IEquatable when overriding Object.Equals
                 GetCSharpResultAt(4, 8, EquatableAnalyzer.ImplementIEquatableDescriptor, expectedMessage1),
-                GetCSharpResultAt(12, 8, EquatableAnalyzer.ImplementIEquatableDescriptor, expectedMessage2));
+                // Test0.cs(12,8): warning CA1066: Implement IEquatable when overriding Object.Equals
+                GetCSharpResultAt(12, 8, EquatableAnalyzer.ImplementIEquatableDescriptor, expectedMessage2),
+                // Test0.cs(12,12): error CS0527: Type 'B' in interface list is not an interface
+                new DiagnosticResult("CS0527", DiagnosticSeverity.Error).WithLocation(12, 12));
         }
 
         [Fact, WorkItem(1914, "https://github.com/dotnet/roslyn-analyzers/issues/1914")]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
@@ -420,7 +420,7 @@ public ref struct S
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string message)
-            => new DiagnosticResult(rule)
+            => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithMessage(message);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
@@ -123,13 +123,13 @@ class C : IEquatable<C>
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
                 // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
                 // Test0.cs(6,17): error CS0548: 'C.Equals': property or indexer must have at least one accessor
-                new DiagnosticResult("CS0548", DiagnosticSeverity.Error).WithLocation(6, 17),
+                DiagnosticResult.CompilerError("CS0548").WithLocation(6, 17),
                 // Test0.cs(8,9): error CS1014: A get or set accessor expected
-                new DiagnosticResult("CS1014", DiagnosticSeverity.Error).WithLocation(8, 9),
+                DiagnosticResult.CompilerError("CS1014").WithLocation(8, 9),
                 // Test0.cs(8,20): error CS1014: A get or set accessor expected
-                new DiagnosticResult("CS1014", DiagnosticSeverity.Error).WithLocation(8, 20));
+                DiagnosticResult.CompilerError("CS1014").WithLocation(8, 20));
         }
 
         [Fact]
@@ -148,9 +148,9 @@ class C : IEquatable<C>
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
                 // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
                 // Test0.cs(6,24): error CS1026: ) expected
-                new DiagnosticResult("CS1026", DiagnosticSeverity.Error).WithLocation(6, 24));
+                DiagnosticResult.CompilerError("CS1026").WithLocation(6, 24));
         }
 
         [Fact]
@@ -169,11 +169,11 @@ class C : IEquatable<C>
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
                 // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
                 // Test0.cs(6,23): error CS1003: Syntax error, ',' expected
-                new DiagnosticResult("CS1003", DiagnosticSeverity.Error).WithLocation(6, 23),
+                DiagnosticResult.CompilerError("CS1003").WithLocation(6, 23),
                 // Test0.cs(10,1): error CS1022: Type or namespace definition, or end-of-file expected
-                new DiagnosticResult("CS1022", DiagnosticSeverity.Error).WithLocation(10, 1));
+                DiagnosticResult.CompilerError("CS1022").WithLocation(10, 1));
         }
 
         [Fact]
@@ -192,7 +192,7 @@ class C : IEquatable<C>
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
                     // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                    new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11));
+                    DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11));
         }
 
         [Fact]
@@ -211,11 +211,11 @@ class C : IEquatable<C>
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
                 // Test0.cs(4, 11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
                 // Test0.cs(6,24): error CS0246: The type or namespace name 'x' could not be found (are you missing a using directive or an assembly reference?)
-                new DiagnosticResult("CS0246", DiagnosticSeverity.Error).WithLocation(6, 24),
+                DiagnosticResult.CompilerError("CS0246").WithLocation(6, 24),
                 // Test0.cs(6,25): error CS1001: Identifier expected
-                new DiagnosticResult("CS1001", DiagnosticSeverity.Error).WithLocation(6, 25));
+                DiagnosticResult.CompilerError("CS1001").WithLocation(6, 25));
         }
 
         [Fact]
@@ -234,7 +234,7 @@ class C : IEquatable<C>
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
                 // Test0.cs(4,11): error CS0738: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'. 'C.Equals(C)' cannot implement 'IEquatable<C>.Equals(C)' because it does not have the matching return type of 'bool'.
-                new DiagnosticResult("CS0738", DiagnosticSeverity.Error).WithLocation(4, 11));
+                DiagnosticResult.CompilerError("CS0738").WithLocation(4, 11));
         }
 
         [Fact]
@@ -253,9 +253,9 @@ class C : IEquatable<C>
                 // Test0.cs(4,7): warning CA1067: Type C should override Equals because it implements IEquatable<T>
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverridesObjectEqualsDescriptor, expectedMessage),
                 // Test0.cs(6,17): error CS0501: 'C.Equals(C)' must declare a body because it is not marked abstract, extern, or partial
-                new DiagnosticResult("CS0501", DiagnosticSeverity.Error).WithLocation(6, 17),
+                DiagnosticResult.CompilerError("CS0501").WithLocation(6, 17),
                 // Test0.cs(6,32): error CS1002: ; expected
-                new DiagnosticResult("CS1002", DiagnosticSeverity.Error).WithLocation(6, 32));
+                DiagnosticResult.CompilerError("CS1002").WithLocation(6, 32));
         }
 
         [Fact]
@@ -274,11 +274,11 @@ class C : IEquatable<C>
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
                 // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                new DiagnosticResult("CS0535", DiagnosticSeverity.Error).WithLocation(4, 11),
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
                 // Test0.cs(6,12): error CS1520: Method must have a return type
-                new DiagnosticResult("CS1520", DiagnosticSeverity.Error).WithLocation(6, 12),
+                DiagnosticResult.CompilerError("CS1520").WithLocation(6, 12),
                 // Test0.cs(8,9): error CS0127: Since 'C.C(C)' returns void, a return keyword must not be followed by an object expression
-                new DiagnosticResult("CS0127", DiagnosticSeverity.Error).WithLocation(8, 9));
+                DiagnosticResult.CompilerError("CS0127").WithLocation(8, 9));
         }
 
         [Fact]
@@ -297,7 +297,7 @@ class C
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
                     // Test0.cs(6,26): error CS0115: 'C.Equals(object, int)': no suitable method found to override
-                    new DiagnosticResult("CS0115", DiagnosticSeverity.Error).WithLocation(6, 26));
+                    DiagnosticResult.CompilerError("CS0115").WithLocation(6, 26));
         }
 
         [Fact]
@@ -349,7 +349,7 @@ struct C : B
                 // Test0.cs(12,8): warning CA1066: Implement IEquatable when overriding Object.Equals
                 GetCSharpResultAt(12, 8, EquatableAnalyzer.ImplementIEquatableDescriptor, expectedMessage2),
                 // Test0.cs(12,12): error CS0527: Type 'B' in interface list is not an interface
-                new DiagnosticResult("CS0527", DiagnosticSeverity.Error).WithLocation(12, 12));
+                DiagnosticResult.CompilerError("CS0527").WithLocation(12, 12));
         }
 
         [Fact, WorkItem(1914, "https://github.com/dotnet/roslyn-analyzers/issues/1914")]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/EquatableAnalyzerTests.cs
@@ -122,14 +122,10 @@ class C : IEquatable<C>
 }
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
-                // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
-                // Test0.cs(6,17): error CS0548: 'C.Equals': property or indexer must have at least one accessor
-                DiagnosticResult.CompilerError("CS0548").WithLocation(6, 17),
-                // Test0.cs(8,9): error CS1014: A get or set accessor expected
-                DiagnosticResult.CompilerError("CS1014").WithLocation(8, 9),
-                // Test0.cs(8,20): error CS1014: A get or set accessor expected
-                DiagnosticResult.CompilerError("CS1014").WithLocation(8, 20));
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11).WithMessage("'C' does not implement interface member 'IEquatable<C>.Equals(C)'"),
+                DiagnosticResult.CompilerError("CS0548").WithLocation(6, 17).WithMessage("'C.Equals': property or indexer must have at least one accessor"),
+                DiagnosticResult.CompilerError("CS1014").WithLocation(8, 9).WithMessage("A get or set accessor expected"),
+                DiagnosticResult.CompilerError("CS1014").WithLocation(8, 20).WithMessage("A get or set accessor expected"));
         }
 
         [Fact]
@@ -147,10 +143,8 @@ class C : IEquatable<C>
 }
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
-                // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
-                // Test0.cs(6,24): error CS1026: ) expected
-                DiagnosticResult.CompilerError("CS1026").WithLocation(6, 24));
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11).WithMessage("'C' does not implement interface member 'IEquatable<C>.Equals(C)'"),
+                DiagnosticResult.CompilerError("CS1026").WithLocation(6, 24).WithMessage(") expected"));
         }
 
         [Fact]
@@ -168,12 +162,9 @@ class C : IEquatable<C>
 }
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
-                // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
-                // Test0.cs(6,23): error CS1003: Syntax error, ',' expected
-                DiagnosticResult.CompilerError("CS1003").WithLocation(6, 23),
-                // Test0.cs(10,1): error CS1022: Type or namespace definition, or end-of-file expected
-                DiagnosticResult.CompilerError("CS1022").WithLocation(10, 1));
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11).WithMessage("'C' does not implement interface member 'IEquatable<C>.Equals(C)'"),
+                DiagnosticResult.CompilerError("CS1003").WithLocation(6, 23).WithMessage("Syntax error, ',' expected"),
+                DiagnosticResult.CompilerError("CS1022").WithLocation(10, 1).WithMessage("Type or namespace definition, or end-of-file expected"));
         }
 
         [Fact]
@@ -191,8 +182,7 @@ class C : IEquatable<C>
 }
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
-                    // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                    DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11));
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11).WithMessage("'C' does not implement interface member 'IEquatable<C>.Equals(C)'"));
         }
 
         [Fact]
@@ -210,12 +200,9 @@ class C : IEquatable<C>
 }
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
-                // Test0.cs(4, 11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
-                // Test0.cs(6,24): error CS0246: The type or namespace name 'x' could not be found (are you missing a using directive or an assembly reference?)
-                DiagnosticResult.CompilerError("CS0246").WithLocation(6, 24),
-                // Test0.cs(6,25): error CS1001: Identifier expected
-                DiagnosticResult.CompilerError("CS1001").WithLocation(6, 25));
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11).WithMessage("'C' does not implement interface member 'IEquatable<C>.Equals(C)'"),
+                DiagnosticResult.CompilerError("CS0246").WithLocation(6, 24).WithMessage("The type or namespace name 'x' could not be found (are you missing a using directive or an assembly reference?)"),
+                DiagnosticResult.CompilerError("CS1001").WithLocation(6, 25).WithMessage("Identifier expected"));
         }
 
         [Fact]
@@ -233,8 +220,7 @@ class C : IEquatable<C>
 }
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
-                // Test0.cs(4,11): error CS0738: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'. 'C.Equals(C)' cannot implement 'IEquatable<C>.Equals(C)' because it does not have the matching return type of 'bool'.
-                DiagnosticResult.CompilerError("CS0738").WithLocation(4, 11));
+                DiagnosticResult.CompilerError("CS0738").WithLocation(4, 11).WithMessage("'C' does not implement interface member 'IEquatable<C>.Equals(C)'. 'C.Equals(C)' cannot implement 'IEquatable<C>.Equals(C)' because it does not have the matching return type of 'bool'."));
         }
 
         [Fact]
@@ -252,10 +238,8 @@ class C : IEquatable<C>
             await VerifyCS.VerifyAnalyzerAsync(code,
                 // Test0.cs(4,7): warning CA1067: Type C should override Equals because it implements IEquatable<T>
                 GetCSharpResultAt(4, 7, EquatableAnalyzer.OverridesObjectEqualsDescriptor, expectedMessage),
-                // Test0.cs(6,17): error CS0501: 'C.Equals(C)' must declare a body because it is not marked abstract, extern, or partial
-                DiagnosticResult.CompilerError("CS0501").WithLocation(6, 17),
-                // Test0.cs(6,32): error CS1002: ; expected
-                DiagnosticResult.CompilerError("CS1002").WithLocation(6, 32));
+                DiagnosticResult.CompilerError("CS0501").WithLocation(6, 17).WithMessage("'C.Equals(C)' must declare a body because it is not marked abstract, extern, or partial"),
+                DiagnosticResult.CompilerError("CS1002").WithLocation(6, 32).WithMessage("; expected"));
         }
 
         [Fact]
@@ -273,12 +257,9 @@ class C : IEquatable<C>
 }
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
-                // Test0.cs(4,11): error CS0535: 'C' does not implement interface member 'IEquatable<C>.Equals(C)'
-                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11),
-                // Test0.cs(6,12): error CS1520: Method must have a return type
-                DiagnosticResult.CompilerError("CS1520").WithLocation(6, 12),
-                // Test0.cs(8,9): error CS0127: Since 'C.C(C)' returns void, a return keyword must not be followed by an object expression
-                DiagnosticResult.CompilerError("CS0127").WithLocation(8, 9));
+                DiagnosticResult.CompilerError("CS0535").WithLocation(4, 11).WithMessage("'C' does not implement interface member 'IEquatable<C>.Equals(C)'"),
+                DiagnosticResult.CompilerError("CS1520").WithLocation(6, 12).WithMessage("Method must have a return type"),
+                DiagnosticResult.CompilerError("CS0127").WithLocation(8, 9).WithMessage("Since 'C.C(C)' returns void, a return keyword must not be followed by an object expression"));
         }
 
         [Fact]
@@ -296,8 +277,7 @@ class C
 }
 ";
             await VerifyCS.VerifyAnalyzerAsync(code,
-                    // Test0.cs(6,26): error CS0115: 'C.Equals(object, int)': no suitable method found to override
-                    DiagnosticResult.CompilerError("CS0115").WithLocation(6, 26));
+                DiagnosticResult.CompilerError("CS0115").WithLocation(6, 26).WithMessage("'C.Equals(object, int)': no suitable method found to override"));
         }
 
         [Fact]
@@ -348,8 +328,7 @@ struct C : B
                 GetCSharpResultAt(4, 8, EquatableAnalyzer.ImplementIEquatableDescriptor, expectedMessage1),
                 // Test0.cs(12,8): warning CA1066: Implement IEquatable when overriding Object.Equals
                 GetCSharpResultAt(12, 8, EquatableAnalyzer.ImplementIEquatableDescriptor, expectedMessage2),
-                // Test0.cs(12,12): error CS0527: Type 'B' in interface list is not an interface
-                DiagnosticResult.CompilerError("CS0527").WithLocation(12, 12));
+                DiagnosticResult.CompilerError("CS0527").WithLocation(12, 12).WithMessage("Type 'B' in interface list is not an interface"));
         }
 
         [Fact, WorkItem(1914, "https://github.com/dotnet/roslyn-analyzers/issues/1914")]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ExceptionsShouldBePublicTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ExceptionsShouldBePublicTests.cs
@@ -103,11 +103,11 @@ Public Class NonException
 End Class");
         }
 
-        private DiagnosticResult GetCA1064CSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCA1064CSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
 
-        private DiagnosticResult GetCA1064VBasicResultAt(int line, int column)
+        private static DiagnosticResult GetCA1064VBasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ExceptionsShouldBePublicTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ExceptionsShouldBePublicTests.cs
@@ -104,13 +104,11 @@ End Class");
         }
 
         private DiagnosticResult GetCA1064CSharpResultAt(int line, int column)
-            => new DiagnosticResult(ExceptionsShouldBePublicAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.ExceptionsShouldBePublicMessage);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
         private DiagnosticResult GetCA1064VBasicResultAt(int line, int column)
-            => new DiagnosticResult(ExceptionsShouldBePublicAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.ExceptionsShouldBePublicMessage);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCaseTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCaseTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
@@ -368,9 +367,6 @@ namespace N
 
         #region Helper Methods
 
-        private const string RuleName = IdentifiersShouldDifferByMoreThanCaseAnalyzer.RuleId;
-        private static readonly string s_message = MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldDifferByMoreThanCaseMessage;
-
         private const string Namespace = IdentifiersShouldDifferByMoreThanCaseAnalyzer.Namespace;
         private const string Type = IdentifiersShouldDifferByMoreThanCaseAnalyzer.Type;
         private const string Member = IdentifiersShouldDifferByMoreThanCaseAnalyzer.Member;
@@ -387,22 +383,21 @@ namespace N
         }
 
         private static DiagnosticResult GetCA1708CSharpResult(string typeName, string objectName)
-            => VerifyCS.Diagnostic(RuleName)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName));
+            => VerifyCS.Diagnostic()
+                .WithArguments(typeName, objectName);
 
         private static DiagnosticResult GetGlobalCA1708CSharpResult(string typeName, string objectName)
-            => VerifyCS.Diagnostic(RuleName)
-                .WithNoLocation()
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName));
+            => VerifyCS.Diagnostic()
+                .WithArguments(typeName, objectName);
 
         private static DiagnosticResult GetCA1708CSharpResultAt(string typeName, string objectName, int line, int column)
-            => VerifyCS.Diagnostic(RuleName)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName));
+                .WithArguments(typeName, objectName);
 
         private static DiagnosticResult GetCA1708CSharpResultAt(string typeName, string objectName, params string[] locations)
-            => VerifyCS.Diagnostic(RuleName)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, s_message, typeName, objectName));
+            => VerifyCS.Diagnostic()
+                .WithArguments(typeName, objectName);
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -14,22 +14,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class IdentifiersShouldHaveCorrectPrefixTests : DiagnosticAnalyzerTestBase
+    public class IdentifiersShouldHaveCorrectPrefixTests
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldHaveCorrectPrefixAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldHaveCorrectPrefixAnalyzer();
-        }
-
         [Fact]
-        public void TestInterfaceNamesCSharp()
+        public async Task TestInterfaceNamesCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public interface Controller
 {
     void SomeMethod();
@@ -73,19 +63,19 @@ public interface IAmAnInterface
     void SomeMethod();
 }
 ",
-                GetCA1715CSharpResultAt(2, 18, CA1715InterfaceMessage, "Controller"),
-                GetCA1715CSharpResultAt(7, 18, CA1715InterfaceMessage, "\u65E5\u672C\u8A9E"),
-                GetCA1715CSharpResultAt(12, 18, CA1715InterfaceMessage, "_Controller"),
-                GetCA1715CSharpResultAt(17, 18, CA1715InterfaceMessage, "_\u65E5\u672C\u8A9E"),
-                GetCA1715CSharpResultAt(22, 18, CA1715InterfaceMessage, "Internet"),
-                GetCA1715CSharpResultAt(27, 18, CA1715InterfaceMessage, "Iinternet"),
-                GetCA1715CSharpResultAt(34, 22, CA1715InterfaceMessage, "Controller"));
+                GetCA1715CSharpResultAt(2, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "Controller"),
+                GetCA1715CSharpResultAt(7, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "\u65E5\u672C\u8A9E"),
+                GetCA1715CSharpResultAt(12, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "_Controller"),
+                GetCA1715CSharpResultAt(17, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "_\u65E5\u672C\u8A9E"),
+                GetCA1715CSharpResultAt(22, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "Internet"),
+                GetCA1715CSharpResultAt(27, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "Iinternet"),
+                GetCA1715CSharpResultAt(34, 22, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "Controller"));
         }
 
         [Fact]
-        public void TestTypeParameterNamesCSharp()
+        public async Task TestTypeParameterNamesCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class IInterface<VSome>
@@ -152,31 +142,31 @@ public class Class6<TTypeParameter>
 {
 }
 ",
-                GetCA1715CSharpResultAt(4, 25, CA1715TypeParameterMessage, "VSome"),
-                GetCA1715CSharpResultAt(8, 32, CA1715TypeParameterMessage, "\u672C\u8A9E"),
-                GetCA1715CSharpResultAt(12, 31, CA1715TypeParameterMessage, "VSome"),
-                GetCA1715CSharpResultAt(14, 21, CA1715TypeParameterMessage, "VSome"),
-                GetCA1715CSharpResultAt(18, 24, CA1715TypeParameterMessage, "VSome"),
-                GetCA1715CSharpResultAt(22, 21, CA1715TypeParameterMessage, "Type"),
-                GetCA1715CSharpResultAt(26, 24, CA1715TypeParameterMessage, "Type"),
-                GetCA1715CSharpResultAt(30, 19, CA1715TypeParameterMessage, "Key"),
-                GetCA1715CSharpResultAt(30, 24, CA1715TypeParameterMessage, "Value"),
-                GetCA1715CSharpResultAt(34, 22, CA1715TypeParameterMessage, "Key"),
-                GetCA1715CSharpResultAt(34, 27, CA1715TypeParameterMessage, "Value"),
-                GetCA1715CSharpResultAt(38, 21, CA1715TypeParameterMessage, "Type1"),
-                GetCA1715CSharpResultAt(40, 31, CA1715TypeParameterMessage, "Type2"),
-                GetCA1715CSharpResultAt(45, 24, CA1715TypeParameterMessage, "Type2"),
-                GetCA1715CSharpResultAt(50, 24, CA1715TypeParameterMessage, "KType"),
-                GetCA1715CSharpResultAt(50, 31, CA1715TypeParameterMessage, "VType"),
-                GetCA1715CSharpResultAt(56, 21, CA1715TypeParameterMessage, "_Type1"),
-                GetCA1715CSharpResultAt(58, 24, CA1715TypeParameterMessage, "_K"),
-                GetCA1715CSharpResultAt(58, 28, CA1715TypeParameterMessage, "_V"));
+                GetCA1715CSharpResultAt(4, 25, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VSome"),
+                GetCA1715CSharpResultAt(8, 32, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "\u672C\u8A9E"),
+                GetCA1715CSharpResultAt(12, 31,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VSome"),
+                GetCA1715CSharpResultAt(14, 21,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VSome"),
+                GetCA1715CSharpResultAt(18, 24,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VSome"),
+                GetCA1715CSharpResultAt(22, 21,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type"),
+                GetCA1715CSharpResultAt(26, 24,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type"),
+                GetCA1715CSharpResultAt(30, 19,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Key"),
+                GetCA1715CSharpResultAt(30, 24,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Value"),
+                GetCA1715CSharpResultAt(34, 22,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Key"),
+                GetCA1715CSharpResultAt(34, 27,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Value"),
+                GetCA1715CSharpResultAt(38, 21,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type1"),
+                GetCA1715CSharpResultAt(40, 31,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type2"),
+                GetCA1715CSharpResultAt(45, 24,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type2"),
+                GetCA1715CSharpResultAt(50, 24,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "KType"),
+                GetCA1715CSharpResultAt(50, 31,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VType"),
+                GetCA1715CSharpResultAt(56, 21,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "_Type1"),
+                GetCA1715CSharpResultAt(58, 24,IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "_K"),
+                GetCA1715CSharpResultAt(58, 28, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "_V"));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestInternalInterfaceNamesCSharp_NoDiagnostic()
+        public async Task TestInternalInterfaceNamesCSharp_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal interface Controller
 {
     void SomeMethod();
@@ -201,9 +191,9 @@ public class C2
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestTypeParameterNamesInternalCSharp_NoDiagnostic()
+        public async Task TestTypeParameterNamesInternalCSharp_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 internal class IInterface<VSome>
@@ -226,9 +216,9 @@ public class C2
 
         [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
         [Fact]
-        public void TestTypeParameterNamesCSharp_SingleLetterCases_Default()
+        public async Task TestTypeParameterNamesCSharp_SingleLetterCases_Default()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class IInterface<V>
@@ -253,11 +243,11 @@ public class Class6<TTypeParameter>
 {
 }
 ",
-            GetCA1715CSharpResultAt(4, 25, CA1715TypeParameterMessage, "V"),
-            GetCA1715CSharpResultAt(8, 31, CA1715TypeParameterMessage, "V"),
-            GetCA1715CSharpResultAt(10, 24, CA1715TypeParameterMessage, "V"),
-            GetCA1715CSharpResultAt(16, 24, CA1715TypeParameterMessage, "K"),
-            GetCA1715CSharpResultAt(16, 27, CA1715TypeParameterMessage, "V"));
+            GetCA1715CSharpResultAt(4, 25, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+            GetCA1715CSharpResultAt(8, 31, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+            GetCA1715CSharpResultAt(10, 24, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+            GetCA1715CSharpResultAt(16, 24, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "K"),
+            GetCA1715CSharpResultAt(16, 27, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"));
         }
 
         [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
@@ -267,9 +257,15 @@ public class Class6<TTypeParameter>
         [InlineData(@"dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = false")]
         [InlineData(@"dotnet_code_quality.exclude_single_letter_type_parameters = true
                       dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = false")]
-        public void TestTypeParameterNamesCSharp_SingleLetterCases_EditorConfig_Diagnostic(string editorConfigText)
+        public async Task TestTypeParameterNamesCSharp_SingleLetterCases_EditorConfig_Diagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 
 public class IInterface<V>
@@ -293,13 +289,19 @@ public class Class4<T>
 public class Class6<TTypeParameter>
 {
 }
-",
-            GetEditorConfigAdditionalFile(editorConfigText),
-            GetCA1715CSharpResultAt(4, 25, CA1715TypeParameterMessage, "V"),
-            GetCA1715CSharpResultAt(8, 31, CA1715TypeParameterMessage, "V"),
-            GetCA1715CSharpResultAt(10, 24, CA1715TypeParameterMessage, "V"),
-            GetCA1715CSharpResultAt(16, 24, CA1715TypeParameterMessage, "K"),
-            GetCA1715CSharpResultAt(16, 27, CA1715TypeParameterMessage, "V"));
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) },
+                    ExpectedDiagnostics =
+                    {
+                        GetCA1715CSharpResultAt(4, 25, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+                        GetCA1715CSharpResultAt(8, 31, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+                        GetCA1715CSharpResultAt(10, 24, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+                        GetCA1715CSharpResultAt(16, 24, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "K"),
+                        GetCA1715CSharpResultAt(16, 27, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+                    }
+                }
+            }.RunAsync();
         }
 
         [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
@@ -308,9 +310,15 @@ public class Class6<TTypeParameter>
         [InlineData(@"dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = true")]
         [InlineData(@"dotnet_code_quality.exclude_single_letter_type_parameters = false
                       dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = true")]
-        public void TestTypeParameterNamesCSharp_SingleLetterCases_EditorConfig_NoDiagnostic(string editorConfigText)
+        public async Task TestTypeParameterNamesCSharp_SingleLetterCases_EditorConfig_NoDiagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 
 public class IInterface<V>
@@ -334,13 +342,17 @@ public class Class4<T>
 public class Class6<TTypeParameter>
 {
 }
-", GetEditorConfigAdditionalFile(editorConfigText));
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestInterfaceNamesBasic()
+        public async Task TestInterfaceNamesBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface Controller
     Sub SomeMethod()
 End Interface
@@ -375,19 +387,19 @@ Public Interface IAmAnInterface
     Sub SomeMethod()
 End Interface
 ",
-                GetCA1715BasicResultAt(2, 18, CA1715InterfaceMessage, "Controller"),
-                GetCA1715BasicResultAt(6, 18, CA1715InterfaceMessage, "\u65E5\u672C\u8A9E"),
-                GetCA1715BasicResultAt(10, 18, CA1715InterfaceMessage, "_Controller"),
-                GetCA1715BasicResultAt(14, 18, CA1715InterfaceMessage, "_\u65E5\u672C\u8A9E"),
-                GetCA1715BasicResultAt(18, 18, CA1715InterfaceMessage, "Internet"),
-                GetCA1715BasicResultAt(22, 18, CA1715InterfaceMessage, "Iinternet"),
-                GetCA1715BasicResultAt(27, 22, CA1715InterfaceMessage, "Controller"));
+                GetCA1715BasicResultAt(2, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "Controller"),
+                GetCA1715BasicResultAt(6, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "\u65E5\u672C\u8A9E"),
+                GetCA1715BasicResultAt(10, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "_Controller"),
+                GetCA1715BasicResultAt(14, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "_\u65E5\u672C\u8A9E"),
+                GetCA1715BasicResultAt(18, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "Internet"),
+                GetCA1715BasicResultAt(22, 18, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "Iinternet"),
+                GetCA1715BasicResultAt(27, 22, IdentifiersShouldHaveCorrectPrefixAnalyzer.InterfaceRule, "Controller"));
         }
 
         [Fact]
-        public void TestTypeParameterNamesBasic()
+        public async Task TestTypeParameterNamesBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class IInterface(Of VSome)
@@ -440,31 +452,31 @@ End Class
 Public Class Class6(Of TTypeParameter)
 End Class
 ",
-                GetCA1715BasicResultAt(4, 28, CA1715TypeParameterMessage, "VSome"),
-                GetCA1715BasicResultAt(7, 35, CA1715TypeParameterMessage, "\u672C\u8A9E"),
-                GetCA1715BasicResultAt(10, 33, CA1715TypeParameterMessage, "VSome"),
-                GetCA1715BasicResultAt(12, 24, CA1715TypeParameterMessage, "VSome"),
-                GetCA1715BasicResultAt(15, 27, CA1715TypeParameterMessage, "VSome"),
-                GetCA1715BasicResultAt(18, 24, CA1715TypeParameterMessage, "Type"),
-                GetCA1715BasicResultAt(21, 27, CA1715TypeParameterMessage, "Type"),
-                GetCA1715BasicResultAt(24, 22, CA1715TypeParameterMessage, "Key"),
-                GetCA1715BasicResultAt(24, 27, CA1715TypeParameterMessage, "Value"),
-                GetCA1715BasicResultAt(27, 25, CA1715TypeParameterMessage, "Key"),
-                GetCA1715BasicResultAt(27, 30, CA1715TypeParameterMessage, "Value"),
-                GetCA1715BasicResultAt(31, 24, CA1715TypeParameterMessage, "Type1"),
-                GetCA1715BasicResultAt(32, 33, CA1715TypeParameterMessage, "Type2"),
-                GetCA1715BasicResultAt(36, 26, CA1715TypeParameterMessage, "Type2"),
-                GetCA1715BasicResultAt(40, 26, CA1715TypeParameterMessage, "KType"),
-                GetCA1715BasicResultAt(40, 33, CA1715TypeParameterMessage, "VType"),
-                GetCA1715BasicResultAt(45, 24, CA1715TypeParameterMessage, "_Type1"),
-                GetCA1715BasicResultAt(46, 26, CA1715TypeParameterMessage, "_K"),
-                GetCA1715BasicResultAt(46, 30, CA1715TypeParameterMessage, "_V"));
+                GetCA1715BasicResultAt(4, 28, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VSome"),
+                GetCA1715BasicResultAt(7, 35, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "\u672C\u8A9E"),
+                GetCA1715BasicResultAt(10, 33, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VSome"),
+                GetCA1715BasicResultAt(12, 24, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VSome"),
+                GetCA1715BasicResultAt(15, 27, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VSome"),
+                GetCA1715BasicResultAt(18, 24, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type"),
+                GetCA1715BasicResultAt(21, 27, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type"),
+                GetCA1715BasicResultAt(24, 22, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Key"),
+                GetCA1715BasicResultAt(24, 27, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Value"),
+                GetCA1715BasicResultAt(27, 25, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Key"),
+                GetCA1715BasicResultAt(27, 30, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Value"),
+                GetCA1715BasicResultAt(31, 24, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type1"),
+                GetCA1715BasicResultAt(32, 33, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type2"),
+                GetCA1715BasicResultAt(36, 26, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "Type2"),
+                GetCA1715BasicResultAt(40, 26, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "KType"),
+                GetCA1715BasicResultAt(40, 33, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "VType"),
+                GetCA1715BasicResultAt(45, 24, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "_Type1"),
+                GetCA1715BasicResultAt(46, 26, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "_K"),
+                GetCA1715BasicResultAt(46, 30, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "_V"));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestInterfaceNamesInternalBasic_NoDiagnostic()
+        public async Task TestInterfaceNamesInternalBasic_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Friend Interface Controller
     Sub SomeMethod()
 End Interface
@@ -484,9 +496,9 @@ End Class
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void TestTypeParameterNamesInternalBasic_NoDiagnostic()
+        public async Task TestTypeParameterNamesInternalBasic_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Friend Class IInterface(Of VSome)
@@ -505,9 +517,9 @@ End Class
 
         [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
         [Fact]
-        public void TestTypeParameterNamesBasic_SingleLetterCases_Default()
+        public async Task TestTypeParameterNamesBasic_SingleLetterCases_Default()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class IInterface(Of V)
@@ -527,11 +539,11 @@ End Class
 Public Class Class6(Of TTypeParameter)
 End Class
 ",
-            GetCA1715BasicResultAt(4, 28, CA1715TypeParameterMessage, "V"),
-            GetCA1715BasicResultAt(7, 33, CA1715TypeParameterMessage, "V"),
-            GetCA1715BasicResultAt(9, 27, CA1715TypeParameterMessage, "V"),
-            GetCA1715BasicResultAt(13, 26, CA1715TypeParameterMessage, "K"),
-            GetCA1715BasicResultAt(13, 29, CA1715TypeParameterMessage, "V"));
+            GetCA1715BasicResultAt(4, 28, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+            GetCA1715BasicResultAt(7, 33, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+            GetCA1715BasicResultAt(9, 27, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+            GetCA1715BasicResultAt(13, 26, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "K"),
+            GetCA1715BasicResultAt(13, 29, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"));
         }
 
         [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
@@ -541,9 +553,15 @@ End Class
         [InlineData(@"dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = false")]
         [InlineData(@"dotnet_code_quality.exclude_single_letter_type_parameters = true
                       dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = false")]
-        public void TestTypeParameterNamesBasic_SingleLetterCases_EditorConfig_Diagnostic(string editorConfigText)
+        public async Task TestTypeParameterNamesBasic_SingleLetterCases_EditorConfig_Diagnostic(string editorConfigText)
         {
-            VerifyBasic(@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Imports System
 
 Public Class IInterface(Of V)
@@ -562,13 +580,19 @@ End Class
 
 Public Class Class6(Of TTypeParameter)
 End Class
-",
-            GetEditorConfigAdditionalFile(editorConfigText),
-            GetCA1715BasicResultAt(4, 28, CA1715TypeParameterMessage, "V"),
-            GetCA1715BasicResultAt(7, 33, CA1715TypeParameterMessage, "V"),
-            GetCA1715BasicResultAt(9, 27, CA1715TypeParameterMessage, "V"),
-            GetCA1715BasicResultAt(13, 26, CA1715TypeParameterMessage, "K"),
-            GetCA1715BasicResultAt(13, 29, CA1715TypeParameterMessage, "V"));
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) },
+                    ExpectedDiagnostics =
+                    {
+                        GetCA1715BasicResultAt(4, 28, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+                        GetCA1715BasicResultAt(7, 33, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+                        GetCA1715BasicResultAt(9, 27, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+                        GetCA1715BasicResultAt(13, 26, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "K"),
+                        GetCA1715BasicResultAt(13, 29, IdentifiersShouldHaveCorrectPrefixAnalyzer.TypeParameterRule, "V"),
+                    }
+                }
+            }.RunAsync();
         }
 
         [WorkItem(1604, "https://github.com/dotnet/roslyn-analyzers/issues/1604")]
@@ -577,9 +601,15 @@ End Class
         [InlineData(@"dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = true")]
         [InlineData(@"dotnet_code_quality.exclude_single_letter_type_parameters = false
                       dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = true")]
-        public void TestTypeParameterNamesBasic_SingleLetterCases_EditorConfig_NoDiagnostic(string editorConfigText)
+        public async Task TestTypeParameterNamesBasic_SingleLetterCases_EditorConfig_NoDiagnostic(string editorConfigText)
         {
-            VerifyBasic(@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Imports System
 
 Public Class IInterface(Of V)
@@ -598,20 +628,21 @@ End Class
 
 Public Class Class6(Of TTypeParameter)
 End Class
-", GetEditorConfigAdditionalFile(editorConfigText));
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
-        internal static readonly string CA1715InterfaceMessage = MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectPrefixMessageInterface;
-        internal static readonly string CA1715TypeParameterMessage = MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectPrefixMessageTypeParameter;
+        private DiagnosticResult GetCA1715CSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+           => VerifyCS.Diagnostic(rule)
+               .WithLocation(line, column)
+               .WithArguments(arguments);
 
-        private static DiagnosticResult GetCA1715CSharpResultAt(int line, int column, string message, string name)
-        {
-            return GetCSharpResultAt(line, column, IdentifiersShouldHaveCorrectPrefixAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, message, name));
-        }
-
-        private static DiagnosticResult GetCA1715BasicResultAt(int line, int column, string message, string name)
-        {
-            return GetBasicResultAt(line, column, IdentifiersShouldHaveCorrectPrefixAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, message, name));
-        }
+        private DiagnosticResult GetCA1715BasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+           => VerifyVB.Diagnostic(rule)
+               .WithLocation(line, column)
+               .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
@@ -635,12 +635,12 @@ End Class
             }.RunAsync();
         }
 
-        private DiagnosticResult GetCA1715CSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCA1715CSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);
 
-        private DiagnosticResult GetCA1715BasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCA1715BasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyVB.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffixTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -1100,29 +1099,17 @@ public class C
         }
 
         private static DiagnosticResult GetCA1710BasicResultAt(int line, int column, string symbolName, string replacementName, bool isSpecial = false)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture,
-                isSpecial ?
-                    MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection :
-                    MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageDefault,
-                symbolName,
-                replacementName);
-            return new DiagnosticResult(IdentifiersShouldHaveCorrectSuffixAnalyzer.DefaultRule)
+            => VerifyCS.Diagnostic(isSpecial
+                    ? IdentifiersShouldHaveCorrectSuffixAnalyzer.SpecialCollectionRule
+                : IdentifiersShouldHaveCorrectSuffixAnalyzer.DefaultRule)
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(symbolName, replacementName);
 
         private static DiagnosticResult GetCA1710CSharpResultAt(int line, int column, string symbolName, string replacementName, bool isSpecial = false)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture,
-               isSpecial ?
-                   MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection :
-                   MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldHaveCorrectSuffixMessageDefault,
-               symbolName,
-               replacementName);
-            return new DiagnosticResult(IdentifiersShouldHaveCorrectSuffixAnalyzer.DefaultRule)
+            => VerifyVB.Diagnostic(isSpecial
+                    ? IdentifiersShouldHaveCorrectSuffixAnalyzer.SpecialCollectionRule
+                : IdentifiersShouldHaveCorrectSuffixAnalyzer.DefaultRule)
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(symbolName, replacementName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
@@ -2,8 +2,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -16,46 +15,53 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class IdentifiersShouldNotContainUnderscoresTests : DiagnosticAnalyzerTestBase
+    public class IdentifiersShouldNotContainUnderscoresTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotContainUnderscoresAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new IdentifiersShouldNotContainUnderscoresAnalyzer();
-        }
-
         #region CSharp Tests
         [Fact]
-        public void CA1707_ForAssembly_CSharp()
+        public async Task CA1707_ForAssembly_CSharp()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 public class DoesNotMatter
 {
 }
 ",
-            testProjectName: "AssemblyNameHasUnderScore_",
-            expected: GetCA1707CSharpResultAt(line: 2, column: 1, symbolKind: SymbolKind.Assembly, identifierNames: "AssemblyNameHasUnderScore_"));
+                SolutionTransforms =
+                {
+                    (solution, projectId) =>
+                        solution.WithProjectAssemblyName(projectId, "AssemblyNameHasUnderScore_")
+                },
+                ExpectedDiagnostics =
+                {
+                    GetCA1707CSharpResultAt(line: 2, column: 1, symbolKind: SymbolKind.Assembly, identifierNames: "AssemblyNameHasUnderScore_")
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1707_ForAssembly_NoDiagnostics_CSharp()
+        public async Task CA1707_ForAssembly_NoDiagnostics_CSharp()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 public class DoesNotMatter
 {
 }
 ",
-            testProjectName: "AssemblyNameHasNoUnderScore");
+                SolutionTransforms =
+                {
+                    (solution, projectId) =>
+                        solution.WithProjectAssemblyName(projectId, "AssemblyNameHasNoUnderScore")
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1707_ForNamespace_CSharp()
+        public async Task CA1707_ForNamespace_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 namespace OuterNamespace
 {
     namespace HasUnderScore_
@@ -76,9 +82,9 @@ namespace HasNoUnderScore
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1707_ForTypes_CSharp()
+        public async Task CA1707_ForTypes_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class OuterType
 {
     public class UnderScoreInName_
@@ -105,9 +111,9 @@ internal class OuterType2
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1707_ForFields_CSharp()
+        public async Task CA1707_ForFields_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class DoesNotMatter
 {
         public const int ConstField_ = 5;
@@ -141,9 +147,9 @@ public class C
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1707_ForMethods_CSharp()
+        public async Task CA1707_ForMethods_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class DoesNotMatter
 {
     public void PublicM1_() { }
@@ -183,9 +189,9 @@ internal class C
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1707_ForProperties_CSharp()
+        public async Task CA1707_ForProperties_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class DoesNotMatter
 {
     public int PublicP1_ { get; set; }
@@ -225,9 +231,9 @@ internal class C
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA1707_ForEvents_CSharp()
+        public async Task CA1707_ForEvents_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class DoesNotMatter
@@ -269,9 +275,9 @@ internal class C
         }
 
         [Fact]
-        public void CA1707_ForDelegates_CSharp()
+        public async Task CA1707_ForDelegates_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public delegate void Dele(int intPublic_, string stringPublic_);
 internal delegate void Dele2(int intInternal_, string stringInternal_); // No diagnostics
 public delegate T Del<T>(int t_);
@@ -282,9 +288,9 @@ public delegate T Del<T>(int t_);
         }
 
         [Fact]
-        public void CA1707_ForMemberparameters_CSharp()
+        public async Task CA1707_ForMemberparameters_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class DoesNotMatter
 {
     public void PublicM1(int int_) { }
@@ -334,9 +340,9 @@ public class Der : Base
         }
 
         [Fact]
-        public void CA1707_ForTypeTypeParameters_CSharp()
+        public async Task CA1707_ForTypeTypeParameters_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class DoesNotMatter<T_>
 {
 }
@@ -348,9 +354,9 @@ class NoDiag<U_>
         }
 
         [Fact]
-        public void CA1707_ForMemberTypeParameters_CSharp()
+        public async Task CA1707_ForMemberTypeParameters_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class DoesNotMatter22
 {
     public void PublicM1<T1_>() { }
@@ -401,9 +407,9 @@ public class Der : Base
         }
 
         [Fact, WorkItem(947, "https://github.com/dotnet/roslyn-analyzers/issues/947")]
-        public void CA1707_ForOperators_CSharp()
+        public async Task CA1707_ForOperators_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
     public static bool operator ==(S left, S right)
@@ -420,9 +426,9 @@ public struct S
         }
 
         [Fact, WorkItem(1319, "https://github.com/dotnet/roslyn-analyzers/issues/1319")]
-        public void CA1707_CustomOperator_CSharp()
+        public async Task CA1707_CustomOperator_CSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Span
 {
     public static implicit operator Span(string text) => new Span(text);
@@ -443,30 +449,47 @@ public class Span
 
         #region Visual Basic Tests
         [Fact]
-        public void CA1707_ForAssembly_VisualBasic()
+        public async Task CA1707_ForAssembly_VisualBasic()
         {
-            VerifyBasic(@"
+            await new VerifyVB.Test
+            {
+                TestCode = @"
 Public Class DoesNotMatter
 End Class
 ",
-            testProjectName: "AssemblyNameHasUnderScore_",
-            expected: GetCA1707BasicResultAt(line: 2, column: 1, symbolKind: SymbolKind.Assembly, identifierNames: "AssemblyNameHasUnderScore_"));
+                SolutionTransforms =
+                {
+                    (solution, projectId) =>
+                        solution.WithProjectAssemblyName(projectId, "AssemblyNameHasUnderScore_")
+                },
+                ExpectedDiagnostics =
+                {
+                    GetCA1707BasicResultAt(line: 2, column: 1, symbolKind: SymbolKind.Assembly, identifierNames: "AssemblyNameHasUnderScore_")
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1707_ForAssembly_NoDiagnostics_VisualBasic()
+        public async Task CA1707_ForAssembly_NoDiagnostics_VisualBasic()
         {
-            VerifyBasic(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 Public Class DoesNotMatter
 End Class
 ",
-            testProjectName: "AssemblyNameHasNoUnderScore");
+                SolutionTransforms =
+                {
+                    (solution, projectId) =>
+                        solution.WithProjectAssemblyName(projectId, "AssemblyNameHasNoUnderScore")
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA1707_ForNamespace_VisualBasic()
+        public async Task CA1707_ForNamespace_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Namespace OuterNamespace
     Namespace HasUnderScore_
         Public Class DoesNotMatter
@@ -482,9 +505,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA1707_ForTypes_VisualBasic()
+        public async Task CA1707_ForTypes_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class OuterType
     Public Class UnderScoreInName_
     End Class
@@ -496,9 +519,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1707_ForFields_VisualBasic()
+        public async Task CA1707_ForFields_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class DoesNotMatter
     Public Const ConstField_ As Integer = 5
     Public Shared ReadOnly SharedReadOnlyField_ As Integer = 5
@@ -519,9 +542,9 @@ End Enum",
         }
 
         [Fact]
-        public void CA1707_ForMethods_VisualBasic()
+        public async Task CA1707_ForMethods_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class DoesNotMatter
     Public Sub PublicM1_()
     End Sub
@@ -561,9 +584,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1707_ForProperties_VisualBasic()
+        public async Task CA1707_ForProperties_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class DoesNotMatter
     Public Property PublicP1_() As Integer
         Get
@@ -638,9 +661,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1707_ForEvents_VisualBasic()
+        public async Task CA1707_ForEvents_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class DoesNotMatter
     Public Event PublicE1_ As System.EventHandler
     Private Event PrivateE2_ As System.EventHandler
@@ -674,9 +697,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1707_ForDelegates_VisualBasic()
+        public async Task CA1707_ForDelegates_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Delegate Sub Dele(intPublic_ As Integer, stringPublic_ As String)
 ' No diagnostics
 Friend Delegate Sub Dele2(intInternal_ As Integer, stringInternal_ As String)
@@ -688,9 +711,9 @@ Public Delegate Function Del(Of T)(t_ As Integer) As T
         }
 
         [Fact]
-        public void CA1707_ForMemberparameters_VisualBasic()
+        public async Task CA1707_ForMemberparameters_VisualBasic()
         {
-            VerifyBasic(@"Public Class DoesNotMatter
+            await VerifyVB.VerifyAnalyzerAsync(@"Public Class DoesNotMatter
     Public Sub PublicM1(int_ As Integer)
     End Sub
     Private Sub PrivateM2(int_ As Integer)
@@ -738,9 +761,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1707_ForTypeTypeParameters_VisualBasic()
+        public async Task CA1707_ForTypeTypeParameters_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class DoesNotMatter(Of T_)
 End Class
 
@@ -750,9 +773,9 @@ End Class",
         }
 
         [Fact]
-        public void CA1707_ForMemberTypeParameters_VisualBasic()
+        public async Task CA1707_ForMemberTypeParameters_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class DoesNotMatter22
     Public Sub PublicM1(Of T1_)()
     End Sub
@@ -800,9 +823,9 @@ End Class",
         }
 
         [Fact, WorkItem(947, "https://github.com/dotnet/roslyn-analyzers/issues/947")]
-        public void CA1707_ForOperators_VisualBasic()
+        public async Task CA1707_ForOperators_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure S
 	Public Shared Operator =(left As S, right As S) As Boolean
 		Return left.Equals(right)
@@ -816,9 +839,9 @@ End Structure
         }
 
         [Fact, WorkItem(1319, "https://github.com/dotnet/roslyn-analyzers/issues/1319")]
-        public void CA1707_CustomOperator_VisualBasic()
+        public async Task CA1707_CustomOperator_VisualBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Span
     Public Shared Narrowing Operator CType(ByVal text As String) As Span
         Return New Span(text)
@@ -850,14 +873,9 @@ End Class
         }
 
         private static DiagnosticResult GetCA1707CSharpResultAt(int line, int column, string message, params string[] identifierName)
-        {
-            return GetCSharpResultAt(line, column, IdentifiersShouldNotContainUnderscoresAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, message, identifierName));
-        }
-
-        private void VerifyCSharp(string source, string testProjectName, params DiagnosticResult[] expected)
-        {
-            Verify(source, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), testProjectName, expected);
-        }
+            => VerifyCS.Diagnostic(IdentifiersShouldNotContainUnderscoresAnalyzer.RuleId)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, message, identifierName));
 
         private static DiagnosticResult GetCA1707BasicResultAt(int line, int column, SymbolKind symbolKind, params string[] identifierNames)
         {
@@ -865,21 +883,9 @@ End Class
         }
 
         private static DiagnosticResult GetCA1707BasicResultAt(int line, int column, string message, params string[] identifierName)
-        {
-            return GetBasicResultAt(line, column, IdentifiersShouldNotContainUnderscoresAnalyzer.RuleId, string.Format(CultureInfo.CurrentCulture, message, identifierName));
-        }
-
-        private void VerifyBasic(string source, string testProjectName, params DiagnosticResult[] expected)
-        {
-            Verify(source, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), testProjectName, expected);
-        }
-
-        private void Verify(string source, string language, DiagnosticAnalyzer analyzer, string testProjectName, DiagnosticResult[] expected)
-        {
-            var sources = new[] { source };
-            var diagnostics = GetSortedDiagnostics(sources.ToFileAndSource(), language, analyzer, compilationOptions: null, parseOptions: null, referenceFlags: ReferenceFlags.None, projectName: testProjectName);
-            diagnostics.Verify(analyzer, GetDefaultPath(language), expected);
-        }
+            => VerifyVB.Diagnostic(IdentifiersShouldNotContainUnderscoresAnalyzer.RuleId)
+                .WithLocation(line, column)
+                .WithMessage(string.Format(CultureInfo.CurrentCulture, message, identifierName));
 
         private static string GetApproriateMessage(SymbolKind symbolKind)
         {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
@@ -2016,12 +2016,12 @@ End Class",
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
@@ -416,12 +416,12 @@ End Class",
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
@@ -636,12 +636,12 @@ End Class",
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
@@ -169,12 +169,12 @@ End Namespace
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
@@ -155,13 +155,13 @@ End Class
                 GetBasicResultAt(3, 21, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "C.Protected", "Protected"));
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2) =>
-            new DiagnosticResult(rule)
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2)
+            => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arg1, arg2);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2) =>
-            new DiagnosticResult(rule)
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2)
+            => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arg1, arg2);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
@@ -155,12 +155,12 @@ End Class
                 GetBasicResultAt(3, 21, IdentifiersShouldNotMatchKeywordsAnalyzer.TypeRule, "C.Protected", "Protected"));
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2)
             => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arg1, arg2);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2)
             => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arg1, arg2);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -14,24 +13,14 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class ImplementIDisposableCorrectlyTests : DiagnosticAnalyzerTestBase
+    public class ImplementIDisposableCorrectlyTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new ImplementIDisposableCorrectlyAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new ImplementIDisposableCorrectlyAnalyzer();
-        }
-
         #region CSharp Unit Tests
 
         [Fact]
-        public void CSharp_CA1063_DisposeSignature_NoDiagnostic_GoodDisposablePattern()
+        public async Task CSharp_CA1063_DisposeSignature_NoDiagnostic_GoodDisposablePattern()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -55,9 +44,9 @@ public class C : IDisposable
         }
 
         [Fact, WorkItem(1435, "https://github.com/dotnet/roslyn-analyzers/issues/1435")]
-        public void CSharp_CA1063_DisposeSignature_NoDiagnostic_GoodDisposablePattern_WithAttributes()
+        public async Task CSharp_CA1063_DisposeSignature_NoDiagnostic_GoodDisposablePattern_WithAttributes()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class MyAttribute : Attribute
@@ -89,9 +78,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeSignature_NoDiagnostic_NotImplementingDisposable()
+        public async Task CSharp_CA1063_DisposeSignature_NoDiagnostic_NotImplementingDisposable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -119,9 +108,9 @@ public class C
         #region CSharp IDisposableReimplementation Unit Tests
 
         [Fact]
-        public void CSharp_CA1063_IDisposableReimplementation_Diagnostic_ReimplementingIDisposable()
+        public async Task CSharp_CA1063_IDisposableReimplementation_Diagnostic_ReimplementingIDisposable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B : IDisposable
@@ -154,9 +143,9 @@ public class B : IDisposable
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ReimplementingIDisposable_Internal()
+        public async Task CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ReimplementingIDisposable_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 internal class B : IDisposable
@@ -187,9 +176,9 @@ internal class B : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_IDisposableReimplementation_Diagnostic_ReimplementingIDisposableWithDeepInheritance()
+        public async Task CSharp_CA1063_IDisposableReimplementation_Diagnostic_ReimplementingIDisposableWithDeepInheritance()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A : IDisposable
@@ -226,9 +215,9 @@ public class B : A
         }
 
         [Fact]
-        public void CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInterfaceInheritedFromIDisposable()
+        public async Task CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInterfaceInheritedFromIDisposable()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface ITest : IDisposable
@@ -266,9 +255,9 @@ public class B : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ReImplementingIDisposableWithNoDisposeMethod()
+        public async Task CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ReImplementingIDisposableWithNoDisposeMethod()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface ITest : IDisposable
@@ -292,9 +281,9 @@ public class B : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInheritedInterfaceWithNoDisposeReimplementation()
+        public async Task CSharp_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInheritedInterfaceWithNoDisposeReimplementation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public interface ITest : IDisposable
@@ -321,9 +310,9 @@ public class B : IDisposable
         #region CSharp DisposeSignature Unit Tests
 
         [Fact]
-        public void CSharp_CA1063_DisposeSignature_Diagnostic_DisposeNotPublic()
+        public async Task CSharp_CA1063_DisposeSignature_Diagnostic_DisposeNotPublic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -349,9 +338,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeSignature_Diagnostic_DisposeIsVirtual()
+        public async Task CSharp_CA1063_DisposeSignature_Diagnostic_DisposeIsVirtual()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -376,9 +365,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeSignature_Diagnostic_DisposeIsOverriden()
+        public async Task CSharp_CA1063_DisposeSignature_Diagnostic_DisposeIsOverriden()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B
@@ -410,9 +399,9 @@ public class C : B, IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeSignature_NoDiagnostic_DisposeIsOverridenAndSealed()
+        public async Task CSharp_CA1063_DisposeSignature_NoDiagnostic_DisposeIsOverridenAndSealed()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B
@@ -447,9 +436,9 @@ public class C : B, IDisposable
         #region CSharp DisposeOverride Unit Tests
 
         [Fact]
-        public void CSharp_CA1063_DisposeOverride_Diagnostic_SimpleDisposeOverride()
+        public async Task CSharp_CA1063_DisposeOverride_Diagnostic_SimpleDisposeOverride()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B : IDisposable
@@ -481,9 +470,9 @@ public class B : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeOverride_Diagnostic_DoubleDisposeOverride()
+        public async Task CSharp_CA1063_DisposeOverride_Diagnostic_DoubleDisposeOverride()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A : IDisposable
@@ -527,9 +516,9 @@ public class B : A
         #region CSharp FinalizeOverride Unit Tests
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void CSharp_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride_OverridesDisposeBool()
+        public async Task CSharp_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride_OverridesDisposeBool()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B : IDisposable
@@ -561,9 +550,9 @@ public class B : IDisposable
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void CSharp_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride()
+        public async Task CSharp_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B : IDisposable
@@ -596,9 +585,9 @@ public class B : IDisposable
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void CSharp_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride()
+        public async Task CSharp_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A : IDisposable
@@ -638,9 +627,9 @@ public class B : A
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void CSharp_CA1063_FinalizeOverride_NoDiagnostic_SimpleFinalizeOverride_InvokesDisposeBool_BaseTypeHasNoFinalizer()
+        public async Task CSharp_CA1063_FinalizeOverride_NoDiagnostic_SimpleFinalizeOverride_InvokesDisposeBool_BaseTypeHasNoFinalizer()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B : IDisposable
@@ -672,9 +661,9 @@ public class B : IDisposable
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void CSharp_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride_InvokesDisposeBool_BaseTypeHasFinalizer()
+        public async Task CSharp_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride_InvokesDisposeBool_BaseTypeHasFinalizer()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B : IDisposable
@@ -713,9 +702,9 @@ public class B : IDisposable
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void CSharp_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride_InvokesDisposeBool()
+        public async Task CSharp_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride_InvokesDisposeBool()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class A : IDisposable
@@ -767,9 +756,9 @@ public class B : A
         }
 
         [Fact]
-        public void CSharp_CA1063_FinalizeOverride_NoDiagnostic_FinalizeNotInBaseType()
+        public async Task CSharp_CA1063_FinalizeOverride_NoDiagnostic_FinalizeNotInBaseType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B : IDisposable
@@ -789,9 +778,9 @@ public class B : IDisposable
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void CSharp_CA1063_FinalizeOverride_NoDiagnostic_FinalizeNotOverriden()
+        public async Task CSharp_CA1063_FinalizeOverride_NoDiagnostic_FinalizeNotOverriden()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class B : IDisposable
@@ -826,9 +815,9 @@ public class B : IDisposable
         #region CSharp ProvideDisposeBool Unit Tests
 
         [Fact]
-        public void CSharp_CA1063_ProvideDisposeBool_Diagnostic_MissingDisposeBool()
+        public async Task CSharp_CA1063_ProvideDisposeBool_Diagnostic_MissingDisposeBool()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -848,9 +837,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_ProvideDisposeBool_NoDiagnostic_SealedClassAndMissingDisposeBool()
+        public async Task CSharp_CA1063_ProvideDisposeBool_NoDiagnostic_SealedClassAndMissingDisposeBool()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public sealed class C : IDisposable
@@ -871,9 +860,9 @@ public sealed class C : IDisposable
         #region CSharp DisposeBoolSignature Unit Tests
 
         [Fact]
-        public void CSharp_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsPublic()
+        public async Task CSharp_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsPublic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -898,9 +887,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsProtectedInternal()
+        public async Task CSharp_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsProtectedInternal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -925,9 +914,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsNotVirtual()
+        public async Task CSharp_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsNotVirtual()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -952,9 +941,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsSealedOverriden()
+        public async Task CSharp_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsSealedOverriden()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public abstract class B
@@ -984,9 +973,9 @@ public class C : B, IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsOverriden()
+        public async Task CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsOverriden()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public abstract class B
@@ -1015,9 +1004,9 @@ public class C : B, IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsAbstract()
+        public async Task CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsAbstract()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public abstract class C : IDisposable
@@ -1039,9 +1028,9 @@ public abstract class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsPublicAndClassIsSealed()
+        public async Task CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsPublicAndClassIsSealed()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public sealed class C : IDisposable
@@ -1065,9 +1054,9 @@ public sealed class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsPrivateAndClassIsSealed()
+        public async Task CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsPrivateAndClassIsSealed()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public sealed class C : IDisposable
@@ -1091,9 +1080,9 @@ public sealed class C : IDisposable
         }
 
         [Fact, WorkItem(1815, "https://github.com/dotnet/roslyn-analyzers/issues/1815")]
-        public void CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsStatic()
+        public async Task CSharp_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsStatic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class Class1 : IDisposable
@@ -1118,9 +1107,9 @@ public class Class1 : IDisposable
         #region CSharp DisposeImplementation Unit Tests
 
         [Fact]
-        public void CSharp_CA1063_DisposeImplementation_Diagnostic_MissingCallDisposeBool()
+        public async Task CSharp_CA1063_DisposeImplementation_Diagnostic_MissingCallDisposeBool()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1144,9 +1133,9 @@ public class C : IDisposable
         }
 
         [Fact, WorkItem(1974, "https://github.com/dotnet/roslyn-analyzers/issues/1974")]
-        public void CSharp_CA1063_DisposeImplementation_Diagnostic_MissingCallSuppressFinalize_HasFinalizer()
+        public async Task CSharp_CA1063_DisposeImplementation_Diagnostic_MissingCallSuppressFinalize_HasFinalizer()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1170,9 +1159,9 @@ public class C : IDisposable
         }
 
         [Fact, WorkItem(1974, "https://github.com/dotnet/roslyn-analyzers/issues/1974")]
-        public void CSharp_CA1063_DisposeImplementation_NoDiagnostic_MissingCallSuppressFinalize_NoFinalizer()
+        public async Task CSharp_CA1063_DisposeImplementation_NoDiagnostic_MissingCallSuppressFinalize_NoFinalizer()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1190,9 +1179,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeImplementation_Diagnostic_EmptyDisposeBody()
+        public async Task CSharp_CA1063_DisposeImplementation_Diagnostic_EmptyDisposeBody()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1215,9 +1204,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeImplementation_Diagnostic_CallDisposeWithFalseArgument()
+        public async Task CSharp_CA1063_DisposeImplementation_Diagnostic_CallDisposeWithFalseArgument()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1242,9 +1231,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeImplementation_Diagnostic_ConditionalStatement()
+        public async Task CSharp_CA1063_DisposeImplementation_Diagnostic_ConditionalStatement()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1274,9 +1263,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeImplementation_NoDiagnostic_ConditionalStatement_Internal()
+        public async Task CSharp_CA1063_DisposeImplementation_NoDiagnostic_ConditionalStatement_Internal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 internal class C : IDisposable
@@ -1305,9 +1294,9 @@ internal class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeImplementation_Diagnostic_CallDisposeBoolTwice()
+        public async Task CSharp_CA1063_DisposeImplementation_Diagnostic_CallDisposeBoolTwice()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1333,9 +1322,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_DisposeImplementation_NoDiagnostic_EmptyDisposeBodyInSealedClass()
+        public async Task CSharp_CA1063_DisposeImplementation_NoDiagnostic_EmptyDisposeBodyInSealedClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public sealed class C : IDisposable
@@ -1356,9 +1345,9 @@ public sealed class C : IDisposable
         #region CSharp FinalizeImplementation Unit Tests
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]
-        public void CSharp_CA1063_FinalizeImplementation_NoDiagnostic_ExpressionBodiedImpl()
+        public async Task CSharp_CA1063_FinalizeImplementation_NoDiagnostic_ExpressionBodiedImpl()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 
@@ -1385,9 +1374,9 @@ public class SomeTestClass : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_FinalizeImplementation_Diagnostic_MissingCallDisposeBool()
+        public async Task CSharp_CA1063_FinalizeImplementation_Diagnostic_MissingCallDisposeBool()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1411,9 +1400,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_FinalizeImplementation_Diagnostic_CallDisposeWithTrueArgument()
+        public async Task CSharp_CA1063_FinalizeImplementation_Diagnostic_CallDisposeWithTrueArgument()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1438,9 +1427,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_FinalizeImplementation_Diagnostic_ConditionalStatement()
+        public async Task CSharp_CA1063_FinalizeImplementation_Diagnostic_ConditionalStatement()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1470,9 +1459,9 @@ public class C : IDisposable
         }
 
         [Fact]
-        public void CSharp_CA1063_FinalizeImplementation_Diagnostic_CallDisposeBoolTwice()
+        public async Task CSharp_CA1063_FinalizeImplementation_Diagnostic_CallDisposeBoolTwice()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C : IDisposable
@@ -1502,9 +1491,9 @@ public class C : IDisposable
         #region VB Unit Tests
 
         [Fact]
-        public void Basic_CA1063_DisposeSignature_NoDiagnostic_GoodDisposablePattern()
+        public async Task Basic_CA1063_DisposeSignature_NoDiagnostic_GoodDisposablePattern()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -1528,9 +1517,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeSignature_NoDiagnostic_NotImplementingDisposable()
+        public async Task Basic_CA1063_DisposeSignature_NoDiagnostic_NotImplementingDisposable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -1557,9 +1546,9 @@ End Class
         #region VB IDisposableReimplementation Unit Tests
 
         [Fact]
-        public void Basic_CA1063_IDisposableReimplementation_Diagnostic_ReimplementingIDisposable()
+        public async Task Basic_CA1063_IDisposableReimplementation_Diagnostic_ReimplementingIDisposable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class B
@@ -1593,9 +1582,9 @@ End Class|]
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void Basic_CA1063_IDisposableReimplementation_NoDiagnostic_ReimplementingIDisposable_Internal()
+        public async Task Basic_CA1063_IDisposableReimplementation_NoDiagnostic_ReimplementingIDisposable_Internal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Friend Class B
@@ -1627,9 +1616,9 @@ End Class|]
         }
 
         [Fact]
-        public void Basic_CA1063_IDisposableReimplementation_Diagnostic_ReimplementingIDisposableWithDeepInheritance()
+        public async Task Basic_CA1063_IDisposableReimplementation_Diagnostic_ReimplementingIDisposableWithDeepInheritance()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A
@@ -1667,9 +1656,9 @@ End Class|]
         }
 
         [Fact]
-        public void Basic_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInterfaceInheritedFromIDisposable()
+        public async Task Basic_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInterfaceInheritedFromIDisposable()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Interface ITest
@@ -1709,9 +1698,9 @@ End Class|]
         }
 
         [Fact]
-        public void Basic_CA1063_IDisposableReimplementation_Diagnostic_ReImplementingIDisposableWithNoDisposeMethod()
+        public async Task Basic_CA1063_IDisposableReimplementation_Diagnostic_ReImplementingIDisposableWithNoDisposeMethod()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Interface ITest
@@ -1740,9 +1729,9 @@ End Class|]
         }
 
         [Fact]
-        public void Basic_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInheritedInterfaceWithNoDisposeReimplementation()
+        public async Task Basic_CA1063_IDisposableReimplementation_NoDiagnostic_ImplementingInheritedInterfaceWithNoDisposeReimplementation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Interface ITest
@@ -1773,9 +1762,9 @@ End Class|]
         #region VB DisposeSignature Unit Tests
 
         [Fact]
-        public void Basic_CA1063_DisposeSignature_Diagnostic_DisposeProtected()
+        public async Task Basic_CA1063_DisposeSignature_Diagnostic_DisposeProtected()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -1800,9 +1789,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeSignature_Diagnostic_DisposePrivate()
+        public async Task Basic_CA1063_DisposeSignature_Diagnostic_DisposePrivate()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -1827,9 +1816,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeSignature_Diagnostic_DisposeIsVirtual()
+        public async Task Basic_CA1063_DisposeSignature_Diagnostic_DisposeIsVirtual()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -1854,9 +1843,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeSignature_Diagnostic_DisposeIsOverriden()
+        public async Task Basic_CA1063_DisposeSignature_Diagnostic_DisposeIsOverriden()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class B
@@ -1887,9 +1876,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeSignature_Diagnostic_DisposeIsOverridenAndSealed()
+        public async Task Basic_CA1063_DisposeSignature_Diagnostic_DisposeIsOverridenAndSealed()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class B
@@ -1923,9 +1912,9 @@ End Class
         #region VB RenameDispose Unit Tests
 
         [Fact]
-        public void Basic_CA1063_RenameDispose_Diagnostic_DisposeNamedD()
+        public async Task Basic_CA1063_RenameDispose_Diagnostic_DisposeNamedD()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -1954,9 +1943,9 @@ End Class
         #region VB DisposeOverride Unit Tests
 
         [Fact]
-        public void Basic_CA1063_DisposeOverride_Diagnostic_SimpleDisposeOverride()
+        public async Task Basic_CA1063_DisposeOverride_Diagnostic_SimpleDisposeOverride()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class B
@@ -1988,9 +1977,9 @@ End Class|]
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeOverride_Diagnostic_DoubleDisposeOverride()
+        public async Task Basic_CA1063_DisposeOverride_Diagnostic_DoubleDisposeOverride()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A
@@ -2030,9 +2019,9 @@ End Class|]
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeOverride_Diagnostic_2DisposeImplementationsOverriden()
+        public async Task Basic_CA1063_DisposeOverride_Diagnostic_2DisposeImplementationsOverriden()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A
@@ -2082,9 +2071,9 @@ End Class|]
         #region VB FinalizeOverride Unit Tests
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void Basic_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride()
+        public async Task Basic_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class B
@@ -2116,9 +2105,9 @@ End Class|]
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void Basic_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride()
+        public async Task Basic_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A
@@ -2159,9 +2148,9 @@ End Class|]
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void Basic_CA1063_FinalizeOverride_NoDiagnostic_SimpleFinalizeOverride_InvokesDisposeBool_BaseTypeHasNoFinalizer()
+        public async Task Basic_CA1063_FinalizeOverride_NoDiagnostic_SimpleFinalizeOverride_InvokesDisposeBool_BaseTypeHasNoFinalizer()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class B
@@ -2189,9 +2178,9 @@ End Class|]
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void Basic_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride_InvokesDisposeBool_BaseTypeHasFinalizer()
+        public async Task Basic_CA1063_FinalizeOverride_Diagnostic_SimpleFinalizeOverride_InvokesDisposeBool_BaseTypeHasFinalizer()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class B
@@ -2226,9 +2215,9 @@ End Class|]
         }
 
         [Fact, WorkItem(1950, "https://github.com/dotnet/roslyn-analyzers/issues/1950")]
-        public void Basic_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride_InvokesDisposeBool()
+        public async Task Basic_CA1063_FinalizeOverride_Diagnostic_DoubleFinalizeOverride_InvokesDisposeBool()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A
@@ -2271,9 +2260,9 @@ End Class|]
         }
 
         [Fact]
-        public void Basic_CA1063_FinalizeOverride_NoDiagnostic_FinalizeNotInBaseType()
+        public async Task Basic_CA1063_FinalizeOverride_NoDiagnostic_FinalizeNotInBaseType()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class B
@@ -2298,9 +2287,9 @@ End Class|]
         #region VB ProvideDisposeBool Unit Tests
 
         [Fact]
-        public void Basic_CA1063_ProvideDisposeBool_Diagnostic_MissingDisposeBool()
+        public async Task Basic_CA1063_ProvideDisposeBool_Diagnostic_MissingDisposeBool()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2319,9 +2308,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_ProvideDisposeBool_Diagnostic_SealedClassAndMissingDisposeBool()
+        public async Task Basic_CA1063_ProvideDisposeBool_Diagnostic_SealedClassAndMissingDisposeBool()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public NotInheritable Class C
@@ -2341,9 +2330,9 @@ End Class
         #region VB DisposeBoolSignature Unit Tests
 
         [Fact]
-        public void Basic_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsPublic()
+        public async Task Basic_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsPublic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2368,9 +2357,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsProtectedInternal()
+        public async Task Basic_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsProtectedInternal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2395,9 +2384,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsNotVirtual()
+        public async Task Basic_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsNotVirtual()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2422,9 +2411,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsSealedOverriden()
+        public async Task Basic_CA1063_DisposeBoolSignature_Diagnostic_DisposeBoolIsSealedOverriden()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public MustInherit Class B
@@ -2454,9 +2443,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsOverriden()
+        public async Task Basic_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsOverriden()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public MustInherit Class B
@@ -2485,9 +2474,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsAbstract()
+        public async Task Basic_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsAbstract()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public MustInherit Class C
@@ -2510,9 +2499,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsPublicAndClassIsSealed()
+        public async Task Basic_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsPublicAndClassIsSealed()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public NotInheritable Class C
@@ -2536,9 +2525,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsPrivateAndClassIsSealed()
+        public async Task Basic_CA1063_DisposeBoolSignature_NoDiagnostic_DisposeBoolIsPrivateAndClassIsSealed()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public NotInheritable Class C
@@ -2566,9 +2555,9 @@ End Class
         #region VB DisposeImplementation Unit Tests
 
         [Fact]
-        public void Basic_CA1063_DisposeImplementation_Diagnostic_MissingCallDisposeBool()
+        public async Task Basic_CA1063_DisposeImplementation_Diagnostic_MissingCallDisposeBool()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2592,9 +2581,9 @@ End Class
         }
 
         [Fact, WorkItem(1974, "https://github.com/dotnet/roslyn-analyzers/issues/1974")]
-        public void Basic_CA1063_DisposeImplementation_Diagnostic_MissingCallSuppressFinalize_HasFinalizer()
+        public async Task Basic_CA1063_DisposeImplementation_Diagnostic_MissingCallSuppressFinalize_HasFinalizer()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2618,9 +2607,9 @@ End Class
         }
 
         [Fact, WorkItem(1974, "https://github.com/dotnet/roslyn-analyzers/issues/1974")]
-        public void Basic_CA1063_DisposeImplementation_NoDiagnostic_MissingCallSuppressFinalize_NoFinalizer()
+        public async Task Basic_CA1063_DisposeImplementation_NoDiagnostic_MissingCallSuppressFinalize_NoFinalizer()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2638,9 +2627,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeImplementation_Diagnostic_EmptyDisposeBody()
+        public async Task Basic_CA1063_DisposeImplementation_Diagnostic_EmptyDisposeBody()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2663,9 +2652,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeImplementation_Diagnostic_CallDisposeWithFalseArgument()
+        public async Task Basic_CA1063_DisposeImplementation_Diagnostic_CallDisposeWithFalseArgument()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2690,9 +2679,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeImplementation_Diagnostic_ConditionalStatement()
+        public async Task Basic_CA1063_DisposeImplementation_Diagnostic_ConditionalStatement()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2721,9 +2710,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeImplementation_NoDiagnostic_ConditionalStatement_Internal()
+        public async Task Basic_CA1063_DisposeImplementation_NoDiagnostic_ConditionalStatement_Internal()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Friend Class C
@@ -2751,9 +2740,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeImplementation_Diagnostic_CallDisposeBoolTwice()
+        public async Task Basic_CA1063_DisposeImplementation_Diagnostic_CallDisposeBoolTwice()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2779,9 +2768,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_DisposeImplementation_NoDiagnostic_EmptyDisposeBodyInSealedClass()
+        public async Task Basic_CA1063_DisposeImplementation_NoDiagnostic_EmptyDisposeBodyInSealedClass()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public NotInheritable Class C
@@ -2803,9 +2792,9 @@ End Class
         #region VB FinalizeImplementation Unit Tests
 
         [Fact]
-        public void Basic_CA1063_FinalizeImplementation_Diagnostic_MissingCallDisposeBool()
+        public async Task Basic_CA1063_FinalizeImplementation_Diagnostic_MissingCallDisposeBool()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2828,9 +2817,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_FinalizeImplementation_Diagnostic_CallDisposeWithTrueArgument()
+        public async Task Basic_CA1063_FinalizeImplementation_Diagnostic_CallDisposeWithTrueArgument()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2855,9 +2844,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_FinalizeImplementation_Diagnostic_ConditionalStatement()
+        public async Task Basic_CA1063_FinalizeImplementation_Diagnostic_ConditionalStatement()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2886,9 +2875,9 @@ End Class
         }
 
         [Fact]
-        public void Basic_CA1063_FinalizeImplementation_Diagnostic_CallDisposeBoolTwice()
+        public async Task Basic_CA1063_FinalizeImplementation_Diagnostic_CallDisposeBoolTwice()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -2918,116 +2907,94 @@ End Class
         #region Helpers
 
         private static DiagnosticResult GetCA1063CSharpIDisposableReimplementationResultAt(int line, int column, string typeName, string baseTypeName)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageIDisposableReimplementation, typeName, baseTypeName);
-            return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.IDisposableReimplementationRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, baseTypeName);
 
         private static DiagnosticResult GetCA1063BasicIDisposableReimplementationResultAt(int line, int column, string typeName, string baseTypeName)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageIDisposableReimplementation, typeName, baseTypeName);
-            return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.IDisposableReimplementationRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, baseTypeName);
 
         private static DiagnosticResult GetCA1063CSharpDisposeSignatureResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageDisposeSignature, typeName + "." + disposeMethod);
-            return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeSignatureRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         private static DiagnosticResult GetCA1063BasicDisposeSignatureResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageDisposeSignature, typeName + "." + disposeMethod);
-            return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeSignatureRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         private static DiagnosticResult GetCA1063CSharpRenameDisposeResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageRenameDispose, typeName + "." + disposeMethod);
-            return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.RenameDisposeRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         private static DiagnosticResult GetCA1063BasicRenameDisposeResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageRenameDispose, typeName + "." + disposeMethod);
-            return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.RenameDisposeRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         private static DiagnosticResult GetCA1063CSharpDisposeOverrideResultAt(int line, int column, string typeName, string method)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageDisposeOverride, typeName + "." + method);
-            return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeOverrideRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, method);
 
         private static DiagnosticResult GetCA1063BasicDisposeOverrideResultAt(int line, int column, string typeName, string method)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageDisposeOverride, typeName + "." + method);
-            return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeOverrideRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, method);
 
         private static DiagnosticResult GetCA1063CSharpFinalizeOverrideResultAt(int line, int column, string typeName, string baseTypeName)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageFinalizeOverride, typeName, baseTypeName);
-            return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.FinalizeOverrideRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, baseTypeName);
 
         private static DiagnosticResult GetCA1063BasicFinalizeOverrideResultAt(int line, int column, string typeName, string baseTypeName)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageFinalizeOverride, typeName, baseTypeName);
-            return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.FinalizeOverrideRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, baseTypeName);
 
         private static DiagnosticResult GetCA1063CSharpProvideDisposeBoolResultAt(int line, int column, string typeName)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageProvideDisposeBool, typeName);
-            return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.ProvideDisposeBoolRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName);
 
         private static DiagnosticResult GetCA1063BasicProvideDisposeBoolResultAt(int line, int column, string typeName)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageProvideDisposeBool, typeName);
-            return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.ProvideDisposeBoolRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName);
 
         private static DiagnosticResult GetCA1063CSharpDisposeBoolSignatureResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageDisposeBoolSignature, typeName + "." + disposeMethod);
-            return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeBoolSignatureRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         private static DiagnosticResult GetCA1063BasicDisposeBoolSignatureResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageDisposeBoolSignature, typeName + "." + disposeMethod);
-            return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeBoolSignatureRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         private static DiagnosticResult GetCA1063CSharpDisposeImplementationResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageDisposeImplementation, typeName + "." + disposeMethod);
-            return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeImplementationRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         private static DiagnosticResult GetCA1063BasicDisposeImplementationResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageDisposeImplementation, typeName + "." + disposeMethod);
-            return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeImplementationRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         private static DiagnosticResult GetCA1063CSharpFinalizeImplementationResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture,
-                MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageFinalizeImplementation, typeName + "." +
-                disposeMethod);
-            return GetCSharpResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.FinalizeImplementationRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         private static DiagnosticResult GetCA1063BasicFinalizeImplementationResultAt(int line, int column, string typeName, string disposeMethod)
-        {
-            string message = string.Format(CultureInfo.CurrentCulture,
-                MicrosoftCodeQualityAnalyzersResources.ImplementIDisposableCorrectlyMessageFinalizeImplementation, typeName + "." +
-                disposeMethod);
-            return GetBasicResultAt(line, column, ImplementIDisposableCorrectlyAnalyzer.RuleId, message);
-        }
+            => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.FinalizeImplementationRule)
+                .WithLocation(line, column)
+                .WithArguments(typeName, disposeMethod);
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
@@ -1966,12 +1966,12 @@ Public Class B
 
 End Class
 
-[|Public Class C
+Public Class [|C|]
     Inherits B
 
     Public Overrides Sub Dispose()
     End Sub
-End Class|]
+End Class
 ",
             GetCA1063BasicDisposeOverrideResultAt(25, 26, "C", "Dispose"));
         }
@@ -2007,13 +2007,13 @@ Public Class B
     End Sub
 End Class
     
-[|Public Class C
+Public Class [|C|]
     Inherits B
 
     Public Overrides Sub Dispose()
         Dispose(True)
     End Sub
-End Class|]
+End Class
 ",
             GetCA1063BasicDisposeOverrideResultAt(32, 26, "C", "Dispose"));
         }
@@ -2050,7 +2050,7 @@ Public Class B
     End Sub
 End Class
     
-[|Public Class C
+Public Class [|C|]
     Inherits B
 
     Public Overrides Sub Dispose()
@@ -2060,7 +2060,7 @@ End Class
     Public Overrides Sub D()
         Dispose()
     End Sub
-End Class|]
+End Class
 ",
             GetCA1063BasicDisposeOverrideResultAt(33, 26, "C", "Dispose"),
             GetCA1063BasicDisposeOverrideResultAt(37, 26, "C", "D"));
@@ -2919,32 +2919,32 @@ End Class
         private static DiagnosticResult GetCA1063CSharpDisposeSignatureResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeSignatureRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{ typeName}.{ disposeMethod}");
 
         private static DiagnosticResult GetCA1063BasicDisposeSignatureResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeSignatureRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{ typeName}.{ disposeMethod}");
 
         private static DiagnosticResult GetCA1063CSharpRenameDisposeResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.RenameDisposeRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{ typeName}.{ disposeMethod}");
 
         private static DiagnosticResult GetCA1063BasicRenameDisposeResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.RenameDisposeRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{typeName}.{disposeMethod}");
 
         private static DiagnosticResult GetCA1063CSharpDisposeOverrideResultAt(int line, int column, string typeName, string method)
             => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeOverrideRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, method);
+                .WithArguments($"{ typeName}.{method}");
 
         private static DiagnosticResult GetCA1063BasicDisposeOverrideResultAt(int line, int column, string typeName, string method)
             => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeOverrideRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, method);
+                .WithArguments($"{ typeName}.{method}");
 
         private static DiagnosticResult GetCA1063CSharpFinalizeOverrideResultAt(int line, int column, string typeName, string baseTypeName)
             => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.FinalizeOverrideRule)
@@ -2969,32 +2969,32 @@ End Class
         private static DiagnosticResult GetCA1063CSharpDisposeBoolSignatureResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeBoolSignatureRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{typeName}.{disposeMethod}");
 
         private static DiagnosticResult GetCA1063BasicDisposeBoolSignatureResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeBoolSignatureRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{typeName}.{disposeMethod}");
 
         private static DiagnosticResult GetCA1063CSharpDisposeImplementationResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeImplementationRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{typeName}.{disposeMethod}");
 
         private static DiagnosticResult GetCA1063BasicDisposeImplementationResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.DisposeImplementationRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{typeName}.{disposeMethod}");
 
         private static DiagnosticResult GetCA1063CSharpFinalizeImplementationResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyCS.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.FinalizeImplementationRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{typeName}.{disposeMethod}");
 
         private static DiagnosticResult GetCA1063BasicFinalizeImplementationResultAt(int line, int column, string typeName, string disposeMethod)
             => VerifyVB.Diagnostic(ImplementIDisposableCorrectlyAnalyzer.FinalizeImplementationRule)
                 .WithLocation(line, column)
-                .WithArguments(typeName, disposeMethod);
+                .WithArguments($"{typeName}.{disposeMethod}");
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
@@ -17,12 +17,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         #region Verifiers
 
         private static DiagnosticResult CSharpResult(int line, int column, string className, string methodName)
-            => new DiagnosticResult(InterfaceMethodsShouldBeCallableByChildTypesAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(className, methodName);
 
         private static DiagnosticResult BasicResult(int line, int column, string className, string methodName)
-            => new DiagnosticResult(InterfaceMethodsShouldBeCallableByChildTypesAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(className, methodName);
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAttributesWithAttributeUsageTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MarkAttributesWithAttributeUsageTests.cs
@@ -96,12 +96,12 @@ End Class
         }
 
         private static DiagnosticResult GetCA1018CSharpResultAt(int line, int column, string objectName)
-            => VerifyCS.Diagnostic(MarkAttributesWithAttributeUsageAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(objectName);
 
         private static DiagnosticResult GetCA1018BasicResultAt(int line, int column, string objectName)
-            => VerifyVB.Diagnostic(MarkAttributesWithAttributeUsageAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(objectName);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
@@ -111,25 +111,24 @@ class BazClass
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
-class FooClass
+class [|FooClass|]
 {
     [DllImport(""user32.dll"")]
     private static extern void Foo();
 }
 
-[|class BarClass
-{
-    [DllImport(""user32.dll"")]
-    private static extern void Foo();
-}|]
-
-class BazClass
+class [|BarClass|]
 {
     [DllImport(""user32.dll"")]
     private static extern void Foo();
 }
-",
-            CSharpResult(10, 7));
+
+class [|BazClass|]
+{
+    [DllImport(""user32.dll"")]
+    private static extern void Foo();
+}
+");
         }
 
         [Fact]
@@ -167,25 +166,24 @@ End Class
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Runtime.InteropServices
 
-Class FooClass
+Class [|FooClass|]
     <DllImport(""user32.dll"")>
     Private Shared Sub Foo()
     End Sub
 End Class
 
-[|Class BarClass
-    <DllImport(""user32.dll"")>
-    Private Shared Sub Foo()
-    End Sub
-End Class|]
-
-Class BazClass
+Class [|BarClass|]
     <DllImport(""user32.dll"")>
     Private Shared Sub Foo()
     End Sub
 End Class
-",
-            BasicResult(10, 7));
+
+Class [|BazClass|]
+    <DllImport(""user32.dll"")>
+    Private Shared Sub Foo()
+    End Sub
+End Class
+");
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MovePInvokesToNativeMethodsClassAnalyzer,
@@ -14,19 +12,9 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class MovePInvokesToNativeMethodsClassTests : DiagnosticAnalyzerTestBase
+    public class MovePInvokesToNativeMethodsClassTests
     {
         #region Verifiers
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new MovePInvokesToNativeMethodsClassAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new MovePInvokesToNativeMethodsClassAnalyzer();
-        }
 
         private static DiagnosticResult CSharpResult(int line, int column)
             => VerifyCS.Diagnostic().WithLocation(line, column);
@@ -118,9 +106,9 @@ class BazClass
         }
 
         [Fact]
-        public void CA1060ImproperlyNamedClassCSharpWithScope()
+        public async Task CA1060ImproperlyNamedClassCSharpWithScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
 class FooClass
@@ -174,9 +162,9 @@ End Class
         }
 
         [Fact]
-        public void CA1060ImproperlyNamedClassBasicWithScope()
+        public async Task CA1060ImproperlyNamedClassBasicWithScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Runtime.InteropServices
 
 Class FooClass

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NestedTypesShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NestedTypesShouldNotBeVisibleTests.cs
@@ -473,17 +473,17 @@ End Class
                 GetBasicCA1034ResultAt(9, 18, "MyDataRow"));
         }
 
-        private DiagnosticResult GetCSharpCA1034ResultAt(int line, int column, string nestedTypeName)
+        private static DiagnosticResult GetCSharpCA1034ResultAt(int line, int column, string nestedTypeName)
             => VerifyCS.Diagnostic(NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(nestedTypeName);
 
-        private DiagnosticResult GetBasicCA1034ResultAt(int line, int column, string nestedTypeName)
+        private static DiagnosticResult GetBasicCA1034ResultAt(int line, int column, string nestedTypeName)
             => VerifyVB.Diagnostic(NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(nestedTypeName);
 
-        private DiagnosticResult GetBasicCA1034ModuleResultAt(int line, int column, string nestedTypeName)
+        private static DiagnosticResult GetBasicCA1034ModuleResultAt(int line, int column, string nestedTypeName)
             => VerifyVB.Diagnostic(NestedTypesShouldNotBeVisibleAnalyzer.VisualBasicModuleRule)
                 .WithLocation(line, column)
                 .WithArguments(nestedTypeName);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NestedTypesShouldNotBeVisibleTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/NestedTypesShouldNotBeVisibleTests.cs
@@ -474,17 +474,17 @@ End Class
         }
 
         private DiagnosticResult GetCSharpCA1034ResultAt(int line, int column, string nestedTypeName)
-            => new DiagnosticResult(NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule)
+            => VerifyCS.Diagnostic(NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(nestedTypeName);
 
         private DiagnosticResult GetBasicCA1034ResultAt(int line, int column, string nestedTypeName)
-            => new DiagnosticResult(NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule)
+            => VerifyVB.Diagnostic(NestedTypesShouldNotBeVisibleAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(nestedTypeName);
 
         private DiagnosticResult GetBasicCA1034ModuleResultAt(int line, int column, string nestedTypeName)
-            => new DiagnosticResult(NestedTypesShouldNotBeVisibleAnalyzer.VisualBasicModuleRule)
+            => VerifyVB.Diagnostic(NestedTypesShouldNotBeVisibleAnalyzer.VisualBasicModuleRule)
                 .WithLocation(line, column)
                 .WithArguments(nestedTypeName);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
@@ -20,8 +20,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 public class A
 {
     public static bool operator==(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
-}", CompilerDiagnostics.None,
-GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="));
+}",
+GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
+// Test0.cs(4,32): error CS0216: The operator 'A.operator ==(A, A)' requires a matching operator '!=' to also be defined
+new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32));
         }
 
         [Fact]
@@ -31,8 +33,10 @@ GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "
 public class A
 {
     public static bool operator!=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '==' to also be defined
-}", CompilerDiagnostics.None,
-GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="));
+}",
+GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="),
+// Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
+new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
@@ -57,7 +61,15 @@ public class B
     }
 }
 
-", CompilerDiagnostics.None);
+",
+                // Test0.cs(4,32): error CS0216: The operator 'A.operator ==(A, A)' requires a matching operator '!=' to also be defined
+                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32),
+                // Test0.cs(11,36): error CS0216: The operator 'B.C.operator ==(B.C, B.C)' requires a matching operator '!=' to also be defined
+                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(11, 36),
+                // Test0.cs(16,38): error CS0216: The operator 'B.D.operator ==(B.D, B.D)' requires a matching operator '!=' to also be defined
+                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(16, 38),
+                // Test0.cs(16,38): error CS0558: User-defined operator 'B.D.operator ==(B.D, B.D)' must be declared static and public
+                new DiagnosticResult("CS0558", DiagnosticSeverity.Error).WithLocation(16, 38));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
@@ -81,7 +93,15 @@ public class B
         internal static bool operator!=(D a1, D a2) { return false; }
     }
 }
-", CompilerDiagnostics.None);
+",
+                // Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
+                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32),
+                // Test0.cs(11,36): error CS0216: The operator 'B.C.operator !=(B.C, B.C)' requires a matching operator '==' to also be defined
+                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(11, 36),
+                // Test0.cs(16,38): error CS0216: The operator 'B.D.operator !=(B.D, B.D)' requires a matching operator '==' to also be defined
+                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(16, 38),
+                // Test0.cs(16,38): error CS0558: User-defined operator 'B.D.operator !=(B.D, B.D)' must be declared static and public
+                new DiagnosticResult("CS0558", DiagnosticSeverity.Error).WithLocation(16, 38));
         }
 
         [Fact]
@@ -102,8 +122,10 @@ public class A
 public class A
 {
     public static bool operator<(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>' to also be defined
-}", CompilerDiagnostics.None,
-GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<", ">"));
+}",
+GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<", ">"),
+// Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
+new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32));
         }
 
         [Fact]
@@ -124,8 +146,10 @@ public class A
 public class A
 {
     public static bool operator<=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>=' to also be defined
-}", CompilerDiagnostics.None,
-GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<=", ">="));
+}",
+GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<=", ">="),
+// Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
+new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32));
         }
 
         [Fact]
@@ -147,9 +171,13 @@ public class A
 {
     public static bool operator==(A a1, int a2) { return false; }
     public static bool operator!=(A a1, string a2) { return false; }
-}", CompilerDiagnostics.None,
+}",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
-GetCSharpResultAt(5, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="));
+// Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
+new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32),
+GetCSharpResultAt(5, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="),
+// Test0.cs(5,32): error CS0216: The operator 'A.operator !=(A, string)' requires a matching operator '==' to also be defined
+new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(5, 32));
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
@@ -19,11 +19,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
-    public static bool operator==(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '!=' to also be defined
+    public static bool operator==(A a1, A a2) { return false; }
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
-// Test0.cs(4,32): error CS0216: The operator 'A.operator ==(A, A)' requires a matching operator '!=' to also be defined
-DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator ==(A, A)' requires a matching operator '!=' to also be defined"));
         }
 
         [Fact]
@@ -32,11 +31,10 @@ DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32));
             await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
-    public static bool operator!=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '==' to also be defined
+    public static bool operator!=(A a1, A a2) { return false; }
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="),
-// Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined"));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
@@ -62,14 +60,10 @@ public class B
 }
 
 ",
-                // Test0.cs(4,32): error CS0216: The operator 'A.operator ==(A, A)' requires a matching operator '!=' to also be defined
-                DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32),
-                // Test0.cs(11,36): error CS0216: The operator 'B.C.operator ==(B.C, B.C)' requires a matching operator '!=' to also be defined
-                DiagnosticResult.CompilerError("CS0216").WithLocation(11, 36),
-                // Test0.cs(16,38): error CS0216: The operator 'B.D.operator ==(B.D, B.D)' requires a matching operator '!=' to also be defined
-                DiagnosticResult.CompilerError("CS0216").WithLocation(16, 38),
-                // Test0.cs(16,38): error CS0558: User-defined operator 'B.D.operator ==(B.D, B.D)' must be declared static and public
-                DiagnosticResult.CompilerError("CS0558").WithLocation(16, 38));
+                DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator ==(A, A)' requires a matching operator '!=' to also be defined"),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(11, 36).WithMessage("The operator 'B.C.operator ==(B.C, B.C)' requires a matching operator '!=' to also be defined"),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(16, 38).WithMessage("The operator 'B.D.operator ==(B.D, B.D)' requires a matching operator '!=' to also be defined"),
+                DiagnosticResult.CompilerError("CS0558").WithLocation(16, 38).WithMessage("User-defined operator 'B.D.operator ==(B.D, B.D)' must be declared static and public"));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
@@ -94,14 +88,10 @@ public class B
     }
 }
 ",
-                // Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-                DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32),
-                // Test0.cs(11,36): error CS0216: The operator 'B.C.operator !=(B.C, B.C)' requires a matching operator '==' to also be defined
-                DiagnosticResult.CompilerError("CS0216").WithLocation(11, 36),
-                // Test0.cs(16,38): error CS0216: The operator 'B.D.operator !=(B.D, B.D)' requires a matching operator '==' to also be defined
-                DiagnosticResult.CompilerError("CS0216").WithLocation(16, 38),
-                // Test0.cs(16,38): error CS0558: User-defined operator 'B.D.operator !=(B.D, B.D)' must be declared static and public
-                DiagnosticResult.CompilerError("CS0558").WithLocation(16, 38));
+                DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined"),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(11, 36).WithMessage("The operator 'B.C.operator !=(B.C, B.C)' requires a matching operator '==' to also be defined"),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(16, 38).WithMessage("The operator 'B.D.operator !=(B.D, B.D)' requires a matching operator '==' to also be defined"),
+                DiagnosticResult.CompilerError("CS0558").WithLocation(16, 38).WithMessage("User-defined operator 'B.D.operator !=(B.D, B.D)' must be declared static and public"));
         }
 
         [Fact]
@@ -121,11 +111,10 @@ public class A
             await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
-    public static bool operator<(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>' to also be defined
+    public static bool operator<(A a1, A a2) { return false; }
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<", ">"),
-// Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator <(A, A)' requires a matching operator '>' to also be defined"));
         }
 
         [Fact]
@@ -145,11 +134,10 @@ public class A
             await VerifyCS.VerifyAnalyzerAsync(@"
 public class A
 {
-    public static bool operator<=(A a1, A a2) { return false; }   // error CS0216: The operator requires a matching operator '>=' to also be defined
+    public static bool operator<=(A a1, A a2) { return false; }
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<=", ">="),
-// Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator <=(A, A)' requires a matching operator '>=' to also be defined"));
         }
 
         [Fact]
@@ -173,11 +161,9 @@ public class A
     public static bool operator!=(A a1, string a2) { return false; }
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
-// Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32),
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator ==(A, int)' requires a matching operator '!=' to also be defined"),
 GetCSharpResultAt(5, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="),
-// Test0.cs(5,32): error CS0216: The operator 'A.operator !=(A, string)' requires a matching operator '==' to also be defined
-DiagnosticResult.CompilerError("CS0216").WithLocation(5, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(5, 32).WithMessage("The operator 'A.operator !=(A, string)' requires a matching operator '==' to also be defined"));
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -21,7 +20,7 @@ public class A
 {
     public static bool operator==(A a1, A a2) { return false; }
 }",
-GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
+GetCSharpResultAt(4, 32, "A", "==", "!="),
 DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator ==(A, A)' requires a matching operator '!=' to also be defined"));
         }
 
@@ -33,7 +32,7 @@ public class A
 {
     public static bool operator!=(A a1, A a2) { return false; }
 }",
-GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="),
+GetCSharpResultAt(4, 32, "A", "!=", "=="),
 DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined"));
         }
 
@@ -113,7 +112,7 @@ public class A
 {
     public static bool operator<(A a1, A a2) { return false; }
 }",
-GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<", ">"),
+GetCSharpResultAt(4, 32, "A", "<", ">"),
 DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator <(A, A)' requires a matching operator '>' to also be defined"));
         }
 
@@ -136,7 +135,7 @@ public class A
 {
     public static bool operator<=(A a1, A a2) { return false; }
 }",
-GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<=", ">="),
+GetCSharpResultAt(4, 32, "A", "<=", ">="),
 DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator <=(A, A)' requires a matching operator '>=' to also be defined"));
         }
 
@@ -160,14 +159,14 @@ public class A
     public static bool operator==(A a1, int a2) { return false; }
     public static bool operator!=(A a1, string a2) { return false; }
 }",
-GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
+GetCSharpResultAt(4, 32, "A", "==", "!="),
 DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32).WithMessage("The operator 'A.operator ==(A, int)' requires a matching operator '!=' to also be defined"),
-GetCSharpResultAt(5, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="),
+GetCSharpResultAt(5, 32, "A", "!=", "=="),
 DiagnosticResult.CompilerError("CS0216").WithLocation(5, 32).WithMessage("The operator 'A.operator !=(A, string)' requires a matching operator '==' to also be defined"));
         }
 
-        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OperatorsShouldHaveSymmetricalOverloadsTests.cs
@@ -23,7 +23,7 @@ public class A
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
 // Test0.cs(4,32): error CS0216: The operator 'A.operator ==(A, A)' requires a matching operator '!=' to also be defined
-new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32));
         }
 
         [Fact]
@@ -36,7 +36,7 @@ public class A
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="),
 // Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
@@ -63,13 +63,13 @@ public class B
 
 ",
                 // Test0.cs(4,32): error CS0216: The operator 'A.operator ==(A, A)' requires a matching operator '!=' to also be defined
-                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32),
                 // Test0.cs(11,36): error CS0216: The operator 'B.C.operator ==(B.C, B.C)' requires a matching operator '!=' to also be defined
-                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(11, 36),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(11, 36),
                 // Test0.cs(16,38): error CS0216: The operator 'B.D.operator ==(B.D, B.D)' requires a matching operator '!=' to also be defined
-                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(16, 38),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(16, 38),
                 // Test0.cs(16,38): error CS0558: User-defined operator 'B.D.operator ==(B.D, B.D)' must be declared static and public
-                new DiagnosticResult("CS0558", DiagnosticSeverity.Error).WithLocation(16, 38));
+                DiagnosticResult.CompilerError("CS0558").WithLocation(16, 38));
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
@@ -95,13 +95,13 @@ public class B
 }
 ",
                 // Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32),
                 // Test0.cs(11,36): error CS0216: The operator 'B.C.operator !=(B.C, B.C)' requires a matching operator '==' to also be defined
-                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(11, 36),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(11, 36),
                 // Test0.cs(16,38): error CS0216: The operator 'B.D.operator !=(B.D, B.D)' requires a matching operator '==' to also be defined
-                new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(16, 38),
+                DiagnosticResult.CompilerError("CS0216").WithLocation(16, 38),
                 // Test0.cs(16,38): error CS0558: User-defined operator 'B.D.operator !=(B.D, B.D)' must be declared static and public
-                new DiagnosticResult("CS0558", DiagnosticSeverity.Error).WithLocation(16, 38));
+                DiagnosticResult.CompilerError("CS0558").WithLocation(16, 38));
         }
 
         [Fact]
@@ -125,7 +125,7 @@ public class A
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<", ">"),
 // Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32));
         }
 
         [Fact]
@@ -149,7 +149,7 @@ public class A
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "<=", ">="),
 // Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32));
         }
 
         [Fact]
@@ -174,10 +174,10 @@ public class A
 }",
 GetCSharpResultAt(4, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "==", "!="),
 // Test0.cs(4,32): error CS0216: The operator 'A.operator !=(A, A)' requires a matching operator '==' to also be defined
-new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(4, 32),
+DiagnosticResult.CompilerError("CS0216").WithLocation(4, 32),
 GetCSharpResultAt(5, 32, OperatorsShouldHaveSymmetricalOverloadsAnalyzer.Rule, "A", "!=", "=="),
 // Test0.cs(5,32): error CS0216: The operator 'A.operator !=(A, string)' requires a matching operator '==' to also be defined
-new DiagnosticResult("CS0216", DiagnosticSeverity.Error).WithLocation(5, 32));
+DiagnosticResult.CompilerError("CS0216").WithLocation(5, 32));
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
-    public struct A
+    public struct [|A|]
     {
         public override bool Equals(Object obj)
         {
@@ -100,14 +100,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
     }
 
-    [|// value type without overriding Equals
+    // value type without overriding Equals
     public struct B
     {    
         public new bool Equals(Object obj)
         {
             return true;
         }
-    }|]
+    }
 ");
         }
 
@@ -238,13 +238,13 @@ End Class
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
-[|Public Class A
+Public Class A
     Public Overloads Overrides Function Equals(obj As Object) As Boolean
         Return True
     End Function
-End Class|]
+End Class
 
-Public Structure B
+Public Structure [|B|]
     Public Overloads Overrides Function Equals(obj As Object) As Boolean
         Return True
     End Function

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEqualsTests.cs
@@ -1,29 +1,25 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OverloadOperatorEqualsOnOverridingValueTypeEqualsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OverloadOperatorEqualsOnOverridingValueTypeEqualsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public partial class OverloadOperatorEqualsOnOverridingValueTypeEqualsTests : DiagnosticAnalyzerTestBase
+    public partial class OverloadOperatorEqualsOnOverridingValueTypeEqualsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new OverloadOperatorEqualsOnOverridingValueTypeEqualsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new OverloadOperatorEqualsOnOverridingValueTypeEqualsAnalyzer();
-        }
-
         [Fact]
-        public void CA2231NoWarningCSharp()
+        public async Task CA2231NoWarningCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     // Non-value type
@@ -47,9 +43,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2231NoEqualsOperatorCSharp()
+        public async Task CA2231NoEqualsOperatorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public struct A
@@ -64,9 +60,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA2231NoEqualsOperatorButNotExternallyVisibleCSharp()
+        public async Task CA2231NoEqualsOperatorButNotExternallyVisibleCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     struct A
@@ -91,9 +87,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2231NoEqualsOperatorCSharpOutofScope()
+        public async Task CA2231NoEqualsOperatorCSharpOutofScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public struct A
@@ -116,9 +112,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2231CSharpInnerClassHasNoEqualsOperatorCSharp()
+        public async Task CA2231CSharpInnerClassHasNoEqualsOperatorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public struct A
@@ -142,9 +138,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2231HasEqualsOperatorCSharp()
+        public async Task CA2231HasEqualsOperatorCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     public struct A
@@ -168,9 +164,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA2231_CSharp_RefStruct_NoDiagnostic()
+        public async Task CA2231_CSharp_RefStruct_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 public ref struct S
 {
     public override bool Equals(object other)
@@ -178,13 +176,15 @@ public ref struct S
         return false;
     }
 }
-", parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+",
+                LanguageVersion = LanguageVersion.CSharp8
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA2231NoWarningBasic()
+        public async Task CA2231NoWarningBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class A
@@ -196,9 +196,9 @@ End Class
         }
 
         [Fact]
-        public void CA2231NoEqualsOperatorBasic()
+        public async Task CA2231NoEqualsOperatorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Structure A
@@ -211,9 +211,9 @@ End Structure
         }
 
         [Fact, WorkItem(1432, "https://github.com/dotnet/roslyn-analyzers/issues/1432")]
-        public void CA2231NoEqualsOperatorButNotExternallyVisibleBasic()
+        public async Task CA2231NoEqualsOperatorButNotExternallyVisibleBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Structure A
@@ -233,9 +233,9 @@ End Class
         }
 
         [Fact]
-        public void CA2231NoEqualsOperatorBasicWithScope()
+        public async Task CA2231NoEqualsOperatorBasicWithScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 [|Public Class A
@@ -253,9 +253,9 @@ End Structure
         }
 
         [Fact]
-        public void CA2231BasicInnerClassHasNoEqualsOperatorBasic()
+        public async Task CA2231BasicInnerClassHasNoEqualsOperatorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Structure A
@@ -275,9 +275,9 @@ End Structure
         }
 
         [Fact]
-        public void CA2231HasEqualsOperatorBasic()
+        public async Task CA2231HasEqualsOperatorBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Structure A
@@ -297,13 +297,11 @@ End Structure
         }
 
         private static DiagnosticResult GetCA2231CSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, OverloadOperatorEqualsOnOverridingValueTypeEqualsAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEqualsMessage);
-        }
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetCA2231BasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, OverloadOperatorEqualsOnOverridingValueTypeEqualsAnalyzer.RuleId, MicrosoftCodeQualityAnalyzersResources.OverloadOperatorEqualsOnOverridingValueTypeEqualsMessage);
-        }
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -356,7 +356,7 @@ End Structure
         {
             await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure A
-    Public Overrides Overloads Function Equals(obj As A) As Boolean ' Test0.vb(3) : error BC30284: function 'Equals' cannot be declared 'Overrides' because it does not override a function in a base class.
+    Public Overrides Overloads Function Equals(obj As A) As Boolean
         Return True
     End Function
 
@@ -370,7 +370,7 @@ Public Structure A
 End Structure
 ",
                 GetBasicOverrideEqualsDiagnostic(2, 18, "A"),
-                DiagnosticResult.CompilerError("BC30284").WithLocation(3, 41));
+                DiagnosticResult.CompilerError("BC30284").WithLocation(3, 41).WithMessage("function 'Equals' cannot be declared 'Overrides' because it does not override a function in a base class."));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -370,7 +370,7 @@ Public Structure A
 End Structure
 ",
                 GetBasicOverrideEqualsDiagnostic(2, 18, "A"),
-                new DiagnosticResult("BC30284", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(3, 41));
+                DiagnosticResult.CompilerError("BC30284").WithLocation(3, 41));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -356,7 +356,7 @@ End Structure
         {
             await VerifyVB.VerifyAnalyzerAsync(@"
 Public Structure A
-    Public Overrides Overloads Function Equals(obj As A) As Boolean
+    Public Overrides Overloads Function Equals(obj As A) As Boolean ' Test0.vb(3) : error BC30284: function 'Equals' cannot be declared 'Overrides' because it does not override a function in a base class.
         Return True
     End Function
 
@@ -369,8 +369,8 @@ Public Structure A
     End Operator
 End Structure
 ",
-            CompilerDiagnostics.None,
-            GetBasicOverrideEqualsDiagnostic(2, 18, "A"));
+                GetBasicOverrideEqualsDiagnostic(2, 18, "A"),
+                new DiagnosticResult("BC30284", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(3, 41));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEqualsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEqualsTests.cs
@@ -101,7 +101,7 @@ Class C
     End Operator
 End Class",
             // Test0.vb(2,7): warning CA2224: Override Equals on overloading operator equals
-            GetBasicResultAt(2, 7, BasicOverrideEqualsOnOverloadingOperatorEqualsAnalyzer.Rule));
+            GetBasicResultAt(2, 7));
         }
 
         [Fact]
@@ -118,7 +118,7 @@ Structure C
     End Operator
 End Structure",
             // Test0.vb(2,11): warning CA2224: Override Equals on overloading operator equals
-            GetBasicResultAt(2, 11, BasicOverrideEqualsOnOverloadingOperatorEqualsAnalyzer.Rule));
+            GetBasicResultAt(2, 11));
         }
 
         [Fact]
@@ -139,7 +139,7 @@ Class C
     End Function
 End Class",
             // Test0.vb(2,7): warning CA2224: Override Equals on overloading operator equals
-            GetBasicResultAt(2, 7, BasicOverrideEqualsOnOverloadingOperatorEqualsAnalyzer.Rule));
+            GetBasicResultAt(2, 7));
         }
 
         [Fact]
@@ -166,11 +166,11 @@ Class Derived : Inherits Base
     End Function
 End Class",
             // Test0.vb(8,7): warning CA2224: Override Equals on overloading operator equals
-            GetBasicResultAt(8, 7, BasicOverrideEqualsOnOverloadingOperatorEqualsAnalyzer.Rule));
+            GetBasicResultAt(8, 7));
         }
 
-        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
-            => new DiagnosticResult(rule)
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideGetHashCodeOnOverridingEqualsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideGetHashCodeOnOverridingEqualsTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
 using Xunit;
 using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
     Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicOverrideGetHashCodeOnOverridingEqualsAnalyzer,
@@ -89,7 +87,7 @@ Class C
     End Function
 End Class",
             // Test0.vb(2,7): warning CA2224: Override GetHashCode on overriding Equals
-            GetBasicResultAt(2, 7, BasicOverrideGetHashCodeOnOverridingEqualsAnalyzer.Rule));
+            GetBasicResultAt(2, 7));
         }
 
         [Fact]
@@ -102,7 +100,7 @@ Structure C
     End Function
 End Structure",
             // Test0.vb(2,11): warning CA2224: Override GetHashCode on overriding Equals
-            GetBasicResultAt(2, 11, BasicOverrideGetHashCodeOnOverridingEqualsAnalyzer.Rule));
+            GetBasicResultAt(2, 11));
         }
 
         [Fact]
@@ -119,7 +117,7 @@ Class C
     End Function
 End Class",
             // Test0.vb(2,7): warning CA2224: Override GetHashCode on overriding Equals
-            GetBasicResultAt(2, 7, BasicOverrideGetHashCodeOnOverridingEqualsAnalyzer.Rule));
+            GetBasicResultAt(2, 7));
         }
 
         [Fact]
@@ -142,11 +140,11 @@ Class Derived : Inherits Base
     End Function
 End Class",
             // Test0.vb(8,7): warning CA2224: Override GetHashCode on overriding Equals
-            GetBasicResultAt(8, 7, BasicOverrideGetHashCodeOnOverridingEqualsAnalyzer.Rule));
+            GetBasicResultAt(8, 7));
         }
 
-        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
-            => new DiagnosticResult(rule)
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
@@ -1308,35 +1307,23 @@ public class DerivedClass<T> : BaseClass<T>
         }
 
         private static DiagnosticResult GetCA1036CSharpOperatorsResultAt(int line, int column, string typeName, string operators)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideMethodsOnComparableTypesMessageOperator, typeName, operators);
-            return new DiagnosticResult(OverrideMethodsOnComparableTypesAnalyzer.RuleOperator)
+            => VerifyCS.Diagnostic(OverrideMethodsOnComparableTypesAnalyzer.RuleOperator)
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(typeName, operators);
 
         private static DiagnosticResult GetCA1036BasicOperatorsResultAt(int line, int column, string typeName, string operators)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideMethodsOnComparableTypesMessageOperator, typeName, operators);
-            return new DiagnosticResult(OverrideMethodsOnComparableTypesAnalyzer.RuleOperator)
+            => VerifyVB.Diagnostic(OverrideMethodsOnComparableTypesAnalyzer.RuleOperator)
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(typeName, operators);
 
         private static DiagnosticResult GetCA1036CSharpBothResultAt(int line, int column, string typeName, string operators)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideMethodsOnComparableTypesMessageBoth, typeName, operators);
-            return new DiagnosticResult(OverrideMethodsOnComparableTypesAnalyzer.RuleBoth)
+            => VerifyCS.Diagnostic(OverrideMethodsOnComparableTypesAnalyzer.RuleBoth)
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(typeName, operators);
 
         private static DiagnosticResult GetCA1036BasicBothResultAt(int line, int column, string typeName, string operators)
-        {
-            var message = string.Format(CultureInfo.CurrentCulture, MicrosoftCodeQualityAnalyzersResources.OverrideMethodsOnComparableTypesMessageBoth, typeName, operators);
-            return new DiagnosticResult(OverrideMethodsOnComparableTypesAnalyzer.RuleBoth)
+            => VerifyVB.Diagnostic(OverrideMethodsOnComparableTypesAnalyzer.RuleBoth)
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(typeName, operators);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -14,18 +13,8 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public partial class OverrideMethodsOnComparableTypesTests : DiagnosticAnalyzerTestBase
+    public partial class OverrideMethodsOnComparableTypesTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new OverrideMethodsOnComparableTypesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new OverrideMethodsOnComparableTypesAnalyzer();
-        }
-
         [Fact]
         public async Task CA1036ClassNoWarningCSharp()
         {
@@ -207,9 +196,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
-        public void CA1036ClassWrongEqualsCSharpwithScope()
+        public async Task CA1036ClassWrongEqualsCSharpwithScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
     [|public class A : IComparable
@@ -819,9 +808,9 @@ End Class
         }
 
         [Fact]
-        public void CA1036StructWrongEqualsBasicWithScope()
+        public async Task CA1036StructWrongEqualsBasicWithScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 [|Public Class A : Implements IComparable

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/OverrideMethodsOnComparableTypesTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
 
-    [|public class A : IComparable
+    public class {|CA1036:A|} : IComparable
     {    
         public override int GetHashCode()
         {
@@ -247,7 +247,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         {
             return true;
         }
-    }|]
+    }
 
     public class B : IComparable
     {    
@@ -813,7 +813,7 @@ End Class
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
-[|Public Class A : Implements IComparable
+Public Class {|CA1036:A|} : Implements IComparable
 
     Public Overrides Function GetHashCode() As Integer
         Return 1234
@@ -851,7 +851,7 @@ Imports System
         Return True
     End Operator
 
-End Class|]
+End Class
 
 Public Structure B : Implements IComparable
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
@@ -333,12 +333,16 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(@"public class TestClass
                            {
                                public override void TestMethod(string arg1, string arg2) { }
-                           }", CompilerDiagnostics.None);
+                                // Test0.cs(3,53): error CS0115: 'TestClass.TestMethod(string, string)': no suitable method found to override
+                           }",
+                           new DiagnosticResult("CS0115", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(3, 53));
 
             await VerifyVB.VerifyAnalyzerAsync(@"Public Class TestClass
                               Public Overrides Sub TestMethod(arg1 As String, arg2 As String)
+                                ' Test0.vb(2) : error BC30284: sub 'TestMethod' cannot be declared 'Overrides' because it does not override a sub in a base class.
                               End Sub
-                          End Class", CompilerDiagnostics.None);
+                          End Class",
+                          new DiagnosticResult("BC30284", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(2, 52));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
@@ -615,12 +615,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, string violatingMember, string violatingParameter, string baseParameter, string baseMember)
-            => new DiagnosticResult(ParameterNamesShouldMatchBaseDeclarationAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(violatingMember, violatingParameter, baseParameter, baseMember);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, string violatingMember, string violatingParameter, string baseParameter, string baseMember)
-            => new DiagnosticResult(ParameterNamesShouldMatchBaseDeclarationAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(violatingMember, violatingParameter, baseParameter, baseMember);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
@@ -335,14 +335,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                                public override void TestMethod(string arg1, string arg2) { }
                                 // Test0.cs(3,53): error CS0115: 'TestClass.TestMethod(string, string)': no suitable method found to override
                            }",
-                           new DiagnosticResult("CS0115", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(3, 53));
+                           DiagnosticResult.CompilerError("CS0115").WithLocation(3, 53));
 
             await VerifyVB.VerifyAnalyzerAsync(@"Public Class TestClass
                               Public Overrides Sub TestMethod(arg1 As String, arg2 As String)
                                 ' Test0.vb(2) : error BC30284: sub 'TestMethod' cannot be declared 'Overrides' because it does not override a sub in a base class.
                               End Sub
                           End Class",
-                          new DiagnosticResult("BC30284", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(2, 52));
+                          DiagnosticResult.CompilerError("BC30284").WithLocation(2, 52));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
@@ -333,16 +333,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(@"public class TestClass
                            {
                                public override void TestMethod(string arg1, string arg2) { }
-                                // Test0.cs(3,53): error CS0115: 'TestClass.TestMethod(string, string)': no suitable method found to override
                            }",
-                           DiagnosticResult.CompilerError("CS0115").WithLocation(3, 53));
+                           DiagnosticResult.CompilerError("CS0115").WithLocation(3, 53).WithMessage("'TestClass.TestMethod(string, string)': no suitable method found to override"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"Public Class TestClass
                               Public Overrides Sub TestMethod(arg1 As String, arg2 As String)
-                                ' Test0.vb(2) : error BC30284: sub 'TestMethod' cannot be declared 'Overrides' because it does not override a sub in a base class.
                               End Sub
                           End Class",
-                          DiagnosticResult.CompilerError("BC30284").WithLocation(2, 52));
+                          DiagnosticResult.CompilerError("BC30284").WithLocation(2, 52).WithMessage("sub 'TestMethod' cannot be declared 'Overrides' because it does not override a sub in a base class."));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStringsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PassSystemUriObjectsInsteadOfStringsTests.cs
@@ -464,10 +464,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         Public Sub Method()
             Method(""test"", 0, ""test"")
         End Sub
-    
+
         Public Sub Method(firstUri As String, i As Integer, lastUrl As String)
         End Sub
-    
+
         Public Sub Method(Uri As Uri, i As Integer, lastUrl As String)
         End Sub
     End Module
@@ -491,12 +491,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCA2234CSharpResultAt(int line, int column, params string[] args)
-            => new DiagnosticResult(PassSystemUriObjectsInsteadOfStringsAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(args);
 
         private static DiagnosticResult GetCA2234BasicResultAt(int line, int column, params string[] args)
-            => new DiagnosticResult(PassSystemUriObjectsInsteadOfStringsAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(args);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnlyTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnlyTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -900,22 +899,17 @@ End NameSpace
         private static readonly string CA1044MessageMakeMoreAccessible = MicrosoftCodeQualityAnalyzersResources.PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible;
 
         private static DiagnosticResult GetCA1044CSharpResultAt(int line, int column, string CA1044Message, string objectName)
-        {
-            var rule = CA1044Message == CA1044MessageAddGetter
-                ? PropertiesShouldNotBeWriteOnlyAnalyzer.AddGetterRule
-                : PropertiesShouldNotBeWriteOnlyAnalyzer.MakeMoreAccessibleRule;
-            return new DiagnosticResult(rule)
+            => VerifyCS.Diagnostic(CA1044Message == CA1044MessageAddGetter
+                    ? PropertiesShouldNotBeWriteOnlyAnalyzer.AddGetterRule
+                    : PropertiesShouldNotBeWriteOnlyAnalyzer.MakeMoreAccessibleRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1044Message, objectName));
-        }
+                .WithArguments(objectName);
+
         private static DiagnosticResult GetCA1044BasicResultAt(int line, int column, string CA1044Message, string objectName)
-        {
-            var rule = CA1044Message == CA1044MessageAddGetter
-                ? PropertiesShouldNotBeWriteOnlyAnalyzer.AddGetterRule
-                : PropertiesShouldNotBeWriteOnlyAnalyzer.MakeMoreAccessibleRule;
-            return new DiagnosticResult(rule)
+            => VerifyVB.Diagnostic(CA1044Message == CA1044MessageAddGetter
+                    ? PropertiesShouldNotBeWriteOnlyAnalyzer.AddGetterRule
+                    : PropertiesShouldNotBeWriteOnlyAnalyzer.MakeMoreAccessibleRule)
                 .WithLocation(line, column)
-                .WithMessage(string.Format(CultureInfo.CurrentCulture, CA1044Message, objectName));
-        }
+                .WithArguments(objectName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotReturnArraysTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertiesShouldNotReturnArraysTests.cs
@@ -139,13 +139,11 @@ End Class");
         }
 
         private static DiagnosticResult CreateCSharpResult(int line, int col)
-            => new DiagnosticResult(PropertiesShouldNotReturnArraysAnalyzer.Rule)
-                .WithLocation(line, col)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.PropertiesShouldNotReturnArraysMessage);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, col);
 
         private static DiagnosticResult CreateBasicResult(int line, int col)
-            => new DiagnosticResult(PropertiesShouldNotReturnArraysAnalyzer.Rule)
-                .WithLocation(line, col)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.PropertiesShouldNotReturnArraysMessage);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, col);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
@@ -589,22 +589,14 @@ End Class
         #region Helpers
 
         private static DiagnosticResult GetCA1721CSharpResultAt(int line, int column, string identifierName, string otherIdentifierName)
-        {
-            // Add a public read-only property accessor for positional argument '{0}' of attribute '{1}'.
-            string message = string.Format(CultureInfo.InvariantCulture, MicrosoftCodeQualityAnalyzersResources.PropertyNamesShouldNotMatchGetMethodsMessage, identifierName, otherIdentifierName);
-            return new DiagnosticResult(PropertyNamesShouldNotMatchGetMethodsAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(identifierName, otherIdentifierName);
 
         private static DiagnosticResult GetCA1721BasicResultAt(int line, int column, string identifierName, string otherIdentifierName)
-        {
-            // Add a public read-only property accessor for positional argument '{0}' of attribute '{1}'.
-            string message = string.Format(CultureInfo.InvariantCulture, MicrosoftCodeQualityAnalyzersResources.PropertyNamesShouldNotMatchGetMethodsMessage, identifierName, otherIdentifierName);
-            return new DiagnosticResult(PropertyNamesShouldNotMatchGetMethodsAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
-                .WithMessage(message);
-        }
+                .WithArguments(identifierName, otherIdentifierName);
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
@@ -186,12 +186,12 @@ End Class
 ");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
@@ -187,12 +187,12 @@ End Class
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
-            => new DiagnosticResult(ProvideObsoleteAttributeMessageAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
         private DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
-            => new DiagnosticResult(ProvideObsoleteAttributeMessageAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -719,8 +719,7 @@ public class C26 :
     public static void Foo() { }
 }
 ",
-                // Test0.cs(2,19): error CS1031: Type expected
-                DiagnosticResult.CompilerError("CS1031").WithLocation(2, 19));
+                DiagnosticResult.CompilerError("CS1031").WithLocation(2, 19).WithMessage("Type expected"));
         }
 
         [Fact]
@@ -733,8 +732,7 @@ Public Class B26
 	End Sub
 End Class
 ",
-                // Test0.vb(3) : error BC30182: Type expected.
-                DiagnosticResult.CompilerError("BC30182").WithLocation(3, 10));
+                DiagnosticResult.CompilerError("BC30182").WithLocation(3, 10).WithMessage("Type expected."));
         }
 
         [Fact]
@@ -745,8 +743,7 @@ public class C27 :
 {
 }
 ",
-                // Test0.cs(2,19): error CS1031: Type expected
-                DiagnosticResult.CompilerError("CS1031").WithLocation(2, 19));
+                DiagnosticResult.CompilerError("CS1031").WithLocation(2, 19).WithMessage("Type expected"));
         }
 
         [Fact]
@@ -757,8 +754,7 @@ Public Class B27
 	Inherits
 End Class
 ",
-                // Test0.vb(3) : error BC30182: Type expected.
-                DiagnosticResult.CompilerError("BC30182").WithLocation(3, 10));
+                DiagnosticResult.CompilerError("BC30182").WithLocation(3, 10).WithMessage("Type expected."));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -18,12 +18,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         #region Verifiers
 
         private static DiagnosticResult CSharpResult(int line, int column, string objectName)
-            => VerifyCS.Diagnostic(StaticHolderTypesAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(objectName);
 
         private static DiagnosticResult BasicResult(int line, int column, string objectName)
-            => VerifyVB.Diagnostic(StaticHolderTypesAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(objectName);
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -720,7 +720,7 @@ public class C26 :
 }
 ",
                 // Test0.cs(2,19): error CS1031: Type expected
-                new DiagnosticResult("CS1031", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(2, 19));
+                DiagnosticResult.CompilerError("CS1031").WithLocation(2, 19));
         }
 
         [Fact]
@@ -734,7 +734,7 @@ Public Class B26
 End Class
 ",
                 // Test0.vb(3) : error BC30182: Type expected.
-                new DiagnosticResult("BC30182", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(3, 10));
+                DiagnosticResult.CompilerError("BC30182").WithLocation(3, 10));
         }
 
         [Fact]
@@ -746,7 +746,7 @@ public class C27 :
 }
 ",
                 // Test0.cs(2,19): error CS1031: Type expected
-                new DiagnosticResult("CS1031", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(2, 19));
+                DiagnosticResult.CompilerError("CS1031").WithLocation(2, 19));
         }
 
         [Fact]
@@ -758,7 +758,7 @@ Public Class B27
 End Class
 ",
                 // Test0.vb(3) : error BC30182: Type expected.
-                new DiagnosticResult("BC30182", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(3, 10));
+                DiagnosticResult.CompilerError("BC30182").WithLocation(3, 10));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -718,7 +718,9 @@ public class C26 :
 {
     public static void Foo() { }
 }
-", CompilerDiagnostics.None);
+",
+                // Test0.cs(2,19): error CS1031: Type expected
+                new DiagnosticResult("CS1031", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(2, 19));
         }
 
         [Fact]
@@ -730,7 +732,9 @@ Public Class B26
 	Public Shared Sub Foo()
 	End Sub
 End Class
-", CompilerDiagnostics.None);
+",
+                // Test0.vb(3) : error BC30182: Type expected.
+                new DiagnosticResult("BC30182", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(3, 10));
         }
 
         [Fact]
@@ -740,7 +744,9 @@ End Class
 public class C27 :
 {
 }
-", CompilerDiagnostics.None);
+",
+                // Test0.cs(2,19): error CS1031: Type expected
+                new DiagnosticResult("CS1031", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(2, 19));
         }
 
         [Fact]
@@ -750,7 +756,9 @@ public class C27 :
 Public Class B27
 	Inherits
 End Class
-", CompilerDiagnostics.None);
+",
+                // Test0.vb(3) : error BC30182: Type expected.
+                new DiagnosticResult("BC30182", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(3, 10));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
@@ -17,22 +17,22 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
     public class TypeNamesShouldNotMatchNamespacesTests
     {
         private static DiagnosticResult CSharpDefaultResultAt(int line, int column, string typeName, string namespaceName)
-            => new DiagnosticResult(TypeNamesShouldNotMatchNamespacesAnalyzer.DefaultRule)
+            => VerifyCS.Diagnostic(TypeNamesShouldNotMatchNamespacesAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(typeName, namespaceName);
 
         private static DiagnosticResult CSharpSystemResultAt(int line, int column, string typeName, string namespaceName)
-            => new DiagnosticResult(TypeNamesShouldNotMatchNamespacesAnalyzer.SystemRule)
+            => VerifyCS.Diagnostic(TypeNamesShouldNotMatchNamespacesAnalyzer.SystemRule)
                 .WithLocation(line, column)
                 .WithArguments(typeName, namespaceName);
 
         private static DiagnosticResult BasicDefaultResultAt(int line, int column, string typeName, string namespaceName)
-            => new DiagnosticResult(TypeNamesShouldNotMatchNamespacesAnalyzer.DefaultRule)
+            => VerifyVB.Diagnostic(TypeNamesShouldNotMatchNamespacesAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(typeName, namespaceName);
 
         private static DiagnosticResult BasicSystemResultAt(int line, int column, string typeName, string namespaceName)
-            => new DiagnosticResult(TypeNamesShouldNotMatchNamespacesAnalyzer.SystemRule)
+            => VerifyVB.Diagnostic(TypeNamesShouldNotMatchNamespacesAnalyzer.SystemRule)
                 .WithLocation(line, column)
                 .WithArguments(typeName, namespaceName);
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
@@ -97,7 +97,7 @@ public class Sdk
                 },
                 ExpectedDiagnostics =
                 {
-                    CSharpDefaultResultAt(2, 14, "Sdk", "Xunit.Sdk")
+                    CSharpDefaultResultAt(2, 14, "Sdk", "Xunit.Sdk"),
                 }
             }.RunAsync();
         }
@@ -294,7 +294,7 @@ End Class"
                 },
                 ExpectedDiagnostics =
                 {
-                    BasicDefaultResultAt(2, 14, "Sdk", "Xunit.Sdk")
+                    BasicDefaultResultAt(2, 14, "Sdk", "Xunit.Sdk"),
                 }
             }.RunAsync();
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -16,18 +13,8 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
-    public class TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzerTests : DiagnosticAnalyzerTestBase
+    public class TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzerTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer();
-        }
-
         [Fact]
         public async Task CA1001CSharpTestWithNoDisposableType()
         {
@@ -124,9 +111,9 @@ using System.IO;
         }
 
         [Fact]
-        public void CA1001CSharpTestWithNoDisposeMethodInScope()
+        public async Task CA1001CSharpTestWithNoDisposeMethodInScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 
     // This class violates the rule.
@@ -144,9 +131,9 @@ using System.IO;
         }
 
         [Fact]
-        public void CA1001CSharpScopedTestWithNoDisposeMethodOutOfScope()
+        public async Task CA1001CSharpScopedTestWithNoDisposeMethodOutOfScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 
@@ -369,9 +356,9 @@ Imports System.IO
         }
 
         [Fact]
-        public void CA1001BasicTestWithNoDisposeMethodInScope()
+        public async Task CA1001BasicTestWithNoDisposeMethodInScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
    Imports System.IO
 
    ' This class violates the rule.
@@ -389,9 +376,9 @@ Imports System.IO
         }
 
         [Fact]
-        public void CA1001BasicTestWithNoDisposeMethodOutOfScope()
+        public async Task CA1001BasicTestWithNoDisposeMethodOutOfScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
    Imports System.IO
 
    ' This class violates the rule.

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -469,12 +469,12 @@ End Namespace
         }
 
         private static DiagnosticResult GetCA1001CSharpResultAt(int line, int column, string objectName, string disposableFields)
-            => VerifyCS.Diagnostic(CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(objectName, disposableFields);
 
         private static DiagnosticResult GetCA1001BasicResultAt(int line, int column, string objectName, string disposableFields)
-            => VerifyVB.Diagnostic(CSharpTypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(objectName, disposableFields);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -117,7 +117,7 @@ using System.IO;
 using System.IO;
 
     // This class violates the rule.
-    [|public class NoDisposeClass
+    public class [|NoDisposeClass|]
     {
         FileStream newFile;
 
@@ -125,9 +125,8 @@ using System.IO;
         {
             newFile = new FileStream(""data.txt"", FileMode.Append);
         }
-    }|]
-",
-            GetCA1001CSharpResultAt(5, 18, "NoDisposeClass", "newFile"));
+    }
+");
         }
 
         [Fact]
@@ -138,7 +137,7 @@ using System;
 using System.IO;
 
 // This class violates the rule.
-public class NoDisposeClass
+public class [|NoDisposeClass|]
 {
     FileStream newFile;
 
@@ -148,10 +147,9 @@ public class NoDisposeClass
     }
 }
 
-[|public class Foo
+public class Foo
 {
 }
-|]
 ");
         }
 
@@ -362,7 +360,7 @@ Imports System.IO
    Imports System.IO
 
    ' This class violates the rule.
-   [|Public Class NoDisposeMethod
+   Public Class [|NoDisposeMethod|]
 
       Dim newFile As FileStream
 
@@ -370,9 +368,8 @@ Imports System.IO
          newFile = New FileStream("""", FileMode.Append)
       End Sub
 
-   End Class|]
-",
-            GetCA1001BasicResultAt(5, 17, "NoDisposeMethod", "newFile"));
+   End Class
+");
         }
 
         [Fact]
@@ -382,7 +379,7 @@ Imports System.IO
    Imports System.IO
 
    ' This class violates the rule.
-   Public Class NoDisposeMethod
+   Public Class [|NoDisposeMethod|]
 
       Dim newFile As FileStream
 
@@ -392,10 +389,8 @@ Imports System.IO
 
    End Class
 
-   [|
    Public Class Foo
    End Class
-   |]
 ");
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriParametersShouldNotBeStringsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriParametersShouldNotBeStringsTests.cs
@@ -194,12 +194,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCA1054CSharpResultAt(int line, int column, params string[] args)
-            => new DiagnosticResult(UriParametersShouldNotBeStringsAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(args);
 
         private static DiagnosticResult GetCA1054BasicResultAt(int line, int column, params string[] args)
-            => new DiagnosticResult(UriParametersShouldNotBeStringsAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(args);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriPropertiesShouldNotBeStringsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriPropertiesShouldNotBeStringsTests.cs
@@ -131,12 +131,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCA1056CSharpResultAt(int line, int column, params string[] args)
-            => new DiagnosticResult(UriPropertiesShouldNotBeStringsAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(args);
 
         private static DiagnosticResult GetCA1056BasicResultAt(int line, int column, params string[] args)
-            => new DiagnosticResult(UriPropertiesShouldNotBeStringsAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(args);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriReturnValuesShouldNotBeStringsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UriReturnValuesShouldNotBeStringsTests.cs
@@ -126,12 +126,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult GetCA1055CSharpResultAt(int line, int column, params string[] args)
-            => new DiagnosticResult(UriReturnValuesShouldNotBeStringsAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(args);
 
         private static DiagnosticResult GetCA1055BasicResultAt(int line, int column, params string[] args)
-            => new DiagnosticResult(UriReturnValuesShouldNotBeStringsAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(args);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseEventsWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseEventsWhereAppropriateTests.cs
@@ -379,21 +379,21 @@ public abstract class ClassWithViolations
 }
 ",
       // Test0.cs(7,10): warning CA1030: Consider making 'FireOnSomething_InterfaceMethod1' an event.
-      GetCSharpResultAt(7, 10, UseEventsWhereAppropriateAnalyzer.Rule, "FireOnSomething_InterfaceMethod1"),
+      GetCSharpResultAt(7, 10, "FireOnSomething_InterfaceMethod1"),
       // Test0.cs(8,10): warning CA1030: Consider making 'FireOnSomething_InterfaceMethod2' an event.
-      GetCSharpResultAt(8, 10, UseEventsWhereAppropriateAnalyzer.Rule, "FireOnSomething_InterfaceMethod2"),
+      GetCSharpResultAt(8, 10, "FireOnSomething_InterfaceMethod2"),
       // Test0.cs(14,24): warning CA1030: Consider making 'RaiseOnSomething_StaticMethod' an event.
-      GetCSharpResultAt(14, 24, UseEventsWhereAppropriateAnalyzer.Rule, "RaiseOnSomething_StaticMethod"),
+      GetCSharpResultAt(14, 24, "RaiseOnSomething_StaticMethod"),
       // Test0.cs(19,25): warning CA1030: Consider making 'FireOnSomething_VirtualMethod' an event.
-      GetCSharpResultAt(19, 25, UseEventsWhereAppropriateAnalyzer.Rule, "FireOnSomething_VirtualMethod"),
+      GetCSharpResultAt(19, 25, "FireOnSomething_VirtualMethod"),
       // Test0.cs(24,26): warning CA1030: Consider making 'FireOnSomething_AbstractMethod' an event.
-      GetCSharpResultAt(24, 26, UseEventsWhereAppropriateAnalyzer.Rule, "FireOnSomething_AbstractMethod"),
+      GetCSharpResultAt(24, 26, "FireOnSomething_AbstractMethod"),
       // Test0.cs(27,26): warning CA1030: Consider making 'RaiseOnSomething_AbstractMethod' an event.
-      GetCSharpResultAt(27, 26, UseEventsWhereAppropriateAnalyzer.Rule, "RaiseOnSomething_AbstractMethod"),
+      GetCSharpResultAt(27, 26, "RaiseOnSomething_AbstractMethod"),
       // Test0.cs(30,26): warning CA1030: Consider making 'AddOnSomething_AbstractMethod' an event.
-      GetCSharpResultAt(30, 26, UseEventsWhereAppropriateAnalyzer.Rule, "AddOnSomething_AbstractMethod"),
+      GetCSharpResultAt(30, 26, "AddOnSomething_AbstractMethod"),
       // Test0.cs(33,26): warning CA1030: Consider making 'RemoveOnSomething_AbstractMethod' an event.
-      GetCSharpResultAt(33, 26, UseEventsWhereAppropriateAnalyzer.Rule, "RemoveOnSomething_AbstractMethod"));
+      GetCSharpResultAt(33, 26, "RemoveOnSomething_AbstractMethod"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Public Interface InterfaceWithViolations
@@ -425,21 +425,21 @@ Public MustInherit Class ClassWithViolations
 End Class
 ",
       // Test0.vb(4,6): warning CA1030: Consider making 'FireOnSomething_InterfaceMethod1' an event.
-      GetBasicResultAt(4, 6, UseEventsWhereAppropriateAnalyzer.Rule, "FireOnSomething_InterfaceMethod1"),
+      GetBasicResultAt(4, 6, "FireOnSomething_InterfaceMethod1"),
       // Test0.vb(5,6): warning CA1030: Consider making 'FireOnSomething_InterfaceMethod2' an event.
-      GetBasicResultAt(5, 6, UseEventsWhereAppropriateAnalyzer.Rule, "FireOnSomething_InterfaceMethod2"),
+      GetBasicResultAt(5, 6, "FireOnSomething_InterfaceMethod2"),
       // Test0.vb(10,20): warning CA1030: Consider making 'RaiseOnSomething_StaticMethod' an event.
-      GetBasicResultAt(10, 20, UseEventsWhereAppropriateAnalyzer.Rule, "RaiseOnSomething_StaticMethod"),
+      GetBasicResultAt(10, 20, "RaiseOnSomething_StaticMethod"),
       // Test0.vb(14,25): warning CA1030: Consider making 'FireOnSomething_VirtualMethod' an event.
-      GetBasicResultAt(14, 25, UseEventsWhereAppropriateAnalyzer.Rule, "FireOnSomething_VirtualMethod"),
+      GetBasicResultAt(14, 25, "FireOnSomething_VirtualMethod"),
       // Test0.vb(18,26): warning CA1030: Consider making 'FireOnSomething_AbstractMethod' an event.
-      GetBasicResultAt(18, 26, UseEventsWhereAppropriateAnalyzer.Rule, "FireOnSomething_AbstractMethod"),
+      GetBasicResultAt(18, 26, "FireOnSomething_AbstractMethod"),
       // Test0.vb(21,26): warning CA1030: Consider making 'RaiseOnSomething_AbstractMethod' an event.
-      GetBasicResultAt(21, 26, UseEventsWhereAppropriateAnalyzer.Rule, "RaiseOnSomething_AbstractMethod"),
+      GetBasicResultAt(21, 26, "RaiseOnSomething_AbstractMethod"),
       // Test0.vb(24,26): warning CA1030: Consider making 'AddOnSomething_AbstractMethod' an event.
-      GetBasicResultAt(24, 26, UseEventsWhereAppropriateAnalyzer.Rule, "AddOnSomething_AbstractMethod"),
+      GetBasicResultAt(24, 26, "AddOnSomething_AbstractMethod"),
       // Test0.vb(27,26): warning CA1030: Consider making 'RemoveOnSomething_AbstractMethod' an event.
-      GetBasicResultAt(27, 26, UseEventsWhereAppropriateAnalyzer.Rule, "RemoveOnSomething_AbstractMethod"));
+      GetBasicResultAt(27, 26, "RemoveOnSomething_AbstractMethod"));
         }
 
         [WorkItem(380, "https://github.com/dotnet/roslyn-analyzers/issues/380")]
@@ -467,21 +467,21 @@ public class EventsClassPascalCased
 }
 ",
       // Test0.cs(4,17): warning CA1030: Consider making 'Fire' an event.
-      GetCSharpResultAt(4, 17, UseEventsWhereAppropriateAnalyzer.Rule, "Fire"),
+      GetCSharpResultAt(4, 17, "Fire"),
       // Test0.cs(6,17): warning CA1030: Consider making 'Raise' an event.
-      GetCSharpResultAt(6, 17, UseEventsWhereAppropriateAnalyzer.Rule, "Raise"),
+      GetCSharpResultAt(6, 17, "Raise"),
       // Test0.cs(8,17): warning CA1030: Consider making 'RaiseFileEvent' an event.
-      GetCSharpResultAt(8, 17, UseEventsWhereAppropriateAnalyzer.Rule, "RaiseFileEvent"),
+      GetCSharpResultAt(8, 17, "RaiseFileEvent"),
       // Test0.cs(10,17): warning CA1030: Consider making 'FireFileEvent' an event.
-      GetCSharpResultAt(10, 17, UseEventsWhereAppropriateAnalyzer.Rule, "FireFileEvent"),
+      GetCSharpResultAt(10, 17, "FireFileEvent"),
       // Test0.cs(12,17): warning CA1030: Consider making 'AddOnFileEvent' an event.
-      GetCSharpResultAt(12, 17, UseEventsWhereAppropriateAnalyzer.Rule, "AddOnFileEvent"),
+      GetCSharpResultAt(12, 17, "AddOnFileEvent"),
       // Test0.cs(14,17): warning CA1030: Consider making 'RemoveOnFileEvent' an event.
-      GetCSharpResultAt(14, 17, UseEventsWhereAppropriateAnalyzer.Rule, "RemoveOnFileEvent"),
+      GetCSharpResultAt(14, 17, "RemoveOnFileEvent"),
       // Test0.cs(16,17): warning CA1030: Consider making 'Add_OnFileEvent' an event.
-      GetCSharpResultAt(16, 17, UseEventsWhereAppropriateAnalyzer.Rule, "Add_OnFileEvent"),
+      GetCSharpResultAt(16, 17, "Add_OnFileEvent"),
       // Test0.cs(18,17): warning CA1030: Consider making 'Remove_OnFileEvent' an event.
-      GetCSharpResultAt(18, 17, UseEventsWhereAppropriateAnalyzer.Rule, "Remove_OnFileEvent"));
+      GetCSharpResultAt(18, 17, "Remove_OnFileEvent"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class EventsClassPascalCased
@@ -511,21 +511,21 @@ Public Class EventsClassPascalCased
 End Class
 ",
       // Test0.vb(3,13): warning CA1030: Consider making 'Fire' an event.
-      GetBasicResultAt(3, 13, UseEventsWhereAppropriateAnalyzer.Rule, "Fire"),
+      GetBasicResultAt(3, 13, "Fire"),
       // Test0.vb(6,13): warning CA1030: Consider making 'Raise' an event.
-      GetBasicResultAt(6, 13, UseEventsWhereAppropriateAnalyzer.Rule, "Raise"),
+      GetBasicResultAt(6, 13, "Raise"),
       // Test0.vb(9,13): warning CA1030: Consider making 'RaiseFileEvent' an event.
-      GetBasicResultAt(9, 13, UseEventsWhereAppropriateAnalyzer.Rule, "RaiseFileEvent"),
+      GetBasicResultAt(9, 13, "RaiseFileEvent"),
       // Test0.vb(12,13): warning CA1030: Consider making 'FireFileEvent' an event.
-      GetBasicResultAt(12, 13, UseEventsWhereAppropriateAnalyzer.Rule, "FireFileEvent"),
+      GetBasicResultAt(12, 13, "FireFileEvent"),
       // Test0.vb(15,13): warning CA1030: Consider making 'AddOnFileEvent' an event.
-      GetBasicResultAt(15, 13, UseEventsWhereAppropriateAnalyzer.Rule, "AddOnFileEvent"),
+      GetBasicResultAt(15, 13, "AddOnFileEvent"),
       // Test0.vb(18,13): warning CA1030: Consider making 'RemoveOnFileEvent' an event.
-      GetBasicResultAt(18, 13, UseEventsWhereAppropriateAnalyzer.Rule, "RemoveOnFileEvent"),
+      GetBasicResultAt(18, 13, "RemoveOnFileEvent"),
       // Test0.vb(21,13): warning CA1030: Consider making 'Add_OnFileEvent' an event.
-      GetBasicResultAt(21, 13, UseEventsWhereAppropriateAnalyzer.Rule, "Add_OnFileEvent"),
+      GetBasicResultAt(21, 13, "Add_OnFileEvent"),
       // Test0.vb(24,13): warning CA1030: Consider making 'Remove_OnFileEvent' an event.
-      GetBasicResultAt(24, 13, UseEventsWhereAppropriateAnalyzer.Rule, "Remove_OnFileEvent"));
+      GetBasicResultAt(24, 13, "Remove_OnFileEvent"));
 
         }
 
@@ -554,21 +554,21 @@ public class EventsClassLowercase
 }
 ",
       // Test0.cs(4,17): warning CA1030: Consider making 'fire' an event.
-      GetCSharpResultAt(4, 17, UseEventsWhereAppropriateAnalyzer.Rule, "fire"),
+      GetCSharpResultAt(4, 17, "fire"),
       // Test0.cs(6,17): warning CA1030: Consider making 'raise' an event.
-      GetCSharpResultAt(6, 17, UseEventsWhereAppropriateAnalyzer.Rule, "raise"),
+      GetCSharpResultAt(6, 17, "raise"),
       // Test0.cs(8,17): warning CA1030: Consider making 'raiseFileEvent' an event.
-      GetCSharpResultAt(8, 17, UseEventsWhereAppropriateAnalyzer.Rule, "raiseFileEvent"),
+      GetCSharpResultAt(8, 17, "raiseFileEvent"),
       // Test0.cs(10,17): warning CA1030: Consider making 'fireFileEvent' an event.
-      GetCSharpResultAt(10, 17, UseEventsWhereAppropriateAnalyzer.Rule, "fireFileEvent"),
+      GetCSharpResultAt(10, 17, "fireFileEvent"),
       // Test0.cs(12,17): warning CA1030: Consider making 'addOnFileEvent' an event.
-      GetCSharpResultAt(12, 17, UseEventsWhereAppropriateAnalyzer.Rule, "addOnFileEvent"),
+      GetCSharpResultAt(12, 17, "addOnFileEvent"),
       // Test0.cs(14,17): warning CA1030: Consider making 'removeOnFileEvent' an event.
-      GetCSharpResultAt(14, 17, UseEventsWhereAppropriateAnalyzer.Rule, "removeOnFileEvent"),
+      GetCSharpResultAt(14, 17, "removeOnFileEvent"),
       // Test0.cs(16,17): warning CA1030: Consider making 'add_onFileEvent' an event.
-      GetCSharpResultAt(16, 17, UseEventsWhereAppropriateAnalyzer.Rule, "add_onFileEvent"),
+      GetCSharpResultAt(16, 17, "add_onFileEvent"),
       // Test0.cs(18,17): warning CA1030: Consider making 'remove_onFileEvent' an event.
-      GetCSharpResultAt(18, 17, UseEventsWhereAppropriateAnalyzer.Rule, "remove_onFileEvent"));
+      GetCSharpResultAt(18, 17, "remove_onFileEvent"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class EventsClassLowercase
@@ -598,33 +598,33 @@ Public Class EventsClassLowercase
 End Class
 ",
       // Test0.vb(3,13): warning CA1030: Consider making 'fire' an event.
-      GetBasicResultAt(3, 13, UseEventsWhereAppropriateAnalyzer.Rule, "fire"),
+      GetBasicResultAt(3, 13, "fire"),
       // Test0.vb(6,13): warning CA1030: Consider making 'raise' an event.
-      GetBasicResultAt(6, 13, UseEventsWhereAppropriateAnalyzer.Rule, "raise"),
+      GetBasicResultAt(6, 13, "raise"),
       // Test0.vb(9,13): warning CA1030: Consider making 'raiseFileEvent' an event.
-      GetBasicResultAt(9, 13, UseEventsWhereAppropriateAnalyzer.Rule, "raiseFileEvent"),
+      GetBasicResultAt(9, 13, "raiseFileEvent"),
       // Test0.vb(12,13): warning CA1030: Consider making 'fireFileEvent' an event.
-      GetBasicResultAt(12, 13, UseEventsWhereAppropriateAnalyzer.Rule, "fireFileEvent"),
+      GetBasicResultAt(12, 13, "fireFileEvent"),
       // Test0.vb(15,13): warning CA1030: Consider making 'addOnFileEvent' an event.
-      GetBasicResultAt(15, 13, UseEventsWhereAppropriateAnalyzer.Rule, "addOnFileEvent"),
+      GetBasicResultAt(15, 13, "addOnFileEvent"),
       // Test0.vb(18,13): warning CA1030: Consider making 'removeOnFileEvent' an event.
-      GetBasicResultAt(18, 13, UseEventsWhereAppropriateAnalyzer.Rule, "removeOnFileEvent"),
+      GetBasicResultAt(18, 13, "removeOnFileEvent"),
       // Test0.vb(21,13): warning CA1030: Consider making 'add_onFileEvent' an event.
-      GetBasicResultAt(21, 13, UseEventsWhereAppropriateAnalyzer.Rule, "add_onFileEvent"),
+      GetBasicResultAt(21, 13, "add_onFileEvent"),
       // Test0.vb(24,13): warning CA1030: Consider making 'remove_onFileEvent' an event.
-      GetBasicResultAt(24, 13, UseEventsWhereAppropriateAnalyzer.Rule, "remove_onFileEvent"));
+      GetBasicResultAt(24, 13, "remove_onFileEvent"));
 
         }
 
         #endregion
 
-        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseGenericEventHandlerInstancesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseGenericEventHandlerInstancesTests.cs
@@ -270,12 +270,12 @@ End Structure
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+            => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexersTests.cs
@@ -201,13 +201,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         private static DiagnosticResult CreateCSharpResult(int line, int col)
-            => new DiagnosticResult(UseIntegralOrStringArgumentForIndexersAnalyzer.Rule)
-                .WithLocation(line, col)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.UseIntegralOrStringArgumentForIndexersMessage);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, col);
 
         private static DiagnosticResult CreateBasicResult(int line, int col)
-            => new DiagnosticResult(UseIntegralOrStringArgumentForIndexersAnalyzer.Rule)
-                .WithLocation(line, col)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.UseIntegralOrStringArgumentForIndexersMessage);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, col);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -343,8 +343,7 @@ End Class
 ",
                 // Test0.vb(3,21): warning CA1024: Use properties where appropriate
                 GetCA1024BasicResultAt(3, 21, "GetSomethingWithUnboundInvocation"),
-                // Test0.vb(4) : error BC30451: 'Console' is not declared. It may be inaccessible due to its protection level.
-                DiagnosticResult.CompilerError("BC30451").WithLocation(4, 9));
+                DiagnosticResult.CompilerError("BC30451").WithLocation(4, 9).WithMessage("'Console' is not declared. It may be inaccessible due to its protection level."));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -441,12 +441,12 @@ public class Foo : IFoo
         }
 
         private static DiagnosticResult GetCA1024CSharpResultAt(int line, int column, string methodName)
-            => VerifyCS.Diagnostic(UsePropertiesWhereAppropriateAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(methodName);
 
         private static DiagnosticResult GetCA1024BasicResultAt(int line, int column, string methodName)
-            => VerifyVB.Diagnostic(UsePropertiesWhereAppropriateAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(methodName);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -330,7 +331,7 @@ public class class1
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7222")]
+        [Fact]
         public async Task VisualBasic_CA1024NoDiagnosticOnUnboundMethodCaller()
         {
             await VerifyVB.VerifyAnalyzerAsync(@"
@@ -340,7 +341,11 @@ Public Class class1
         Return 0
     End Function
 End Class
-", CompilerDiagnostics.None);
+",
+                // Test0.vb(3,21): warning CA1024: Use properties where appropriate
+                GetCA1024BasicResultAt(3, 21, "GetSomethingWithUnboundInvocation"),
+                // Test0.vb(4) : error BC30451: 'Console' is not declared. It may be inaccessible due to its protection level.
+                new DiagnosticResult("BC30451", DiagnosticSeverity.Error).WithLocation(4, 9));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -345,7 +344,7 @@ End Class
                 // Test0.vb(3,21): warning CA1024: Use properties where appropriate
                 GetCA1024BasicResultAt(3, 21, "GetSomethingWithUnboundInvocation"),
                 // Test0.vb(4) : error BC30451: 'Console' is not declared. It may be inaccessible due to its protection level.
-                new DiagnosticResult("BC30451", DiagnosticSeverity.Error).WithLocation(4, 9));
+                DiagnosticResult.CompilerError("BC30451").WithLocation(4, 9));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Documentation/AvoidUsingCrefTagsWithAPrefixTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Documentation/AvoidUsingCrefTagsWithAPrefixTests.cs
@@ -81,13 +81,11 @@ End Class
         #endregion
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-            => new DiagnosticResult(AvoidUsingCrefTagsWithAPrefixAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.AvoidUsingCrefTagsWithAPrefixMessage);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column)
-            => new DiagnosticResult(AvoidUsingCrefTagsWithAPrefixAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.AvoidUsingCrefTagsWithAPrefixMessage);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -16,22 +16,22 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
     public partial class AvoidDeadConditionalCodeTests
     {
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string condition, string reason)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string condition, string reason)
             => VerifyCS.Diagnostic(AvoidDeadConditionalCode.AlwaysTrueFalseOrNullRule)
                 .WithLocation(line, column)
                 .WithArguments(condition, reason);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, string condition, string reason)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, string condition, string reason)
             => VerifyVB.Diagnostic(AvoidDeadConditionalCode.AlwaysTrueFalseOrNullRule)
                 .WithLocation(line, column)
                 .WithArguments(condition, reason);
 
-        private DiagnosticResult GetCSharpNeverNullResultAt(int line, int column, string condition, string reason)
+        private static DiagnosticResult GetCSharpNeverNullResultAt(int line, int column, string condition, string reason)
             => VerifyCS.Diagnostic(AvoidDeadConditionalCode.NeverNullRule)
                 .WithLocation(line, column)
                 .WithArguments(condition, reason);
 
-        private DiagnosticResult GetBasicNeverNullResultAt(int line, int column, string condition, string reason)
+        private static DiagnosticResult GetBasicNeverNullResultAt(int line, int column, string condition, string reason)
             => VerifyVB.Diagnostic(AvoidDeadConditionalCode.NeverNullRule)
                 .WithLocation(line, column)
                 .WithArguments(condition, reason);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidDeadConditionalCode_ValueContentAnalysis.cs
@@ -1,32 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.VisualBasic;
+using System.Threading.Tasks;
 using Test.Utilities;
 using Xunit;
 using CSharpLanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.Maintainability.AvoidDeadConditionalCode,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.Maintainability.AvoidDeadConditionalCode,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 {
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
-    public partial class AvoidDeadConditionalCodeTests : DiagnosticAnalyzerTestBase
+    public partial class AvoidDeadConditionalCodeTests
     {
-        protected void VerifyCSharp(string source, CSharpParseOptions parseOptions, params DiagnosticResult[] expected)
-        {
-            VerifyCSharp(source, GetEditorConfigToEnableCopyAnalysis(), compilationOptions: null, parseOptions: parseOptions, expected: expected);
-        }
-
-        protected void VerifyBasic(string source, VisualBasicParseOptions parseOptions, params DiagnosticResult[] expected)
-        {
-            VerifyBasic(source, GetEditorConfigToEnableCopyAnalysis(), compilationOptions: null, parseOptions: parseOptions, expected: expected);
-        }
-
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void SimpleStringCompare_NoDiagnostic()
+        public async Task SimpleStringCompare_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param)
@@ -42,7 +36,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String)
         If param = """" Then
@@ -56,9 +50,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void SimpleValueCompare_NoDiagnostic()
+        public async Task SimpleValueCompare_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(int param)
@@ -74,7 +68,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As Integer)
         If param = 0 Then
@@ -88,9 +82,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ValueCompareWithAdd_Diagnostic()
+        public async Task ValueCompareWithAdd_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(int param, int param2, int param3)
@@ -108,7 +102,7 @@ class Test
             // Test0.cs(9,17): warning CA1508: 'param3 == 3' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(9, 17, "param3 == 3", "true"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As Integer, param2 As Integer, param3 As Integer)
         param2 = 2
@@ -124,9 +118,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ValueCompareWithSubtract_Diagnostic()
+        public async Task ValueCompareWithSubtract_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(int param, int param2, int param3)
@@ -144,7 +138,7 @@ class Test
             // Test0.cs(9,17): warning CA1508: 'param == 1' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(9, 17, "param == 1", "true"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As Integer, param2 As Integer, param3 As Integer)
         param2 = 2
@@ -160,9 +154,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void SimpleStringCompare_AfterAssignment_Diagnostic()
+        public async Task SimpleStringCompare_AfterAssignment_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param)
@@ -183,7 +177,7 @@ class Test
             // Test0.cs(11,13): warning CA1508: '"" != param' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(11, 13, @""""" != param", "false"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String)
         param = """"
@@ -202,9 +196,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void SimpleValueCompare_AfterAssignment_Diagnostic()
+        public async Task SimpleValueCompare_AfterAssignment_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(int param)
@@ -225,7 +219,7 @@ class Test
             // Test0.cs(11,13): warning CA1508: '0 != param' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(11, 13, @"0 != param", "false"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As Integer)
         param = 0
@@ -244,9 +238,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ElseIf_NestedIf_StringCompare_Diagnostic()
+        public async Task ElseIf_NestedIf_StringCompare_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param)
@@ -273,7 +267,7 @@ class Test
             // Test0.cs(16,17): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(16, 17, "param != str", "false"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String)
         Dim str = """"
@@ -295,9 +289,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ConditionaAndOrStringCompare_Diagnostic()
+        public async Task ConditionaAndOrStringCompare_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param)
@@ -318,7 +312,7 @@ class Test
             // Test0.cs(11,28): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(11, 28, "param != str", "false"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String)
         Dim str = """"
@@ -337,9 +331,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ElseIf_NestedIf_StringCompare_DifferentLiteral_Diagnostic()
+        public async Task ElseIf_NestedIf_StringCompare_DifferentLiteral_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param)
@@ -366,7 +360,7 @@ class Test
             // Test0.cs(16,17): warning CA1508: 'param != str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(16, 17, "param != str", "true"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String)
         Dim str = ""a""
@@ -388,9 +382,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ElseIf_NestedIf_ValueCompare_DifferentLiteral_Diagnostic()
+        public async Task ElseIf_NestedIf_ValueCompare_DifferentLiteral_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(int param)
@@ -417,7 +411,7 @@ class Test
             // Test0.cs(16,17): warning CA1508: 'param != str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(16, 17, "param != str", "true"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As Integer)
         Dim str As Long = 0
@@ -439,9 +433,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ElseIf_NestedIf_StringCompare_DifferentLiterals_NoDiagnostic()
+        public async Task ElseIf_NestedIf_StringCompare_DifferentLiterals_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param, bool flag)
@@ -464,7 +458,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String, flag As Boolean)
         Dim str = If(flag, ""a"", """")
@@ -482,9 +476,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ElseIf_NestedIf_ValueCompare_DifferentLiterals_NoDiagnostic()
+        public async Task ElseIf_NestedIf_ValueCompare_DifferentLiterals_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(ulong param, bool flag)
@@ -507,7 +501,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As ULong, flag As Boolean)
         Dim str As Short = If(flag, 0, 1)
@@ -525,9 +519,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_WhileLoop()
+        public async Task StringCompare_WhileLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M(string param)
@@ -559,7 +553,7 @@ class Test
             // Test0.cs(13,17): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(13, 17, "param != str", "false"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     ' While loop
     Private Sub M1(ByVal param As String)
@@ -587,9 +581,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ValueCompare_WhileLoop()
+        public async Task ValueCompare_WhileLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M(double param)
@@ -621,7 +615,7 @@ class Test
             // Test0.cs(13,17): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(13, 17, "param != str", "false"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     ' While loop
     Private Sub M1(ByVal param As Double)
@@ -649,9 +643,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_DoWhileLoop()
+        public async Task StringCompare_DoWhileLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M(string param)
@@ -684,7 +678,7 @@ class Test
             // Test0.cs(23,13): warning CA1508: 'param != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(23, 13, "param != str", "false"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     ' Do-While top loop
     Private Sub M(ByVal param As String)
@@ -734,9 +728,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_DoUntilLoop()
+        public async Task StringCompare_DoUntilLoop()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     ' Do-Until top loop
     Private Sub M(ByVal param As String)
@@ -786,9 +780,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_ForLoop()
+        public async Task StringCompare_ForLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M(string param, string param2)
@@ -812,7 +806,7 @@ class Test
             {
             }
         }
-        
+
         // param2 == str here
         if (str == param2)
         {
@@ -820,7 +814,7 @@ class Test
         if (str != param2)
         {
         }
-        
+
         // param == str here
         if (str == param)
         {
@@ -847,9 +841,9 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void IntegralValueCompare_ForLoop()
+        public async Task IntegralValueCompare_ForLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M(int param, uint param2)
@@ -908,9 +902,9 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void IntegralValueCompare_ForLoop_02()
+        public async Task IntegralValueCompare_ForLoop_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M(int param, string param2, string param3)
@@ -926,9 +920,9 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void EnumValueCompare_ForEachLoop()
+        public async Task EnumValueCompare_ForEachLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 enum Kind
 {
     Kind1 = 1,
@@ -962,9 +956,9 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void EnumValueCompare_ForEachLoop_02()
+        public async Task EnumValueCompare_ForEachLoop_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 enum Kind
 {
     Kind1 = 1,
@@ -1001,9 +995,9 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void EnumValueCompare_ForEachLoop_03()
+        public async Task EnumValueCompare_ForEachLoop_03()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 enum Kind
 {
     Kind1 = 1,
@@ -1043,9 +1037,9 @@ class Test
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void StringCompare_CopyAnalysis()
+        public async Task StringCompare_CopyAnalysis()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param, string param2)
@@ -1067,7 +1061,7 @@ class Test
             // Test0.cs(12,29): warning CA1508: 'param2 != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(12, 29, "param2 != str", "false"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String, param2 As String)
         Dim str = ""a""
@@ -1088,9 +1082,9 @@ End Module",
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_CopyAnalysis()
+        public async Task ValueCompare_CopyAnalysis()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(int param, int param2)
@@ -1112,7 +1106,7 @@ class Test
             // Test0.cs(12,29): warning CA1508: 'param2 != str' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(12, 29, "param2 != str", "false"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As Integer, param2 As Integer)
         Dim str As Integer = 1
@@ -1132,9 +1126,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_WithNonLiteral_ConditionalOr_NoDiagnostic()
+        public async Task StringCompare_WithNonLiteral_ConditionalOr_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param, string param2, bool flag)
@@ -1158,7 +1152,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String, param2 As String, flag As Boolean)
         Dim str = """"
@@ -1179,9 +1173,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ValueCompare_WithNonLiteral_ConditionalOr_NoDiagnostic()
+        public async Task ValueCompare_WithNonLiteral_ConditionalOr_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(uint param, uint param2, bool flag)
@@ -1205,7 +1199,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As UInteger, param2 As UInteger, flag As Boolean)
         Dim str As Long = 1
@@ -1226,9 +1220,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_WithNonLiteral_ConditionalAnd_NoDiagnostic()
+        public async Task StringCompare_WithNonLiteral_ConditionalAnd_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param, string param2, bool flag)
@@ -1260,7 +1254,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String, param2 As String, flag As Boolean)
         Dim str = """"
@@ -1275,10 +1269,10 @@ Module Test
 
         If str2 <> param AndAlso param <> str Then
         End If
-        
+
         If str2 <> param AndAlso param2 <> str Then
         End If
-        
+
         If str2 <> param AndAlso param = strMayBeConst Then
         End If
     End Sub
@@ -1287,9 +1281,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ValueCompare_WithNonLiteral_ConditionalAnd_NoDiagnostic()
+        public async Task ValueCompare_WithNonLiteral_ConditionalAnd_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(int param, int param2, bool flag)
@@ -1321,7 +1315,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As Integer, param2 As Integer, flag As Boolean)
         Dim str As Integer = 1
@@ -1348,9 +1342,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_ConditionalAndOrNegation_NoDiagnostic()
+        public async Task StringCompare_ConditionalAndOrNegation_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param, bool flag, string param2)
@@ -1374,7 +1368,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String, param2 As String, flag As Boolean)
         Dim strConst As String = """"
@@ -1395,9 +1389,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_ConditionalAndOrNegation_Diagnostic()
+        public async Task StringCompare_ConditionalAndOrNegation_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param, bool flag, string param2, string param3)
@@ -1432,7 +1426,7 @@ class Test
             // Test0.cs(16,58): warning CA1508: 'param == strConst' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(16, 58, "param == strConst", "true"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1(param As String, param2 As String, flag As Boolean, param3 As String)
         Dim strConst As String = """"
@@ -1464,9 +1458,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_ContractCheck_NoDiagnostic()
+        public async Task StringCompare_ContractCheck_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M1(string param)
@@ -1487,7 +1481,7 @@ class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Private Sub M1(ByVal param As String)
         System.Diagnostics.Contracts.Contract.Requires(param <> """")
@@ -1506,9 +1500,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void StringCompare_ContractCheck_Diagnostic()
+        public async Task StringCompare_ContractCheck_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     void M(string param)
@@ -1522,7 +1516,7 @@ class Test
             // Test0.cs(8,56): warning CA1508: 'param == str' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
             GetCSharpResultAt(8, 56, "param == str", "true"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Private Sub M(ByVal param As String)
         Dim str = """"
@@ -1537,9 +1531,9 @@ End Module",
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact, WorkItem(1650, "https://github.com/dotnet/roslyn-analyzers/issues/1650")]
-        public void StringCompare_InsideConstructorInitializer_Diagnostic()
+        public async Task StringCompare_InsideConstructorInitializer_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public bool Flag;
@@ -1566,9 +1560,9 @@ class Test : Base
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact, WorkItem(1650, "https://github.com/dotnet/roslyn-analyzers/issues/1650")]
-        public void StringCompare_InsideFieldInitializer_Diagnostic()
+        public async Task StringCompare_InsideFieldInitializer_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public bool Flag;
@@ -1587,9 +1581,9 @@ class Test
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact, WorkItem(1650, "https://github.com/dotnet/roslyn-analyzers/issues/1650")]
-        public void StringCompare_InsidePropertyInitializer_ExpressionBody_Diagnostic()
+        public async Task StringCompare_InsidePropertyInitializer_ExpressionBody_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public bool Flag;
@@ -1611,9 +1605,9 @@ class Test
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_IsConstantPattern_Diagnostic()
+        public async Task ValueCompare_IsConstantPattern_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
 }
@@ -1665,9 +1659,9 @@ class Test
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_IsConstantPattern_NoDiagnostic()
+        public async Task ValueCompare_IsConstantPattern_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
 }
@@ -1707,11 +1701,11 @@ class Test
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_GotoLoop()
+        public async Task ValueCompare_GotoLoop()
         {
             // Ensure we bound the number of value content literals
             // and avoid infinite analysis iterations.
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     internal static uint ComputeStringHash(string text)
@@ -1740,9 +1734,9 @@ start:
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_MayBeLiteralAssignedInLoop()
+        public async Task ValueCompare_MayBeLiteralAssignedInLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Diagnostics;
 
 class C
@@ -1776,9 +1770,9 @@ class C
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_YieldBreakInTryFinally()
+        public async Task ValueCompare_YieldBreakInTryFinally()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Collections.Generic;
 
 class C
@@ -1813,9 +1807,9 @@ class C
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_NullableBool()
+        public async Task ValueCompare_NullableBool()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     private object Field;
@@ -1829,9 +1823,9 @@ class C
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_DefaultExpression()
+        public async Task ValueCompare_DefaultExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 struct S
 {
 }
@@ -1850,9 +1844,9 @@ class C
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_Boxing_Diagnostic()
+        public async Task ValueCompare_Boxing_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public void M(int i)
@@ -1888,9 +1882,9 @@ class C
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_Boxing_NoDiagnostic()
+        public async Task ValueCompare_Boxing_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public void M(int i, int i2, int i3, int i4)
@@ -1937,9 +1931,9 @@ class C
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_Unboxing_Diagnostic()
+        public async Task ValueCompare_Unboxing_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public void M(object o, object o2, object o3)
@@ -1970,9 +1964,9 @@ class C
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void ValueCompare_Unboxing_NoDiagnostic()
+        public async Task ValueCompare_Unboxing_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     public void M(object o, object o2, object o3, object o4)
@@ -2005,10 +1999,12 @@ class C
         }
 
         [Fact, WorkItem(1571, "https://github.com/dotnet/roslyn-analyzers/issues/1571")]
-        public void ValueCompare_AssignedToTuple_NotDisposed_SpecialCases_Diagnostic()
+        public async Task ValueCompare_AssignedToTuple_NotDisposed_SpecialCases_Diagnostic()
         {
             // NOTE: We do not support predicate analysis for tuple binary operator comparison yet.
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 using System;
 
 class A
@@ -2104,25 +2100,32 @@ public class Test
         return c;
     }
 }
-", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(CSharpLanguageVersion.CSharp7_3), expected: new[] {
-            // Test0.cs(30,13): warning CA1508: 'a2 == a' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(30, 13, "a2 == a", "true"),
-            // Test0.cs(42,13): warning CA1508: 'a2 == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(42, 13, "a2 == null", "false"),
-            // Test0.cs(54,13): warning CA1508: 'a == a2' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(54, 13, "a == a2", "true"),
-            // Test0.cs(54,24): warning CA1508: 'x == 0' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(54, 24, "x == 0", "true"),
-            // Test0.cs(54,34): warning CA1508: 'y == 1' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(54, 34, "y == 1", "true"),
-            // Test0.cs(66,13): warning CA1508: 'null == a2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(66, 13, "null == a2", "false") });
+",
+                LanguageVersion = CSharpLanguageVersion.CSharp7_3,
+                ExpectedDiagnostics =
+                {
+                    // Test0.cs(30,13): warning CA1508: 'a2 == a' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(30, 13, "a2 == a", "true"),
+                    // Test0.cs(42,13): warning CA1508: 'a2 == null' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(42, 13, "a2 == null", "false"),
+                    // Test0.cs(54,13): warning CA1508: 'a == a2' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(54, 13, "a == a2", "true"),
+                    // Test0.cs(54,24): warning CA1508: 'x == 0' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(54, 24, "x == 0", "true"),
+                    // Test0.cs(54,34): warning CA1508: 'y == 1' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(54, 34, "y == 1", "true"),
+                    // Test0.cs(66,13): warning CA1508: 'null == a2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(66, 13, "null == a2", "false"),
+                }
+            }.RunAsync();
         }
 
         [Fact, WorkItem(1571, "https://github.com/dotnet/roslyn-analyzers/issues/1571")]
-        public void ValueCompare_AddedToTupleLiteral_SpecialCases_Diagnostic()
+        public async Task ValueCompare_AddedToTupleLiteral_SpecialCases_Diagnostic()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 using System;
 
 class A
@@ -2175,28 +2178,33 @@ public class Test
         }
     }
 }
-", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(CSharpLanguageVersion.CSharp7_3), expected: new[]{
-            // Test0.cs(16,13): warning CA1508: 'x.Item1.Item1 == a' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(16, 13, "x.Item1.Item1 == a", "true"),
-            // Test0.cs(16,35): warning CA1508: 'x.Item1.a == a' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(16, 35, "x.Item1.a == a", "true"),
-            // Test0.cs(16,53): warning CA1508: 'x.Item2 == 1' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(16, 53, "x.Item2 == 1", "true"),
-            // Test0.cs(26,13): warning CA1508: 'x.a == a' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(26, 13, "x.a == a", "true"),
-            // Test0.cs(26,25): warning CA1508: 'x.Item2 == a2' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(26, 25, "x.Item2 == a2", "true"),
-            // Test0.cs(49,13): warning CA1508: 'arg.a == a' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(49, 13, "arg.a == a", "false"),
-            // Test0.cs(49,27): warning CA1508: 'arg.Item2 == a2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
-            GetCSharpResultAt(49, 27, "arg.Item2 == a2", "false")});
+",
+                LanguageVersion = CSharpLanguageVersion.CSharp7_3,
+                ExpectedDiagnostics =
+                {
+                    // Test0.cs(16,13): warning CA1508: 'x.Item1.Item1 == a' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(16, 13, "x.Item1.Item1 == a", "true"),
+                    // Test0.cs(16,35): warning CA1508: 'x.Item1.a == a' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(16, 35, "x.Item1.a == a", "true"),
+                    // Test0.cs(16,53): warning CA1508: 'x.Item2 == 1' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(16, 53, "x.Item2 == 1", "true"),
+                    // Test0.cs(26,13): warning CA1508: 'x.a == a' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(26, 13, "x.a == a", "true"),
+                    // Test0.cs(26,25): warning CA1508: 'x.Item2 == a2' is always 'true'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(26, 25, "x.Item2 == a2", "true"),
+                    // Test0.cs(49,13): warning CA1508: 'arg.a == a' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(49, 13, "arg.a == a", "false"),
+                    // Test0.cs(49,27): warning CA1508: 'arg.Item2 == a2' is always 'false'. Remove or refactor the condition(s) to avoid dead code.
+                    GetCSharpResultAt(49, 27, "arg.Item2 == a2", "false"),
+                }
+            }.RunAsync();
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void MethodWithNonConstantReturn_DefaultSwitchCaseInsideLoop()
+        public async Task MethodWithNonConstantReturn_DefaultSwitchCaseInsideLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Operation
 {
     public OperationKind Kind { get; }
@@ -2238,9 +2246,9 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void LogicalOrWrappedInsideParenthesisAndUnary()
+        public async Task LogicalOrWrappedInsideParenthesisAndUnary()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Test
     Public Sub M(x1 As Boolean, x2 As Boolean, t As Test)
         Dim y = Not (x1 Or x2)
@@ -2255,9 +2263,9 @@ End Class
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void DoWhileLoopWithSwitch()
+        public async Task DoWhileLoopWithSwitch()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Runtime.CompilerServices
 
@@ -2302,9 +2310,9 @@ End Enum
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ConditionalAccessInConditionalAndOperand()
+        public async Task ConditionalAccessInConditionalAndOperand()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class Test
     Public ReadOnly Property Flag As Boolean
     Public Sub M(t As Test, flag As Boolean)
@@ -2317,9 +2325,9 @@ End Class
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void LoopWithMethodInvocationInConditional()
+        public async Task LoopWithMethodInvocationInConditional()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class Test
@@ -2349,9 +2357,9 @@ End Enum
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void LoopWithGotoTargetBeforeLoop()
+        public async Task LoopWithGotoTargetBeforeLoop()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class A
 {
     public static A M(int? x, A[] listOfA, A a)
@@ -2385,9 +2393,9 @@ enum Kind
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ConditionalAccess_OperationNone()
+        public async Task ConditionalAccess_OperationNone()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Xml.Linq
 
@@ -2401,9 +2409,9 @@ End Class
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void Assignment_OperationNone()
+        public async Task Assignment_OperationNone()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Xml.Linq
 
@@ -2419,9 +2427,9 @@ End Class
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ConditionalExpression_OperationNone()
+        public async Task ConditionalExpression_OperationNone()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Linq
 
@@ -2460,9 +2468,9 @@ End Enum
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void PointsToAnalysisForLoopOnStructFields()
+        public async Task PointsToAnalysisForLoopOnStructFields()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 
 namespace ClassLibrary14
@@ -2500,7 +2508,7 @@ namespace ClassLibrary14
                 var x4 = fileDetails.f1;
 
                 foreach (var residual in Directory.GetFiles(destinationDir, fileDetails.f1 + "".delete.*""))
-                {                    
+                {
                 }
             }
         }
@@ -2511,11 +2519,17 @@ namespace ClassLibrary14
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ValueContentAnalysisWithLocalFunctionInvocationsInStaticMethods()
+        public async Task ValueContentAnalysisWithLocalFunctionInvocationsInStaticMethods()
         {
             var editorconfig = "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive";
 
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 
 public static class C
@@ -2532,14 +2546,18 @@ public static class C
         return minValue;
     }
 }
-", GetEditorConfigAdditionalFile(editorconfig));
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorconfig) }
+                }
+            }.RunAsync();
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void PredicateAnalysisWithCast()
+        public async Task PredicateAnalysisWithCast()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public static class C
@@ -2561,9 +2579,9 @@ public static class C
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact, WorkItem(2246, "https://github.com/dotnet/roslyn-analyzers/issues/2246")]
-        public void NestedPredicateAnalysisWithDifferentStrings()
+        public async Task NestedPredicateAnalysisWithDifferentStrings()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public static class C
@@ -2589,12 +2607,12 @@ public static class C
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
         [WorkItem(2681, "https://github.com/dotnet/roslyn-analyzers/issues/2681")]
-        public void InterlockedOperations_NoDiagnostic()
+        public async Task InterlockedOperations_NoDiagnostic()
         {
             // Ensure that Interlocked increment/decrement/add operations
             // are not treated as absolute writes as it likely involves multiple threads
             // invoking the method and that can lead to false positives.
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class Test
 {
     private int a;
@@ -2620,7 +2638,7 @@ class Test
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Module Test
     Sub M1()
         Dim a As Integer = 0
@@ -2643,11 +2661,17 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
         [Fact]
-        public void ValueContentAnalysis_MergeForUnreachableCode()
+        public async Task ValueContentAnalysis_MergeForUnreachableCode()
         {
             var editorconfig = "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive";
 
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 
 public class C
@@ -2670,7 +2694,11 @@ public class C
         _ = feedLocationUri.LocalPath;
     }
 }
-", GetEditorConfigAdditionalFile(editorconfig));
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorconfig) }
+                }
+            }.RunAsync();
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -389,7 +389,7 @@ End Class",
 End Class",
                 ExpectedDiagnostics =
                 {
-                    DiagnosticResult.CompilerError("BC30737").WithMessage("No accessible 'Main' method with an appropriate signature was found in 'TestProject'.")
+                    DiagnosticResult.CompilerError("BC30737").WithMessage("No accessible 'Main' method with an appropriate signature was found in 'TestProject'."),
                 },
                 SolutionTransforms =
                 {

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -389,7 +389,7 @@ End Class",
 End Class",
                 ExpectedDiagnostics =
                 {
-                    new DiagnosticResult("BC30737", DiagnosticSeverity.Error)
+                    DiagnosticResult.CompilerError("BC30737")
                 },
                 SolutionTransforms =
                 {
@@ -1345,9 +1345,9 @@ internal interface IFoo4 {}
 
 internal class CFoo {}  // Test0.cs(16,16): warning CA1812: CFoo is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).
 ",
-                new DiagnosticResult("CS7036", DiagnosticSeverity.Error).WithLocation(4, 2),
-                new DiagnosticResult("CS0119", DiagnosticSeverity.Error).WithLocation(7, 10),
-                new DiagnosticResult("CS1729", DiagnosticSeverity.Error).WithLocation(10, 2),
+                DiagnosticResult.CompilerError("CS7036").WithLocation(4, 2),
+                DiagnosticResult.CompilerError("CS0119").WithLocation(7, 10),
+                DiagnosticResult.CompilerError("CS1729").WithLocation(10, 2),
                 GetCSharpResultAt(16, 16, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "CFoo"));
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -384,12 +384,12 @@ End Class",
             {
                 TestCode =
 @"Friend Class C
-    Private Shared Sub mAiN() ' error BC30737: No accessible 'Main' method with an appropriate signature was found in 'TestProject'.
+    Private Shared Sub mAiN()
     End Sub
 End Class",
                 ExpectedDiagnostics =
                 {
-                    DiagnosticResult.CompilerError("BC30737")
+                    DiagnosticResult.CompilerError("BC30737").WithMessage("No accessible 'Main' method with an appropriate signature was found in 'TestProject'.")
                 },
                 SolutionTransforms =
                 {
@@ -1331,13 +1331,13 @@ internal class CFoo {}
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Runtime.InteropServices;
 
-[CoClass]  // Test0.cs(4,2): error CS7036: There is no argument given that corresponds to the required formal parameter 'coClass' of 'CoClassAttribute.CoClassAttribute(Type)'
+[CoClass]
 internal interface IFoo1 {}
 
-[CoClass(CFoo)]  // Test0.cs(7,10): error CS0119: 'CFoo' is a type, which is not valid in the given context
+[CoClass(CFoo)]
 internal interface IFoo2 {}
 
-[CoClass(typeof(CFoo), null)]   // Test0.cs(10,2): error CS1729: 'CoClassAttribute' does not contain a constructor that takes 2 arguments
+[CoClass(typeof(CFoo), null)]
 internal interface IFoo3 {}
 
 [CoClass(typeof(IFoo3))] // This isn't a class-type
@@ -1345,9 +1345,9 @@ internal interface IFoo4 {}
 
 internal class CFoo {}  // Test0.cs(16,16): warning CA1812: CFoo is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).
 ",
-                DiagnosticResult.CompilerError("CS7036").WithLocation(4, 2),
-                DiagnosticResult.CompilerError("CS0119").WithLocation(7, 10),
-                DiagnosticResult.CompilerError("CS1729").WithLocation(10, 2),
+                DiagnosticResult.CompilerError("CS7036").WithLocation(4, 2).WithMessage("There is no argument given that corresponds to the required formal parameter 'coClass' of 'CoClassAttribute.CoClassAttribute(Type)'"),
+                DiagnosticResult.CompilerError("CS0119").WithLocation(7, 10).WithMessage("'CFoo' is a type, which is not valid in the given context"),
+                DiagnosticResult.CompilerError("CS1729").WithLocation(10, 2).WithMessage("'CoClassAttribute' does not contain a constructor that takes 2 arguments"),
                 GetCSharpResultAt(16, 16, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "CFoo"));
         }
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(
 @"internal class C { }
 ",
-                GetCSharpResultAt(1, 16, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C"));
+                GetCSharpResultAt(1, 16, "C"));
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
             await VerifyVB.VerifyAnalyzerAsync(
 @"Friend Class C
 End Class",
-                GetBasicResultAt(1, 14, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C"));
+                GetBasicResultAt(1, 14, "C"));
         }
 
         [Fact]
@@ -97,7 +97,7 @@ End Class");
 {
     internal class D { }
 }",
-                GetCSharpResultAt(3, 20, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C.D"));
+                GetCSharpResultAt(3, 20, "C.D"));
         }
 
         [Fact]
@@ -108,7 +108,7 @@ End Class");
     Friend Class D
     End Class
 End Class",
-                GetBasicResultAt(2, 18, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C.D"));
+                GetBasicResultAt(2, 18, "C.D"));
         }
 
         [Fact]
@@ -363,7 +363,7 @@ internal static class C
 {
     private void Main() {}
 }",
-                GetCSharpResultAt(1, 16, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C"));
+                GetCSharpResultAt(1, 16, "C"));
         }
 
         [Fact]
@@ -374,7 +374,7 @@ internal static class C
     Private Sub Main()
     End Sub
 End Class",
-                GetBasicResultAt(1, 14, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C"));
+                GetBasicResultAt(1, 14, "C"));
         }
 
         [Fact]
@@ -412,7 +412,7 @@ End Class",
 {
     internal class C { }
 }",
-                GetCSharpResultAt(3, 20, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C"));
+                GetCSharpResultAt(3, 20, "C"));
         }
 
         [Fact]
@@ -423,7 +423,7 @@ End Class",
     Friend Class C
     End Class
 End Namespace",
-                GetBasicResultAt(2, 18, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C"));
+                GetBasicResultAt(2, 18, "C"));
         }
 
         [Fact]
@@ -437,7 +437,7 @@ End Namespace",
         internal class D { }
     }
 }",
-                GetCSharpResultAt(5, 24, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C.D"));
+                GetCSharpResultAt(5, 24, "C.D"));
         }
 
         [Fact]
@@ -450,7 +450,7 @@ End Namespace",
         End Class
     End Class
 End Namespace",
-                GetBasicResultAt(3, 22, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "C.D"));
+                GetBasicResultAt(3, 22, "C.D"));
         }
 
         [Fact]
@@ -717,7 +717,6 @@ End Class");
 }",
                 GetCSharpResultAt(
                     3, 20,
-                    AvoidUninstantiatedInternalClassesAnalyzer.Rule,
                     "C.C2"));
         }
 
@@ -731,7 +730,6 @@ End Class");
 End Class",
                 GetBasicResultAt(
                     2, 18,
-                    AvoidUninstantiatedInternalClassesAnalyzer.Rule,
                     "C.C2"));
         }
 
@@ -748,7 +746,6 @@ End Class",
 }",
                 GetCSharpResultAt(
                     1, 16,
-                    AvoidUninstantiatedInternalClassesAnalyzer.Rule,
                     "C"));
         }
 
@@ -764,7 +761,6 @@ End Class",
 End Class",
                 GetBasicResultAt(
                     1, 14,
-                    AvoidUninstantiatedInternalClassesAnalyzer.Rule,
                     "C"));
         }
 
@@ -868,7 +864,6 @@ End Module");
 
                 GetCSharpResultAt(
                     1, 23,
-                    AvoidUninstantiatedInternalClassesAnalyzer.Rule,
                     "S"));
         }
 
@@ -1208,11 +1203,9 @@ internal class Program
 }",
                 GetCSharpResultAt(
                     4, 16,
-                    AvoidUninstantiatedInternalClassesAnalyzer.Rule,
                     "InstantiatedType"),
                 GetCSharpResultAt(
                     8, 16,
-                    AvoidUninstantiatedInternalClassesAnalyzer.Rule,
                     "Factory<T>"));
         }
 
@@ -1235,11 +1228,9 @@ Module Library
 End Module",
                 GetBasicResultAt(
                     5, 18,
-                    AvoidUninstantiatedInternalClassesAnalyzer.Rule,
                     "Library.InstantiatedType"),
                 GetBasicResultAt(
                     8, 18,
-                    AvoidUninstantiatedInternalClassesAnalyzer.Rule,
                     "Library.Factory(Of T)"));
         }
 
@@ -1348,16 +1339,16 @@ internal class CFoo {}  // Test0.cs(16,16): warning CA1812: CFoo is an internal 
                 DiagnosticResult.CompilerError("CS7036").WithLocation(4, 2).WithMessage("There is no argument given that corresponds to the required formal parameter 'coClass' of 'CoClassAttribute.CoClassAttribute(Type)'"),
                 DiagnosticResult.CompilerError("CS0119").WithLocation(7, 10).WithMessage("'CFoo' is a type, which is not valid in the given context"),
                 DiagnosticResult.CompilerError("CS1729").WithLocation(10, 2).WithMessage("'CoClassAttribute' does not contain a constructor that takes 2 arguments"),
-                GetCSharpResultAt(16, 16, AvoidUninstantiatedInternalClassesAnalyzer.Rule, "CFoo"));
+                GetCSharpResultAt(16, 16, "CFoo"));
         }
 
-        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
-            => new DiagnosticResult(rule)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
@@ -442,12 +442,12 @@ End Class
         }
 
         private static DiagnosticResult GetCA1823CSharpResultAt(int line, int column, string fieldName)
-            => VerifyCS.Diagnostic(AvoidUnusedPrivateFieldsAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(fieldName);
 
         private static DiagnosticResult GetCA1823BasicResultAt(int line, int column, string fieldName)
-            => VerifyVB.Diagnostic(AvoidUnusedPrivateFieldsAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(fieldName);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -108,9 +107,9 @@ public class Class
 }
 ",
                 // Test0.cs(5,6): error CS7036: There is no argument given that corresponds to the required formal parameter 'offset' of 'FieldOffsetAttribute.FieldOffsetAttribute(int)'
-                new DiagnosticResult("CS7036", DiagnosticSeverity.Error).WithLocation(5, 6),
+                DiagnosticResult.CompilerError("CS7036").WithLocation(5, 6),
                 // Test0.cs(6,17): error CS0625: 'Class.fieldWithFieldOffsetAttribute': instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
-                new DiagnosticResult("CS0625", DiagnosticSeverity.Error).WithLocation(6, 17));
+                DiagnosticResult.CompilerError("CS0625").WithLocation(6, 17));
         }
 
         [Fact, WorkItem(1219, "https://github.com/dotnet/roslyn-analyzers/issues/1219")]
@@ -159,7 +158,7 @@ class Class
     // Test0.cs(5,17): warning CA1823: Unused field 'field'.
     GetCA1823CSharpResultAt(5, 17, "field"),
     // Test0.cs(5,17): error CS0625: 'Class.field': instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
-    new DiagnosticResult("CS0625", DiagnosticSeverity.Error).WithLocation(5, 17));
+    DiagnosticResult.CompilerError("CS0625").WithLocation(5, 17));
         }
 
         [Fact, WorkItem(1219, "https://github.com/dotnet/roslyn-analyzers/issues/1219")]
@@ -179,7 +178,7 @@ class Class2
 }
 ",
     // Test0.cs(2,2): error CS1729: 'StructLayoutAttribute' does not contain a constructor that takes 0 arguments
-    new DiagnosticResult("CS1729", DiagnosticSeverity.Error).WithLocation(2, 2),
+    DiagnosticResult.CompilerError("CS1729").WithLocation(2, 2),
     // Test0.cs(5,17): warning CA1823: Unused field 'field'.
     GetCA1823CSharpResultAt(5, 17, "field"),
     // Test0.cs(11,17): warning CA1823: Unused field 'field'.
@@ -215,9 +214,9 @@ public class Class
 }
 ",
                  // Test0.cs(18,6): error CS1729: 'ExportAttribute' does not contain a constructor that takes 1 arguments
-                 new DiagnosticResult("CS1729", DiagnosticSeverity.Error).WithLocation(18, 6),
+                 DiagnosticResult.CompilerError("CS1729").WithLocation(18, 6),
                  // Test0.cs(21,6): error CS1729: 'ExportAttribute' does not contain a constructor that takes 1 arguments
-                 new DiagnosticResult("CS1729", DiagnosticSeverity.Error).WithLocation(21, 6));
+                 DiagnosticResult.CompilerError("CS1729").WithLocation(21, 6));
         }
 
         [Fact, WorkItem(1217, "https://github.com/dotnet/roslyn-analyzers/issues/1217")]
@@ -239,11 +238,11 @@ public class Class
                 ExpectedDiagnostics =
                 {
                     // Test0.cs(4,13): error CS0234: The type or namespace name 'Composition' does not exist in the namespace 'System' (are you missing an assembly reference?)
-                    new DiagnosticResult("CS0234", DiagnosticSeverity.Error).WithLocation(4, 13),
+                    DiagnosticResult.CompilerError("CS0234").WithLocation(4, 13),
                     // Test0.cs(5,17): warning CA1823: Unused field 'fieldWithMefV1ExportAttribute'.
                     GetCA1823CSharpResultAt(5, 17, "fieldWithMefV1ExportAttribute"),
                     // Test0.cs(7,28): error CS0234: The type or namespace name 'Composition' does not exist in the namespace 'System.ComponentModel' (are you missing an assembly reference?)
-                    new DiagnosticResult("CS0234", DiagnosticSeverity.Error).WithLocation(7, 28),
+                    DiagnosticResult.CompilerError("CS0234").WithLocation(7, 28),
                     // Test0.cs(8,17): warning CA1823: Unused field 'fieldWithMefV2ExportAttribute'.
                     GetCA1823CSharpResultAt(8, 17, "fieldWithMefV2ExportAttribute")
                 },
@@ -384,11 +383,11 @@ Public Class Class2
 End Class
 ",
     // Test0.vb(2) : error BC30516: Overload resolution failed because no accessible 'New' accepts this number of arguments.
-    new DiagnosticResult("BC30516", DiagnosticSeverity.Error).WithLocation(2, 33),
+    DiagnosticResult.CompilerError("BC30516").WithLocation(2, 33),
     // Test0.vb(4,13): warning CA1823: Unused field 'field'.
     GetCA1823BasicResultAt(4, 13, "field"),
     // Test0.vb(7) : error BC30519: Overload resolution failed because no accessible 'New' can be called without a narrowing conversion:
-    new DiagnosticResult("BC30519", DiagnosticSeverity.Error).WithLocation(7, 33),
+    DiagnosticResult.CompilerError("BC30519").WithLocation(7, 33),
     // Test0.vb(9,13): warning CA1823: Unused field 'field'.
     GetCA1823BasicResultAt(9, 13, "field"));
         }
@@ -420,9 +419,9 @@ Public Class [Class]
 End Class
 ",
                 // Test0.vb(15) : error BC30057: Too many arguments to 'Public Sub New()'.
-                new DiagnosticResult("BC30057", DiagnosticSeverity.Error).WithLocation(15, 41),
+                DiagnosticResult.CompilerError("BC30057").WithLocation(15, 41),
                 // Test0.vb(18) : error BC30057: Too many arguments to 'Public Sub New()'.
-                new DiagnosticResult("BC30057", DiagnosticSeverity.Error).WithLocation(18, 56));
+                DiagnosticResult.CompilerError("BC30057").WithLocation(18, 56));
         }
 
         [Fact, WorkItem(1217, "https://github.com/dotnet/roslyn-analyzers/issues/1217")]
@@ -444,11 +443,11 @@ End Class
                 ExpectedDiagnostics =
                 {
                     // Test0.vb(3) : error BC30002: Type 'System.Composition.ExportAttribute' is not defined.
-                    new DiagnosticResult("BC30002", DiagnosticSeverity.Error).WithLocation(3, 6),
+                    DiagnosticResult.CompilerError("BC30002").WithLocation(3, 6),
                     // Test0.vb(4,13): warning CA1823: Unused field 'fieldWithMefV1ExportAttribute'.
                     GetCA1823BasicResultAt(4, 13, "fieldWithMefV1ExportAttribute"),
                     // Test0.vb(6) : error BC30002: Type 'System.ComponentModel.Composition.ExportAttribute' is not defined.
-                    new DiagnosticResult("BC30002", DiagnosticSeverity.Error).WithLocation(6, 6),
+                    DiagnosticResult.CompilerError("BC30002").WithLocation(6, 6),
                     // Test0.vb(7,13): warning CA1823: Unused field 'fieldWithMefV2ExportAttribute'.
                     GetCA1823BasicResultAt(7, 13, "fieldWithMefV2ExportAttribute")
                 },

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
@@ -106,10 +106,8 @@ public class Class
     private int fieldWithFieldOffsetAttribute;
 }
 ",
-                // Test0.cs(5,6): error CS7036: There is no argument given that corresponds to the required formal parameter 'offset' of 'FieldOffsetAttribute.FieldOffsetAttribute(int)'
-                DiagnosticResult.CompilerError("CS7036").WithLocation(5, 6),
-                // Test0.cs(6,17): error CS0625: 'Class.fieldWithFieldOffsetAttribute': instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
-                DiagnosticResult.CompilerError("CS0625").WithLocation(6, 17));
+                DiagnosticResult.CompilerError("CS7036").WithLocation(5, 6).WithMessage("There is no argument given that corresponds to the required formal parameter 'offset' of 'FieldOffsetAttribute.FieldOffsetAttribute(int)'"),
+                DiagnosticResult.CompilerError("CS0625").WithLocation(6, 17).WithMessage("'Class.fieldWithFieldOffsetAttribute': instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute"));
         }
 
         [Fact, WorkItem(1219, "https://github.com/dotnet/roslyn-analyzers/issues/1219")]
@@ -157,8 +155,7 @@ class Class
 ",
     // Test0.cs(5,17): warning CA1823: Unused field 'field'.
     GetCA1823CSharpResultAt(5, 17, "field"),
-    // Test0.cs(5,17): error CS0625: 'Class.field': instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
-    DiagnosticResult.CompilerError("CS0625").WithLocation(5, 17));
+    DiagnosticResult.CompilerError("CS0625").WithLocation(5, 17).WithMessage("'Class.field': instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute"));
         }
 
         [Fact, WorkItem(1219, "https://github.com/dotnet/roslyn-analyzers/issues/1219")]
@@ -177,8 +174,7 @@ class Class2
     private int field;
 }
 ",
-    // Test0.cs(2,2): error CS1729: 'StructLayoutAttribute' does not contain a constructor that takes 0 arguments
-    DiagnosticResult.CompilerError("CS1729").WithLocation(2, 2),
+    DiagnosticResult.CompilerError("CS1729").WithLocation(2, 2).WithMessage("'StructLayoutAttribute' does not contain a constructor that takes 0 arguments"),
     // Test0.cs(5,17): warning CA1823: Unused field 'field'.
     GetCA1823CSharpResultAt(5, 17, "field"),
     // Test0.cs(11,17): warning CA1823: Unused field 'field'.
@@ -213,10 +209,8 @@ public class Class
     private int fieldWithMefV2ExportAttribute;
 }
 ",
-                 // Test0.cs(18,6): error CS1729: 'ExportAttribute' does not contain a constructor that takes 1 arguments
-                 DiagnosticResult.CompilerError("CS1729").WithLocation(18, 6),
-                 // Test0.cs(21,6): error CS1729: 'ExportAttribute' does not contain a constructor that takes 1 arguments
-                 DiagnosticResult.CompilerError("CS1729").WithLocation(21, 6));
+                 DiagnosticResult.CompilerError("CS1729").WithLocation(18, 6).WithMessage("'ExportAttribute' does not contain a constructor that takes 1 arguments"),
+                 DiagnosticResult.CompilerError("CS1729").WithLocation(21, 6).WithMessage("'ExportAttribute' does not contain a constructor that takes 1 arguments"));
         }
 
         [Fact, WorkItem(1217, "https://github.com/dotnet/roslyn-analyzers/issues/1217")]
@@ -237,12 +231,10 @@ public class Class
 ",
                 ExpectedDiagnostics =
                 {
-                    // Test0.cs(4,13): error CS0234: The type or namespace name 'Composition' does not exist in the namespace 'System' (are you missing an assembly reference?)
-                    DiagnosticResult.CompilerError("CS0234").WithLocation(4, 13),
+                    DiagnosticResult.CompilerError("CS0234").WithLocation(4, 13).WithMessage("The type or namespace name 'Composition' does not exist in the namespace 'System' (are you missing an assembly reference?)"),
                     // Test0.cs(5,17): warning CA1823: Unused field 'fieldWithMefV1ExportAttribute'.
                     GetCA1823CSharpResultAt(5, 17, "fieldWithMefV1ExportAttribute"),
-                    // Test0.cs(7,28): error CS0234: The type or namespace name 'Composition' does not exist in the namespace 'System.ComponentModel' (are you missing an assembly reference?)
-                    DiagnosticResult.CompilerError("CS0234").WithLocation(7, 28),
+                    DiagnosticResult.CompilerError("CS0234").WithLocation(7, 28).WithMessage("The type or namespace name 'Composition' does not exist in the namespace 'System.ComponentModel' (are you missing an assembly reference?)"),
                     // Test0.cs(8,17): warning CA1823: Unused field 'fieldWithMefV2ExportAttribute'.
                     GetCA1823CSharpResultAt(8, 17, "fieldWithMefV2ExportAttribute")
                 },
@@ -382,12 +374,12 @@ Public Class Class2
     Private field As Integer
 End Class
 ",
-    // Test0.vb(2) : error BC30516: Overload resolution failed because no accessible 'New' accepts this number of arguments.
-    DiagnosticResult.CompilerError("BC30516").WithLocation(2, 33),
+    DiagnosticResult.CompilerError("BC30516").WithLocation(2, 33).WithMessage("Overload resolution failed because no accessible 'New' accepts this number of arguments."),
     // Test0.vb(4,13): warning CA1823: Unused field 'field'.
     GetCA1823BasicResultAt(4, 13, "field"),
-    // Test0.vb(7) : error BC30519: Overload resolution failed because no accessible 'New' can be called without a narrowing conversion:
-    DiagnosticResult.CompilerError("BC30519").WithLocation(7, 33),
+    DiagnosticResult.CompilerError("BC30519").WithLocation(7, 33).WithMessage(@"Overload resolution failed because no accessible 'New' can be called without a narrowing conversion:
+    'Public Overloads Sub New(layoutKind As LayoutKind)': Argument matching parameter 'layoutKind' narrows from 'Integer' to 'LayoutKind'.
+    'Public Overloads Sub New(layoutKind As Short)': Argument matching parameter 'layoutKind' narrows from 'Integer' to 'Short'."),
     // Test0.vb(9,13): warning CA1823: Unused field 'field'.
     GetCA1823BasicResultAt(9, 13, "field"));
         }
@@ -418,10 +410,8 @@ Public Class [Class]
     Private fieldWithMefV2ExportAttribute As Integer
 End Class
 ",
-                // Test0.vb(15) : error BC30057: Too many arguments to 'Public Sub New()'.
-                DiagnosticResult.CompilerError("BC30057").WithLocation(15, 41),
-                // Test0.vb(18) : error BC30057: Too many arguments to 'Public Sub New()'.
-                DiagnosticResult.CompilerError("BC30057").WithLocation(18, 56));
+                DiagnosticResult.CompilerError("BC30057").WithLocation(15, 41).WithMessage("Too many arguments to 'Public Sub New()'."),
+                DiagnosticResult.CompilerError("BC30057").WithLocation(18, 56).WithMessage("Too many arguments to 'Public Sub New()'."));
         }
 
         [Fact, WorkItem(1217, "https://github.com/dotnet/roslyn-analyzers/issues/1217")]
@@ -441,12 +431,10 @@ End Class
 ",
                 ExpectedDiagnostics =
                 {
-                    // Test0.vb(3) : error BC30002: Type 'System.Composition.ExportAttribute' is not defined.
-                    DiagnosticResult.CompilerError("BC30002").WithLocation(3, 6),
+                    DiagnosticResult.CompilerError("BC30002").WithLocation(3, 6).WithMessage("Type 'System.Composition.ExportAttribute' is not defined."),
                     // Test0.vb(4,13): warning CA1823: Unused field 'fieldWithMefV1ExportAttribute'.
                     GetCA1823BasicResultAt(4, 13, "fieldWithMefV1ExportAttribute"),
-                    // Test0.vb(6) : error BC30002: Type 'System.ComponentModel.Composition.ExportAttribute' is not defined.
-                    DiagnosticResult.CompilerError("BC30002").WithLocation(6, 6),
+                    DiagnosticResult.CompilerError("BC30002").WithLocation(6, 6).WithMessage("Type 'System.ComponentModel.Composition.ExportAttribute' is not defined."),
                     // Test0.vb(7,13): warning CA1823: Unused field 'fieldWithMefV2ExportAttribute'.
                     GetCA1823BasicResultAt(7, 13, "fieldWithMefV2ExportAttribute")
                 },

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
@@ -236,7 +236,7 @@ public class Class
                     GetCA1823CSharpResultAt(5, 17, "fieldWithMefV1ExportAttribute"),
                     DiagnosticResult.CompilerError("CS0234").WithLocation(7, 28).WithMessage("The type or namespace name 'Composition' does not exist in the namespace 'System.ComponentModel' (are you missing an assembly reference?)"),
                     // Test0.cs(8,17): warning CA1823: Unused field 'fieldWithMefV2ExportAttribute'.
-                    GetCA1823CSharpResultAt(8, 17, "fieldWithMefV2ExportAttribute")
+                    GetCA1823CSharpResultAt(8, 17, "fieldWithMefV2ExportAttribute"),
                 },
             }.RunAsync();
         }
@@ -436,7 +436,7 @@ End Class
                     GetCA1823BasicResultAt(4, 13, "fieldWithMefV1ExportAttribute"),
                     DiagnosticResult.CompilerError("BC30002").WithLocation(6, 6).WithMessage("Type 'System.ComponentModel.Composition.ExportAttribute' is not defined."),
                     // Test0.vb(7,13): warning CA1823: Unused field 'fieldWithMefV2ExportAttribute'.
-                    GetCA1823BasicResultAt(7, 13, "fieldWithMefV2ExportAttribute")
+                    GetCA1823BasicResultAt(7, 13, "fieldWithMefV2ExportAttribute"),
                 },
             }.RunAsync();
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
@@ -439,7 +439,6 @@ Public Class [Class]
     Private fieldWithMefV2ExportAttribute As Integer
 End Class
 ",
-                CompilerDiagnostics = CompilerDiagnostics.None,
                 ExpectedDiagnostics =
                 {
                     // Test0.vb(3) : error BC30002: Type 'System.Composition.ExportAttribute' is not defined.

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/AvoidUnusedPrivateFieldsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -105,7 +106,11 @@ public class Class
     [System.Runtime.InteropServices.FieldOffsetAttribute]
     private int fieldWithFieldOffsetAttribute;
 }
-", CompilerDiagnostics.None);
+",
+                // Test0.cs(5,6): error CS7036: There is no argument given that corresponds to the required formal parameter 'offset' of 'FieldOffsetAttribute.FieldOffsetAttribute(int)'
+                new DiagnosticResult("CS7036", DiagnosticSeverity.Error).WithLocation(5, 6),
+                // Test0.cs(6,17): error CS0625: 'Class.fieldWithFieldOffsetAttribute': instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
+                new DiagnosticResult("CS0625", DiagnosticSeverity.Error).WithLocation(6, 17));
         }
 
         [Fact, WorkItem(1219, "https://github.com/dotnet/roslyn-analyzers/issues/1219")]
@@ -150,9 +155,11 @@ class Class
 {
     private int field;
 }
-", CompilerDiagnostics.None,
+",
     // Test0.cs(5,17): warning CA1823: Unused field 'field'.
-    GetCA1823CSharpResultAt(5, 17, "field"));
+    GetCA1823CSharpResultAt(5, 17, "field"),
+    // Test0.cs(5,17): error CS0625: 'Class.field': instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
+    new DiagnosticResult("CS0625", DiagnosticSeverity.Error).WithLocation(5, 17));
         }
 
         [Fact, WorkItem(1219, "https://github.com/dotnet/roslyn-analyzers/issues/1219")]
@@ -170,7 +177,9 @@ class Class2
 {
     private int field;
 }
-", CompilerDiagnostics.None,
+",
+    // Test0.cs(2,2): error CS1729: 'StructLayoutAttribute' does not contain a constructor that takes 0 arguments
+    new DiagnosticResult("CS1729", DiagnosticSeverity.Error).WithLocation(2, 2),
     // Test0.cs(5,17): warning CA1823: Unused field 'field'.
     GetCA1823CSharpResultAt(5, 17, "field"),
     // Test0.cs(11,17): warning CA1823: Unused field 'field'.
@@ -204,7 +213,11 @@ public class Class
     [System.ComponentModel.Composition.ExportAttribute(0)]
     private int fieldWithMefV2ExportAttribute;
 }
-", CompilerDiagnostics.None);
+",
+                 // Test0.cs(18,6): error CS1729: 'ExportAttribute' does not contain a constructor that takes 1 arguments
+                 new DiagnosticResult("CS1729", DiagnosticSeverity.Error).WithLocation(18, 6),
+                 // Test0.cs(21,6): error CS1729: 'ExportAttribute' does not contain a constructor that takes 1 arguments
+                 new DiagnosticResult("CS1729", DiagnosticSeverity.Error).WithLocation(21, 6));
         }
 
         [Fact, WorkItem(1217, "https://github.com/dotnet/roslyn-analyzers/issues/1217")]
@@ -223,13 +236,16 @@ public class Class
     private int fieldWithMefV2ExportAttribute;
 }
 ",
-                CompilerDiagnostics = CompilerDiagnostics.None,
                 ExpectedDiagnostics =
                 {
+                    // Test0.cs(4,13): error CS0234: The type or namespace name 'Composition' does not exist in the namespace 'System' (are you missing an assembly reference?)
+                    new DiagnosticResult("CS0234", DiagnosticSeverity.Error).WithLocation(4, 13),
                     // Test0.cs(5,17): warning CA1823: Unused field 'fieldWithMefV1ExportAttribute'.
                     GetCA1823CSharpResultAt(5, 17, "fieldWithMefV1ExportAttribute"),
+                    // Test0.cs(7,28): error CS0234: The type or namespace name 'Composition' does not exist in the namespace 'System.ComponentModel' (are you missing an assembly reference?)
+                    new DiagnosticResult("CS0234", DiagnosticSeverity.Error).WithLocation(7, 28),
                     // Test0.cs(8,17): warning CA1823: Unused field 'fieldWithMefV2ExportAttribute'.
-                    GetCA1823CSharpResultAt(8, 17, "fieldWithMefV2ExportAttribute"),
+                    GetCA1823CSharpResultAt(8, 17, "fieldWithMefV2ExportAttribute")
                 },
             }.RunAsync();
         }
@@ -307,7 +323,7 @@ Public Class [Class]
     <System.Runtime.InteropServices.FieldOffsetAttribute(8)> _
     Private fieldWithFieldOffsetAttribute As Integer
 End Class
-", CompilerDiagnostics.None);
+");
         }
 
         [Fact, WorkItem(1219, "https://github.com/dotnet/roslyn-analyzers/issues/1219")]
@@ -348,7 +364,7 @@ End Class
 Public Class [Class]
     Private field As Integer
 End Class
-", CompilerDiagnostics.None,
+",
     // Test0.vb(4,13): warning CA1823: Unused field 'field'.
     GetCA1823BasicResultAt(4, 13, "field"));
         }
@@ -366,9 +382,13 @@ End Class
 Public Class Class2
     Private field As Integer
 End Class
-", CompilerDiagnostics.None,
+",
+    // Test0.vb(2) : error BC30516: Overload resolution failed because no accessible 'New' accepts this number of arguments.
+    new DiagnosticResult("BC30516", DiagnosticSeverity.Error).WithLocation(2, 33),
     // Test0.vb(4,13): warning CA1823: Unused field 'field'.
     GetCA1823BasicResultAt(4, 13, "field"),
+    // Test0.vb(7) : error BC30519: Overload resolution failed because no accessible 'New' can be called without a narrowing conversion:
+    new DiagnosticResult("BC30519", DiagnosticSeverity.Error).WithLocation(7, 33),
     // Test0.vb(9,13): warning CA1823: Unused field 'field'.
     GetCA1823BasicResultAt(9, 13, "field"));
         }
@@ -398,7 +418,11 @@ Public Class [Class]
     <System.ComponentModel.Composition.ExportAttribute(0)> _
     Private fieldWithMefV2ExportAttribute As Integer
 End Class
-", CompilerDiagnostics.None);
+",
+                // Test0.vb(15) : error BC30057: Too many arguments to 'Public Sub New()'.
+                new DiagnosticResult("BC30057", DiagnosticSeverity.Error).WithLocation(15, 41),
+                // Test0.vb(18) : error BC30057: Too many arguments to 'Public Sub New()'.
+                new DiagnosticResult("BC30057", DiagnosticSeverity.Error).WithLocation(18, 56));
         }
 
         [Fact, WorkItem(1217, "https://github.com/dotnet/roslyn-analyzers/issues/1217")]
@@ -419,10 +443,14 @@ End Class
                 CompilerDiagnostics = CompilerDiagnostics.None,
                 ExpectedDiagnostics =
                 {
+                    // Test0.vb(3) : error BC30002: Type 'System.Composition.ExportAttribute' is not defined.
+                    new DiagnosticResult("BC30002", DiagnosticSeverity.Error).WithLocation(3, 6),
                     // Test0.vb(4,13): warning CA1823: Unused field 'fieldWithMefV1ExportAttribute'.
                     GetCA1823BasicResultAt(4, 13, "fieldWithMefV1ExportAttribute"),
+                    // Test0.vb(6) : error BC30002: Type 'System.ComponentModel.Composition.ExportAttribute' is not defined.
+                    new DiagnosticResult("BC30002", DiagnosticSeverity.Error).WithLocation(6, 6),
                     // Test0.vb(7,13): warning CA1823: Unused field 'fieldWithMefV2ExportAttribute'.
-                    GetCA1823BasicResultAt(7, 13, "fieldWithMefV2ExportAttribute"),
+                    GetCA1823BasicResultAt(7, 13, "fieldWithMefV2ExportAttribute")
                 },
             }.RunAsync();
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/CodeMetricsAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/CodeMetricsAnalyzerTests.cs
@@ -1,19 +1,23 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.Maintainability.CodeMetrics.CodeMetricsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.CodeQuality.Analyzers.Maintainability.CodeMetrics.CodeMetricsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability.CodeMetrics.UnitTests
 {
-    public class CodeMetricsAnalyzerTests : DiagnosticAnalyzerTestBase
+    public class CodeMetricsAnalyzerTests
     {
         #region CA1501: Avoid excessive inheritance
 
         [Fact]
-        public void CA1501_CSharp_VerifyDiagnostic()
+        public async Task CA1501_CSharp_VerifyDiagnostic()
         {
             var source = @"
 class BaseClass { }
@@ -28,11 +32,11 @@ class FifthDerivedClass : FourthDerivedClass { }
             DiagnosticResult[] expected = new[] {
                 // Test0.cs(9, 7): warning CA1501: 'FifthDerivedClass' has an object hierarchy '6' levels deep within the defining module. If possible, eliminate base classes within the hierarchy to decrease its hierarchy level below '6': 'FourthDerivedClass, ThirdDerivedClass, SecondDerivedClass, FirstDerivedClass, BaseClass, Object'
                 GetCSharpCA1501ExpectedDiagnostic(9, 7, "FifthDerivedClass", 6, 6, "FourthDerivedClass, ThirdDerivedClass, SecondDerivedClass, FirstDerivedClass, BaseClass, Object")};
-            VerifyCSharp(source, expected);
+            await VerifyCS.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
-        public void CA1501_Basic_VerifyDiagnostic()
+        public async Task CA1501_Basic_VerifyDiagnostic()
         {
             var source = @"
 Class BaseClass
@@ -61,11 +65,11 @@ End Class
             DiagnosticResult[] expected = new[] {
                 // Test0.vb(21, 7): warning CA1501: 'FifthDerivedClass' has an object hierarchy '6' levels deep within the defining module. If possible, eliminate base classes within the hierarchy to decrease its hierarchy level below '6': 'FourthDerivedClass, ThirdDerivedClass, SecondDerivedClass, FirstDerivedClass, BaseClass, Object'
                 GetBasicCA1501ExpectedDiagnostic(21, 7, "FifthDerivedClass", 6, 6, "FourthDerivedClass, ThirdDerivedClass, SecondDerivedClass, FirstDerivedClass, BaseClass, Object")};
-            VerifyBasic(source, expected);
+            await VerifyVB.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
-        public void CA1501_Configuration_CSharp_VerifyDiagnostic()
+        public async Task CA1501_Configuration_CSharp_VerifyDiagnostic()
         {
             var source = @"
 class BaseClass { }
@@ -80,11 +84,11 @@ CA1501: 1
             DiagnosticResult[] expected = new[] {
                 // Test0.cs(3, 7): warning CA1501: 'BaseClass' has an object hierarchy '2' levels deep within the defining module. If possible, eliminate base classes within the hierarchy to decrease its hierarchy level below '2': 'BaseClass, Object'
                 GetCSharpCA1501ExpectedDiagnostic(3, 7, "FirstDerivedClass", 2, 2, "BaseClass, Object")};
-            VerifyCSharp(source, GetAdditionalFile(additionalText), expected);
+            await VerifyCSharp(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1501_Configuration_Basic_VerifyDiagnostic()
+        public async Task CA1501_Configuration_Basic_VerifyDiagnostic()
         {
             var source = @"
 Class BaseClass
@@ -103,7 +107,7 @@ CA1501: 1
             DiagnosticResult[] expected = new[] {
                 // Test0.vb(5, 7): warning CA1501: 'BaseClass' has an object hierarchy '2' levels deep within the defining module. If possible, eliminate base classes within the hierarchy to decrease its hierarchy level below '2': 'BaseClass, Object'
                 GetBasicCA1501ExpectedDiagnostic(5, 7, "FirstDerivedClass", 2, 2, "BaseClass, Object")};
-            VerifyBasic(source, GetAdditionalFile(additionalText), expected);
+            await VerifyBasic(source, additionalText, expected);
         }
 
         #endregion
@@ -111,7 +115,7 @@ CA1501: 1
         #region CA1502: Avoid excessive complexity
 
         [Fact]
-        public void CA1502_CSharp_VerifyDiagnostic()
+        public async Task CA1502_CSharp_VerifyDiagnostic()
         {
             var source = @"
 class C
@@ -129,11 +133,11 @@ class C
             DiagnosticResult[] expected = new[] {
                 // Test0.cs(4,10): warning CA1502: 'M' has a cyclomatic complexity of '28'. Rewrite or refactor the code to decrease its complexity below '26'.
                 GetCSharpCA1502ExpectedDiagnostic(4, 10, "M", 28, 26)};
-            VerifyCSharp(source, expected);
+            await VerifyCS.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
-        public void CA1502_Basic_VerifyDiagnostic()
+        public async Task CA1502_Basic_VerifyDiagnostic()
         {
             var source = @"
 Class C
@@ -148,11 +152,11 @@ End Class
             DiagnosticResult[] expected = new[] {
                 // Test0.vb(3,17): warning CA1502: 'M' has a cyclomatic complexity of '28'. Rewrite or refactor the code to decrease its complexity below '26'.
                 GetBasicCA1502ExpectedDiagnostic(3, 17, "M", 28, 26)};
-            VerifyBasic(source, expected);
+            await VerifyVB.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
-        public void CA1502_Configuration_CSharp_VerifyDiagnostic()
+        public async Task CA1502_Configuration_CSharp_VerifyDiagnostic()
         {
             var source = @"
 class C
@@ -176,13 +180,13 @@ class C
 CA1502: 2
 ";
             DiagnosticResult[] expected = new[] {
-                // Test0.cs(4,10): warning CA1502: 'M1' has a cyclomatic complexity of '4'. Rewrite or refactor the code to decrease its complexity below '3'.                
+                // Test0.cs(4,10): warning CA1502: 'M1' has a cyclomatic complexity of '4'. Rewrite or refactor the code to decrease its complexity below '3'.
                 GetCSharpCA1502ExpectedDiagnostic(4, 10, "M1", 4, 3)};
-            VerifyCSharp(source, GetAdditionalFile(additionalText), expected);
+            await VerifyCSharp(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1502_Configuration_Basic_VerifyDiagnostic()
+        public async Task CA1502_Configuration_Basic_VerifyDiagnostic()
         {
             var source = @"
 Class C
@@ -204,11 +208,11 @@ CA1502: 2
             DiagnosticResult[] expected = new[] {
                 // Test0.vb(3,17): warning CA1502: 'M1' has a cyclomatic complexity of '4'. Rewrite or refactor the code to decrease its complexity below '3'.
                 GetBasicCA1502ExpectedDiagnostic(3, 17, "M1", 4, 3)};
-            VerifyBasic(source, GetAdditionalFile(additionalText), expected);
+            await VerifyBasic(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1502_SymbolBasedConfiguration_CSharp_VerifyDiagnostic()
+        public async Task CA1502_SymbolBasedConfiguration_CSharp_VerifyDiagnostic()
         {
             var source = @"
 class C
@@ -233,15 +237,15 @@ CA1502(Type): 4
 CA1502(Method): 2
 ";
             DiagnosticResult[] expected = new[] {
-                // Test0.cs(2,7): warning CA1502: 'C' has a cyclomatic complexity of '6'. Rewrite or refactor the code to decrease its complexity below '5'.                
+                // Test0.cs(2,7): warning CA1502: 'C' has a cyclomatic complexity of '6'. Rewrite or refactor the code to decrease its complexity below '5'.
                 GetCSharpCA1502ExpectedDiagnostic(2, 7, "C", 6, 5),
                 // Test0.cs(4,10): warning CA1502: 'M1' has a cyclomatic complexity of '4'. Rewrite or refactor the code to decrease its complexity below '3'.
                 GetCSharpCA1502ExpectedDiagnostic(4, 10, "M1", 4, 3)};
-            VerifyCSharp(source, GetAdditionalFile(additionalText), expected);
+            await VerifyCSharp(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1502_SymbolBasedConfiguration_Basic_VerifyDiagnostic()
+        public async Task CA1502_SymbolBasedConfiguration_Basic_VerifyDiagnostic()
         {
             var source = @"
 Class C
@@ -266,7 +270,7 @@ CA1502(Method): 2
                 GetBasicCA1502ExpectedDiagnostic(2, 7, "C", 6, 5),
                 // Test0.vb(3,17): warning CA1502: 'M1' has a cyclomatic complexity of '4'. Rewrite or refactor the code to decrease its complexity below '3'.
                 GetBasicCA1502ExpectedDiagnostic(3, 17, "M1", 4, 3)};
-            VerifyBasic(source, GetAdditionalFile(additionalText), expected);
+            await VerifyBasic(source, additionalText, expected);
         }
 
         #endregion
@@ -274,7 +278,7 @@ CA1502(Method): 2
         #region CA1505: Avoid unmaintainable code
 
         [Fact]
-        public void CA1505_Configuration_CSharp_VerifyDiagnostic()
+        public async Task CA1505_Configuration_CSharp_VerifyDiagnostic()
         {
             var source = @"
 class C
@@ -297,11 +301,11 @@ CA1505: 95
                 GetCSharpCA1505ExpectedDiagnostic(2, 7, "C", 91, 94),
                 // Test0.cs(4,10): warning CA1505: 'M1' has a maintainability index of '91'. Rewrite or refactor the code to increase its maintainability index (MI) above '94'.
                 GetCSharpCA1505ExpectedDiagnostic(4, 10, "M1", 91, 94)};
-            VerifyCSharp(source, GetAdditionalFile(additionalText), expected);
+            await VerifyCSharp(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1505_Configuration_Basic_VerifyDiagnostic()
+        public async Task CA1505_Configuration_Basic_VerifyDiagnostic()
         {
             var source = @"
 Class C
@@ -322,11 +326,11 @@ CA1505: 95
                 GetBasicCA1505ExpectedDiagnostic(2, 7, "C", 91, 94),
                 // Test0.vb(3,17): warning CA1505: 'M1' has a maintainability index of '91'. Rewrite or refactor the code to increase its maintainability index (MI) above '94'.
                 GetBasicCA1505ExpectedDiagnostic(3, 17, "M1", 91, 94)};
-            VerifyBasic(source, GetAdditionalFile(additionalText), expected);
+            await VerifyBasic(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1505_SymbolBasedConfiguration_CSharp_VerifyDiagnostic()
+        public async Task CA1505_SymbolBasedConfiguration_CSharp_VerifyDiagnostic()
         {
             var source = @"
 class C
@@ -347,11 +351,11 @@ CA1505(Type): 95
             DiagnosticResult[] expected = new[] {
                 // Test0.cs(2,7): warning CA1505: 'C' has a maintainability index of '91'. Rewrite or refactor the code to increase its maintainability index (MI) above '94'.
                 GetCSharpCA1505ExpectedDiagnostic(2, 7, "C", 91, 94)};
-            VerifyCSharp(source, GetAdditionalFile(additionalText), expected);
+            await VerifyCSharp(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1505_SymbolBasedConfiguration_Basic_VerifyDiagnostic()
+        public async Task CA1505_SymbolBasedConfiguration_Basic_VerifyDiagnostic()
         {
             var source = @"
 Class C
@@ -370,7 +374,7 @@ CA1505(Type): 95
             DiagnosticResult[] expected = new[] {
                 // Test0.vb(2,7): warning CA1505: 'C' has a maintainability index of '91'. Rewrite or refactor the code to increase its maintainability index (MI) above '94'.
                 GetBasicCA1505ExpectedDiagnostic(2, 7, "C", 91, 94)};
-            VerifyBasic(source, GetAdditionalFile(additionalText), expected);
+            await VerifyBasic(source, additionalText, expected);
         }
 
         #endregion
@@ -378,7 +382,7 @@ CA1505(Type): 95
         #region CA1506: Avoid excessive class coupling
 
         [Fact]
-        public void CA1506_Configuration_CSharp_VerifyDiagnostic()
+        public async Task CA1506_Configuration_CSharp_VerifyDiagnostic()
         {
             var source = @"
 class C
@@ -404,11 +408,11 @@ CA1506: 2
                 GetCSharpCA1506ExpectedDiagnostic(2, 7, "C", 4, 2, 3),
                 // Test0.cs(4,10): warning CA1506: 'M1' is coupled with '4' different types from '2' different namespaces. Rewrite or refactor the code to decrease its class coupling below '3'.
                 GetCSharpCA1506ExpectedDiagnostic(4, 10, "M1", 4, 2, 3)};
-            VerifyCSharp(source, GetAdditionalFile(additionalText), expected);
+            await VerifyCSharp(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1506_Configuration_Basic_VerifyDiagnostic()
+        public async Task CA1506_Configuration_Basic_VerifyDiagnostic()
         {
             var source = @"
 Class C
@@ -441,11 +445,11 @@ CA1506: 2
                 GetBasicCA1506ExpectedDiagnostic(2, 7, "C", 4, 2, 3),
                 // Test0.vb(3,17): warning CA1506: 'M1' is coupled with '4' different types from '2' different namespaces. Rewrite or refactor the code to decrease its class coupling below '3'.
                 GetBasicCA1506ExpectedDiagnostic(3, 17, "M1", 4, 2, 3)};
-            VerifyBasic(source, GetAdditionalFile(additionalText), expected);
+            await VerifyBasic(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1506_SymbolBasedConfiguration_CSharp_VerifyDiagnostic()
+        public async Task CA1506_SymbolBasedConfiguration_CSharp_VerifyDiagnostic()
         {
             var source = @"
 class C
@@ -470,11 +474,11 @@ CA1506(Type): 10
             DiagnosticResult[] expected = new[] {
                 // Test0.cs(4,10): warning CA1506: 'M1' is coupled with '4' different types from '2' different namespaces. Rewrite or refactor the code to decrease its class coupling below '3'.
                 GetCSharpCA1506ExpectedDiagnostic(4, 10, "M1", 4, 2, 3)};
-            VerifyCSharp(source, GetAdditionalFile(additionalText), expected);
+            await VerifyCSharp(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1506_SymbolBasedConfiguration_Basic_VerifyDiagnostic()
+        public async Task CA1506_SymbolBasedConfiguration_Basic_VerifyDiagnostic()
         {
             var source = @"
 Class C
@@ -506,7 +510,7 @@ CA1506(Type): 10
             DiagnosticResult[] expected = new[] {
                 // Test0.vb(3,17): warning CA1506: 'M1' is coupled with '4' different types from '2' different namespaces. Rewrite or refactor the code to decrease its class coupling below '3'.
                 GetBasicCA1506ExpectedDiagnostic(3, 17, "M1", 4, 2, 3)};
-            VerifyBasic(source, GetAdditionalFile(additionalText), expected);
+            await VerifyBasic(source, additionalText, expected);
         }
 
         #endregion
@@ -514,7 +518,7 @@ CA1506(Type): 10
         #region CA1509: Invalid entry in code metrics rule specification file
 
         [Fact]
-        public void CA1509_VerifyDiagnostics()
+        public async Task CA1509_VerifyDiagnostics()
         {
             var source = @"";
 
@@ -568,11 +572,11 @@ CA1501
                 GetCA1509ExpectedDiagnostic(27, 1, "CA1501(Method)(Type): 1", AdditionalFileName),
                 // CodeMetricsConfig.txt(30,1): warning CA1509: Invalid entry 'CA1501' in code metrics rule specification file 'CodeMetricsConfig.txt'
                 GetCA1509ExpectedDiagnostic(30, 1, "CA1501", AdditionalFileName)};
-            VerifyCSharp(source, GetAdditionalFile(additionalText), expected);
+            await VerifyCSharp(source, additionalText, expected);
         }
 
         [Fact]
-        public void CA1509_NoDiagnostics()
+        public async Task CA1509_NoDiagnostics()
         {
             var source = @"";
 
@@ -603,11 +607,11 @@ CA1502(Event): 1
 # 5. Whitespaces before and after the colon are allowed.
 CA1501    :    1
 ";
-            VerifyCSharp(source, GetAdditionalFile(additionalText));
+            await VerifyCSharp(source, additionalText);
         }
 
         [Fact]
-        public void CA1509_VerifyNoMetricDiagnostics()
+        public async Task CA1509_VerifyNoMetricDiagnostics()
         {
             // Ensure we don't report any code metric diagnostics when we have invalid entries in code metrics configuration file.
             var source = @"
@@ -629,109 +633,90 @@ CA 1501: 10
             DiagnosticResult[] expected = new[] {
                 // CodeMetricsConfig.txt(5,1): warning CA1509: Invalid entry 'CA 1501: 10' in code metrics rule specification file 'CodeMetricsConfig.txt'
                 GetCA1509ExpectedDiagnostic(5, 1, "CA 1501: 10", AdditionalFileName)};
-            VerifyCSharp(source, GetAdditionalFile(additionalText), expected);
+            await VerifyCSharp(source, additionalText, expected);
         }
 
         #endregion
 
         #region Helpers
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CodeMetricsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new CodeMetricsAnalyzer();
-        }
-
         private static DiagnosticResult GetCSharpCA1501ExpectedDiagnostic(int line, int column, string symbolName, int metricValue, int threshold, string baseTypes)
-        {
-            return GetCA1501ExpectedDiagnostic(line, column, symbolName, metricValue, threshold, baseTypes);
-        }
+            => VerifyCS.Diagnostic(CodeMetricsAnalyzer.CA1501Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, metricValue, threshold, baseTypes);
 
         private static DiagnosticResult GetBasicCA1501ExpectedDiagnostic(int line, int column, string symbolName, int metricValue, int threshold, string baseTypes)
-        {
-            return GetCA1501ExpectedDiagnostic(line, column, symbolName, metricValue, threshold, baseTypes);
-        }
+            => VerifyVB.Diagnostic(CodeMetricsAnalyzer.CA1501Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, metricValue, threshold, baseTypes);
 
         private static DiagnosticResult GetCSharpCA1502ExpectedDiagnostic(int line, int column, string symbolName, int metricValue, int threshold)
-        {
-            return GetCA1502ExpectedDiagnostic(line, column, symbolName, metricValue, threshold);
-        }
+            => VerifyCS.Diagnostic(CodeMetricsAnalyzer.CA1502Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, metricValue, threshold);
 
         private static DiagnosticResult GetBasicCA1502ExpectedDiagnostic(int line, int column, string symbolName, int metricValue, int threshold)
-        {
-            return GetCA1502ExpectedDiagnostic(line, column, symbolName, metricValue, threshold);
-        }
+            => VerifyVB.Diagnostic(CodeMetricsAnalyzer.CA1502Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, metricValue, threshold);
 
         private static DiagnosticResult GetCSharpCA1505ExpectedDiagnostic(int line, int column, string symbolName, int metricValue, int threshold)
-        {
-            return GetCA1505ExpectedDiagnostic(line, column, symbolName, metricValue, threshold);
-        }
+            => VerifyCS.Diagnostic(CodeMetricsAnalyzer.CA1505Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, metricValue, threshold);
 
         private static DiagnosticResult GetBasicCA1505ExpectedDiagnostic(int line, int column, string symbolName, int metricValue, int threshold)
-        {
-            return GetCA1505ExpectedDiagnostic(line, column, symbolName, metricValue, threshold);
-        }
+            => VerifyVB.Diagnostic(CodeMetricsAnalyzer.CA1505Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, metricValue, threshold);
 
         private static DiagnosticResult GetCSharpCA1506ExpectedDiagnostic(int line, int column, string symbolName, int coupledTypesCount, int namespaceCount, int threshold)
-        {
-            return GetCA1506ExpectedDiagnostic(line, column, symbolName, coupledTypesCount, namespaceCount, threshold);
-        }
+            => VerifyCS.Diagnostic(CodeMetricsAnalyzer.CA1506Rule)
+                .WithLocation(line, column)
+                .WithArguments(symbolName, coupledTypesCount, namespaceCount, threshold);
 
         private static DiagnosticResult GetBasicCA1506ExpectedDiagnostic(int line, int column, string symbolName, int coupledTypesCount, int namespaceCount, int threshold)
-        {
-            return GetCA1506ExpectedDiagnostic(line, column, symbolName, coupledTypesCount, namespaceCount, threshold);
-        }
-
-        // '{0}' has an object hierarchy '{1}' levels deep within the defining module. If possible, eliminate base classes within the hierarchy to decrease its hierarchy level below '{2}': '{3}'
-        private static DiagnosticResult GetCA1501ExpectedDiagnostic(int line, int column, string symbolName, int metricValue, int threshold, string baseTypes)
-        {
-            return new DiagnosticResult(CodeMetricsAnalyzer.CA1501RuleId, DiagnosticHelpers.DefaultDiagnosticSeverity)
+            => VerifyVB.Diagnostic(CodeMetricsAnalyzer.CA1506Rule)
                 .WithLocation(line, column)
-                .WithMessageFormat(MicrosoftCodeQualityAnalyzersResources.AvoidExcessiveInheritanceMessage)
-                .WithArguments(symbolName, metricValue, threshold, baseTypes);
-        }
-
-        // '{0}' has a cyclomatic complexity of '{1}'. Rewrite or refactor the code to decrease its complexity below '{2}'.
-        private static DiagnosticResult GetCA1502ExpectedDiagnostic(int line, int column, string symbolName, int metricValue, int threshold)
-        {
-            return new DiagnosticResult(CodeMetricsAnalyzer.CA1502RuleId, DiagnosticHelpers.DefaultDiagnosticSeverity)
-                .WithLocation(line, column)
-                .WithMessageFormat(MicrosoftCodeQualityAnalyzersResources.AvoidExcessiveComplexityMessage)
-                .WithArguments(symbolName, metricValue, threshold);
-        }
-
-        // '{0}' has a maintainability index of '{1}'. Rewrite or refactor the code to increase its maintainability index (MI) above '{2}'.
-        private static DiagnosticResult GetCA1505ExpectedDiagnostic(int line, int column, string symbolName, int metricValue, int threshold)
-        {
-            return new DiagnosticResult(CodeMetricsAnalyzer.CA1505RuleId, DiagnosticHelpers.DefaultDiagnosticSeverity)
-                .WithLocation(line, column)
-                .WithMessageFormat(MicrosoftCodeQualityAnalyzersResources.AvoidUnmantainableCodeMessage)
-                .WithArguments(symbolName, metricValue, threshold);
-        }
-
-        // '{0}' is coupled with '{1}' different types from '{2}' different namespaces. Rewrite or refactor the code to decrease its class coupling below '{3}'.
-        private static DiagnosticResult GetCA1506ExpectedDiagnostic(int line, int column, string symbolName, int coupledTypesCount, int namespaceCount, int threshold)
-        {
-            return new DiagnosticResult(CodeMetricsAnalyzer.CA1506RuleId, DiagnosticHelpers.DefaultDiagnosticSeverity)
-                .WithLocation(line, column)
-                .WithMessageFormat(MicrosoftCodeQualityAnalyzersResources.AvoidExcessiveClassCouplingMessage)
                 .WithArguments(symbolName, coupledTypesCount, namespaceCount, threshold);
-        }
 
         private static DiagnosticResult GetCA1509ExpectedDiagnostic(int line, int column, string entry, string additionalFile)
-        {
-            return new DiagnosticResult(CodeMetricsAnalyzer.CA1509RuleId, DiagnosticHelpers.DefaultDiagnosticSeverity)
-                .WithLocation(AdditionalFileName, line, column)
-                .WithMessageFormat(MicrosoftCodeQualityAnalyzersResources.InvalidEntryInCodeMetricsConfigFileMessage)
+            => VerifyCS.Diagnostic(CodeMetricsAnalyzer.InvalidEntryInCodeMetricsConfigFileRule)
+                .WithLocation(line, column)
                 .WithArguments(entry, additionalFile);
-        }
 
         private const string AdditionalFileName = "CodeMetricsConfig.txt";
-        private FileAndSource GetAdditionalFile(string source)
-            => new FileAndSource() { Source = source, FilePath = AdditionalFileName };
+
+        private async Task VerifyCSharp(string source, string codeMetricsConfigSource, params DiagnosticResult[] expected)
+        {
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { (AdditionalFileName, codeMetricsConfigSource) }
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
+        }
+
+        private async Task VerifyBasic(string source, string codeMetricsConfigSource, params DiagnosticResult[] expected)
+        {
+            var vbTest = new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { (AdditionalFileName, codeMetricsConfigSource) }
+                }
+            };
+
+            vbTest.ExpectedDiagnostics.AddRange(expected);
+
+            await vbTest.RunAsync();
+        }
 
         #endregion
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/CodeMetricsAnalyzerTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/CodeMetricsAnalyzerTests.cs
@@ -681,7 +681,7 @@ CA 1501: 10
 
         private static DiagnosticResult GetCA1509ExpectedDiagnostic(int line, int column, string entry, string additionalFile)
             => VerifyCS.Diagnostic(CodeMetricsAnalyzer.InvalidEntryInCodeMetricsConfigFileRule)
-                .WithLocation(line, column)
+                .WithLocation(additionalFile, line, column)
                 .WithArguments(entry, additionalFile);
 
         private const string AdditionalFileName = "CodeMetricsConfig.txt";

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
@@ -303,7 +303,7 @@ Class C
     End Sub
 End Class
 ",
-                new DiagnosticResult("BC30035", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 9));
+                DiagnosticResult.CompilerError("BC30035").WithLocation(7, 9));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
@@ -488,7 +488,7 @@ public class Test
                 },
                 ExpectedDiagnostics =
                 {
-                    GetCSharpObjectCreationResultAt(10, 13, "ThrowsException", "Test")
+                    GetCSharpObjectCreationResultAt(10, 13, "ThrowsException", "Test"),
                 }
             }.RunAsync();
 
@@ -516,7 +516,7 @@ End Class", useXunit ? XunitApis.VisualBasic : NUnitApis.VisualBasic
                 },
                 ExpectedDiagnostics =
                 {
-                    GetBasicStringCreationResultAt(10, 41, "ThrowsException", "ToLower")
+                    GetBasicStringCreationResultAt(10, 41, "ThrowsException", "ToLower"),
                 }
             }.RunAsync();
         }
@@ -554,7 +554,7 @@ public class Test
                 },
                 ExpectedDiagnostics =
                 {
-                    GetCSharpObjectCreationResultAt(10, 13, "ThrowsException", "Test")
+                    GetCSharpObjectCreationResultAt(10, 13, "ThrowsException", "Test"),
                 }
             }.RunAsync();
 
@@ -582,7 +582,7 @@ End Class", useXunit ? XunitApis.VisualBasic : NUnitApis.VisualBasic
                 },
                 ExpectedDiagnostics =
                 {
-                    GetBasicStringCreationResultAt(10, 41, "ThrowsException", "ToLower")
+                    GetBasicStringCreationResultAt(10, 41, "ThrowsException", "ToLower"),
                 }
             }.RunAsync();
         }
@@ -613,7 +613,7 @@ public class Test
                 },
                 ExpectedDiagnostics =
                 {
-                    GetCSharpObjectCreationResultAt(9, 9, "ThrowsException", "Test")
+                    GetCSharpObjectCreationResultAt(9, 9, "ThrowsException", "Test"),
                 }
             }.RunAsync();
 
@@ -641,7 +641,7 @@ End Class", MSTestAttributes.VisualBasic
                 },
                 ExpectedDiagnostics =
                 {
-                    GetBasicStringCreationResultAt(11, 9, "ThrowsException", "ToLower")
+                    GetBasicStringCreationResultAt(11, 9, "ThrowsException", "ToLower"),
                 }
             }.RunAsync();
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
@@ -299,11 +299,11 @@ Imports System.Globalization
 
 Class C
     Public Sub DoesNotAssignObjectToVariable()
-        New C() ' error BC30035: Syntax error
+        New C()
     End Sub
 End Class
 ",
-                DiagnosticResult.CompilerError("BC30035").WithLocation(7, 9));
+                DiagnosticResult.CompilerError("BC30035").WithLocation(7, 9).WithMessage("Syntax error."));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/DoNotIgnoreMethodResultsTests.cs
@@ -302,7 +302,8 @@ Class C
         New C() ' error BC30035: Syntax error
     End Sub
 End Class
-", CompilerDiagnostics.None);
+",
+                new DiagnosticResult("BC30035", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 9));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -904,7 +904,7 @@ class C
     {
     }
 }
-", CompilerDiagnostics.None,
+",
           // Test0.cs(6,18): warning CA1801: Parameter param of method .ctor is never used. Remove the parameter or use it in the method body.
           GetCSharpUnusedParameterResultAt(6, 18, "param", ".ctor"),
           // Test0.cs(10,39): warning CA1801: Parameter param of method UnusedParamMethod is never used. Remove the parameter or use it in the method body.
@@ -921,6 +921,8 @@ class C
           GetCSharpUnusedParameterResultAt(26, 60, "param2", "MultipleUnusedParamsMethod"),
           // Test0.cs(30,47): warning CA1801: Parameter param1 of method UnusedRefParamMethod is never used. Remove the parameter or use it in the method body.
           GetCSharpUnusedParameterResultAt(30, 47, "param1", "UnusedRefParamMethod"),
+          // Test0.cs(34,44): error CS0246: The type or namespace name 'UndefinedType' could not be found (are you missing a using directive or an assembly reference?)
+          new DiagnosticResult("CS0246", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(34, 44),
           // Test0.cs(34,58): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
           GetCSharpUnusedParameterResultAt(34, 58, "param1", "UnusedErrorTypeParamMethod"));
         }
@@ -955,7 +957,7 @@ Class C
     Public Sub UnusedErrorTypeParamMethod(param1 As UndefinedType) ' error BC30002: Type 'UndefinedType' is not defined.
     End Sub
 End Class
-", CompilerDiagnostics.None,
+",
       // Test0.vb(3,20): warning CA1801: Parameter param of method .ctor is never used. Remove the parameter or use it in the method body.
       GetBasicUnusedParameterResultAt(3, 20, "param", ".ctor"),
       // Test0.vb(6,34): warning CA1801: Parameter param of method UnusedParamMethod is never used. Remove the parameter or use it in the method body.
@@ -973,7 +975,9 @@ End Class
       // Test0.vb(21,44): warning CA1801: Parameter param1 of method UnusedRefParamMethod is never used. Remove the parameter or use it in the method body.
       GetBasicUnusedParameterResultAt(21, 44, "param1", "UnusedRefParamMethod"),
       // Test0.vb(24,43): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
-      GetBasicUnusedParameterResultAt(24, 43, "param1", "UnusedErrorTypeParamMethod"));
+      GetBasicUnusedParameterResultAt(24, 43, "param1", "UnusedErrorTypeParamMethod"),
+      // Test0.vb(24) : error BC30002: Type 'UndefinedType' is not defined.
+      new DiagnosticResult("BC30002", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(24, 53));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -921,8 +921,7 @@ class C
           GetCSharpUnusedParameterResultAt(26, 60, "param2", "MultipleUnusedParamsMethod"),
           // Test0.cs(30,47): warning CA1801: Parameter param1 of method UnusedRefParamMethod is never used. Remove the parameter or use it in the method body.
           GetCSharpUnusedParameterResultAt(30, 47, "param1", "UnusedRefParamMethod"),
-          // Test0.cs(34,44): error CS0246: The type or namespace name 'UndefinedType' could not be found (are you missing a using directive or an assembly reference?)
-          DiagnosticResult.CompilerError("CS0246").WithLocation(34, 44),
+          DiagnosticResult.CompilerError("CS0246").WithLocation(34, 44).WithMessage("The type or namespace name 'UndefinedType' could not be found (are you missing a using directive or an assembly reference?)"),
           // Test0.cs(34,58): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
           GetCSharpUnusedParameterResultAt(34, 58, "param1", "UnusedErrorTypeParamMethod"));
         }
@@ -976,8 +975,7 @@ End Class
       GetBasicUnusedParameterResultAt(21, 44, "param1", "UnusedRefParamMethod"),
       // Test0.vb(24,43): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
       GetBasicUnusedParameterResultAt(24, 43, "param1", "UnusedErrorTypeParamMethod"),
-      // Test0.vb(24) : error BC30002: Type 'UndefinedType' is not defined.
-      DiagnosticResult.CompilerError("BC30002").WithLocation(24, 53));
+      DiagnosticResult.CompilerError("BC30002").WithLocation(24, 53).WithMessage("Type 'UndefinedType' is not defined."));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -1040,12 +1040,12 @@ public class C
         #region Helpers
 
         private static DiagnosticResult GetCSharpUnusedParameterResultAt(int line, int column, string parameterName, string methodName)
-            => VerifyCS.Diagnostic(ReviewUnusedParametersAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(parameterName, methodName);
 
         private static DiagnosticResult GetBasicUnusedParameterResultAt(int line, int column, string parameterName, string methodName)
-            => VerifyVB.Diagnostic(ReviewUnusedParametersAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(parameterName, methodName);
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/ReviewUnusedParametersTests.cs
@@ -922,7 +922,7 @@ class C
           // Test0.cs(30,47): warning CA1801: Parameter param1 of method UnusedRefParamMethod is never used. Remove the parameter or use it in the method body.
           GetCSharpUnusedParameterResultAt(30, 47, "param1", "UnusedRefParamMethod"),
           // Test0.cs(34,44): error CS0246: The type or namespace name 'UndefinedType' could not be found (are you missing a using directive or an assembly reference?)
-          new DiagnosticResult("CS0246", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(34, 44),
+          DiagnosticResult.CompilerError("CS0246").WithLocation(34, 44),
           // Test0.cs(34,58): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
           GetCSharpUnusedParameterResultAt(34, 58, "param1", "UnusedErrorTypeParamMethod"));
         }
@@ -977,7 +977,7 @@ End Class
       // Test0.vb(24,43): warning CA1801: Parameter param1 of method UnusedErrorTypeParamMethod is never used. Remove the parameter or use it in the method body.
       GetBasicUnusedParameterResultAt(24, 43, "param1", "UnusedErrorTypeParamMethod"),
       // Test0.vb(24) : error BC30002: Type 'UndefinedType' is not defined.
-      new DiagnosticResult("BC30002", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(24, 53));
+      DiagnosticResult.CompilerError("BC30002").WithLocation(24, 53));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -618,12 +618,12 @@ namespace ConsoleApp14
         #endregion
 
         private DiagnosticResult GetBasicNameofResultAt(int line, int column, string name)
-            => VerifyVB.Diagnostic(UseNameofInPlaceOfStringAnalyzer.RuleWithSuggestion)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(name);
 
         private DiagnosticResult GetCSharpNameofResultAt(int line, int column, string name)
-            => VerifyCS.Diagnostic(UseNameofInPlaceOfStringAnalyzer.RuleWithSuggestion)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(name);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -617,12 +617,12 @@ namespace ConsoleApp14
 
         #endregion
 
-        private DiagnosticResult GetBasicNameofResultAt(int line, int column, string name)
+        private static DiagnosticResult GetBasicNameofResultAt(int line, int column, string name)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(name);
 
-        private DiagnosticResult GetCSharpNameofResultAt(int line, int column, string name)
+        private static DiagnosticResult GetCSharpNameofResultAt(int line, int column, string name)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(name);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -128,8 +128,8 @@ class C
         throw new ArgumentNullException(
     }
 }",
-                DiagnosticResult.CompilerError("CS1002").WithLocation(7, 41),
-                DiagnosticResult.CompilerError("CS1026").WithLocation(7, 41));
+                DiagnosticResult.CompilerError("CS1002").WithLocation(7, 41).WithMessage("; expected"),
+                DiagnosticResult.CompilerError("CS1026").WithLocation(7, 41).WithMessage(") expected"));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -127,7 +127,9 @@ class C
     {
         throw new ArgumentNullException(
     }
-}", CompilerDiagnostics.None);
+}",
+                new DiagnosticResult("CS1002", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 41),
+                new DiagnosticResult("CS1026", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 41));
         }
 
         [Fact]
@@ -139,9 +141,9 @@ class C
 {
     void M(int x)
     {
-        throw new ArgumentNullException(""test"", ""test2"", ""test3"");
+        throw new ArgumentNullException(""test"", ""test2"");
     }
-}", CompilerDiagnostics.None);
+}");
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -128,8 +128,8 @@ class C
         throw new ArgumentNullException(
     }
 }",
-                new DiagnosticResult("CS1002", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 41),
-                new DiagnosticResult("CS1026", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(7, 41));
+                DiagnosticResult.CompilerError("CS1002").WithLocation(7, 41),
+                DiagnosticResult.CompilerError("CS1026").WithLocation(7, 41));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/Maintainability/UseNameOfInPlaceOfStringTests.cs
@@ -267,7 +267,7 @@ class C
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp6,
                 ExpectedDiagnostics =
                 {
-                    GetCSharpNameofResultAt(7, 41, "x")
+                    GetCSharpNameofResultAt(7, 41, "x"),
                 }
             }.RunAsync();
         }
@@ -307,7 +307,7 @@ End Module",
                 LanguageVersion = CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic14,
                 ExpectedDiagnostics =
                 {
-                    GetBasicNameofResultAt(6, 41, "s")
+                    GetBasicNameofResultAt(6, 41, "s"),
                 }
             }.RunAsync();
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
@@ -289,8 +289,8 @@ public class Test
     }
 }
 ",
-                new DiagnosticResult("CS0523", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 14),
-                new DiagnosticResult("CS0165", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(12, 23));
+                DiagnosticResult.CompilerError("CS0523").WithLocation(4, 14),
+                DiagnosticResult.CompilerError("CS0165").WithLocation(12, 23));
         }
 
         [Fact]
@@ -313,10 +313,10 @@ public class Test
     }
 }
 ",
-                new DiagnosticResult("CS0523", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 14),
-                new DiagnosticResult("CS0165", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(12, 9),
-                new DiagnosticResult("CS0103", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(12, 22),
-                new DiagnosticResult("CS0165", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(12, 30));
+                DiagnosticResult.CompilerError("CS0523").WithLocation(4, 14),
+                DiagnosticResult.CompilerError("CS0165").WithLocation(12, 9),
+                DiagnosticResult.CompilerError("CS0103").WithLocation(12, 22),
+                DiagnosticResult.CompilerError("CS0165").WithLocation(12, 30));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
@@ -277,7 +277,7 @@ public class Test
             await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
-    public S Field;         // error CS0523: Struct member 'S.Field' of type 'S' causes a cycle in the struct layout
+    public S Field;
 }
 
 public class Test
@@ -285,12 +285,12 @@ public class Test
     public void Method()
     {
         S a, b;
-        a.Field = a = b;    // error CS0165: Use of unassigned local variable 'b'
+        a.Field = a = b;
     }
 }
 ",
-                DiagnosticResult.CompilerError("CS0523").WithLocation(4, 14),
-                DiagnosticResult.CompilerError("CS0165").WithLocation(12, 23));
+                DiagnosticResult.CompilerError("CS0523").WithLocation(4, 14).WithMessage("Struct member 'S.Field' of type 'S' causes a cycle in the struct layout"),
+                DiagnosticResult.CompilerError("CS0165").WithLocation(12, 23).WithMessage("Use of unassigned local variable 'b'"));
         }
 
         [Fact]
@@ -299,7 +299,7 @@ public class Test
             await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
-    public S Property { get; set; }     // error CS0523: Struct member 'S.Property' of type 'S' causes a cycle in the struct layout
+    public S Property { get; set; }
 }
 
 public class Test
@@ -307,16 +307,14 @@ public class Test
     public void Method()
     {
         S a, b;
-        a.Property = c = a = b;     // error CS0165: Use of unassigned local variable 'a'
-                                    // error CS0103: The name 'c' does not exist in the current context
-                                    // error CS0165: Use of unassigned local variable 'b'
+        a.Property = c = a = b;
     }
 }
 ",
-                DiagnosticResult.CompilerError("CS0523").WithLocation(4, 14),
-                DiagnosticResult.CompilerError("CS0165").WithLocation(12, 9),
-                DiagnosticResult.CompilerError("CS0103").WithLocation(12, 22),
-                DiagnosticResult.CompilerError("CS0165").WithLocation(12, 30));
+                DiagnosticResult.CompilerError("CS0523").WithLocation(4, 14).WithMessage("Struct member 'S.Property' of type 'S' causes a cycle in the struct layout"),
+                DiagnosticResult.CompilerError("CS0165").WithLocation(12, 9).WithMessage("Use of unassigned local variable 'a'"),
+                DiagnosticResult.CompilerError("CS0103").WithLocation(12, 22).WithMessage("The name 'c' does not exist in the current context"),
+                DiagnosticResult.CompilerError("CS0165").WithLocation(12, 30).WithMessage("Use of unassigned local variable 'b'"));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
@@ -277,7 +277,7 @@ public class Test
             await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
-    public S Field;
+    public S Field;         // error CS0523: Struct member 'S.Field' of type 'S' causes a cycle in the struct layout
 }
 
 public class Test
@@ -285,10 +285,12 @@ public class Test
     public void Method()
     {
         S a, b;
-        a.Field = a = b;
+        a.Field = a = b;    // error CS0165: Use of unassigned local variable 'b'
     }
 }
-", CompilerDiagnostics.None);
+",
+                new DiagnosticResult("CS0523", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 14),
+                new DiagnosticResult("CS0165", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(12, 23));
         }
 
         [Fact]
@@ -297,7 +299,7 @@ public class Test
             await VerifyCS.VerifyAnalyzerAsync(@"
 public struct S
 {
-    public S Property { get; set; }
+    public S Property { get; set; }     // error CS0523: Struct member 'S.Property' of type 'S' causes a cycle in the struct layout
 }
 
 public class Test
@@ -305,10 +307,16 @@ public class Test
     public void Method()
     {
         S a, b;
-        a.Property = c = a = b;
+        a.Property = c = a = b;     // error CS0165: Use of unassigned local variable 'a'
+                                    // error CS0103: The name 'c' does not exist in the current context
+                                    // error CS0165: Use of unassigned local variable 'b'
     }
 }
-", CompilerDiagnostics.None);
+",
+                new DiagnosticResult("CS0523", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 14),
+                new DiagnosticResult("CS0165", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(12, 9),
+                new DiagnosticResult("CS0103", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(12, 22),
+                new DiagnosticResult("CS0165", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(12, 30));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AssigningSymbolAndItsMemberInSameStatementTests.cs
@@ -2,7 +2,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.Analyzers.QualityGuidelines;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -349,7 +348,7 @@ public static class Class1
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
-            => new DiagnosticResult(AssigningSymbolAndItsMemberInSameStatement.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidDuplicateElementInitializationTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidDuplicateElementInitializationTests.cs
@@ -328,7 +328,7 @@ class C
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
-            => new DiagnosticResult(AvoidDuplicateElementInitialization.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidDuplicateElementInitializationTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidDuplicateElementInitializationTests.cs
@@ -327,7 +327,7 @@ class C
 ");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
@@ -402,12 +402,12 @@ End Class
 ");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/AvoidPropertySelfAssignmentTests.cs
@@ -2,7 +2,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.Analyzers.QualityGuidelines;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidPropertySelfAssignment,
@@ -404,12 +403,12 @@ End Class
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
-            => new DiagnosticResult(AvoidPropertySelfAssignment.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
         private DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
-            => new DiagnosticResult(AvoidPropertySelfAssignment.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotCallOverridableMethodsInConstructorsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotCallOverridableMethodsInConstructorsTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -16,18 +14,8 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
-    public partial class DoNotCallOverridableMethodsInConstructorsTests : DiagnosticAnalyzerTestBase
+    public class DoNotCallOverridableMethodsInConstructorsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotCallOverridableMethodsInConstructorsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotCallOverridableMethodsInConstructorsAnalyzer();
-        }
-
         [Fact]
         public async Task CA2214VirtualMethodCSharp()
         {
@@ -46,17 +34,17 @@ class C
         }
 
         [Fact]
-        public void CA2214VirtualMethodCSharpWithScope()
+        public async Task CA2214VirtualMethodCSharpWithScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     C()
     {
-        Foo();
+        [|Foo()|];
     }
 
-    [|protected virtual void Foo() { }|]
+    protected virtual void Foo() { }
 }
 ");
         }
@@ -77,15 +65,15 @@ End Class
         }
 
         [Fact]
-        public void CA2214VirtualMethodBasicwithScope()
+        public async Task CA2214VirtualMethodBasicwithScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Class C
     Public Sub New()
-        Foo()
+        [|Foo()|]
     End Sub
-    [|Overridable Sub Foo()
-    End Sub|]
+    Overridable Sub Foo()
+    End Sub
 End Class
 ");
         }
@@ -237,9 +225,15 @@ End Class
         }
 
         [Fact]
-        public void CA2214SpecialInheritanceCSharp()
+        public async Task CA2214SpecialInheritanceCSharp()
         {
-            var source = @"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 abstract class C : System.Web.UI.Control
 {
     C()
@@ -286,18 +280,27 @@ abstract class F : System.ComponentModel.Component
 
     protected abstract void Foo();
 }
-";
-            Document document = CreateDocument(source, LanguageNames.CSharp);
-            Project project = document.Project.AddMetadataReference(MetadataReference.CreateFromFile(typeof(System.Web.UI.Control).Assembly.Location));
-            project = project.AddMetadataReference(MetadataReference.CreateFromFile(typeof(System.Windows.Forms.Control).Assembly.Location));
-            DiagnosticAnalyzer analyzer = GetCSharpDiagnosticAnalyzer();
-            GetSortedDiagnostics(analyzer, project.Documents.Single()).Verify(analyzer, GetDefaultPath(LanguageNames.CSharp));
+"
+                    },
+                    AdditionalReferences =
+                    {
+                        MetadataReference.CreateFromFile(typeof(System.Web.UI.Control).Assembly.Location),
+                        MetadataReference.CreateFromFile(typeof(System.Windows.Forms.Control).Assembly.Location),
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA2214SpecialInheritanceBasic()
+        public async Task CA2214SpecialInheritanceBasic()
         {
-            var source = @"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 MustInherit Class C
     Inherits System.Web.UI.Control
     Public Sub New()
@@ -337,12 +340,15 @@ MustInherit Class F
     End Sub
     MustOverride Sub Foo()
 End Class
-";
-            Document document = CreateDocument(source, LanguageNames.VisualBasic);
-            Project project = document.Project.AddMetadataReference(MetadataReference.CreateFromFile(typeof(System.Web.UI.Control).Assembly.Location));
-            project = project.AddMetadataReference(MetadataReference.CreateFromFile(typeof(System.Windows.Forms.Control).Assembly.Location));
-            DiagnosticAnalyzer analyzer = GetBasicDiagnosticAnalyzer();
-            GetSortedDiagnostics(analyzer, project.Documents.Single()).Verify(analyzer, GetDefaultPath(LanguageNames.VisualBasic));
+"
+                    },
+                    AdditionalReferences =
+                    {
+                        MetadataReference.CreateFromFile(typeof(System.Web.UI.Control).Assembly.Location),
+                        MetadataReference.CreateFromFile(typeof(System.Windows.Forms.Control).Assembly.Location),
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotCallOverridableMethodsInConstructorsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotCallOverridableMethodsInConstructorsTests.cs
@@ -424,13 +424,11 @@ End Class
         }
 
         private static DiagnosticResult GetCA2214CSharpResultAt(int line, int column)
-            => new DiagnosticResult(DoNotCallOverridableMethodsInConstructorsAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DoNotCallOverridableMethodsInConstructors);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetCA2214BasicResultAt(int line, int column)
-            => new DiagnosticResult(DoNotCallOverridableMethodsInConstructorsAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.DoNotCallOverridableMethodsInConstructors);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotRaiseExceptionsInExceptionClausesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/DoNotRaiseExceptionsInExceptionClausesTests.cs
@@ -140,11 +140,11 @@ End Class
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-            => new DiagnosticResult(DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column)
-            => new DiagnosticResult(DoNotRaiseExceptionsInExceptionClausesAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -701,13 +701,13 @@ class C
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
-        {
-            return VerifyCS.Diagnostic().WithLocation(line, column).WithArguments(symbolName);
-        }
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
 
         private DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
-        {
-            return VerifyVB.Diagnostic().WithLocation(line, column).WithArguments(symbolName);
-        }
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(symbolName);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -700,12 +700,12 @@ class C
             DiagnosticResult.CompilerError("CS0156").WithLocation(8, 9).WithMessage("A throw statement with no arguments is not allowed outside of a catch clause"));
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, string symbolName)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(symbolName);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/PreferJaggedArraysOverMultidimensionalTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/PreferJaggedArraysOverMultidimensionalTests.cs
@@ -214,43 +214,33 @@ End Class
         }
 
         private DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)
-        {
-            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule)
+            => VerifyCS.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
-        }
 
         private DiagnosticResult GetCSharpReturnResultAt(int line, int column, string symbolName, string typeName)
-        {
-            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule)
+            => VerifyCS.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName, typeName);
-        }
+
         private DiagnosticResult GetCSharpBodyResultAt(int line, int column, string symbolName, string typeName)
-        {
-            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule)
+            => VerifyCS.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName, typeName);
-        }
 
         private DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName)
-        {
-            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule)
+            => VerifyVB.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
-        }
 
         private DiagnosticResult GetBasicReturnResultAt(int line, int column, string symbolName, string typeName)
-        {
-            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule)
+            => VerifyVB.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName, typeName);
-        }
+
         private DiagnosticResult GetBasicBodyResultAt(int line, int column, string symbolName, string typeName)
-        {
-            return new DiagnosticResult(PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule)
+            => VerifyVB.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName, typeName);
-        }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/PreferJaggedArraysOverMultidimensionalTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/PreferJaggedArraysOverMultidimensionalTests.cs
@@ -213,32 +213,32 @@ End Class
             GetBasicReturnResultAt(9, 33, "MethodReturningMultidimensionalArray", "Integer(*,*)"));
         }
 
-        private DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)
             => VerifyCS.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
-        private DiagnosticResult GetCSharpReturnResultAt(int line, int column, string symbolName, string typeName)
+        private static DiagnosticResult GetCSharpReturnResultAt(int line, int column, string symbolName, string typeName)
             => VerifyCS.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName, typeName);
 
-        private DiagnosticResult GetCSharpBodyResultAt(int line, int column, string symbolName, string typeName)
+        private static DiagnosticResult GetCSharpBodyResultAt(int line, int column, string symbolName, string typeName)
             => VerifyCS.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName, typeName);
 
-        private DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName)
             => VerifyVB.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
-        private DiagnosticResult GetBasicReturnResultAt(int line, int column, string symbolName, string typeName)
+        private static DiagnosticResult GetBasicReturnResultAt(int line, int column, string symbolName, string typeName)
             => VerifyVB.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.ReturnRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName, typeName);
 
-        private DiagnosticResult GetBasicBodyResultAt(int line, int column, string symbolName, string typeName)
+        private static DiagnosticResult GetBasicBodyResultAt(int line, int column, string symbolName, string typeName)
             => VerifyVB.Diagnostic(PreferJaggedArraysOverMultidimensionalAnalyzer.BodyRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName, typeName);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
@@ -122,27 +122,24 @@ public class Class2
         public async Task CA1821CSharpTestRemoveEmptyFinalizersWithScope()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
-[|
 public class Class1
 {
 	// Violation occurs because the finalizer is empty.
-	~Class1()
+	~[|Class1|]()
 	{
 	}
 }
-|]
 
 public class Class2
 {
 	// Violation occurs because the finalizer is empty.
-	~Class2()
+	~[|Class2|]()
 	{
         //// Comments here
 	}
 }
 
-",
-                GetCA1821CSharpResultAt(6, 3));
+");
         }
 
         [Fact]
@@ -346,26 +343,25 @@ Imports System.Diagnostics
 
 Public Class Class1
     '  Violation occurs because the finalizer is empty.
-    Protected Overrides Sub Finalize()
+    Protected Overrides Sub [|Finalize|]()
 
     End Sub
 End Class
 
-[|Public Class Class2
+Public Class Class2
     '  Violation occurs because the finalizer is empty.
-    Protected Overrides Sub Finalize()
+    Protected Overrides Sub [|Finalize|]()
         ' Comments
     End Sub
-End Class|]
+End Class
 
 Public Class Class3
     '  Violation occurs because Debug.Fail is a conditional method.
-    Protected Overrides Sub Finalize()
+    Protected Overrides Sub [|Finalize|]()
         Debug.Fail(""Finalizer called!"")
     End Sub
 End Class
-",
-                GetCA1821BasicResultAt(13, 29));
+");
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
@@ -456,8 +456,8 @@ public class C1
     }
 }
 ",
-                DiagnosticResult.CompilerError("CS0103").WithLocation(6, 9),
-                DiagnosticResult.CompilerError("CS1002").WithLocation(6, 10));
+                DiagnosticResult.CompilerError("CS0103").WithLocation(6, 9).WithMessage("The name 'a' does not exist in the current context"),
+                DiagnosticResult.CompilerError("CS1002").WithLocation(6, 10).WithMessage("; expected"));
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]
@@ -470,8 +470,8 @@ public class C1
     => ;
 }
 ",
-                DiagnosticResult.CompilerError("CS8057").WithLocation(4, 5),
-                DiagnosticResult.CompilerError("CS1525").WithLocation(5, 8));
+                DiagnosticResult.CompilerError("CS8057").WithLocation(4, 5).WithMessage("Block bodies and expression bodies cannot both be provided."),
+                DiagnosticResult.CompilerError("CS1525").WithLocation(5, 8).WithMessage("Invalid expression term ';'"));
         }
 
         [Fact, WorkItem(1211, "https://github.com/dotnet/roslyn-analyzers/issues/1211")]
@@ -484,7 +484,7 @@ Public Class Class1
     End Sub
 End Class
 ",
-                DiagnosticResult.CompilerError("BC30451").WithLocation(4, 9));
+                DiagnosticResult.CompilerError("BC30451").WithLocation(4, 9).WithMessage("'a' is not declared. It may be inaccessible due to its protection level."));
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
@@ -517,13 +517,11 @@ public class SomeTestClass : IDisposable
         }
 
         private static DiagnosticResult GetCA1821CSharpResultAt(int line, int column)
-            => new DiagnosticResult(AbstractRemoveEmptyFinalizersAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.RemoveEmptyFinalizers);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetCA1821BasicResultAt(int line, int column)
-            => new DiagnosticResult(AbstractRemoveEmptyFinalizersAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.RemoveEmptyFinalizers);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -16,18 +13,8 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
-    public partial class RemoveEmptyFinalizersTests : DiagnosticAnalyzerTestBase
+    public partial class RemoveEmptyFinalizersTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicRemoveEmptyFinalizersAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpRemoveEmptyFinalizersAnalyzer();
-        }
-
         [Fact]
         public async Task CA1821CSharpTestNoWarning()
         {
@@ -107,9 +94,9 @@ public class Class7
         }
 
         [Fact]
-        public void CA1821CSharpTestRemoveEmptyFinalizers()
+        public async Task CA1821CSharpTestRemoveEmptyFinalizers()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
 	// Violation occurs because the finalizer is empty.
@@ -132,9 +119,9 @@ public class Class2
         }
 
         [Fact]
-        public void CA1821CSharpTestRemoveEmptyFinalizersWithScope()
+        public async Task CA1821CSharpTestRemoveEmptyFinalizersWithScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 [|
 public class Class1
 {
@@ -181,9 +168,9 @@ public class Class1
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]
-        public void CA1821CSharpTestRemoveEmptyFinalizersWithDebugFail_ExpressionBody()
+        public async Task CA1821CSharpTestRemoveEmptyFinalizersWithDebugFail_ExpressionBody()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Diagnostics;
 
 public class Class1
@@ -220,9 +207,9 @@ public class Class1
         }
 
         [Fact]
-        public void CA1821CSharpTestRemoveEmptyFinalizersWithDebugFailAndDirectiveAroundStatements()
+        public async Task CA1821CSharpTestRemoveEmptyFinalizersWithDebugFailAndDirectiveAroundStatements()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Diagnostics;
 
 public class Class1
@@ -320,9 +307,9 @@ End Class
         }
 
         [Fact]
-        public void CA1821BasicTestRemoveEmptyFinalizers()
+        public async Task CA1821BasicTestRemoveEmptyFinalizers()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Diagnostics
 
 Public Class Class1
@@ -352,9 +339,9 @@ End Class
         }
 
         [Fact]
-        public void CA1821BasicTestRemoveEmptyFinalizersWithScope()
+        public async Task CA1821BasicTestRemoveEmptyFinalizersWithScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Diagnostics
 
 Public Class Class1
@@ -382,9 +369,9 @@ End Class
         }
 
         [Fact]
-        public void CA1821BasicTestRemoveEmptyFinalizersWithDebugFail()
+        public async Task CA1821BasicTestRemoveEmptyFinalizersWithDebugFail()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Diagnostics
 
 Public Class Class1
@@ -406,9 +393,9 @@ End Class
         }
 
         [Fact]
-        public void CA1821CSharpTestRemoveEmptyFinalizersWithThrowStatement()
+        public async Task CA1821CSharpTestRemoveEmptyFinalizersWithThrowStatement()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     ~Class1()
@@ -420,9 +407,9 @@ public class Class1
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]
-        public void CA1821CSharpTestRemoveEmptyFinalizersWithThrowExpression()
+        public async Task CA1821CSharpTestRemoveEmptyFinalizersWithThrowExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class Class1
 {
     ~Class1() => throw new System.Exception();
@@ -431,9 +418,9 @@ public class Class1
         }
 
         [Fact]
-        public void CA1821BasicTestRemoveEmptyFinalizersWithThrowStatement()
+        public async Task CA1821BasicTestRemoveEmptyFinalizersWithThrowStatement()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class Class1
 	' Violation occurs because Debug.Fail is a conditional method.
     Protected Overrides Sub Finalize()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
@@ -456,7 +456,8 @@ public class C1
     }
 }
 ",
-                CompilerDiagnostics.None);
+                new DiagnosticResult("CS0103", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(6, 9),
+                new DiagnosticResult("CS1002", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(6, 10));
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]
@@ -469,7 +470,8 @@ public class C1
     => ;
 }
 ",
-                CompilerDiagnostics.None);
+                new DiagnosticResult("CS8057", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 5),
+                new DiagnosticResult("CS1525", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(5, 8));
         }
 
         [Fact, WorkItem(1211, "https://github.com/dotnet/roslyn-analyzers/issues/1211")]
@@ -482,7 +484,7 @@ Public Class Class1
     End Sub
 End Class
 ",
-                CompilerDiagnostics.None);
+                new DiagnosticResult("BC30451", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 9));
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RemoveEmptyFinalizersTests.cs
@@ -456,8 +456,8 @@ public class C1
     }
 }
 ",
-                new DiagnosticResult("CS0103", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(6, 9),
-                new DiagnosticResult("CS1002", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(6, 10));
+                DiagnosticResult.CompilerError("CS0103").WithLocation(6, 9),
+                DiagnosticResult.CompilerError("CS1002").WithLocation(6, 10));
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]
@@ -470,8 +470,8 @@ public class C1
     => ;
 }
 ",
-                new DiagnosticResult("CS8057", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 5),
-                new DiagnosticResult("CS1525", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(5, 8));
+                DiagnosticResult.CompilerError("CS8057").WithLocation(4, 5),
+                DiagnosticResult.CompilerError("CS1525").WithLocation(5, 8));
         }
 
         [Fact, WorkItem(1211, "https://github.com/dotnet/roslyn-analyzers/issues/1211")]
@@ -484,7 +484,7 @@ Public Class Class1
     End Sub
 End Class
 ",
-                new DiagnosticResult("BC30451", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(4, 9));
+                DiagnosticResult.CompilerError("BC30451").WithLocation(4, 9));
         }
 
         [Fact, WorkItem(1788, "https://github.com/dotnet/roslyn-analyzers/issues/1788")]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -235,14 +235,14 @@ class Program
         }
         catch (ArithmeticException e)
         {
-            throw e;
+            [|throw e;|]
         }
     }
 
-    [|void ThrowException()
+    void ThrowException()
     {
         throw new ArithmeticException();
-    }|]
+    }
 }
 ");
         }
@@ -258,10 +258,10 @@ Class Program
         Try
             Throw New ArithmeticException()
         Catch e As ArithmeticException
+            [|Throw e|]
+        Catch e As Exception
             Throw e
-        [|Catch e As Exception
-            Throw e
-        End Try|]
+        End Try
     End Sub
 End Class
 ",

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -403,7 +403,7 @@ class Program
             {
                 throw;
             }
-            catch (ArithmeticException)   // error CS0160: A previous catch clause already catches all exceptions of this or of a super type ('ArithmeticException')
+            catch (ArithmeticException)
             {
                 try
                 {
@@ -411,7 +411,7 @@ class Program
                 }
                 catch (ArithmeticException i)
                 {
-                    throw e;   // error CS0103: The name 'e' does not exist in the current context
+                    throw e;
                 }
             }
         }
@@ -422,8 +422,8 @@ class Program
     }
 }
 ",
-            DiagnosticResult.CompilerError("CS0160").WithLocation(18, 20),
-            DiagnosticResult.CompilerError("CS0103").WithLocation(26, 27));
+            DiagnosticResult.CompilerError("CS0160").WithLocation(18, 20).WithMessage("A previous catch clause already catches all exceptions of this or of a super type ('ArithmeticException')"),
+            DiagnosticResult.CompilerError("CS0103").WithLocation(26, 27).WithMessage("The name 'e' does not exist in the current context"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -438,7 +438,7 @@ Class Program
                 Try
                     Throw New ArithmeticException()
                 Catch e As Exception
-                    Throw ex   ' error BC30451: 'ex' is not declared. It may be inaccessible due to its protection level.
+                    Throw ex
                 End Try
             End Try
         Catch ex As Exception
@@ -447,7 +447,7 @@ Class Program
     End Sub
 End Class
 ",
-            DiagnosticResult.CompilerError("BC30451").WithLocation(14, 27));
+            DiagnosticResult.CompilerError("BC30451").WithLocation(14, 27).WithMessage("'ex' is not declared. It may be inaccessible due to its protection level."));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -422,8 +422,8 @@ class Program
     }
 }
 ",
-            new DiagnosticResult("CS0160", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(18, 20),
-            new DiagnosticResult("CS0103", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(26, 27));
+            DiagnosticResult.CompilerError("CS0160").WithLocation(18, 20),
+            DiagnosticResult.CompilerError("CS0103").WithLocation(26, 27));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -447,7 +447,7 @@ Class Program
     End Sub
 End Class
 ",
-            new DiagnosticResult("BC30451", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(14, 27));
+            DiagnosticResult.CompilerError("BC30451").WithLocation(14, 27));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -512,13 +512,11 @@ End Class
         }
 
         private static DiagnosticResult GetCA2200BasicResultAt(int line, int column)
-            => new DiagnosticResult(RethrowToPreserveStackDetailsAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.RethrowToPreserveStackDetailsMessage);
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetCA2200CSharpResultAt(int line, int column)
-            => new DiagnosticResult(RethrowToPreserveStackDetailsAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftCodeQualityAnalyzersResources.RethrowToPreserveStackDetailsMessage);
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -16,18 +13,8 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
-    public partial class RethrowToPreserveStackDetailsTests : DiagnosticAnalyzerTestBase
+    public partial class RethrowToPreserveStackDetailsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicRethrowToPreserveStackDetailsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpRethrowToPreserveStackDetailsAnalyzer();
-        }
-
         [Fact]
         public async Task CA2200_NoDiagnosticsForRethrow()
         {
@@ -233,9 +220,9 @@ End Class
         }
 
         [Fact]
-        public void CA2200_NoDiagnosticsForThrowCaughtExceptionInAnotherScope()
+        public async Task CA2200_NoDiagnosticsForThrowCaughtExceptionInAnotherScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class Program
@@ -261,9 +248,9 @@ class Program
         }
 
         [Fact]
-        public void CA2200_SingleDiagnosticForThrowCaughtExceptionInSpecificScope()
+        public async Task CA2200_SingleDiagnosticForThrowCaughtExceptionInSpecificScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Class Program
     Sub CatchAndRethrowExplicitly()

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -421,7 +421,9 @@ class Program
         }
     }
 }
-", CompilerDiagnostics.None);
+",
+            new DiagnosticResult("CS0160", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(18, 20),
+            new DiagnosticResult("CS0103", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(26, 27));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -444,7 +446,8 @@ Class Program
         End Try
     End Sub
 End Class
-", CompilerDiagnostics.None);
+",
+            new DiagnosticResult("BC30451", CodeAnalysis.DiagnosticSeverity.Error).WithLocation(14, 27));
         }
 
         [Fact]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
@@ -428,11 +428,11 @@ End Class
         // sealed overrides - no diagnostic
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-            => new DiagnosticResult(SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column)
-            => new DiagnosticResult(SealMethodsThatSatisfyPrivateInterfacesAnalyzer.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
@@ -170,22 +170,22 @@ End Class
         }
 
         private DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)
-            => new DiagnosticResult(UseLiteralsWhereAppropriateAnalyzer.DefaultRule)
+            => VerifyCS.Diagnostic(UseLiteralsWhereAppropriateAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
         private DiagnosticResult GetCSharpEmptyStringResultAt(int line, int column, string symbolName)
-            => new DiagnosticResult(UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule)
+            => VerifyCS.Diagnostic(UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
         private DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName)
-            => new DiagnosticResult(UseLiteralsWhereAppropriateAnalyzer.DefaultRule)
+            => VerifyVB.Diagnostic(UseLiteralsWhereAppropriateAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
         private DiagnosticResult GetBasicEmptyStringResultAt(int line, int column, string symbolName)
-            => new DiagnosticResult(UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule)
+            => VerifyVB.Diagnostic(UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
     }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/UseLiteralsWhereAppropriateTests.cs
@@ -169,22 +169,22 @@ End Class
             await vbTest.RunAsync();
         }
 
-        private DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetCSharpDefaultResultAt(int line, int column, string symbolName)
             => VerifyCS.Diagnostic(UseLiteralsWhereAppropriateAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
-        private DiagnosticResult GetCSharpEmptyStringResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetCSharpEmptyStringResultAt(int line, int column, string symbolName)
             => VerifyCS.Diagnostic(UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
-        private DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetBasicDefaultResultAt(int line, int column, string symbolName)
             => VerifyVB.Diagnostic(UseLiteralsWhereAppropriateAnalyzer.DefaultRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);
 
-        private DiagnosticResult GetBasicEmptyStringResultAt(int line, int column, string symbolName)
+        private static DiagnosticResult GetBasicEmptyStringResultAt(int line, int column, string symbolName)
             => VerifyVB.Diagnostic(UseLiteralsWhereAppropriateAnalyzer.EmptyStringRule)
                 .WithLocation(line, column)
                 .WithArguments(symbolName);

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -3768,7 +3769,9 @@ public class C
         var x = c._field;
     }
 }
-", CompilerDiagnostics.None,
+",
+            // Test0.cs(8,9): error CS0165: Use of unassigned local variable 'c2'
+            new DiagnosticResult("CS0165", DiagnosticSeverity.Error).WithLocation(8, 9),
             // Test0.cs(8,15): warning CA1062: In externally visible method 'void C.M(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(8, 15, "void C.M(C c)", "c"));
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -20,17 +19,14 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
-    public partial class ValidateArgumentsOfPublicMethodsTests : DiagnosticAnalyzerTestBase
+    public partial class ValidateArgumentsOfPublicMethodsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new ValidateArgumentsOfPublicMethods();
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new ValidateArgumentsOfPublicMethods();
-
-        private static new DiagnosticResult GetCSharpResultAt(int line, int column, string methodSignature, string parameterName)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string methodSignature, string parameterName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(methodSignature, parameterName);
 
-        private static new DiagnosticResult GetBasicResultAt(int line, int column, string methodSignature, string parameterName)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, string methodSignature, string parameterName)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(methodSignature, parameterName);
@@ -793,9 +789,15 @@ End Class",
         }
 
         [Fact]
-        public void ConditionalButDefiniteNonNullAssigned_BeforeHazardousUsages_NoDiagnostic_CopyAnalysis()
+        public async Task ConditionalButDefiniteNonNullAssigned_BeforeHazardousUsages_NoDiagnostic_CopyAnalysis()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 public class C
 {
     public int X;
@@ -855,9 +857,19 @@ public class Test
         var z = c.X;
     }
 }
-", GetEditorConfigToEnableCopyAnalysis());
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") }
+                }
+            }.RunAsync();
 
-            VerifyBasic(@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Public Class C
     Public X As Integer
 End Class
@@ -908,7 +920,11 @@ Public Class Test
         Dim z = c.X
     End Sub
 
-End Class", GetEditorConfigToEnableCopyAnalysis());
+End Class"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") }
+                }
+            }.RunAsync();
         }
 
         [Fact]
@@ -1256,9 +1272,15 @@ End Class");
         }
 
         [Fact]
-        public void ContractCheck_NoDiagnostic_CopyAnalysis()
+        public async Task ContractCheck_NoDiagnostic_CopyAnalysis()
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 public class C
 {
     public int X;
@@ -1301,9 +1323,19 @@ public class Test
         var z = c.X;
     }
 }
-", GetEditorConfigToEnableCopyAnalysis());
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") }
+                }
+            }.RunAsync();
 
-            VerifyBasic(@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Public Class C
 
     Public X As Integer
@@ -1341,7 +1373,11 @@ Public Class Test
         Dim z = c.X
     End Sub
 End Class
-", GetEditorConfigToEnableCopyAnalysis());
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") }
+                }
+            }.RunAsync();
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -3771,7 +3770,7 @@ public class C
 }
 ",
             // Test0.cs(8,9): error CS0165: Use of unassigned local variable 'c2'
-            new DiagnosticResult("CS0165", DiagnosticSeverity.Error).WithLocation(8, 9),
+            DiagnosticResult.CompilerError("CS0165").WithLocation(8, 9),
             // Test0.cs(8,15): warning CA1062: In externally visible method 'void C.M(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(8, 15, "void C.M(C c)", "c"));
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -3769,8 +3769,7 @@ public class C
     }
 }
 ",
-            // Test0.cs(8,9): error CS0165: Use of unassigned local variable 'c2'
-            DiagnosticResult.CompilerError("CS0165").WithLocation(8, 9),
+            DiagnosticResult.CompilerError("CS0165").WithLocation(8, 9).WithMessage("Use of unassigned local variable 'c2'"),
             // Test0.cs(8,15): warning CA1062: In externally visible method 'void C.M(C c)', validate parameter 'c' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
             GetCSharpResultAt(8, 15, "void C.M(C c)", "c"));
         }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -26,12 +26,12 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new ValidateArgumentsOfPublicMethods();
 
         private static new DiagnosticResult GetCSharpResultAt(int line, int column, string methodSignature, string parameterName)
-            => new DiagnosticResult(ValidateArgumentsOfPublicMethods.Rule)
+            => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(methodSignature, parameterName);
 
         private static new DiagnosticResult GetBasicResultAt(int line, int column, string methodSignature, string parameterName)
-            => new DiagnosticResult(ValidateArgumentsOfPublicMethods.Rule)
+            => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(methodSignature, parameterName);
 

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -1972,7 +1972,7 @@ public class C
                 ExpectedDiagnostics =
                 {
                     // Test0.cs(14,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2)', validate parameter 'c2' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-                    GetCSharpResultAt(14, 13, "void C.M1(C c1, C c2)", "c2")
+                    GetCSharpResultAt(14, 13, "void C.M1(C c1, C c2)", "c2"),
                 }
             }.RunAsync();
         }
@@ -2148,7 +2148,7 @@ internal static class Helper<T>
                     // Test0.cs(19,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c5' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
                     GetCSharpResultAt(19, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c5"),
                     // Test0.cs(22,13): warning CA1062: In externally visible method 'void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)', validate parameter 'c6' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-                    GetCSharpResultAt(22, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c6")
+                    GetCSharpResultAt(22, 13, "void C.M1(C c1, C c2, C c3, C c4, C c5, C c6)", "c6"),
                 }
             }.RunAsync();
         }
@@ -4055,7 +4055,7 @@ public class Class1
                     // Test0.cs(115,28): warning CA1062: In externally visible method 'void Class1.Method(IContext aContext)', validate parameter 'aContext' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
                     GetCSharpResultAt(115, 28, "void Class1.Method(IContext aContext)", "aContext"),
                     // Test0.cs(156,13): warning CA1062: In externally visible method 'bool Class1.HasUrl(IContext filterContext)', validate parameter 'filterContext' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
-                    GetCSharpResultAt(156, 13, "bool Class1.HasUrl(IContext filterContext)", "filterContext")
+                    GetCSharpResultAt(156, 13, "bool Class1.HasUrl(IContext filterContext)", "filterContext"),
                 }
             }.RunAsync();
         }

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeMethodsShouldCallBaseClassDispose.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeMethodsShouldCallBaseClassDispose.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 {
     /// <summary>
     /// CA2215: Dispose methods should call base class dispose
-    /// 
+    ///
     /// A type that implements System.IDisposable inherits from a type that also implements IDisposable.
     /// The Dispose method of the inheriting type does not call the Dispose method of the parent type.
     /// To fix a violation of this rule, call base.Dispose in your Dispose method.
@@ -36,8 +36,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              helpLinkUri: "https://docs.microsoft.com/visualstudio/code-quality/ca2215-dispose-methods-should-call-base-class-dispose",
                                                                              customTags: FxCopWellKnownDiagnosticTags.PortedFxCopRule);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
-        //ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests.cs
@@ -15,12 +15,12 @@ namespace Microsoft.NetCore.Analyzers.Data.UnitTests
 {
     public class ReviewSQLQueriesForSecurityVulnerabilitiesTests
     {
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string invokedSymbol, string containingMethod)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string invokedSymbol, string containingMethod)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(invokedSymbol, containingMethod);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, string invokedSymbol, string containingMethod)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, string invokedSymbol, string containingMethod)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(invokedSymbol, containingMethod);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests.cs
@@ -1,23 +1,29 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Data.ReviewSqlQueriesForSecurityVulnerabilities,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Data.ReviewSqlQueriesForSecurityVulnerabilities,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Data.UnitTests
 {
-    public partial class ReviewSQLQueriesForSecurityVulnerabilitiesTests : DiagnosticAnalyzerTestBase
+    public class ReviewSQLQueriesForSecurityVulnerabilitiesTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new ReviewSqlQueriesForSecurityVulnerabilities();
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new ReviewSqlQueriesForSecurityVulnerabilities();
+        private DiagnosticResult GetCSharpResultAt(int line, int column, string invokedSymbol, string containingMethod)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(invokedSymbol, containingMethod);
 
-        protected new DiagnosticResult GetCSharpResultAt(int line, int column, string invokedSymbol, string containingMethod) =>
-            GetCSharpResultAt(line, column, ReviewSqlQueriesForSecurityVulnerabilities.Rule, invokedSymbol, containingMethod);
-
-        protected new DiagnosticResult GetBasicResultAt(int line, int column, string invokedSymbol, string containingMethod) =>
-            GetBasicResultAt(line, column, ReviewSqlQueriesForSecurityVulnerabilities.Rule, invokedSymbol, containingMethod);
+        private DiagnosticResult GetBasicResultAt(int line, int column, string invokedSymbol, string containingMethod)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(invokedSymbol, containingMethod);
 
         protected const string SetupCodeCSharp = @"
 using System.Data;
@@ -226,9 +232,9 @@ Class Adapter
 End Class";
 
         [Fact]
-        public void Unrelated_ConstructorParameter_NoDiagnostic()
+        public async Task Unrelated_ConstructorParameter_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 class Test
 {{
     public Test(string test) {{ }}
@@ -242,9 +248,9 @@ class Test
         }
 
         [Fact]
-        public void DbCommand_CommandText_StringLiteral_NoDiagnostic()
+        public async Task DbCommand_CommandText_StringLiteral_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Test
@@ -256,7 +262,7 @@ class Test
     }}
 }}");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Module Test
@@ -268,9 +274,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_ConstructorParameter_StringLiteral_NoDiagnostic()
+        public async Task DbCommand_ConstructorParameter_StringLiteral_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -289,7 +295,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -308,9 +314,9 @@ End Module");
         }
 
         [Fact]
-        public void DataAdapter_ConstructorParameter_StringLiteral_NoDiagnostic()
+        public async Task DataAdapter_ConstructorParameter_StringLiteral_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -329,7 +335,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -347,9 +353,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_CommandText_ClassConstant_NoDiagnostic()
+        public async Task DbCommand_CommandText_ClassConstant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Test
@@ -363,7 +369,7 @@ class Test
     }}
 }}");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Module Test
@@ -376,9 +382,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_ConstructorParameter_ClassConstant_NoDiagnostic()
+        public async Task DbCommand_ConstructorParameter_ClassConstant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -399,7 +405,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -418,9 +424,9 @@ End Module");
         }
 
         [Fact]
-        public void DataAdapter_ConstructorParameter_ClassConstant_NoDiagnostic()
+        public async Task DataAdapter_ConstructorParameter_ClassConstant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -440,7 +446,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -460,9 +466,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_ConstructorParameter_CallingAnotherConstructor_NoDiagnostic()
+        public async Task DbCommand_ConstructorParameter_CallingAnotherConstructor_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -485,7 +491,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -508,9 +514,9 @@ End Module");
         }
 
         [Fact]
-        public void DataAdapter_ConstructorParameter_CallingAnotherConstructor_NoDiagnostic()
+        public async Task DataAdapter_ConstructorParameter_CallingAnotherConstructor_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -532,7 +538,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -555,9 +561,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_BaseConstructor_NoDiagnostic()
+        public async Task DbCommand_BaseConstructor_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -582,7 +588,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -609,9 +615,9 @@ End Module");
         }
 
         [Fact]
-        public void DataAdapter_BaseConstructor_NoDiagnostic()
+        public async Task DataAdapter_BaseConstructor_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -636,7 +642,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -664,9 +670,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_PropertyAssignment_NotCommandText_NoDiagnostic()
+        public async Task DbCommand_PropertyAssignment_NotCommandText_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -684,7 +690,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -704,9 +710,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_CommandTextUsage_NoDiagnostic()
+        public async Task DbCommand_CommandTextUsage_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Test
@@ -719,7 +725,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Module Test
@@ -731,9 +737,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_CommandTextUsage_InClass_NoDiagnostic()
+        public async Task DbCommand_CommandTextUsage_InClass_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -754,7 +760,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -775,9 +781,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_OtherMethodInvocation_NoDiagnostic()
+        public async Task DbCommand_OtherMethodInvocation_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -797,7 +803,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -818,9 +824,9 @@ End Module");
         }
 
         [Fact]
-        public void DataAdapter_OtherMethodInvocation_NoDiagnostic()
+        public async Task DataAdapter_OtherMethodInvocation_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -840,7 +846,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -860,9 +866,9 @@ End Module");
         }
 
         [Fact]
-        public void DataAdapter_SingleConstructorParameter_NotCmdOrCommand()
+        public async Task DataAdapter_SingleConstructorParameter_NotCmdOrCommand()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -881,7 +887,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -901,9 +907,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_ConstructorParameter_MultipleParameters_NeitherNamedCommandOrCmd_NoDiagnostic()
+        public async Task DbCommand_ConstructorParameter_MultipleParameters_NeitherNamedCommandOrCmd_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -923,7 +929,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -942,9 +948,9 @@ End Module");
         }
 
         [Fact]
-        public void DataAdapter_ConstructorParameter_MultipleParameters_NeitherNamedCommandOrCmd_NoDiagnostic()
+        public async Task DataAdapter_ConstructorParameter_MultipleParameters_NeitherNamedCommandOrCmd_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -964,7 +970,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -983,9 +989,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_ConstructorParameter_MultipleParameters_OneNamedCmd_WithStringLiteral_NoDiagnostic()
+        public async Task DbCommand_ConstructorParameter_MultipleParameters_OneNamedCmd_WithStringLiteral_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1005,7 +1011,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1024,9 +1030,9 @@ End Module");
         }
 
         [Fact]
-        public void DataAdapter_ConstructorParameter_MultipleParameters_OneNamedCmd_WithStringLiteral_NoDiagnostic()
+        public async Task DataAdapter_ConstructorParameter_MultipleParameters_OneNamedCmd_WithStringLiteral_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1046,7 +1052,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1065,9 +1071,9 @@ End Module");
         }
 
         [Fact]
-        public void DbCommand_CommandText_LocalVariable_Diagnostic()
+        public async Task DbCommand_CommandText_LocalVariable_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Test
@@ -1081,7 +1087,7 @@ class Test
 }}",
             GetCSharpResultAt(92, 9, "string Command.CommandText", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Module Test
@@ -1095,9 +1101,9 @@ End Module",
         }
 
         [Fact]
-        public void DbCommand_ConstructorParameter_LocalVariable_Diagnostic()
+        public async Task DbCommand_ConstructorParameter_LocalVariable_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1118,7 +1124,7 @@ class Test
 ",
             GetCSharpResultAt(98, 21, "Command1.Command1(string parameter)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1137,10 +1143,10 @@ End Module",
         }
 
         [Fact]
-        public void DataAdapter_ConstructorParameter_LocalVariableName_Diagnostic()
+        public async Task DataAdapter_ConstructorParameter_LocalVariableName_Diagnostic()
         {
             // Constructor Parameter named command
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1161,7 +1167,7 @@ class Test
 ",
             GetCSharpResultAt(98, 17, "Adapter1.Adapter1(string command)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1179,7 +1185,7 @@ End Module",
             GetBasicResultAt(133, 18, "Sub Adapter1.New(command As String)", "M1"));
 
             // Constructor parameter named cmd
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1200,7 +1206,7 @@ class Test
 ",
             GetCSharpResultAt(98, 17, "Adapter1.Adapter1(string cmd)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1219,9 +1225,9 @@ End Module",
         }
 
         [Fact]
-        public void DbCommand_CommandText_Parameter_Diagnostic()
+        public async Task DbCommand_CommandText_Parameter_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Test
@@ -1234,7 +1240,7 @@ class Test
 }}",
             GetCSharpResultAt(91, 9, "string Command.CommandText", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Module Test
@@ -1248,9 +1254,9 @@ End Module",
         }
 
         [Fact, WorkItem(1625, "https://github.com/dotnet/roslyn-analyzers/issues/1625")]
-        public void DbCommand_CommandText_PropertyOverride_Diagnostic()
+        public async Task DbCommand_CommandText_PropertyOverride_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1269,7 +1275,7 @@ class Test
             // Test0.cs(96,9): warning CA2100: Review if the query string passed to 'string Command1.CommandText' in 'M1', accepts any user input.
             GetCSharpResultAt(96, 9, "string Command1.CommandText", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1289,9 +1295,9 @@ End Module",
         }
 
         [Fact]
-        public void DbCommand_ConstructorParameter_Parameter_Diagnostic()
+        public async Task DbCommand_ConstructorParameter_Parameter_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1311,7 +1317,7 @@ class Test
 ",
             GetCSharpResultAt(97, 21, "Command1.Command1(string parameter)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1329,10 +1335,10 @@ End Module",
         }
 
         [Fact]
-        public void DataAdapter_ConstructorParameter_Parameter_Diagnostic()
+        public async Task DataAdapter_ConstructorParameter_Parameter_Diagnostic()
         {
             // Constructor parameter named command
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1352,7 +1358,7 @@ class Test
 ",
             GetCSharpResultAt(97, 21, "Adapter1.Adapter1(string command)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1370,7 +1376,7 @@ End Module",
 
             // Constructor parameter named cmd
 
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1390,7 +1396,7 @@ class Test
 ",
             GetCSharpResultAt(97, 21, "Adapter1.Adapter1(string cMd)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1408,9 +1414,9 @@ End Module",
         }
 
         [Fact]
-        public void DbCommand_ConstructorParameter_MultipleParameters_OneNamedCmd_WithLocal_Diagnostic()
+        public async Task DbCommand_ConstructorParameter_MultipleParameters_OneNamedCmd_WithLocal_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1431,7 +1437,7 @@ class Test
 ",
             GetCSharpResultAt(98, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1451,9 +1457,9 @@ End Module",
         }
 
         [Fact]
-        public void DataAdapter_ConstructorParameter_MultipleParameters_OneNamedCmd_WithLocal_Diagnostic()
+        public async Task DataAdapter_ConstructorParameter_MultipleParameters_OneNamedCmd_WithLocal_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1474,7 +1480,7 @@ class Test
 ",
             GetCSharpResultAt(98, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1494,9 +1500,9 @@ End Module",
         }
 
         [Fact]
-        public void DbCommand_ConstructorParameter_MultipleParameters_NonConstants_Diagnostic()
+        public async Task DbCommand_ConstructorParameter_MultipleParameters_NonConstants_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1517,7 +1523,7 @@ class Test
 ",
             GetCSharpResultAt(98, 21, "Command1.Command1(string cmd, string command)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1537,9 +1543,9 @@ End Module",
         }
 
         [Fact]
-        public void DataAdapter_ConstructorParameter_MultipleParameters_NonConstants_Diagnostic()
+        public async Task DataAdapter_ConstructorParameter_MultipleParameters_NonConstants_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1560,7 +1566,7 @@ class Test
 ",
             GetCSharpResultAt(98, 21, "Adapter1.Adapter1(string cmd, string command)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1580,20 +1586,21 @@ End Module",
         }
 
         [Fact]
-        public void MissingWellKnownTypes_NoDiagnostic()
+        public async Task MissingWellKnownTypes_NoDiagnostic()
         {
-            VerifyCSharp(@"
-class C { }", ReferenceFlags.RemoveSystemData);
+            // TODO: Amaury - Fix this code
+//            await VerifyCS.VerifyAnalyzerAsync(@"
+//class C { }", ReferenceFlags.RemoveSystemData);
 
-            VerifyBasic(@"
-Class C
-End Class", ReferenceFlags.RemoveSystemData);
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Class C
+//End Class", ReferenceFlags.RemoveSystemData);
         }
 
         [Fact]
-        public void HttpRequest_Form_LocalString_Diagnostic()
+        public async Task HttpRequest_Form_LocalString_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
     using System;
     using System.Data;
     using System.Data.SqlClient;
@@ -1627,18 +1634,15 @@ End Class", ReferenceFlags.RemoveSystemData);
         [InlineData("dotnet_code_quality.excluded_symbol_names = M1")]
         [InlineData("dotnet_code_quality." + ReviewSqlQueriesForSecurityVulnerabilities.RuleId + ".excluded_symbol_names = M1")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = M1")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (editorConfigText.Length == 0)
+            var csharpTest = new VerifyCS.Test
             {
-                expected = new DiagnosticResult[]
+                TestState =
                 {
-                    GetCSharpResultAt(92, 9, "string Command.CommandText", "M1")
-                };
-            }
-
-            VerifyCSharp($@"
+                    Sources =
+                    {
+                        $@"
 {SetupCodeCSharp}
 
 class Test
@@ -1649,18 +1653,28 @@ class Test
         var str = param;
         c.CommandText = str;
     }}
-}}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
 
-            expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length == 0)
             {
-                expected = new DiagnosticResult[]
-                {
-                    GetBasicResultAt(128, 9, "Property Command.CommandText As String", "M1")
-                };
+                csharpTest.ExpectedDiagnostics.Add(
+                    GetCSharpResultAt(92, 9, "string Command.CommandText", "M1")
+                );
             }
 
-            VerifyBasic($@"
+            await csharpTest.RunAsync();
+
+            var vbTest = new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 {SetupCodeBasic}
 
 Module Test
@@ -1669,7 +1683,20 @@ Module Test
         Dim str As String = param
         c.CommandText = str
     End Sub
-End Module", GetEditorConfigAdditionalFile(editorConfigText), expected);
+End Module"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (editorConfigText.Length == 0)
+            {
+                vbTest.ExpectedDiagnostics.Add(
+                    GetBasicResultAt(128, 9, "Property Command.CommandText As String", "M1")
+                );
+            }
+
+            await vbTest.RunAsync();
         }
 
 

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
@@ -1,17 +1,35 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Data.ReviewSqlQueriesForSecurityVulnerabilities,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Data.ReviewSqlQueriesForSecurityVulnerabilities,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Data.UnitTests
 {
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
     public class ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis : ReviewSQLQueriesForSecurityVulnerabilitiesTests
     {
+        private DiagnosticResult GetCSharpResultAt(int line, int column, string invokedSymbol, string containingMethod)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(invokedSymbol, containingMethod);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, string invokedSymbol, string containingMethod)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(invokedSymbol, containingMethod);
+
         [Fact]
-        public void FlowAnalysis_LocalWithConstantInitializer_NoDiagnostic()
+        public async Task FlowAnalysis_LocalWithConstantInitializer_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -31,7 +49,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -50,9 +68,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_LocalWithConstantAssignment_NoDiagnostic()
+        public async Task FlowAnalysis_LocalWithConstantAssignment_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -73,7 +91,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -93,9 +111,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_ParameterWithConstantAssignment_NoDiagnostic()
+        public async Task FlowAnalysis_ParameterWithConstantAssignment_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -115,7 +133,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -134,9 +152,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_LocalWithAllConstantAssignments_NoDiagnostic()
+        public async Task FlowAnalysis_LocalWithAllConstantAssignments_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -159,7 +177,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -184,9 +202,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_ParameterWithAllConstantAssignments_NoDiagnostic()
+        public async Task FlowAnalysis_ParameterWithAllConstantAssignments_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -210,7 +228,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -236,9 +254,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_ConstantFieldInitializer_NoDiagnostic()
+        public async Task FlowAnalysis_ConstantFieldInitializer_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -259,7 +277,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -279,9 +297,9 @@ End Class");
         }
 
         [Fact]
-        public void FlowAnalysis_ConversionsInInitializer_NoDiagnostic()
+        public async Task FlowAnalysis_ConversionsInInitializer_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -302,7 +320,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -322,9 +340,9 @@ End Class");
         }
 
         [Fact]
-        public void FlowAnalysis_ImplicitUserDefinedConversionsInInitializer_Diagnostic()
+        public async Task FlowAnalysis_ImplicitUserDefinedConversionsInInitializer_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -360,7 +378,7 @@ class Test
 ",
             GetCSharpResultAt(103, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -394,9 +412,9 @@ End Class",
         }
 
         [Fact]
-        public void FlowAnalysis_ExplicitUserDefinedConversionsInInitializer_Diagnostic()
+        public async Task FlowAnalysis_ExplicitUserDefinedConversionsInInitializer_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -432,7 +450,7 @@ class Test
 ",
             GetCSharpResultAt(103, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 Option Strict On
 
 {SetupCodeBasic}
@@ -468,11 +486,11 @@ End Class",
         }
 
         [Fact]
-        public void FlowAnalysis_LocalInitializerWithInvocation_Diagnostic()
+        public async Task FlowAnalysis_LocalInitializerWithInvocation_Diagnostic()
         {
             // Currently, we do not do any interprocedural or context sensitive flow analysis.
             // So method calls are assumed to always return a MayBe result.
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -495,7 +513,7 @@ class Test
 ",
             GetCSharpResultAt(98, 21, "Adapter1.Adapter1(string cmd, string command)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -519,10 +537,10 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_LocalWithByRefEscape_Diagnostic()
+        public async Task FlowAnalysis_LocalWithByRefEscape_Diagnostic()
         {
             // Local/parameter passed by ref/out are assumed to be non-constant after the usage.
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -554,7 +572,7 @@ class Test
             GetCSharpResultAt(99, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
             GetCSharpResultAt(103, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -584,9 +602,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_StringEmptyInitializer_NoDiagnostic()
+        public async Task FlowAnalysis_StringEmptyInitializer_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -606,7 +624,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -625,9 +643,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_NameOfExpression_NoDiagnostic()
+        public async Task FlowAnalysis_NameOfExpression_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -647,7 +665,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -666,9 +684,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_NullOrDefaultValue_NoDiagnostic()
+        public async Task FlowAnalysis_NullOrDefaultValue_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -691,7 +709,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -710,9 +728,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_InterpolatedString_Constant_NoDiagnostic()
+        public async Task FlowAnalysis_InterpolatedString_Constant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -736,7 +754,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -759,9 +777,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_InterpolatedString_NonConstant_Diagnostic()
+        public async Task FlowAnalysis_InterpolatedString_NonConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -783,7 +801,7 @@ class Test
 ",
             GetCSharpResultAt(99, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -804,9 +822,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_BinaryAdd_Constant_NoDiagnostic()
+        public async Task FlowAnalysis_BinaryAdd_Constant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -830,7 +848,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -853,9 +871,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_BinaryAdd_NonConstant_Diagnostic()
+        public async Task FlowAnalysis_BinaryAdd_NonConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -882,7 +900,7 @@ class Test
             GetCSharpResultAt(99, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
             GetCSharpResultAt(103, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -908,9 +926,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_NullCoalesce_Constant_NoDiagnostic()
+        public async Task FlowAnalysis_NullCoalesce_Constant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -935,7 +953,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -959,9 +977,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_NullCoalesce_NonConstant_Diagnostic()
+        public async Task FlowAnalysis_NullCoalesce_NonConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -992,7 +1010,7 @@ class Test
             GetCSharpResultAt(102, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
             GetCSharpResultAt(106, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1022,9 +1040,9 @@ End Module",
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1569")]
-        public void FlowAnalysis_ConditionalAccess_Constant_NoDiagnostic()
+        public async Task FlowAnalysis_ConditionalAccess_Constant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1057,7 +1075,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1088,9 +1106,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_ConditionalAccess_NonConstant_Diagnostic()
+        public async Task FlowAnalysis_ConditionalAccess_NonConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1134,7 +1152,7 @@ class Test
         GetCSharpResultAt(107, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"),
         GetCSharpResultAt(115, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1176,9 +1194,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_WhileLoop_NonConstant_Diagnostic()
+        public async Task FlowAnalysis_WhileLoop_NonConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1203,7 +1221,7 @@ class Test
 ",
             GetCSharpResultAt(100, 25, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1226,9 +1244,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_ForLoop_NonConstant_Diagnostic()
+        public async Task FlowAnalysis_ForLoop_NonConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1253,7 +1271,7 @@ class Test
 ",
             GetCSharpResultAt(100, 25, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1276,9 +1294,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_ForEachLoop_NonConstant_Diagnostic()
+        public async Task FlowAnalysis_ForEachLoop_NonConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1303,7 +1321,7 @@ class Test
 ",
             GetCSharpResultAt(100, 25, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1326,9 +1344,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_Conditional_Constant_NoDiagnostic()
+        public async Task FlowAnalysis_Conditional_Constant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -1352,7 +1370,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -1374,9 +1392,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_LocalFunctionInvocation_EmptyBody_NoDiagnostic()
+        public async Task FlowAnalysis_LocalFunctionInvocation_EmptyBody_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1407,9 +1425,9 @@ class Test
         }
 
         [Fact]
-        public void FlowAnalysis_LocalFunctionInvocation_ChangesCapturedValueToConstant_NoDiagnostic()
+        public async Task FlowAnalysis_LocalFunctionInvocation_ChangesCapturedValueToConstant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1441,9 +1459,9 @@ class Test
         }
 
         [Fact]
-        public void FlowAnalysis_LocalFunctionInvocation_ChangesCapturedValueToNonConstant_Diagnostic()
+        public async Task FlowAnalysis_LocalFunctionInvocation_ChangesCapturedValueToNonConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1477,7 +1495,7 @@ class Test
         void MyLocalFunction()
         {{
             str2 = str;
-            str = param;            
+            str = param;
         }};
 
         MyLocalFunction();    // This should change state of 'str' to be a non-constant and 'str2' to be a constant.
@@ -1498,9 +1516,9 @@ class Test
         }
 
         [Fact]
-        public void FlowAnalysis_LocalFunctionInvocation_ChangesCapturedValueContextSensitive_NoDiagnostic()
+        public async Task FlowAnalysis_LocalFunctionInvocation_ChangesCapturedValueContextSensitive_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1532,9 +1550,9 @@ class Test
         }
 
         [Fact]
-        public void FlowAnalysis_LocalFunctionInvocation_ReturnValueContextSensitive_NoDiagnostic()
+        public async Task FlowAnalysis_LocalFunctionInvocation_ReturnValueContextSensitive_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1566,9 +1584,9 @@ class Test
         }
 
         [Fact]
-        public void FlowAnalysis_LambdaInvocation_EmptyBody_NoDiagnostic()
+        public async Task FlowAnalysis_LambdaInvocation_EmptyBody_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1595,7 +1613,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1620,9 +1638,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_LambdaInvocation_ChangesCapturedValueToConstant_NoDiagnostic()
+        public async Task FlowAnalysis_LambdaInvocation_ChangesCapturedValueToConstant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1650,7 +1668,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1676,9 +1694,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_LambdaInvocation_ChangesCapturedValueToNonConstant_Diagnostic()
+        public async Task FlowAnalysis_LambdaInvocation_ChangesCapturedValueToNonConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1729,7 +1747,7 @@ class Test
             // Test0.cs(125,13): warning CA2100: Review if the query string passed to 'Command3.Command3(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(125, 13, "Command3.Command3(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1760,7 +1778,7 @@ Module Test
 
         Dim myLambda As System.Action = Sub()
                                            str2 = str
-                                           str = param 
+                                           str = param
                                         End Sub
 
         myLambda()      ' This should change state of 'str' to be a non-constant and 'str2' to be a constant.
@@ -1778,9 +1796,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_LambdaInvocation_ChangesCapturedValueContextSensitive_Diagnostic()
+        public async Task FlowAnalysis_LambdaInvocation_ChangesCapturedValueContextSensitive_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1808,7 +1826,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1824,7 +1842,7 @@ Module Test
         str = """"
 
         Dim myLambda As System.Action(Of String) =  Sub(param2 As String)
-                                                        str = param2 
+                                                        str = param2
                                                     End Sub
 
         myLambda(str)      '  This should change state of 'str' to be a constant.
@@ -1834,9 +1852,9 @@ End Module");
         }
 
         [Fact]
-        public void FlowAnalysis_LambdaInvocation_ReturnValueContextSensitive_NoDiagnostic()
+        public async Task FlowAnalysis_LambdaInvocation_ReturnValueContextSensitive_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1864,7 +1882,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1880,7 +1898,7 @@ Module Test
         str = """"
 
         Dim myLambda As System.Func(Of String, String) =    Function (param2 As String)
-                                                                Return param2 
+                                                                Return param2
                                                             End Function
 
         str = myLambda(str)      '  This should change state of 'str' to be a constant.
@@ -1891,9 +1909,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsToAnalysis_CopySemanticsForString_NoDiagnostic()
+        public async Task FlowAnalysis_PointsToAnalysis_CopySemanticsForString_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1916,7 +1934,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1939,9 +1957,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceTypeCopy_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceTypeCopy_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -1964,7 +1982,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -1987,9 +2005,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueTypeCopy_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueTypeCopy_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2012,7 +2030,7 @@ struct Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2035,9 +2053,9 @@ End Structure");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceTypeNestingCopy_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceTypeNestingCopy_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2066,19 +2084,19 @@ class Test
         A a = t.a;
         str = a.Field;
         c = new Command1(str, str);
- 
+
         t.a.Field = param;
         a = t.a;
         A b = a;
         t2.a.Field = """";
         str = b.Field;
         c = new Command1(str, str);
- 
+
     }}
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2104,7 +2122,7 @@ Class Test
         Dim a As A = t.a
         str = a.Field
         c = New Command1(str, str)
- 
+
         t.a.Field = param
         a = t.a
         Dim b As A = a
@@ -2117,9 +2135,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueTypeNestingCopy_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueTypeNestingCopy_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2148,7 +2166,7 @@ class Test
         A a = t.a;
         str = a.Field;
         c = new Command1(str, str);
- 
+
         t.a.Field = param;
         a = t.a;
         A b = a;
@@ -2161,7 +2179,7 @@ class Test
         // Test0.cs(118,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
         GetCSharpResultAt(118, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2187,7 +2205,7 @@ Class Test
         Dim a As A = t.a
         str = a.Field
         c = New Command1(str, str)
- 
+
         t.a.Field = param
         a = t.a
         Dim b As A = a
@@ -2203,9 +2221,9 @@ End Class",
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
 
-        public void FlowAnalysis_PointsTo_ValueTypeNestingCopy_02_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueTypeNestingCopy_02_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2245,7 +2263,7 @@ class Test
         // Test0.cs(114,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
         GetCSharpResultAt(114, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2284,9 +2302,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceTypeAllocationAndInitializer_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceTypeAllocationAndInitializer_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2315,7 +2333,7 @@ class Test
             // Test0.cs(105,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(105, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2346,9 +2364,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceTypeAllocationAndInitializer_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceTypeAllocationAndInitializer_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2373,16 +2391,16 @@ class Test
         t = new Test() {{ a = b }};
         string str = t.a.Field;                 //  'a' and 'b' point to same object.
         Command c = new Command1(str, str);
- 
+
         str = param;
         t = new Test() {{ a = {{ Field = """" }} }};
         str = t.a.Field;
-        c = new Command1(str, str); 
+        c = new Command1(str, str);
     }}
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2418,9 +2436,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2449,7 +2467,7 @@ class Test
             // Test0.cs(105,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(105, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2480,9 +2498,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2507,17 +2525,17 @@ class Test
         t = new Test() {{ a = b }};
         string str = t.a.Field;                 //  'a' and 'b' have the same value.
         Command c = new Command1(str, str);
- 
+
         t.a.Field = param;
         str = param;
         t = new Test() {{ a = {{ Field = """" }} }};
         str = t.a.Field;
-        c = new Command1(str, str); 
+        c = new Command1(str, str);
     }}
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2553,9 +2571,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_02_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueTypeAllocationAndInitializer_02_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2581,18 +2599,18 @@ struct Test
         Test t2 = t;
         string str = t2.a.Field;                 //  'a' and 'b' have the same value.
         Command1 c = new Command1(str, str);
- 
+
         t.a.Field = param;
         str = param;
         t = new Test() {{ a = {{ Field = """" }} }};
         t2 = t;
         str = t2.a.Field;
-        c = new Command1(str, str); 
+        c = new Command1(str, str);
     }}
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2630,9 +2648,9 @@ End Structure");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceTypeCollectionInitializer_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceTypeCollectionInitializer_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2670,7 +2688,7 @@ class Test
             // Test0.cs(112,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(112, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2711,9 +2729,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1570")]
-        public void FlowAnalysis_PointsTo_ReferenceTypeCollectionInitializer_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceTypeCollectionInitializer_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2747,7 +2765,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2784,9 +2802,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_DynamicObjectCreation_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_DynamicObjectCreation_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2825,9 +2843,9 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_DynamicObjectCreation_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_DynamicObjectCreation_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2859,11 +2877,11 @@ class Test
         t = new Test(d) {{ a = b }};
         string str = t.a.Field;                 //  'a' and 'b' point to same object.
         Command c = new Command1(str, str);
- 
+
         str = param;
         t = new Test(d) {{ a = {{ Field = """" }} }};
         str = t.a.Field;
-        c = new Command1(str, str); 
+        c = new Command1(str, str);
     }}
 }}
 ");
@@ -2871,9 +2889,9 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_AnonymousObjectCreation_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_AnonymousObjectCreation_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2896,7 +2914,7 @@ class Test
             // Test0.cs(99,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(99, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2919,9 +2937,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void CSharp_FlowAnalysis_PointsTo_AnonymousObjectCreation_NoDiagnostic()
+        public async Task CSharp_FlowAnalysis_PointsTo_AnonymousObjectCreation_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -2940,7 +2958,7 @@ class Test
 
         string str = t.Field;
         Command c = new Command1(str, str);
- 
+
         str = param;
         t = t2;
         str = t.Field2 + t2.Field2;
@@ -2952,9 +2970,9 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1568")]
-        public void VisualBasic_FlowAnalysis_PointsTo_AnonymousObjectCreation_NoDiagnostic()
+        public async Task VisualBasic_FlowAnalysis_PointsTo_AnonymousObjectCreation_NoDiagnostic()
         {
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -2971,7 +2989,7 @@ Class Test
 
         Dim str As String = t.Field2
         Dim c As Command = New Command1(str, str)
- 
+
         str = param
         t = t2
         str = t.Field2 + t2.Field2
@@ -2982,9 +3000,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived__Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_BaseDerived__Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3021,7 +3039,7 @@ class Test
             // Test0.cs(113,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(113, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3059,9 +3077,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_BaseDerived_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3096,7 +3114,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3132,9 +3150,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3170,9 +3188,9 @@ class Test
         {{
             Base b = new Base();
             b.Field = """";
-            t.B = b;                    // t.B now points to b       
+            t.B = b;                    // t.B now points to b
         }}
-        
+
         string str = t.B.Field;         // t.B now points to either b or d, but d.Field could be an unknown value (param) in one code path.
         Command c = new Command1(str, str);
     }}
@@ -3181,7 +3199,7 @@ class Test
             // Test0.cs(123,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(123, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3225,9 +3243,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_02_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_02_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3263,13 +3281,13 @@ class Test
                 d.Field = param;        // t.B.Field is unknown in this code path.
             }}
         }}
-        else 
+        else
         {{
             Base b = new Base();
             b.Field = """";
-            t.B = b;                    // t.B now points to b       
+            t.B = b;                    // t.B now points to b
         }}
-        
+
         string str = t.B.Field;         // t.B now points to either b or d, but d.Field could be an unknown value (param) in one code path.
         Command c = new Command1(str, str);
     }}
@@ -3278,7 +3296,7 @@ class Test
             // Test0.cs(127,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(127, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3325,9 +3343,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_BaseDerived_IfStatement_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3363,16 +3381,16 @@ class Test
         {{
             Base b = new Base();
             b.Field = """";
-            t.B = b;                    // t.B now points to b       
+            t.B = b;                    // t.B now points to b
         }}
-        
+
         string str = t.B.Field;         // t.B now points to either b or d, both of which have .Field = """"
         Command c = new Command1(str, str);
     }}
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3414,9 +3432,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_ThisInstanceReference_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_ThisInstanceReference_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3451,7 +3469,7 @@ class Test
             // Test0.cs(109,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(109, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3487,9 +3505,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_ThisInstanceReference_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_ThisInstanceReference_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3521,7 +3539,7 @@ class Test
         this.a = new A() {{ Field = """" }};
         str = this.a.Field;
         c = new Command1(str, str);
- 
+
         str = param;
         Field = """";
         str = this.Field;
@@ -3530,7 +3548,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3574,9 +3592,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueType_ThisInstanceReference_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueType_ThisInstanceReference_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3611,7 +3629,7 @@ struct Test
             // Test0.cs(109,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(109, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3647,9 +3665,9 @@ End Structure",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueType_ThisInstanceReference_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueType_ThisInstanceReference_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3681,7 +3699,7 @@ struct Test
         this.a = new A() {{ Field = """" }};
         str = this.a.Field;
         c = new Command1(str, str);
- 
+
         str = param;
         Field = """";
         str = this.Field;
@@ -3690,7 +3708,7 @@ struct Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3734,9 +3752,9 @@ End Structure");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_InvocationInstanceReceiver_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_InvocationInstanceReceiver_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3769,7 +3787,7 @@ class Test
         str = t.Field;                     // Unknown value.
         c = new Command1(str, str);
     }}
-    
+
     public void M2()
     {{
     }}
@@ -3780,7 +3798,7 @@ class Test
             // Test0.cs(114,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(114, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3823,9 +3841,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueType_InvocationInstanceReceiver_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueType_InvocationInstanceReceiver_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3858,7 +3876,7 @@ struct Test
         str = t.Field;                     // Unknown value.
         c = new Command1(str, str);
     }}
-    
+
     public void M2()
     {{
     }}
@@ -3869,7 +3887,7 @@ struct Test
             // Test0.cs(114,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(114, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -3912,9 +3930,9 @@ End Structure",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_Argument_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_Argument_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -3952,11 +3970,11 @@ class Test
         str = t.a.Field;                    // Unknown value.
         c = new Command1(str, str);
     }}
-    
+
     public void M2(Test t)
     {{
     }}
-    
+
     public void M3(ref Test t)
     {{
     }}
@@ -3969,7 +3987,7 @@ class Test
             // Test0.cs(119,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(119, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -4022,9 +4040,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceType_ThisArgument_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceType_ThisArgument_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -4057,7 +4075,7 @@ class Test
         str = Field;                        // Unknown value.
         c = new Command1(str, str);
     }}
-    
+
     public void M2(Test t)
     {{
     }}
@@ -4068,7 +4086,7 @@ class Test
             // Test0.cs(114,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(114, 13, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -4093,7 +4111,7 @@ Class Test
         t.M2(Me)
         Dim str As String = a.Field                        ' Unknown value.
         Dim c As Command = New Command1(str, str)
-        
+
         Me.Field = """"
         t.M2(Me)
         str = Field                                        ' Unknown value.
@@ -4111,9 +4129,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueType_Argument_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueType_Argument_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -4146,14 +4164,14 @@ struct Test
         str = t.a.Field;
         c = new Command1(str, str);
     }}
-    
+
     public void M2(Test t)
     {{
     }}
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -4195,9 +4213,9 @@ End Structure");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueType_Argument_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueType_Argument_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -4225,7 +4243,7 @@ struct Test
         string str = t.a.Field;                    // Passing by ref can change contents of a value type.
         Command c = new Command1(str, str);
     }}
-    
+
     public void M2(ref Test t)
     {{
     }}
@@ -4234,7 +4252,7 @@ struct Test
             // Test0.cs(109,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(109, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -4270,9 +4288,9 @@ End Structure",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ValueType_ThisArgument_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ValueType_ThisArgument_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -4305,14 +4323,14 @@ struct Test
         str = Field;
         c = new Command1(str, str);
     }}
-    
+
     public void M2(Test t)
     {{
     }}
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -4337,7 +4355,7 @@ Structure Test
         t.M2(Me)
         Dim str As String = a.Field                        ' Unknown value.
         Dim c As Command = New Command1(str, str)
-        
+
         Me.Field = """"
         t.M2(Me)
         str = Field                                        ' Unknown value.
@@ -4351,9 +4369,9 @@ End Structure");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ConstantArrayElement_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ConstantArrayElement_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4374,7 +4392,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4395,9 +4413,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_NonConstantArrayElement_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_NonConstantArrayElement_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4420,7 +4438,7 @@ class Test
             // Test0.cs(99,21): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(99, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4443,9 +4461,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1577")]
-        public void FlowAnalysis_PointsTo_ConstantArrayElement_NonConstantIndex_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ConstantArrayElement_NonConstantIndex_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4466,7 +4484,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4487,9 +4505,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_NonConstantArrayElement_NonConstantIndex_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_NonConstantArrayElement_NonConstantIndex_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4513,7 +4531,7 @@ class Test
             // Test0.cs(100,21): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(100, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4537,9 +4555,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ArrayInitializer_ConstantArrayElement_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ArrayInitializer_ConstantArrayElement_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4560,7 +4578,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4581,9 +4599,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ArrayInitializer_NonConstantArrayElement_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ArrayInitializer_NonConstantArrayElement_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4605,7 +4623,7 @@ class Test
 ",
             GetCSharpResultAt(99, 21, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4627,9 +4645,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ConstantArrayElement_ArrayFieldInReferenceType_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ConstantArrayElement_ArrayFieldInReferenceType_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4670,7 +4688,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4710,9 +4728,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_NonConstantArrayElement_ArrayFieldInReferenceType_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_NonConstantArrayElement_ArrayFieldInReferenceType_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4761,7 +4779,7 @@ class Test
             // Test0.cs(121,13): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(121, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4809,9 +4827,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ConstantArrayElement_ArrayFieldInValueType_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ConstantArrayElement_ArrayFieldInValueType_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4852,7 +4870,7 @@ struct Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4892,9 +4910,9 @@ End Structure");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_NonConstantArrayElement_ArrayFieldInValueType_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_NonConstantArrayElement_ArrayFieldInValueType_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -4943,7 +4961,7 @@ struct Test
             // Test0.cs(121,13): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(121, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -4991,9 +5009,9 @@ End Structure",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ConstantArrayElement_IndexerFieldInReferenceType_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ConstantArrayElement_IndexerFieldInReferenceType_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -5042,7 +5060,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -5095,9 +5113,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_NonConstantArrayElement_IndexerFieldInReferenceType_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_NonConstantArrayElement_IndexerFieldInReferenceType_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Adapter1 : Adapter
@@ -5149,7 +5167,7 @@ class Test
             // Test0.cs(126,13): warning CA2100: Review if the query string passed to 'Adapter1.Adapter1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(126, 13, "Adapter1.Adapter1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Adapter1
@@ -5204,9 +5222,9 @@ End Class",
         }
 
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceTypeArray_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceTypeArray_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5235,7 +5253,7 @@ class Test
 
         b.Field = param;
         str = testArray[0].a.Field;         // testArray[0].a points to b.
-        cmd = new Command1(str, str);        
+        cmd = new Command1(str, str);
     }}
 }}
 ",
@@ -5244,7 +5262,7 @@ class Test
             // Test0.cs(112,15): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(112, 15, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5283,9 +5301,9 @@ End Class
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_ReferenceTypeArray_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_ReferenceTypeArray_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5314,12 +5332,12 @@ class Test
 
         c.Field = b.Field;
         str = testArray[1].a.Field;         // testArray[1].a points to c.
-        cmd = new Command1(str, str);        
+        cmd = new Command1(str, str);
     }}
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5353,9 +5371,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_AutoGeneratedProperty_NoDiagnostic()
+        public async Task FlowAnalysis_PointsTo_AutoGeneratedProperty_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5378,7 +5396,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5400,9 +5418,9 @@ End Class");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
         [Fact]
-        public void FlowAnalysis_PointsTo_CustomProperty_Diagnostic()
+        public async Task FlowAnalysis_PointsTo_CustomProperty_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5430,7 +5448,7 @@ class Test
             // Test0.cs(104,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(104, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5464,9 +5482,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5509,7 +5527,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5530,12 +5548,12 @@ Module Test
         End If
 
         If param <> """" Then
-        Else 
+        Else
             Dim c3 As New Command1(param, param)
         End If
 
         If """" <> param Then
-        Else 
+        Else
             Dim c4 As New Command1(param, param)
         End If
     End Sub
@@ -5544,9 +5562,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5577,7 +5595,7 @@ class Test
             // Test0.cs(104,26): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(104, 26, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5606,9 +5624,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_WithNegation_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_WithNegation_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5651,7 +5669,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5672,12 +5690,12 @@ Module Test
         End If
 
         If Not Not (param <> """") Then
-        Else 
+        Else
             Dim c3 As New Command1(param, param)
         End If
 
         If Not ("""" = param) Then
-        Else 
+        Else
             Dim c4 As New Command1(param, param)
         End If
     End Sub
@@ -5686,9 +5704,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_WithNegation_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ParameterComparedWithConstant_WithNegation_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5729,7 +5747,7 @@ class Test
             // Test0.cs(112,26): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(112, 26, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5765,9 +5783,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithLocal_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ParameterComparedWithLocal_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5811,7 +5829,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5833,12 +5851,12 @@ Module Test
         End If
 
         If param <> str Then
-        Else 
+        Else
             Dim c3 As New Command1(param, param)
         End If
 
         If str <> param Then
-        Else 
+        Else
             Dim c4 As New Command1(param, param)
         End If
     End Sub
@@ -5847,9 +5865,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ParameterComparedWithLocal_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ParameterComparedWithLocal_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5902,7 +5920,7 @@ class Test
             // Test0.cs(122,26): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(122, 26, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -5925,12 +5943,12 @@ Module Test
         End If
 
         If param <> str2 Then
-        Else 
+        Else
             Dim c3 As New Command1(param, param)
         End If
 
         If str <> param Then
-        Else 
+        Else
             Dim c4 As New Command1(param, param)
         End If
     End Sub
@@ -5946,9 +5964,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_NestedIfElse_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_NestedIfElse_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -5993,7 +6011,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -6028,9 +6046,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_NestedIfElse_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_NestedIfElse_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -6103,7 +6121,7 @@ class Test
             // Test0.cs(142,26): warning CA2100: Review if the query string passed to 'Command4.Command4(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(142, 26, "Command4.Command4(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -6164,9 +6182,9 @@ End Class",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_Loops()
+        public async Task FlowAnalysis_PredicateAnalysis_Loops()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -6219,7 +6237,7 @@ class Test
             c = new Command1(param, param); // param == str here
             c = new Command2(param2, param2); // param2 != str here
         }}
-        
+
         c = new Command1(param2, param2); // param2 == str here
         c = new Command1(param, param); // param == str here
     }}
@@ -6232,7 +6250,7 @@ class Test
             // Test0.cs(134,17): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M3', accepts any user input.
             GetCSharpResultAt(134, 17, "Command2.Command2(string cmd, string parameter2)", "M3"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -6318,9 +6336,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_SwitchStatement()
+        public async Task FlowAnalysis_SwitchStatement()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -6438,7 +6456,7 @@ class Test
             // Test0.cs(176,21): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M4', accepts any user input.
             GetCSharpResultAt(176, 21, "Command2.Command2(string cmd, string parameter2)", "M4"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -6536,9 +6554,9 @@ End Module",
         }
 
         [Fact]
-        public void FlowAnalysis_TryCatch()
+        public async Task FlowAnalysis_TryCatch()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -6666,7 +6684,7 @@ class Test
             // Test0.cs(200,21): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M6', accepts any user input.
             GetCSharpResultAt(200, 21, "Command2.Command2(string cmd, string parameter2)", "M6"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -6767,9 +6785,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_CatchFilter()
+        public async Task FlowAnalysis_PredicateAnalysis_CatchFilter()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -6809,7 +6827,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -6843,9 +6861,15 @@ End Module");
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_CopyAnalysis_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_CopyAnalysis_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -6888,9 +6912,19 @@ class Test
         }}
     }}
 }}
-", GetEditorConfigToEnableCopyAnalysis());
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") }
+                }
+            }.RunAsync();
 
-            VerifyBasic($@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 {SetupCodeBasic}
 
 Class Command1
@@ -6924,15 +6958,25 @@ Module Test
             Dim c As Command = New Command1(param, param)
         End If
     End Sub
-End Module", GetEditorConfigToEnableCopyAnalysis());
+End Module"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") }
+                }
+            }.RunAsync();
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.CopyAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_CopyAnalysis_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_CopyAnalysis_Diagnostic()
         {
-            VerifyCSharp($@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -7030,19 +7074,32 @@ class Test
         }}
     }}
 }}
-", GetEditorConfigToEnableCopyAnalysis(),
-            // Test0.cs(142,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
-            GetCSharpResultAt(142, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
-            // Test0.cs(157,25): warning CA2100: Review if the query string passed to 'Command3.Command3(string cmd, string parameter2)' in 'M1', accepts any user input.
-            GetCSharpResultAt(157, 25, "Command3.Command3(string cmd, string parameter2)", "M1"),
-            // Test0.cs(169,25): warning CA2100: Review if the query string passed to 'Command5.Command5(string cmd, string parameter2)' in 'M1', accepts any user input.
-            GetCSharpResultAt(169, 25, "Command5.Command5(string cmd, string parameter2)", "M1"),
-            // Test0.cs(170,17): warning CA2100: Review if the query string passed to 'Command6.Command6(string cmd, string parameter2)' in 'M1', accepts any user input.
-            GetCSharpResultAt(170, 17, "Command6.Command6(string cmd, string parameter2)", "M1"),
-            // Test0.cs(177,25): warning CA2100: Review if the query string passed to 'Command7.Command7(string cmd, string parameter2)' in 'M1', accepts any user input.
-            GetCSharpResultAt(177, 25, "Command7.Command7(string cmd, string parameter2)", "M1"));
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") },
+                    ExpectedDiagnostics =
+                    {
+                        // Test0.cs(142,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
+                        GetCSharpResultAt(142, 25, "Command1.Command1(string cmd, string parameter2)", "M1"),
+                        // Test0.cs(157,25): warning CA2100: Review if the query string passed to 'Command3.Command3(string cmd, string parameter2)' in 'M1', accepts any user input.
+                        GetCSharpResultAt(157, 25, "Command3.Command3(string cmd, string parameter2)", "M1"),
+                        // Test0.cs(169,25): warning CA2100: Review if the query string passed to 'Command5.Command5(string cmd, string parameter2)' in 'M1', accepts any user input.
+                        GetCSharpResultAt(169, 25, "Command5.Command5(string cmd, string parameter2)", "M1"),
+                        // Test0.cs(170,17): warning CA2100: Review if the query string passed to 'Command6.Command6(string cmd, string parameter2)' in 'M1', accepts any user input.
+                        GetCSharpResultAt(170, 17, "Command6.Command6(string cmd, string parameter2)", "M1"),
+                        // Test0.cs(177,25): warning CA2100: Review if the query string passed to 'Command7.Command7(string cmd, string parameter2)' in 'M1', accepts any user input.
+                        GetCSharpResultAt(177, 25, "Command7.Command7(string cmd, string parameter2)", "M1"),
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic($@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 {SetupCodeBasic}
 
 Class Command1
@@ -7128,24 +7185,31 @@ Module Test
             Dim c As Command = New Command7(param, param)
         End If
     End Sub
-End Module", GetEditorConfigToEnableCopyAnalysis(),
-            // Test0.vb(177,32): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
-            GetBasicResultAt(177, 32, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
-            // Test0.vb(190,32): warning CA2100: Review if the query string passed to 'Sub Command3.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
-            GetBasicResultAt(190, 32, "Sub Command3.New(cmd As String, parameter2 As String)", "M1"),
-            // Test0.vb(197,32): warning CA2100: Review if the query string passed to 'Sub Command5.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
-            GetBasicResultAt(197, 32, "Sub Command5.New(cmd As String, parameter2 As String)", "M1"),
-            // Test0.vb(198,17): warning CA2100: Review if the query string passed to 'Sub Command6.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
-            GetBasicResultAt(198, 17, "Sub Command6.New(cmd As String, parameter2 As String)", "M1"),
-            // Test0.vb(204,32): warning CA2100: Review if the query string passed to 'Sub Command7.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
-            GetBasicResultAt(204, 32, "Sub Command7.New(cmd As String, parameter2 As String)", "M1"));
+End Module"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") },
+                    ExpectedDiagnostics =
+                    {
+                        // Test0.vb(177,32): warning CA2100: Review if the query string passed to 'Sub Command1.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+                        GetBasicResultAt(177, 32, "Sub Command1.New(cmd As String, parameter2 As String)", "M1"),
+                        // Test0.vb(190,32): warning CA2100: Review if the query string passed to 'Sub Command3.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+                        GetBasicResultAt(190, 32, "Sub Command3.New(cmd As String, parameter2 As String)", "M1"),
+                        // Test0.vb(197,32): warning CA2100: Review if the query string passed to 'Sub Command5.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+                        GetBasicResultAt(197, 32, "Sub Command5.New(cmd As String, parameter2 As String)", "M1"),
+                        // Test0.vb(198,17): warning CA2100: Review if the query string passed to 'Sub Command6.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+                        GetBasicResultAt(198, 17, "Sub Command6.New(cmd As String, parameter2 As String)", "M1"),
+                        // Test0.vb(204,32): warning CA2100: Review if the query string passed to 'Sub Command7.New(cmd As String, parameter2 As String)' in 'M1', accepts any user input.
+                        GetBasicResultAt(204, 32, "Sub Command7.New(cmd As String, parameter2 As String)", "M1"),
+                    }
+                }
+            }.RunAsync();
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ConditionalOr_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ConditionalOr_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -7190,7 +7254,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -7228,9 +7292,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ConditionalOr_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ConditionalOr_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -7288,7 +7352,7 @@ class Test
             // Test0.cs(127,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(127, 25, "Command2.Command2(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -7339,9 +7403,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ConditionalOr_02_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ConditionalOr_02_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -7414,7 +7478,7 @@ class Test
             // Test0.cs(138,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(138, 25, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -7454,7 +7518,7 @@ Module Test
         ' 5. maybe-const in left and right.
         If param = strMayBeConst OrElse param = strMayBeConst + ""c"" Then
             Dim c As New Command1(param, param)
-        Else 
+        Else
             Dim c As New Command1(param, param)
         End If
     End Sub
@@ -7475,9 +7539,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ConditionalAnd_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ConditionalAnd_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -7519,7 +7583,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -7556,9 +7620,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ConditionalAnd_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ConditionalAnd_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -7642,7 +7706,7 @@ class Test
             // Test0.cs(149,25): warning CA2100: Review if the query string passed to 'Command2.Command2(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(149, 25, "Command2.Command2(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -7689,7 +7753,7 @@ Module Test
         Else
             Dim c As New Command2(param, param) ' Diagnostic (if left is true and right is false, param maybe non-const)
         End If
-        
+
         ' 5. Creation in else: negation of non-const in left, maybe-const in right.
         If str2 <> param AndAlso param = strMayBeConst Then
         Else
@@ -7713,9 +7777,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ConditionalAnd_02_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ConditionalAnd_02_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -7791,7 +7855,7 @@ class Test
             // Test0.cs(141,25): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(141, 25, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -7833,7 +7897,7 @@ Module Test
         ' 5. maybe-const in left and right.
         If param = strMayBeConst AndAlso param = strMayBeConst + ""c"" Then
             Dim c As New Command1(param, param)
-        Else 
+        Else
             Dim c As New Command1(param, param)
         End If
     End Sub
@@ -7854,9 +7918,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_Conditional_WithNegation_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_Conditional_WithNegation_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -7901,7 +7965,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -7924,12 +7988,12 @@ Module Test
         End If
 
         If Not (param = str OrElse param = str2) Then
-        Else 
+        Else
             Dim c3 As New Command1(param, param)
         End If
 
         If Not (Not (str <> param) AndAlso Not Not (param <> str2)) Then
-        Else 
+        Else
             Dim c4 As New Command1(param, param)
         End If
     End Sub
@@ -7938,9 +8002,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ConditionalAndOrNegation_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ConditionalAndOrNegation_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -7979,7 +8043,7 @@ class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -8013,9 +8077,9 @@ End Module");
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ConditionalAndOrNegation_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ConditionalAndOrNegation_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -8104,7 +8168,7 @@ class Test
             // Test0.cs(160,25): warning CA2100: Review if the query string passed to 'Command6.Command6(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(160, 25, "Command6.Command6(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -8184,9 +8248,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ComparisonInNonCondition_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ComparisonInNonCondition_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -8208,7 +8272,7 @@ class Test
             // Test0.cs(98,21): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M1', accepts any user input.
             GetCSharpResultAt(98, 21, "Command1.Command1(string cmd, string parameter2)", "M1"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1
@@ -8230,9 +8294,9 @@ End Module",
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ComparisonInNonCondition_02_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ComparisonInNonCondition_02_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -8265,9 +8329,15 @@ class Test
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ContractCheck_NoDiagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ContractCheck_NoDiagnostic()
         {
-            VerifyCSharp($@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -8309,11 +8379,21 @@ class Test
     {{
         System.Diagnostics.Contracts.Contract.Assert(param == """");
         Command c = new Command1(param, param);
-    }}    
+    }}
 }}
-", GetEditorConfigToEnableCopyAnalysis());
+"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") }
+                }
+            }.RunAsync();
 
-            VerifyBasic($@"
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
 {SetupCodeBasic}
 
 Class Command1
@@ -8350,14 +8430,18 @@ Module Test
         System.Diagnostics.Contracts.Contract.Assert(param = """")
         Dim c As Command = New Command1(param, param)
     End Sub
-End Module", GetEditorConfigToEnableCopyAnalysis());
+End Module"
+                    },
+                    AdditionalFiles = { (".editorconfig", "dotnet_code_quality.copy_analysis = true") }
+                }
+            }.RunAsync();
         }
 
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PredicateAnalysis)]
         [Fact]
-        public void FlowAnalysis_PredicateAnalysis_ContractCheck_Diagnostic()
+        public async Task FlowAnalysis_PredicateAnalysis_ContractCheck_Diagnostic()
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 {SetupCodeCSharp}
 
 class Command1 : Command
@@ -8407,7 +8491,7 @@ class Test
             // Test0.cs(120,13): warning CA2100: Review if the query string passed to 'Command1.Command1(string cmd, string parameter2)' in 'M3', accepts any user input.
             GetCSharpResultAt(120, 13, "Command1.Command1(string cmd, string parameter2)", "M3"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 {SetupCodeBasic}
 
 Class Command1

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis.cs
@@ -16,12 +16,12 @@ namespace Microsoft.NetCore.Analyzers.Data.UnitTests
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
     public class ReviewSQLQueriesForSecurityVulnerabilitiesTests_FlowAnalysis : ReviewSQLQueriesForSecurityVulnerabilitiesTests
     {
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string invokedSymbol, string containingMethod)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string invokedSymbol, string containingMethod)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(invokedSymbol, containingMethod);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, string invokedSymbol, string containingMethod)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, string invokedSymbol, string containingMethod)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(invokedSymbol, containingMethod);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/InteropServices/AlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttributeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/InteropServices/AlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttributeTests.cs
@@ -3,20 +3,16 @@
 using Microsoft.NetCore.CSharp.Analyzers.InteropServices;
 using Microsoft.NetCore.VisualBasic.Analyzers.InteropServices;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.CSharp.Analyzers.InteropServices.CSharpAlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttributeAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.VisualBasic.Analyzers.InteropServices.BasicAlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttributeAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
 {
-    public class AlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttributeTests : DiagnosticAnalyzerTestBase
+    public class AlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttributeTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new CSharpAlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttributeAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new BasicAlwaysConsumeTheValueReturnedByMethodsMarkedWithPreserveSigAttributeAnalyzer();
-        }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Resources/MarkAssembliesWithNeutralResourcesLanguageTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Resources/MarkAssembliesWithNeutralResourcesLanguageTests.cs
@@ -1,26 +1,19 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.NetCore.CSharp.Analyzers.Resources;
-using Microsoft.NetCore.VisualBasic.Analyzers.Resources;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.CSharp.Analyzers.Resources.CSharpMarkAssembliesWithNeutralResourcesLanguageAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.VisualBasic.Analyzers.Resources.BasicMarkAssembliesWithNeutralResourcesLanguageAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Resources.UnitTests
 {
-    public class MarkAssembliesWithNeutralResourcesLanguageTests : DiagnosticAnalyzerTestBase
+    public class MarkAssembliesWithNeutralResourcesLanguageTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicMarkAssembliesWithNeutralResourcesLanguageAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpMarkAssembliesWithNeutralResourcesLanguageAnalyzer();
-        }
-
         private const string CSharpDesignerFile = @"
 namespace DesignerFile {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Resources.Tools.StronglyTypedResourceBuilder"", ""4.0.0.0"")]
@@ -35,79 +28,85 @@ Namespace My.Resources
 End Namespace";
 
         [Fact]
-        public void TestCSharpNoResourceFile()
+        public async Task TestCSharpNoResourceFile()
         {
-            VerifyCSharp(@"class C {}");
+            await VerifyCS.VerifyAnalyzerAsync(@"class C {}");
         }
 
         [Fact]
-        public void TestBasicNoResourceFile()
+        public async Task TestBasicNoResourceFile()
         {
-            VerifyBasic(@"Class C
+            await VerifyVB.VerifyAnalyzerAsync(@"Class C
 End Class");
         }
 
         [Fact]
-        public void TestCSharpResourceFile()
+        public async Task TestCSharpResourceFile()
         {
-            VerifyCSharp(GetSources(@"class C {}", LanguageNames.CSharp), GetGlobalResult(MarkAssembliesWithNeutralResourcesLanguageAnalyzer.Rule));
+            await VerifyCSharpWithDependencies(@"class C {}", VerifyCS.Diagnostic());
         }
 
         [Fact]
-        public void TestBasicResourceFile()
+        public async Task TestBasicResourceFile()
         {
-            VerifyBasic(GetSources(@"Class C
-End Class", LanguageNames.VisualBasic), GetGlobalResult(MarkAssembliesWithNeutralResourcesLanguageAnalyzer.Rule));
+            await VerifyBasicWithDependencies(@"Class C
+End Class", VerifyVB.Diagnostic());
         }
 
         [Fact]
-        public void TestCSharpInvalidAttribute1()
+        public async Task TestCSharpInvalidAttribute1()
         {
-            VerifyCSharp(GetSources(@"[assembly: System.Resources.NeutralResourcesLanguage("""")]", LanguageNames.CSharp), GetCSharpResultAt(1, 12, MarkAssembliesWithNeutralResourcesLanguageAnalyzer.Rule));
+            await VerifyCSharpWithDependencies(@"[assembly: System.Resources.NeutralResourcesLanguage("""")]", VerifyCS.Diagnostic().WithLocation(1, 12));
         }
 
         [Fact]
-        public void TestCSharpInvalidAttribute2()
+        public async Task TestCSharpInvalidAttribute2()
         {
-            VerifyCSharp(GetSources(@"[assembly: System.Resources.NeutralResourcesLanguage(null)]", LanguageNames.CSharp), GetCSharpResultAt(1, 12, MarkAssembliesWithNeutralResourcesLanguageAnalyzer.Rule));
+            await VerifyCSharpWithDependencies(@"[assembly: System.Resources.NeutralResourcesLanguage(null)]", VerifyCS.Diagnostic().WithLocation(1, 12));
         }
 
         [Fact]
-        public void TestBasicInvalidAttribute1()
+        public async Task TestBasicInvalidAttribute1()
         {
-            VerifyBasic(GetSources(@"<Assembly: System.Resources.NeutralResourcesLanguage("""")>", LanguageNames.VisualBasic), GetBasicResultAt(1, 2, MarkAssembliesWithNeutralResourcesLanguageAnalyzer.Rule));
+            await VerifyBasicWithDependencies(@"<Assembly: System.Resources.NeutralResourcesLanguage("""")>", VerifyVB.Diagnostic().WithLocation(1, 2));
         }
 
         [Fact]
-        public void TestBasicInvalidAttribute2()
+        public async Task TestBasicInvalidAttribute2()
         {
-            VerifyBasic(GetSources(@"<Assembly: System.Resources.NeutralResourcesLanguage(Nothing)>", LanguageNames.VisualBasic), GetBasicResultAt(1, 2, MarkAssembliesWithNeutralResourcesLanguageAnalyzer.Rule));
+            await VerifyBasicWithDependencies(@"<Assembly: System.Resources.NeutralResourcesLanguage(Nothing)>", VerifyVB.Diagnostic().WithLocation(1, 2));
         }
 
         [Fact]
-        public void TestCSharpvalidAttribute()
+        public async Task TestCSharpvalidAttribute()
         {
-            VerifyCSharp(GetSources(@"[assembly: System.Resources.NeutralResourcesLanguage(""en"")]", LanguageNames.CSharp));
+            await VerifyCSharpWithDependencies(@"[assembly: System.Resources.NeutralResourcesLanguage(""en"")]");
         }
 
         [Fact]
-        public void TestBasicvalidAttribute()
+        public async Task TestBasicvalidAttribute()
         {
-            VerifyBasic(GetSources(@"<Assembly: System.Resources.NeutralResourcesLanguage(""en"")>", LanguageNames.VisualBasic));
+            await VerifyBasicWithDependencies(@"<Assembly: System.Resources.NeutralResourcesLanguage(""en"")>");
         }
 
-        private FileAndSource[] GetSources(string code, string language)
+        private async Task VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
         {
-            return new[] { GetDesignerFile(language), new FileAndSource { FilePath = null, Source = code } };
+            var csharpTest = new VerifyCS.Test { TestCode = source };
+
+            csharpTest.TestState.Sources.Add(("Test.Designer.cs", CSharpDesignerFile));
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
         }
 
-        private FileAndSource GetDesignerFile(string language)
+        private async Task VerifyBasicWithDependencies(string source, params DiagnosticResult[] expected)
         {
-            return new FileAndSource
-            {
-                FilePath = "Test.Designer" + (language == LanguageNames.CSharp ? ".cs" : ".vb"),
-                Source = language == LanguageNames.CSharp ? CSharpDesignerFile : BasicDesignerFile
-            };
+            var vbTest = new VerifyVB.Test { TestCode = source };
+
+            vbTest.TestState.Sources.Add(("Test.Designer.vb", BasicDesignerFile));
+            vbTest.ExpectedDiagnostics.AddRange(expected);
+
+            await vbTest.RunAsync();
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidUnsealedAttributesTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidUnsealedAttributesTests.cs
@@ -128,11 +128,11 @@ End Class
 
         #endregion
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
            => VerifyCS.Diagnostic()
                .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column)
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidUnsealedAttributesTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidUnsealedAttributesTests.cs
@@ -43,18 +43,17 @@ public class C
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
-[|public class AttributeClass: Attribute
+public class [|AttributeClass|]: Attribute
 {
-}|]
+}
 
 public class Outer
 {
-    private class AttributeClass2: Attribute
+    private class [|AttributeClass2|]: Attribute
     {
     }
 }
-",
-            GetCSharpResultAt(4, 14));
+");
         }
 
         [Fact]
@@ -98,17 +97,16 @@ End Class
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
-Public Class AttributeClass
+Public Class [|AttributeClass|]
     Inherits Attribute
 End Class
 
 Public Class Outer
-    [|Private Class AttributeClass2
+    Private Class [|AttributeClass2|]
         Inherits Attribute
-    End Class|]
+    End Class
 End Class
-",
-            GetBasicResultAt(9, 19));
+");
         }
 
         [Fact]

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidUnsealedAttributesTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/AvoidUnsealedAttributesTests.cs
@@ -1,30 +1,25 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.AvoidUnsealedAttributesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.AvoidUnsealedAttributesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public partial class AvoidUnsealedAttributeTests : DiagnosticAnalyzerTestBase
+    public class AvoidUnsealedAttributeTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new AvoidUnsealedAttributesAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new AvoidUnsealedAttributesAnalyzer();
-        }
-
         #region Diagnostic Tests
 
         [Fact]
-        public void CA1813CSharpDiagnosticProviderTestFired()
+        public async Task CA1813CSharpDiagnosticProviderTestFired()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -38,14 +33,14 @@ public class C
     }
 }
 ",
-            GetCA1813CSharpResultAt(6, 18),
-            GetCA1813CSharpResultAt(10, 19));
+            GetCSharpResultAt(6, 18),
+            GetCSharpResultAt(10, 19));
         }
 
         [Fact]
-        public void CA1813CSharpDiagnosticProviderTestFiredWithScope()
+        public async Task CA1813CSharpDiagnosticProviderTestFiredWithScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [|public class AttributeClass: Attribute
@@ -59,13 +54,13 @@ public class Outer
     }
 }
 ",
-            GetCA1813CSharpResultAt(4, 14));
+            GetCSharpResultAt(4, 14));
         }
 
         [Fact]
-        public void CA1813CSharpDiagnosticProviderTestNotFired()
+        public async Task CA1813CSharpDiagnosticProviderTestNotFired()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public sealed class AttributeClass: Attribute
@@ -78,9 +73,9 @@ public sealed class AttributeClass: Attribute
         }
 
         [Fact]
-        public void CA1813VisualBasicDiagnosticProviderTestFired()
+        public async Task CA1813VisualBasicDiagnosticProviderTestFired()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class AttributeClass
@@ -93,14 +88,14 @@ Public Class Outer
     End Class
 End Class
 ",
-            GetCA1813BasicResultAt(4, 14),
-            GetCA1813BasicResultAt(9, 19));
+            GetBasicResultAt(4, 14),
+            GetBasicResultAt(9, 19));
         }
 
         [Fact]
-        public void CA1813VisualBasicDiagnosticProviderTestFiredwithScope()
+        public async Task CA1813VisualBasicDiagnosticProviderTestFiredwithScope()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class AttributeClass
@@ -113,13 +108,13 @@ Public Class Outer
     End Class|]
 End Class
 ",
-            GetCA1813BasicResultAt(9, 19));
+            GetBasicResultAt(9, 19));
         }
 
         [Fact]
-        public void CA1813VisualBasicDiagnosticProviderTestNotFired()
+        public async Task CA1813VisualBasicDiagnosticProviderTestNotFired()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public NotInheritable Class AttributeClass
@@ -135,14 +130,12 @@ End Class
 
         #endregion
 
-        private static DiagnosticResult GetCA1813CSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, AvoidUnsealedAttributesAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.AvoidUnsealedAttributesMessage);
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+           => VerifyCS.Diagnostic()
+               .WithLocation(line, column);
 
-        private static DiagnosticResult GetCA1813BasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, AvoidUnsealedAttributesAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.AvoidUnsealedAttributesMessage);
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposableFieldsShouldBeDisposedTests.cs
@@ -19,12 +19,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
     public class DisposableFieldsShouldBeDisposedTests
     {
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
            => VerifyCS.Diagnostic()
                .WithLocation(line, column)
                .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeMethodsShouldCallBaseClassDisposeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeMethodsShouldCallBaseClassDisposeTests.cs
@@ -15,12 +15,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class DisposeMethodsShouldCallBaseClassDisposeTests
     {
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
            => VerifyCS.Diagnostic()
                .WithLocation(line, column)
                .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeMethodsShouldCallBaseClassDisposeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeMethodsShouldCallBaseClassDisposeTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -13,21 +13,22 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public partial class DisposeMethodsShouldCallBaseClassDisposeTests : DiagnosticAnalyzerTestBase
+    public class DisposeMethodsShouldCallBaseClassDisposeTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new DisposeMethodsShouldCallBaseClassDispose();
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new DisposeMethodsShouldCallBaseClassDispose();
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+           => VerifyCS.Diagnostic()
+               .WithLocation(line, column)
+               .WithArguments(arguments);
 
-        private new DiagnosticResult GetCSharpResultAt(int line, int column, string containingMethod, string baseDisposeSignature) =>
-            GetCSharpResultAt(line, column, DisposeMethodsShouldCallBaseClassDispose.Rule, containingMethod, baseDisposeSignature);
-
-        private new DiagnosticResult GetBasicResultAt(int line, int column, string containingMethod, string baseDisposeSignature) =>
-            GetBasicResultAt(line, column, DisposeMethodsShouldCallBaseClassDispose.Rule, containingMethod, baseDisposeSignature);
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
         [Fact]
-        public void NoBaseDisposeImplementation_NoBaseDisposeCall_NoDiagnostic()
+        public async Task NoBaseDisposeImplementation_NoBaseDisposeCall_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A 
@@ -42,7 +43,7 @@ class B : A, IDisposable
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -58,9 +59,9 @@ End Class");
         }
 
         [Fact]
-        public void NoBaseDisposeImplementation_NoBaseDisposeCall_02_NoDiagnostic()
+        public async Task NoBaseDisposeImplementation_NoBaseDisposeCall_02_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A 
@@ -78,7 +79,7 @@ class B : A, IDisposable
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -96,9 +97,9 @@ End Class");
         }
 
         [Fact]
-        public void BaseDisposeCall_NoDiagnostic()
+        public async Task BaseDisposeCall_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -117,7 +118,7 @@ class B : A
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -137,9 +138,9 @@ End Class");
         }
 
         [Fact]
-        public void NoBaseDisposeCall_Diagnostic()
+        public async Task NoBaseDisposeCall_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -159,7 +160,7 @@ class B : A
             // Test0.cs(13,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
             GetCSharpResultAt(13, 26, "void B.Dispose()", "base.Dispose()"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -180,9 +181,9 @@ End Class",
         }
 
         [Fact]
-        public void BaseDisposeCall_IgnoreCase_VB_NoDiagnostic()
+        public async Task BaseDisposeCall_IgnoreCase_VB_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -202,9 +203,9 @@ End Class");
         }
 
         [Fact]
-        public void BaseDisposeBoolCall_NoDiagnostic()
+        public async Task BaseDisposeBoolCall_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -229,7 +230,7 @@ class B : A
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -254,9 +255,9 @@ End Class");
         }
 
         [Fact]
-        public void NoBaseDisposeBoolCall_Diagnostic()
+        public async Task NoBaseDisposeBoolCall_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -282,7 +283,7 @@ class B : A
             // Test0.cs(19,26): warning CA2215: Ensure that method 'void B.Dispose(bool b)' calls 'base.Dispose(bool)' in all possible control flow paths.
             GetCSharpResultAt(19, 26, "void B.Dispose(bool b)", "base.Dispose(bool)"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -308,9 +309,9 @@ End Class",
         }
 
         [Fact]
-        public void NoBaseDisposeCloseCall_NoDiagnostic()
+        public async Task NoBaseDisposeCloseCall_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -334,7 +335,7 @@ class B : A
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -358,9 +359,9 @@ End Class");
         }
 
         [Fact, WorkItem(1796, "https://github.com/dotnet/roslyn-analyzers/issues/1796")]
-        public void BaseDisposeAsyncCall_NoDiagnostic()
+        public async Task BaseDisposeAsyncCall_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading.Tasks;
 
@@ -383,7 +384,7 @@ class B : A
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading.Tasks
 
@@ -409,9 +410,9 @@ End Class");
         }
 
         [Fact, WorkItem(1796, "https://github.com/dotnet/roslyn-analyzers/issues/1796")]
-        public void NoBaseDisposeAsyncCall_Diagnostic()
+        public async Task NoBaseDisposeAsyncCall_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading.Tasks;
 
@@ -436,7 +437,7 @@ class B : A
             // Test0.cs(17,26): warning CA2215: Ensure that method 'Task B.DisposeAsync()' calls 'base.DisposeAsync()' in all possible control flow paths.
             GetCSharpResultAt(17, 26, "Task B.DisposeAsync()", "base.DisposeAsync()"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading.Tasks
 
@@ -464,9 +465,9 @@ End Class",
         }
 
         [Fact, WorkItem(1796, "https://github.com/dotnet/roslyn-analyzers/issues/1796")]
-        public void BaseDisposeCoreAsyncCall_NoDiagnostic()
+        public async Task BaseDisposeCoreAsyncCall_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading.Tasks;
 
@@ -496,7 +497,7 @@ class C : B
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading.Tasks
 
@@ -532,9 +533,9 @@ End Class");
         }
 
         [Fact, WorkItem(1796, "https://github.com/dotnet/roslyn-analyzers/issues/1796")]
-        public void NoBaseDisposeCoreAsyncCall_Diagnostic()
+        public async Task NoBaseDisposeCoreAsyncCall_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Threading.Tasks;
 
@@ -566,7 +567,7 @@ class C : B
             // Test0.cs(24,29): warning CA2215: Ensure that method 'Task C.DisposeCoreAsync(bool initialized)' calls 'base.DisposeCoreAsync(bool)' in all possible control flow paths.
             GetCSharpResultAt(24, 29, "Task C.DisposeCoreAsync(bool initialized)", "base.DisposeCoreAsync(bool)"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Threading.Tasks
 
@@ -604,9 +605,9 @@ End Class",
         }
 
         [Fact]
-        public void AbstractBaseDisposeMethod_NoBaseDisposeCall_NoDiagnostic()
+        public async Task AbstractBaseDisposeMethod_NoBaseDisposeCall_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 abstract class A : IDisposable
@@ -622,7 +623,7 @@ class B : A
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 MustInherit Class A
@@ -640,9 +641,9 @@ End Class");
         }
 
         [Fact]
-        public void ShadowsBaseDisposeMethod_NoBaseDisposeCall_NoDiagnostic()
+        public async Task ShadowsBaseDisposeMethod_NoBaseDisposeCall_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -660,7 +661,7 @@ class B : A
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -679,9 +680,9 @@ End Class");
         }
 
         [Fact]
-        public void Multiple_BaseDisposeCalls_NoDiagnostic()
+        public async Task Multiple_BaseDisposeCalls_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -701,7 +702,7 @@ class B : A
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -722,9 +723,9 @@ End Class");
         }
 
         [Fact]
-        public void BaseDisposeCalls_AllPaths_NoDiagnostic()
+        public async Task BaseDisposeCalls_AllPaths_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -751,7 +752,7 @@ class B : A
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -776,9 +777,9 @@ End Class");
         }
 
         [Fact, WorkItem(1654, "https://github.com/dotnet/roslyn-analyzers/issues/1654")]
-        public void BaseDisposeCalls_SomePaths_Diagnostic()
+        public async Task BaseDisposeCalls_SomePaths_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -803,7 +804,7 @@ class B : A
             // Test0.cs(14,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
             GetCSharpResultAt(14, 26, "void B.Dispose()", "base.Dispose()"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -828,9 +829,9 @@ End Class",
         }
 
         [Fact]
-        public void BaseDisposeCall_GuardedWithBoolField_NoDiagnostic()
+        public async Task BaseDisposeCall_GuardedWithBoolField_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -857,7 +858,7 @@ class B : A
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -884,9 +885,9 @@ End Class");
         }
 
         [Fact]
-        public void BaseDisposeCall_DifferentOverload_Diagnostic()
+        public async Task BaseDisposeCall_DifferentOverload_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -911,7 +912,7 @@ class B : A
             // Test0.cs(17,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
             GetCSharpResultAt(17, 26, "void B.Dispose()", "base.Dispose()"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -936,9 +937,9 @@ End Class",
         }
 
         [Fact]
-        public void DisposeCall_DifferentInstance_Diagnostic()
+        public async Task DisposeCall_DifferentInstance_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -960,7 +961,7 @@ class B : A
             // Test0.cs(14,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
             GetCSharpResultAt(14, 26, "void B.Dispose()", "base.Dispose()"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -983,9 +984,9 @@ End Class",
         }
 
         [Fact]
-        public void DisposeCall_StaticMethod_Diagnostic()
+        public async Task DisposeCall_StaticMethod_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -1010,7 +1011,7 @@ class B : A
             // Test0.cs(17,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
             GetCSharpResultAt(17, 26, "void B.Dispose()", "base.Dispose()"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -1035,9 +1036,9 @@ End Class",
         }
 
         [Fact]
-        public void DisposeCall_ThisOrMeInstance_Diagnostic()
+        public async Task DisposeCall_ThisOrMeInstance_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class A : IDisposable
@@ -1058,7 +1059,7 @@ class B : A
             // Test0.cs(13,26): warning CA2215: Ensure that method 'void B.Dispose()' calls 'base.Dispose()' in all possible control flow paths.
             GetCSharpResultAt(13, 26, "void B.Dispose()", "base.Dispose()"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class A
@@ -1080,10 +1081,10 @@ End Class",
         }
 
         [Fact, WorkItem(1671, "https://github.com/dotnet/roslyn-analyzers/issues/1671")]
-        public void ErrorCase_NoDiagnostic()
+        public async Task ErrorCase_NoDiagnostic()
         {
             // Missing "using System;" causes "Equals" method be marked as IsOverride but with null OverriddenMethod.
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class BaseClass<T> : IComparable<T>
      where T : IComparable<T>
 {
@@ -1112,7 +1113,7 @@ public class DerivedClass<T> : BaseClass<T>
     where T : IComparable<T>
 {
 }
-", TestValidationMode.AllowCompileErrors);
+");
         }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -7016,7 +7016,7 @@ class Test
                         // Test0.cs(87,18): warning CA2000: Use recommended dispose pattern to ensure that object created by 'new FileStream(filePath + filePath, fileMode)' is disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.
                         GetCSharpMayBeNotDisposedResultAt(87, 18, "new FileStream(filePath + filePath, fileMode)"),
                         // Test0.cs(92,30): warning CA2000: Use recommended dispose pattern to ensure that object created by 'new ResourceReader(stream)' is disposed on all exception paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.
-                        GetCSharpMayBeNotDisposedOnExceptionPathsResultAt(92, 30, "new ResourceReader(stream)")
+                        GetCSharpMayBeNotDisposedOnExceptionPathsResultAt(92, 30, "new ResourceReader(stream)"),
                     }
                 }
             }.RunAsync();
@@ -7126,7 +7126,7 @@ End Class
                         // Test0.vb(66,18): warning CA2000: Use recommended dispose pattern to ensure that object created by 'New FileStream(filePath + filePath, fileMode)' is disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.
                         GetBasicMayBeNotDisposedResultAt(66, 18, "New FileStream(filePath + filePath, fileMode)"),
                         // Test0.vb(70,30): warning CA2000: Use recommended dispose pattern to ensure that object created by 'New ResourceReader(stream)' is disposed on all exception paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'.
-                        GetBasicMayBeNotDisposedOnExceptionPathsResultAt(70, 30, "New ResourceReader(stream)")
+                        GetBasicMayBeNotDisposedOnExceptionPathsResultAt(70, 30, "New ResourceReader(stream)"),
                     }
                 }
             }.RunAsync();
@@ -8998,7 +8998,7 @@ public class Test
                         // Test0.cs(40,21): warning CA2000: Call System.IDisposable.Dispose on object created by 'new A(2)' before all references to it are out of scope.
                         GetCSharpResultAt(40, 21, "new A(2)"),
                         // Test0.cs(49,17): warning CA2000: Call System.IDisposable.Dispose on object created by 'new A(3)' before all references to it are out of scope.
-                        GetCSharpResultAt(49, 17, "new A(3)")
+                        GetCSharpResultAt(49, 17, "new A(3)"),
                     }
                 },
                 LanguageVersion = CSharpLanguageVersion.CSharp7_3
@@ -11506,7 +11506,7 @@ namespace ConsoleApp1
                     ExpectedDiagnostics =
                     {
                         // Test0.cs(18,21): warning CA2000: Call System.IDisposable.Dispose on object created by 'File.Open(fileName, FileMode.Open)' before all references to it are out of scope.
-                        GetCSharpResultAt(18, 21, "File.Open(fileName, FileMode.Open)")
+                        GetCSharpResultAt(18, 21, "File.Open(fileName, FileMode.Open)"),
                     }
                 },
                 LanguageVersion = CSharpLanguageVersion.CSharp8
@@ -11547,7 +11547,7 @@ namespace ConsoleApp1
                     ExpectedDiagnostics =
                     {
                         // Test0.cs(17,19): warning CA2000: Call System.IDisposable.Dispose on object created by 'File.Open(fileName, FileMode.Open)' before all references to it are out of scope.
-                        GetCSharpResultAt(17, 19, "File.Open(fileName, FileMode.Open)")
+                        GetCSharpResultAt(17, 19, "File.Open(fileName, FileMode.Open)"),
                     }
                 },
                 LanguageVersion = CSharpLanguageVersion.CSharp8

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -23,32 +23,32 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
     public partial class DisposeObjectsBeforeLosingScopeTests
     {
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
             => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string allocationText) =>
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, string allocationText) =>
             GetCSharpResultAt(line, column, DisposeObjectsBeforeLosingScope.NotDisposedRule, allocationText);
-        private DiagnosticResult GetCSharpMayBeNotDisposedResultAt(int line, int column, string allocationText) =>
+        private static DiagnosticResult GetCSharpMayBeNotDisposedResultAt(int line, int column, string allocationText) =>
             GetCSharpResultAt(line, column, DisposeObjectsBeforeLosingScope.MayBeDisposedRule, allocationText);
-        private DiagnosticResult GetCSharpNotDisposedOnExceptionPathsResultAt(int line, int column, string allocationText) =>
+        private static DiagnosticResult GetCSharpNotDisposedOnExceptionPathsResultAt(int line, int column, string allocationText) =>
             GetCSharpResultAt(line, column, DisposeObjectsBeforeLosingScope.NotDisposedOnExceptionPathsRule, allocationText);
-        private DiagnosticResult GetCSharpMayBeNotDisposedOnExceptionPathsResultAt(int line, int column, string allocationText) =>
+        private static DiagnosticResult GetCSharpMayBeNotDisposedOnExceptionPathsResultAt(int line, int column, string allocationText) =>
             GetCSharpResultAt(line, column, DisposeObjectsBeforeLosingScope.MayBeDisposedOnExceptionPathsRule, allocationText);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, string allocationText) =>
+        private static DiagnosticResult GetBasicResultAt(int line, int column, string allocationText) =>
             GetBasicResultAt(line, column, DisposeObjectsBeforeLosingScope.NotDisposedRule, allocationText);
-        private DiagnosticResult GetBasicMayBeNotDisposedResultAt(int line, int column, string allocationText) =>
+        private static DiagnosticResult GetBasicMayBeNotDisposedResultAt(int line, int column, string allocationText) =>
             GetBasicResultAt(line, column, DisposeObjectsBeforeLosingScope.MayBeDisposedRule, allocationText);
-        private DiagnosticResult GetBasicNotDisposedOnExceptionPathsResultAt(int line, int column, string allocationText) =>
+        private static DiagnosticResult GetBasicNotDisposedOnExceptionPathsResultAt(int line, int column, string allocationText) =>
             GetBasicResultAt(line, column, DisposeObjectsBeforeLosingScope.NotDisposedOnExceptionPathsRule, allocationText);
-        private DiagnosticResult GetBasicMayBeNotDisposedOnExceptionPathsResultAt(int line, int column, string allocationText) =>
+        private static DiagnosticResult GetBasicMayBeNotDisposedOnExceptionPathsResultAt(int line, int column, string allocationText) =>
             GetBasicResultAt(line, column, DisposeObjectsBeforeLosingScope.MayBeDisposedOnExceptionPathsRule, allocationText);
 
         private string GetEditorConfigContentToDisableInterproceduralAnalysis(DisposeAnalysisKind disposeAnalysisKind)

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotLockOnObjectsWithWeakIdentityTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotLockOnObjectsWithWeakIdentityTests.cs
@@ -1,32 +1,26 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.DoNotLockOnObjectsWithWeakIdentityAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.DoNotLockOnObjectsWithWeakIdentityAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public partial class DoNotLockOnObjectsWithWeakIdentityTests : DiagnosticAnalyzerTestBase
+    public class DoNotLockOnObjectsWithWeakIdentityTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotLockOnObjectsWithWeakIdentityAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotLockOnObjectsWithWeakIdentityAnalyzer();
-        }
-
         [Fact]
-        public void CA2002TestLockOnStrongType()
+        public async Task CA2002TestLockOnStrongType()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             public class foo {
-                public void Test() {
+                public async Task Test() {
                     object o = new object();
                     lock (o) {
                         Console.WriteLine();
@@ -34,7 +28,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }
             }
 ");
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
             Public Class foo
                 Public Sub Test()
@@ -48,13 +42,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public void CA2002TestLockOnWeakIdentities()
+        public async Task CA2002TestLockOnWeakIdentities()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             public class foo
             {
-                public void Test()
+                public async Task Test()
                 {
                     string s1 = """";
                     lock (s1) { }
@@ -90,20 +84,20 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }
             }
             ",
-            GetCA2002CSharpResultAt(8, 27, "string"),
-            GetCA2002CSharpResultAt(9, 27, "string"),
-            GetCA2002CSharpResultAt(12, 27, "System.OutOfMemoryException"),
-            GetCA2002CSharpResultAt(14, 27, "System.StackOverflowException"),
-            GetCA2002CSharpResultAt(16, 27, "System.ExecutionEngineException"),
-            GetCA2002CSharpResultAt(18, 27, "System.Threading.Thread"),
-            GetCA2002CSharpResultAt(20, 27, "System.Type"),
-            GetCA2002CSharpResultAt(23, 27, "System.Reflection.MemberInfo"),
-            GetCA2002CSharpResultAt(26, 27, "System.Reflection.ConstructorInfo"),
-            GetCA2002CSharpResultAt(29, 27, "System.Reflection.ParameterInfo"),
-            GetCA2002CSharpResultAt(32, 27, "int[]"),
-            GetCA2002CSharpResultAt(37, 27, "this"));
+            GetCSharpResultAt(8, 27, "string"),
+            GetCSharpResultAt(9, 27, "string"),
+            GetCSharpResultAt(12, 27, "System.OutOfMemoryException"),
+            GetCSharpResultAt(14, 27, "System.StackOverflowException"),
+            GetCSharpResultAt(16, 27, "System.ExecutionEngineException"),
+            GetCSharpResultAt(18, 27, "System.Threading.Thread"),
+            GetCSharpResultAt(20, 27, "System.Type"),
+            GetCSharpResultAt(23, 27, "System.Reflection.MemberInfo"),
+            GetCSharpResultAt(26, 27, "System.Reflection.ConstructorInfo"),
+            GetCSharpResultAt(29, 27, "System.Reflection.ParameterInfo"),
+            GetCSharpResultAt(32, 27, "int[]"),
+            GetCSharpResultAt(37, 27, "this"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
             Public Class foo
                 Public Sub Test()
@@ -153,28 +147,28 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     End SyncLock
                 End Sub
             End Class",
-            GetCA2002BasicResultAt(6, 30, "String"),
-            GetCA2002BasicResultAt(8, 30, "String"),
-            GetCA2002BasicResultAt(12, 30, "System.OutOfMemoryException"),
-            GetCA2002BasicResultAt(15, 30, "System.StackOverflowException"),
-            GetCA2002BasicResultAt(18, 30, "System.ExecutionEngineException"),
-            GetCA2002BasicResultAt(21, 30, "System.Threading.Thread"),
-            GetCA2002BasicResultAt(24, 30, "System.Type"),
-            GetCA2002BasicResultAt(28, 30, "System.Reflection.MemberInfo"),
-            GetCA2002BasicResultAt(32, 30, "System.Reflection.ConstructorInfo"),
-            GetCA2002BasicResultAt(36, 30, "System.Reflection.ParameterInfo"),
-            GetCA2002BasicResultAt(40, 30, "Integer()"),
-            GetCA2002BasicResultAt(47, 30, "Me"));
+            GetBasicResultAt(6, 30, "String"),
+            GetBasicResultAt(8, 30, "String"),
+            GetBasicResultAt(12, 30, "System.OutOfMemoryException"),
+            GetBasicResultAt(15, 30, "System.StackOverflowException"),
+            GetBasicResultAt(18, 30, "System.ExecutionEngineException"),
+            GetBasicResultAt(21, 30, "System.Threading.Thread"),
+            GetBasicResultAt(24, 30, "System.Type"),
+            GetBasicResultAt(28, 30, "System.Reflection.MemberInfo"),
+            GetBasicResultAt(32, 30, "System.Reflection.ConstructorInfo"),
+            GetBasicResultAt(36, 30, "System.Reflection.ParameterInfo"),
+            GetBasicResultAt(40, 30, "Integer()"),
+            GetBasicResultAt(47, 30, "Me"));
         }
 
         [Fact]
-        public void CA2002TestLockOnWeakIdentitiesWithScope()
+        public async Task CA2002TestLockOnWeakIdentitiesWithScope()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
             using System;
             public class foo
             {
-                public void Test()
+                public async Task Test()
                 {
                     string s1 = """";
                     lock (s1) { }
@@ -208,11 +202,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }
             }
             ",
-            GetCA2002CSharpResultAt(12, 27, "System.OutOfMemoryException"),
-            GetCA2002CSharpResultAt(14, 27, "System.StackOverflowException"),
-            GetCA2002CSharpResultAt(16, 27, "System.ExecutionEngineException"));
+            GetCSharpResultAt(12, 27, "System.OutOfMemoryException"),
+            GetCSharpResultAt(14, 27, "System.StackOverflowException"),
+            GetCSharpResultAt(16, 27, "System.ExecutionEngineException"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
             Imports System
             Public Class foo
                 Public Sub Test()
@@ -259,21 +253,19 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     End SyncLock
                 End Sub
             End Class",
-            GetCA2002BasicResultAt(12, 30, "System.OutOfMemoryException"),
-            GetCA2002BasicResultAt(15, 30, "System.StackOverflowException"),
-            GetCA2002BasicResultAt(18, 30, "System.ExecutionEngineException"));
+            GetBasicResultAt(12, 30, "System.OutOfMemoryException"),
+            GetBasicResultAt(15, 30, "System.StackOverflowException"),
+            GetBasicResultAt(18, 30, "System.ExecutionEngineException"));
         }
 
-        private const string CA2002RuleName = "CA2002";
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+           => VerifyCS.Diagnostic()
+               .WithLocation(line, column)
+               .WithArguments(arguments);
 
-        private DiagnosticResult GetCA2002CSharpResultAt(int line, int column, string typeName)
-        {
-            return GetCSharpResultAt(line, column, CA2002RuleName, string.Format(CultureInfo.CurrentCulture, MicrosoftNetCoreAnalyzersResources.DoNotLockOnObjectsWithWeakIdentityMessage, typeName));
-        }
-
-        private DiagnosticResult GetCA2002BasicResultAt(int line, int column, string typeName)
-        {
-            return GetBasicResultAt(line, column, CA2002RuleName, string.Format(CultureInfo.CurrentCulture, MicrosoftNetCoreAnalyzersResources.DoNotLockOnObjectsWithWeakIdentityMessage, typeName));
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotLockOnObjectsWithWeakIdentityTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotLockOnObjectsWithWeakIdentityTests.cs
@@ -258,12 +258,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             GetBasicResultAt(18, 30, "System.ExecutionEngineException"));
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
            => VerifyCS.Diagnostic()
                .WithLocation(line, column)
                .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -1,10 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.DoNotPassLiteralsAsLocalizedParameters,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.DoNotPassLiteralsAsLocalizedParameters,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
@@ -12,21 +17,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
-    public partial class DoNotPassLiteralsAsLocalizedParametersTests : DiagnosticAnalyzerTestBase
+    public class DoNotPassLiteralsAsLocalizedParametersTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer() => new DoNotPassLiteralsAsLocalizedParameters();
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new DoNotPassLiteralsAsLocalizedParameters();
-
-        private DiagnosticResult GetCSharpResultAt(int line, int column, string containingMethod, string parameterName, string invokedMethod, string literals) =>
-            GetCSharpResultAt(line, column, DoNotPassLiteralsAsLocalizedParameters.Rule, containingMethod, parameterName, invokedMethod, literals);
-
-        private DiagnosticResult GetBasicResultAt(int line, int column, string containingMethod, string parameterName, string invokedMethod, string literals) =>
-            GetBasicResultAt(line, column, DoNotPassLiteralsAsLocalizedParameters.Rule, containingMethod, parameterName, invokedMethod, literals);
-
         [Fact]
-        public void NonLocalizableParameter_NoDiagnostic()
+        public async Task NonLocalizableParameter_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 public class C
 {
     public void M(string param)
@@ -48,7 +44,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Public Class C
     Public Sub M(param As String)
     End Sub
@@ -68,9 +64,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_NonLiteralArgument_NoDiagnostic()
+        public async Task ParameterWithLocalizableAttribute_NonLiteralArgument_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -89,7 +85,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -106,9 +102,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_EmptyStringLiteralArgument_NoDiagnostic()
+        public async Task ParameterWithLocalizableAttribute_EmptyStringLiteralArgument_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -128,7 +124,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -146,9 +142,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_NonEmptyStringLiteralArgument_AllControlChars_NoDiagnostic()
+        public async Task ParameterWithLocalizableAttribute_NonEmptyStringLiteralArgument_AllControlChars_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -168,7 +164,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 Imports Microsoft.VisualBasic
 
@@ -187,9 +183,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_MultipleLineStringLiteralArgument_Method_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_MultipleLineStringLiteralArgument_Method_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -211,7 +207,7 @@ public class Test
                 // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a a".
                 GetCSharpResultAt(16, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports Microsoft.VisualBasic
 Imports System.ComponentModel
 
@@ -232,9 +228,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_StringLiteralArgument_Method_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_StringLiteralArgument_Method_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -256,7 +252,7 @@ public class Test
             // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(16, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -276,9 +272,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_StringLiteralArgument_Constructor_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_StringLiteralArgument_Constructor_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -300,7 +296,7 @@ public class Test
             // Test0.cs(16,19): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'C.C(string param)'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(16, 19, "void Test.M1(C c)", "param", "C.C(string param)", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -320,9 +316,9 @@ End Class
         }
 
         [Fact]
-        public void PropertyWithLocalizableAttribute_StringLiteralArgument_Diagnostic()
+        public async Task PropertyWithLocalizableAttribute_StringLiteralArgument_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -343,7 +339,7 @@ public class Test
             // Test0.cs(15,9): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'value' of a call to 'void C.P.set'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(15, 9, "void Test.M1(C c)", "value", "void C.P.set", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -363,9 +359,9 @@ End Class
         }
 
         [Fact]
-        public void PropertySetterWithLocalizableAttribute_StringLiteralArgument_Diagnostic()
+        public async Task PropertySetterWithLocalizableAttribute_StringLiteralArgument_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -385,7 +381,7 @@ public class Test
             // Test0.cs(14,9): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'value' of a call to 'void C.P.set'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(14, 9, "void Test.M1(C c)", "value", "void C.P.set", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -414,9 +410,9 @@ End Class
         }
 
         [Fact]
-        public void PropertySetterParameterWithLocalizableAttribute_StringLiteralArgument_Diagnostic()
+        public async Task PropertySetterParameterWithLocalizableAttribute_StringLiteralArgument_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -437,7 +433,7 @@ public class Test
             // Test0.cs(15,9): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'value' of a call to 'void C.P.set'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(15, 9, "void Test.M1(C c)", "value", "void C.P.set", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -466,9 +462,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_MultipleStringLiteralArguments_Method_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_MultipleStringLiteralArguments_Method_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -493,7 +489,7 @@ public class Test
             // Test0.cs(17,18): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'message' of a call to 'void C.M(string param, string message)'. Retrieve the following string(s) from a resource table instead: "m".
             GetCSharpResultAt(17, 18, "void Test.M1(C c)", "message", "void C.M(string param, string message)", "m"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -516,9 +512,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableFalseAttribute_StringLiteralArgument_NoDiagnostic()
+        public async Task ParameterWithLocalizableFalseAttribute_StringLiteralArgument_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -538,7 +534,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -556,9 +552,9 @@ End Class
         }
 
         [Fact]
-        public void ContainingSymbolWithLocalizableTrueAttribute_Diagnostic()
+        public async Task ContainingSymbolWithLocalizableTrueAttribute_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 [LocalizableAttribute(true)]
@@ -581,7 +577,7 @@ public class Test
             // Test0.cs(17,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(17, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 <LocalizableAttribute(True)> _
@@ -602,9 +598,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableFalseAttribute_ContainingSymbolWithLocalizableTrueAttribute_NoDiagnostic()
+        public async Task ParameterWithLocalizableFalseAttribute_ContainingSymbolWithLocalizableTrueAttribute_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 [LocalizableAttribute(true)]
@@ -625,7 +621,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 <LocalizableAttribute(True)>
@@ -644,9 +640,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableTrueAttribute_ContainingSymbolWithLocalizableFalseAttribute_Diagnostic()
+        public async Task ParameterWithLocalizableTrueAttribute_ContainingSymbolWithLocalizableFalseAttribute_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 [LocalizableAttribute(false)]
@@ -669,7 +665,7 @@ public class Test
             // Test0.cs(17,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(17, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 <LocalizableAttribute(False)> _
@@ -690,9 +686,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_OverriddenMethod_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_OverriddenMethod_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class B
@@ -730,7 +726,7 @@ public class Test
             // Test0.cs(32,29): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.LocalizableMethod(string param)'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(32, 29, "void Test.M1(C c)", "param", "void C.LocalizableMethod(string param)", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class B
@@ -763,9 +759,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_StringLiteralArgument_MultiplePossibleLiterals_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_StringLiteralArgument_MultiplePossibleLiterals_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -787,7 +783,7 @@ public class Test
             // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c, bool flag)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a, b".
             GetCSharpResultAt(16, 13, "void Test.M1(C c, bool flag)", "param", "void C.M(string param)", "a, b"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -807,9 +803,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_StringLiteralArgument_MultiplePossibleLiterals_Ordering_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_StringLiteralArgument_MultiplePossibleLiterals_Ordering_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -831,7 +827,7 @@ public class Test
             // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c, bool flag)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a, b".
             GetCSharpResultAt(16, 13, "void Test.M1(C c, bool flag)", "param", "void C.M(string param)", "a, b"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -851,9 +847,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_StringLiteralArgument_DefaultValue_NoDiagnostic()
+        public async Task ParameterWithLocalizableAttribute_StringLiteralArgument_DefaultValue_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -872,7 +868,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -889,9 +885,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_ConstantField_StringLiteralArgument_Method_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_ConstantField_StringLiteralArgument_Method_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -913,7 +909,7 @@ public class Test
             // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(16, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -922,7 +918,7 @@ Public Class C
 End Class
 
 Public Class Test
-    Private Const _field As String = ""a"" 
+    Private Const _field As String = ""a""
 
     Public Sub M1(c As C)
         c.M(_field)
@@ -934,9 +930,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_XmlStringLiteralArgument_NoDiagnostic()
+        public async Task ParameterWithLocalizableAttribute_XmlStringLiteralArgument_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -956,7 +952,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -974,9 +970,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_XmlStringLiteralArgument_Filtering_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_XmlStringLiteralArgument_Filtering_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 
 public class C
@@ -998,7 +994,7 @@ public class Test
             // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c, bool flag)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "b".
             GetCSharpResultAt(16, 13, "void Test.M1(C c, bool flag)", "param", "void C.M(string param)", "b"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 
 Public Class C
@@ -1018,9 +1014,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_SpecialCases_ConditionalMethod_NoDiagnostic()
+        public async Task ParameterWithLocalizableAttribute_SpecialCases_ConditionalMethod_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Diagnostics;
 
 public class C
@@ -1041,7 +1037,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Diagnostics
 
 Public Class C
@@ -1060,9 +1056,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_SpecialCases_XmlWriterMethod_NoDiagnostic()
+        public async Task ParameterWithLocalizableAttribute_SpecialCases_XmlWriterMethod_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 using System.Xml;
 
@@ -1083,7 +1079,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 Imports System.Xml
 
@@ -1102,9 +1098,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_SpecialCases_SystemConsoleWriteMethods_Diagnostic()
+        public async Task ParameterWithLocalizableAttribute_SpecialCases_SystemConsoleWriteMethods_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class Test
@@ -1128,7 +1124,7 @@ public class Test
             // Test0.cs(12,27): warning CA1303: Method 'void Test.M1(string param)' passes a literal string as parameter 'format' of a call to 'void Console.WriteLine(string format, object arg0)'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(12, 27, "void Test.M1(string param)", "format", "void Console.WriteLine(string format, object arg0)", "a"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class Test
@@ -1152,9 +1148,9 @@ End Class
         }
 
         [Fact]
-        public void ParameterWithLocalizableAttribute_SpecialCases_SystemWebUILiteralControl_NoDiagnostic()
+        public async Task ParameterWithLocalizableAttribute_SpecialCases_SystemWebUILiteralControl_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.ComponentModel;
 using System.Web.UI;
 
@@ -1185,7 +1181,7 @@ public class Test
 }
 ");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.ComponentModel
 Imports System.Web.UI
 
@@ -1214,9 +1210,9 @@ End Class
         [InlineData("CollectionAssert")]
         [InlineData("StringAssert")]
         [Theory]
-        public void ParameterWithLocalizableAttribute_SpecialCases_UnitTestApis_NoDiagnostic(string assertClassName)
+        public async Task ParameterWithLocalizableAttribute_SpecialCases_UnitTestApis_NoDiagnostic(string assertClassName)
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 using System.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -1238,7 +1234,7 @@ public class Test
 }}
 ");
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 Imports System.ComponentModel
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 
@@ -1266,9 +1262,9 @@ End Class
         [InlineData("Text")]
         [InlineData("Caption")]
         [Theory]
-        public void ParameterWithLocalizableName_StringLiteralArgument_Method_Diagnostic(string parameterName)
+        public async Task ParameterWithLocalizableName_StringLiteralArgument_Method_Diagnostic(string parameterName)
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 public class C
 {{
     public void M(string {parameterName})
@@ -1288,7 +1284,7 @@ public class Test
             // Test0.cs(14,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(14, 13, "void Test.M1(C c)", parameterName, $"void C.M(string {parameterName})", "a"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 Public Class C
     Public Sub M({parameterName} As String)
     End Sub
@@ -1312,9 +1308,9 @@ End Class
         [InlineData("Text")]
         [InlineData("Caption")]
         [Theory]
-        public void PropertyWithLocalizableName_StringLiteralArgument_Diagnostic(string propertyName)
+        public async Task PropertyWithLocalizableName_StringLiteralArgument_Diagnostic(string propertyName)
         {
-            VerifyCSharp($@"
+            await VerifyCS.VerifyAnalyzerAsync($@"
 public class C
 {{
     public string {propertyName} {{ get; set; }}
@@ -1333,7 +1329,7 @@ public class Test
             // Test0.cs(12,9): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'value' of a call to 'void C.caption.set'. Retrieve the following string(s) from a resource table instead: "a".
             GetCSharpResultAt(12, 9, "void Test.M1(C c)", "value", $"void C.{propertyName}.set", "a"));
 
-            VerifyBasic($@"
+            await VerifyVB.VerifyAnalyzerAsync($@"
 Public Class C
     Public Property {propertyName} As String
 End Class
@@ -1351,9 +1347,9 @@ End Class
         }
 
         [Fact, WorkItem(1919, "https://github.com/dotnet/roslyn-analyzers/issues/1919")]
-        public void ShouldBeLocalizedRegressionTest()
+        public async Task ShouldBeLocalizedRegressionTest()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal static class Program
 {
     public static void Main()
@@ -1376,9 +1372,9 @@ internal static class Program
         }
 
         [Fact, WorkItem(1919, "https://github.com/dotnet/roslyn-analyzers/issues/1919")]
-        public void ShouldBeLocalizedRegressionTest_02()
+        public async Task ShouldBeLocalizedRegressionTest_02()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 internal static class Program
 {
     public static void Main()
@@ -1394,7 +1390,7 @@ internal static class Program
     {
         public override T Generic<T>(string text) => base.Generic<T>(text);
     }
-}", TestValidationMode.AllowCompileErrors,
+}",
             // Test0.cs(6,45): warning CA1303: Method 'void Program.Main()' passes a literal string as parameter 'text' of a call to 'decimal DerivedClass.Generic<decimal>(string text)'. Retrieve the following string(s) from a resource table instead: "number".
             GetCSharpResultAt(6, 45, "void Program.Main()", "text", "decimal DerivedClass.Generic<decimal>(string text)", "number"));
         }
@@ -1410,21 +1406,15 @@ internal static class Program
         [InlineData(@"dotnet_code_quality.excluded_symbol_names = M:C.M(System.String)|M:C.M2(System.String)")]
         // Match by type documentation ID with "T:" prefix
         [InlineData(@"dotnet_code_quality.excluded_symbol_names = T:C")]
-        public void ShouldBeLocalized_MethodExcludedByConfiguration_NoDiagnostic(string editorConfigText)
+        public async Task ShouldBeLocalized_MethodExcludedByConfiguration_NoDiagnostic(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (string.IsNullOrEmpty(editorConfigText))
+            var csharpTest = new VerifyCS.Test
             {
-                expected = new[]
+                TestState =
                 {
-                    // Test0.cs(20,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(20, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"),
-                    // Test0.cs(21,14): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M2(string param)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(21, 14, "void Test.M1(C c)", "param", "void C.M2(string param)", "a")
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                            @"
 using System.ComponentModel;
 
 public class C
@@ -1446,7 +1436,24 @@ public class Test
         c.M(str);
         c.M2(str);
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (string.IsNullOrEmpty(editorConfigText))
+            {
+                csharpTest.ExpectedDiagnostics.AddRange(new[]
+                {
+                    // Test0.cs(20,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(20, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a"),
+                    // Test0.cs(21,14): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M2(string param)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(21, 14, "void Test.M1(C c)", "param", "void C.M2(string param)", "a")
+                });
+            }
+
+            await csharpTest.RunAsync();
         }
 
         [Theory, WorkItem(2602, "https://github.com/dotnet/roslyn-analyzers/issues/2602")]
@@ -1464,19 +1471,15 @@ public class Test
         [InlineData(@"dotnet_code_quality.excluded_symbol_names = T:System.Exception")]
         // Match by namespace documentation ID with "N:" prefix
         [InlineData(@"dotnet_code_quality.excluded_symbol_names = N:System")]
-        public void ShouldBeLocalized_ConstructorExcludedByConfiguration_NoDiagnostic(string editorConfigText)
+        public async Task ShouldBeLocalized_ConstructorExcludedByConfiguration_NoDiagnostic(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (string.IsNullOrEmpty(editorConfigText))
+            var csharpTest = new VerifyCS.Test
             {
-                expected = new[]
+                TestState =
                 {
-                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", "Exception.Exception(string message)", "a")
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 using System;
 
 public class Test
@@ -1486,7 +1489,22 @@ public class Test
         var str = ""a"";
         var x = new Exception(str);
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (string.IsNullOrEmpty(editorConfigText))
+            {
+                csharpTest.ExpectedDiagnostics.AddRange(new[]
+                {
+                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", "Exception.Exception(string message)", "a")
+                });
+            }
+
+            await csharpTest.RunAsync();
         }
 
         [Theory, WorkItem(2602, "https://github.com/dotnet/roslyn-analyzers/issues/2602")]
@@ -1498,23 +1516,15 @@ public class Test
         [InlineData(@"dotnet_code_quality.excluded_type_names_with_derived_types = System.Exception")]
         // Match by type documentation ID with "T:" prefix
         [InlineData(@"dotnet_code_quality.excluded_type_names_with_derived_types = T:System.Exception")]
-        public void ShouldBeLocalized_SubTypesExcludedByConfiguration_NoDiagnostic(string editorConfigText)
+        public async Task ShouldBeLocalized_SubTypesExcludedByConfiguration_NoDiagnostic(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (string.IsNullOrEmpty(editorConfigText))
+            var csharpTest = new VerifyCS.Test
             {
-                expected = new[]
+                TestState =
                 {
-                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", "Exception.Exception(string message)", "a"),
-                    // Test0.cs(10,39): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'ArgumentException.ArgumentException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(10, 39, "void Test.M1()", "message", "ArgumentException.ArgumentException(string message)", "a"),
-                    // Test0.cs(11,47): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'InvalidOperationException.InvalidOperationException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(11, 47, "void Test.M1()", "message", "InvalidOperationException.InvalidOperationException(string message)", "a")
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 using System;
 
 public class Test
@@ -1526,7 +1536,26 @@ public class Test
         var y = new ArgumentException(str);
         var z = new InvalidOperationException(str);
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (string.IsNullOrEmpty(editorConfigText))
+            {
+                csharpTest.ExpectedDiagnostics.AddRange(new[]
+                {
+                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", "Exception.Exception(string message)", "a"),
+                    // Test0.cs(10,39): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'ArgumentException.ArgumentException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(10, 39, "void Test.M1()", "message", "ArgumentException.ArgumentException(string message)", "a"),
+                    // Test0.cs(11,47): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'InvalidOperationException.InvalidOperationException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(11, 47, "void Test.M1()", "message", "InvalidOperationException.InvalidOperationException(string message)", "a")
+                });
+            }
+
+            await csharpTest.RunAsync();
         }
 
         [Theory]
@@ -1534,23 +1563,15 @@ public class Test
         [InlineData("dotnet_code_quality.excluded_symbol_names = M1")]
         [InlineData("dotnet_code_quality." + DoNotPassLiteralsAsLocalizedParameters.RuleId + ".excluded_symbol_names = M1")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = M1")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (string.IsNullOrEmpty(editorConfigText))
+            var csharpTest = new VerifyCS.Test
             {
-                expected = new[]
+                TestState =
                 {
-                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", "Exception.Exception(string message)", "a"),
-                    // Test0.cs(10,39): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'ArgumentException.ArgumentException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(10, 39, "void Test.M1()", "message", "ArgumentException.ArgumentException(string message)", "a"),
-                    // Test0.cs(11,47): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'InvalidOperationException.InvalidOperationException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(11, 47, "void Test.M1()", "message", "InvalidOperationException.InvalidOperationException(string message)", "a")
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 using System;
 
 public class Test
@@ -1562,7 +1583,36 @@ public class Test
         var y = new ArgumentException(str);
         var z = new InvalidOperationException(str);
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (string.IsNullOrEmpty(editorConfigText))
+            {
+                csharpTest.ExpectedDiagnostics.AddRange(new[]
+                {
+                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", "Exception.Exception(string message)", "a"),
+                    // Test0.cs(10,39): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'ArgumentException.ArgumentException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(10, 39, "void Test.M1()", "message", "ArgumentException.ArgumentException(string message)", "a"),
+                    // Test0.cs(11,47): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'InvalidOperationException.InvalidOperationException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(11, 47, "void Test.M1()", "message", "InvalidOperationException.InvalidOperationException(string message)", "a")
+                });
+            }
+
+            await csharpTest.RunAsync();
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+           => VerifyCS.Diagnostic()
+               .WithLocation(line, column)
+               .WithArguments(arguments);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -1605,12 +1605,12 @@ public class Test
             await csharpTest.RunAsync();
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
            => VerifyCS.Diagnostic()
                .WithLocation(line, column)
                .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyTests.cs
@@ -1,26 +1,21 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyAnalyzer();
-        }
-
         [Fact]
-        public void CSharpCases()
+        public async Task CSharpCases()
         {
             var code = @"
 using System;
@@ -88,7 +83,7 @@ class C
 }
 ";
 
-            VerifyCSharp(code,
+            await VerifyCS.VerifyAnalyzerAsync(code,
                 GetCSharpResultAt(39, 13),
                 GetCSharpResultAt(40, 13),
                 GetCSharpResultAt(42, 13),
@@ -100,7 +95,7 @@ class C
         }
 
         [Fact]
-        public void BasicCases()
+        public async Task BasicCases()
         {
             var code = @"
 Imports System
@@ -182,7 +177,7 @@ Class C
     End Sub
 End Class
 ";
-            VerifyBasic(code,
+            await VerifyVB.VerifyAnalyzerAsync(code,
                 GetBasicResultAt(54, 13),
                 GetBasicResultAt(55, 13),
                 GetBasicResultAt(57, 13),
@@ -192,14 +187,12 @@ End Class
                 GetBasicResultAt(76, 13));
         }
 
-        private static DiagnosticResult GetCSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyMessage);
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
-        private static DiagnosticResult GetBasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyMessage);
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyTests.cs
@@ -187,11 +187,11 @@ End Class
                 GetBasicResultAt(76, 13));
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column)
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -1,31 +1,26 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.ProvideCorrectArgumentsToFormattingMethodsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.ProvideCorrectArgumentsToFormattingMethodsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class ProvideCorrectArgumentsToFormattingMethodsTests : DiagnosticAnalyzerTestBase
+    public class ProvideCorrectArgumentsToFormattingMethodsTests
     {
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new ProvideCorrectArgumentsToFormattingMethodsAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new ProvideCorrectArgumentsToFormattingMethodsAnalyzer();
-        }
-
         #region Diagnostic Tests
 
         [Fact]
-        public void CA2241CSharpString()
+        public async Task CA2241CSharpString()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -46,22 +41,22 @@ public class C
     }
 }
 ",
-            GetCA2241CSharpResultAt(8, 17),
-            GetCA2241CSharpResultAt(9, 17),
-            GetCA2241CSharpResultAt(10, 17),
-            GetCA2241CSharpResultAt(11, 17),
-            GetCA2241CSharpResultAt(12, 17),
+            GetCSharpResultAt(8, 17),
+            GetCSharpResultAt(9, 17),
+            GetCSharpResultAt(10, 17),
+            GetCSharpResultAt(11, 17),
+            GetCSharpResultAt(12, 17),
 
-            GetCA2241CSharpResultAt(15, 17),
-            GetCA2241CSharpResultAt(16, 17),
-            GetCA2241CSharpResultAt(17, 17),
-            GetCA2241CSharpResultAt(18, 17));
+            GetCSharpResultAt(15, 17),
+            GetCSharpResultAt(16, 17),
+            GetCSharpResultAt(17, 17),
+            GetCSharpResultAt(18, 17));
         }
 
         [Fact]
-        public void CA2241CSharpConsoleWrite()
+        public async Task CA2241CSharpConsoleWrite()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -76,17 +71,17 @@ public class C
     }
 }
 ",
-            GetCA2241CSharpResultAt(8, 9),
-            GetCA2241CSharpResultAt(9, 9),
-            GetCA2241CSharpResultAt(10, 9),
-            GetCA2241CSharpResultAt(11, 9),
-            GetCA2241CSharpResultAt(12, 9));
+            GetCSharpResultAt(8, 9),
+            GetCSharpResultAt(9, 9),
+            GetCSharpResultAt(10, 9),
+            GetCSharpResultAt(11, 9),
+            GetCSharpResultAt(12, 9));
         }
 
         [Fact]
-        public void CA2241CSharpConsoleWriteLine()
+        public async Task CA2241CSharpConsoleWriteLine()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -101,17 +96,17 @@ public class C
     }
 }
 ",
-            GetCA2241CSharpResultAt(8, 9),
-            GetCA2241CSharpResultAt(9, 9),
-            GetCA2241CSharpResultAt(10, 9),
-            GetCA2241CSharpResultAt(11, 9),
-            GetCA2241CSharpResultAt(12, 9));
+            GetCSharpResultAt(8, 9),
+            GetCSharpResultAt(9, 9),
+            GetCSharpResultAt(10, 9),
+            GetCSharpResultAt(11, 9),
+            GetCSharpResultAt(12, 9));
         }
 
         [Fact]
-        public void CA2241CSharpPassing()
+        public async Task CA2241CSharpPassing()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -143,9 +138,9 @@ public class C
         }
 
         [Fact]
-        public void CA2241CSharpExplicitObjectArraySupported()
+        public async Task CA2241CSharpExplicitObjectArraySupported()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -158,16 +153,16 @@ public class C
     }
 }
 ",
-            GetCA2241CSharpResultAt(8, 17),
-            GetCA2241CSharpResultAt(9, 9),
-            GetCA2241CSharpResultAt(10, 9));
+            GetCSharpResultAt(8, 17),
+            GetCSharpResultAt(9, 9),
+            GetCSharpResultAt(10, 9));
         }
 
         [Fact]
-        public void CA2241CSharpVarArgsNotSupported()
+        public async Task CA2241CSharpVarArgsNotSupported()
         {
             // currently not supported due to "https://github.com/dotnet/roslyn/issues/7346"
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -182,9 +177,9 @@ public class C
         }
 
         [Fact]
-        public void CA2241VBString()
+        public async Task CA2241VBString()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -202,26 +197,26 @@ Public Class C
     End Sub
 End Class
 ",
-            GetCA2241BasicResultAt(6, 17),
-            GetCA2241BasicResultAt(7, 17),
-            GetCA2241BasicResultAt(8, 17),
-            GetCA2241BasicResultAt(9, 17),
+            GetBasicResultAt(6, 17),
+            GetBasicResultAt(7, 17),
+            GetBasicResultAt(8, 17),
+            GetBasicResultAt(9, 17),
 
-            GetCA2241BasicResultAt(12, 17),
-            GetCA2241BasicResultAt(13, 17),
-            GetCA2241BasicResultAt(14, 17),
-            GetCA2241BasicResultAt(15, 17));
+            GetBasicResultAt(12, 17),
+            GetBasicResultAt(13, 17),
+            GetBasicResultAt(14, 17),
+            GetBasicResultAt(15, 17));
         }
 
         [Fact]
-        public void CA2241VBConsoleWrite()
+        public async Task CA2241VBConsoleWrite()
         {
             // this works in VB
             // Dim s = Console.WriteLine(""{0} {1} {2}"", 1, 2, 3, 4)
             // since VB bind it to __arglist version where we skip analysis
             // due to a bug - https://github.com/dotnet/roslyn/issues/7346
             // we might skip it only in C# since VB doesnt support __arglist
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -234,21 +229,21 @@ Public Class C
     End Sub
 End Class
 ",
-            GetCA2241BasicResultAt(6, 9),
-            GetCA2241BasicResultAt(7, 9),
-            GetCA2241BasicResultAt(8, 9),
-            GetCA2241BasicResultAt(10, 9));
+            GetBasicResultAt(6, 9),
+            GetBasicResultAt(7, 9),
+            GetBasicResultAt(8, 9),
+            GetBasicResultAt(10, 9));
         }
 
         [Fact]
-        public void CA2241VBConsoleWriteLine()
+        public async Task CA2241VBConsoleWriteLine()
         {
             // this works in VB
             // Dim s = Console.WriteLine(""{0} {1} {2}"", 1, 2, 3, 4)
             // since VB bind it to __arglist version where we skip analysis
             // due to a bug - https://github.com/dotnet/roslyn/issues/7346
             // we might skip it only in C# since VB doesnt support __arglist
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -261,16 +256,16 @@ Public Class C
     End Sub
 End Class
 ",
-            GetCA2241BasicResultAt(6, 9),
-            GetCA2241BasicResultAt(7, 9),
-            GetCA2241BasicResultAt(8, 9),
-            GetCA2241BasicResultAt(10, 9));
+            GetBasicResultAt(6, 9),
+            GetBasicResultAt(7, 9),
+            GetBasicResultAt(8, 9),
+            GetBasicResultAt(10, 9));
         }
 
         [Fact]
-        public void CA2241VBPassing()
+        public async Task CA2241VBPassing()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -297,9 +292,9 @@ End Class
         }
 
         [Fact]
-        public void CA2241VBExplicitObjectArraySupported()
+        public async Task CA2241VBExplicitObjectArraySupported()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class C
@@ -310,15 +305,15 @@ Public Class C
     End Sub
 End Class
 ",
-            GetCA2241BasicResultAt(6, 17),
-            GetCA2241BasicResultAt(7, 9),
-            GetCA2241BasicResultAt(8, 9));
+            GetBasicResultAt(6, 17),
+            GetBasicResultAt(7, 9),
+            GetBasicResultAt(8, 9));
         }
 
         [Fact]
-        public void CA2241CSharpFormatStringParser()
+        public async Task CA2241CSharpFormatStringParser()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class C
@@ -352,19 +347,15 @@ public class C
         [InlineData("dotnet_code_quality.additional_string_formatting_methods = Test.MyFormat(System.String,System.Object[])~System.String")]
         // Match by documentation ID with "M:" prefix
         [InlineData("dotnet_code_quality.additional_string_formatting_methods = M:Test.MyFormat(System.String,System.Object[])~System.String")]
-        public void EditorConfigConfiguration_AdditionalStringFormattingMethods(string editorConfigText)
+        public async Task EditorConfigConfiguration_AdditionalStringFormattingMethods(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (editorConfigText.Length > 0)
+            var csharpTest = new VerifyCS.Test
             {
-                expected = new DiagnosticResult[]
+                TestState =
                 {
-                    // Test0.cs(8,17): warning CA2241: Provide correct arguments to formatting methods
-                    GetCA2241CSharpResultAt(8, 17)
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 class Test
 {
     public static string MyFormat(string format, params object[] args) => format;
@@ -373,19 +364,29 @@ class Test
     {
         var a = MyFormat("""", 1);
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
 
-            expected = Array.Empty<DiagnosticResult>();
+
             if (editorConfigText.Length > 0)
             {
-                expected = new DiagnosticResult[]
-                {
-                    // Test0.vb(8,17): warning CA2241: Provide correct arguments to formatting methods
-                    GetCA2241BasicResultAt(8, 17)
-                };
+                csharpTest.ExpectedDiagnostics.Add(
+                    // Test0.cs(8,17): warning CA2241: Provide correct arguments to formatting methods
+                    GetCSharpResultAt(8, 17));
             }
 
-            VerifyBasic(@"
+            await csharpTest.RunAsync();
+
+            var basicTest = new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 Class Test
     Public Shared Function MyFormat(format As String, ParamArray args As Object()) As String
         Return format
@@ -394,19 +395,31 @@ Class Test
     Private Sub M1(ByVal param As String)
         Dim a = MyFormat("""", 1)
     End Sub
-End Class", GetEditorConfigAdditionalFile(editorConfigText), expected);
+End Class"
+},
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+
+            if (editorConfigText.Length > 0)
+            {
+                basicTest.ExpectedDiagnostics.Add(
+                    // Test0.vb(8,17): warning CA2241: Provide correct arguments to formatting methods
+                    GetBasicResultAt(8, 17));
+            }
+
+            await basicTest.RunAsync();
         }
 
         #endregion
 
-        private static DiagnosticResult GetCA2241CSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, ProvideCorrectArgumentsToFormattingMethodsAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.ProvideCorrectArgumentsToFormattingMethodsMessage);
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
-        private static DiagnosticResult GetCA2241BasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, ProvideCorrectArgumentsToFormattingMethodsAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.ProvideCorrectArgumentsToFormattingMethodsMessage);
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -414,11 +414,11 @@ End Class"
 
         #endregion
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column)
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyCultureInfoTests.cs
@@ -653,12 +653,12 @@ Public Class DerivedCultureInfo
 End Class");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2, string arg3) =>
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2, string arg3) =>
             new DiagnosticResult(rule)
                 .WithLocation(line, column)
                 .WithArguments(arg1, arg2, arg3);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2, string arg3) =>
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, string arg1, string arg2, string arg3) =>
             new DiagnosticResult(rule)
                 .WithLocation(line, column)
                 .WithArguments(arg1, arg2, arg3);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyStringComparisonTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/SpecifyStringComparisonTests.cs
@@ -324,14 +324,14 @@ GetCA1307BasicResultsAt(7, 9, "StringComparisonTests.DoNothing(String)",
                               "StringComparisonTests.DoNothing(Of T)(String, System.StringComparison)"));
         }
 
-        private DiagnosticResult GetCA1307CSharpResultsAt(int line, int column, string arg1, string arg2, string arg3)
+        private static DiagnosticResult GetCA1307CSharpResultsAt(int line, int column, string arg1, string arg2, string arg3)
         {
             return new DiagnosticResult(SpecifyStringComparisonAnalyzer.Rule)
                 .WithLocation(line, column)
                 .WithArguments(arg1, arg2, arg3);
         }
 
-        private DiagnosticResult GetCA1307BasicResultsAt(int line, int column, string arg1, string arg2, string arg3)
+        private static DiagnosticResult GetCA1307BasicResultsAt(int line, int column, string arg1, string arg2, string arg3)
         {
             return new DiagnosticResult(SpecifyStringComparisonAnalyzer.Rule)
                 .WithLocation(line, column)

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForEmptyStringsUsingStringLengthTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForEmptyStringsUsingStringLengthTests.cs
@@ -1,39 +1,30 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.TestForEmptyStringsUsingStringLengthAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class TestForEmptyStringsUsingStringLengthTests : DiagnosticAnalyzerTestBase
+    public class TestForEmptyStringsUsingStringLengthTests
     {
         #region Helper methods
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new TestForEmptyStringsUsingStringLengthAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return null;
-        }
-
-        private static DiagnosticResult CSharpResult(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, TestForEmptyStringsUsingStringLengthAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.TestForEmptyStringsUsingStringLengthMessage);
-        }
+        private DiagnosticResult CSharpResult(int line, int column)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
         #endregion
 
-        #region Diagnostic tests 
+        #region Diagnostic tests
 
         [Fact]
-        public void CA1820StaticEqualsTestCSharp()
+        public async Task CA1820StaticEqualsTestCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class C
@@ -63,9 +54,9 @@ class C
         }
 
         [Fact]
-        public void CA1820InstanceEqualsTestCSharp()
+        public async Task CA1820InstanceEqualsTestCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class C
@@ -91,9 +82,9 @@ class C
         }
 
         [Fact]
-        public void CA1820OperatorOverloadTestCSharp()
+        public async Task CA1820OperatorOverloadTestCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class C

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.cs
@@ -250,7 +250,8 @@ public class A
     }
 }
 ";
-            await VerifyCS.VerifyAnalyzerAsync(code);
+            await VerifyCS.VerifyAnalyzerAsync(code,
+                DiagnosticResult.CompilerError("CS0117").WithLocation(6, 27).WithMessage("'float' does not contain a definition for 'NbN'"));
         }
 
         [Fact]
@@ -263,7 +264,8 @@ Public Class A
     End Function
 End Class
 ";
-            await VerifyVB.VerifyAnalyzerAsync(code);
+            await VerifyVB.VerifyAnalyzerAsync(code,
+                DiagnosticResult.CompilerError("BC30456").WithLocation(4, 27).WithMessage("'NbN' is not a member of 'Single'."));
         }
 
         [Fact]

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.cs
@@ -1,16 +1,21 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.TestForNaNCorrectlyAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.TestForNaNCorrectlyAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class TestForNaNCorrectlyTests : DiagnosticAnalyzerTestBase
+    public class TestForNaNCorrectlyTests
     {
         [Fact]
-        public void CSharpDiagnosticForEqualityWithFloatNaN()
+        public async Task CSharpDiagnosticForEqualityWithFloatNaN()
         {
             var code = @"
 public class A
@@ -21,11 +26,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(6, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(6, 16));
         }
 
         [Fact]
-        public void BasicDiagnosticForEqualityWithFloatNaN()
+        public async Task BasicDiagnosticForEqualityWithFloatNaN()
         {
             var code = @"
 Public Class A
@@ -34,11 +39,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(4, 16));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(4, 16));
         }
 
         [Fact]
-        public void CSharpDiagnosticForInequalityWithFloatNaN()
+        public async Task CSharpDiagnosticForInequalityWithFloatNaN()
         {
             var code = @"
 public class A
@@ -49,11 +54,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(6, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(6, 16));
         }
 
         [Fact]
-        public void BasicDiagnosticForInEqualityWithFloatNaN()
+        public async Task BasicDiagnosticForInEqualityWithFloatNaN()
         {
             var code = @"
 Public Class A
@@ -62,11 +67,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(4, 16));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(4, 16));
         }
 
         [Fact]
-        public void CSharpDiagnosticForGreaterThanFloatNaN()
+        public async Task CSharpDiagnosticForGreaterThanFloatNaN()
         {
             var code = @"
 public class A
@@ -77,11 +82,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(6, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(6, 16));
         }
 
         [Fact]
-        public void BasicDiagnosticForGreaterThanFloatNaN()
+        public async Task BasicDiagnosticForGreaterThanFloatNaN()
         {
             var code = @"
 Public Class A
@@ -90,11 +95,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(4, 16));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(4, 16));
         }
 
         [Fact]
-        public void CSharpDiagnosticForGreaterThanOrEqualToFloatNaN()
+        public async Task CSharpDiagnosticForGreaterThanOrEqualToFloatNaN()
         {
             var code = @"
 public class A
@@ -105,11 +110,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(6, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(6, 16));
         }
 
         [Fact]
-        public void BasicDiagnosticForGreaterThanOrEqualToFloatNaN()
+        public async Task BasicDiagnosticForGreaterThanOrEqualToFloatNaN()
         {
             var code = @"
 Public Class A
@@ -118,11 +123,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(4, 16));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(4, 16));
         }
 
         [Fact]
-        public void CSharpDiagnosticForLessThanFloatNaN()
+        public async Task CSharpDiagnosticForLessThanFloatNaN()
         {
             var code = @"
 public class A
@@ -133,11 +138,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(6, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(6, 16));
         }
 
         [Fact]
-        public void BasicDiagnosticForLessThanFloatNaN()
+        public async Task BasicDiagnosticForLessThanFloatNaN()
         {
             var code = @"
 Public Class A
@@ -146,11 +151,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(4, 16));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(4, 16));
         }
 
         [Fact]
-        public void CSharpDiagnosticForLessThanOrEqualToFloatNaN()
+        public async Task CSharpDiagnosticForLessThanOrEqualToFloatNaN()
         {
             var code = @"
 public class A
@@ -161,11 +166,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(6, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(6, 16));
         }
 
         [Fact]
-        public void BasicDiagnosticForLessThanOrEqualToFloatNaN()
+        public async Task BasicDiagnosticForLessThanOrEqualToFloatNaN()
         {
             var code = @"
 Public Class A
@@ -174,11 +179,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(4, 16));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(4, 16));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithDoubleNaN()
+        public async Task CSharpDiagnosticForComparisonWithDoubleNaN()
         {
             var code = @"
 public class A
@@ -189,11 +194,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(6, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(6, 16));
         }
 
         [Fact]
-        public void BasicDiagnosticForComparisonWithDoubleNaN()
+        public async Task BasicDiagnosticForComparisonWithDoubleNaN()
         {
             var code = @"
 Public Class A
@@ -202,11 +207,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(4, 16));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(4, 16));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNOnLeft()
+        public async Task CSharpDiagnosticForComparisonWithNaNOnLeft()
         {
             var code = @"
 public class A
@@ -217,11 +222,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(6, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(6, 16));
         }
 
         [Fact]
-        public void BasicDiagnosticForComparisonWithNaNOnLeft()
+        public async Task BasicDiagnosticForComparisonWithNaNOnLeft()
         {
             var code = @"
 Public Class A
@@ -230,11 +235,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(4, 16));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(4, 16));
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForComparisonWithBadExpression()
+        public async Task CSharpNoDiagnosticForComparisonWithBadExpression()
         {
             var code = @"
 public class A
@@ -245,11 +250,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, TestValidationMode.AllowCompileErrors);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticForComparisonWithBadExpression()
+        public async Task BasicNoDiagnosticForComparisonWithBadExpression()
         {
             var code = @"
 Public Class A
@@ -258,11 +263,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, TestValidationMode.AllowCompileErrors);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForComparisonWithFunctionReturningNaN()
+        public async Task CSharpNoDiagnosticForComparisonWithFunctionReturningNaN()
         {
             var code = @"
 public class A
@@ -278,11 +283,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticForComparisonWithFunctionReturningNaN()
+        public async Task BasicNoDiagnosticForComparisonWithFunctionReturningNaN()
         {
             var code = @"
 Public Class A
@@ -295,11 +300,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForEqualityWithNonNaN()
+        public async Task CSharpNoDiagnosticForEqualityWithNonNaN()
         {
             var code = @"
 public class A
@@ -310,11 +315,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticForEqualityWithNonNaN()
+        public async Task BasicNoDiagnosticForEqualityWithNonNaN()
         {
             var code = @"
 Public Class A
@@ -323,11 +328,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpNoDiagnosticForNonComparisonOperationWithNaN()
+        public async Task CSharpNoDiagnosticForNonComparisonOperationWithNaN()
         {
             var code = @"
 public class A
@@ -338,11 +343,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code);
+            await VerifyCS.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void BasicNoDiagnosticForNonComparisonOperationWithNonNaN()
+        public async Task BasicNoDiagnosticForNonComparisonOperationWithNonNaN()
         {
             var code = @"
 Public Class A
@@ -351,11 +356,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code);
+            await VerifyVB.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public void CSharpOnlyOneDiagnosticForComparisonWithNaNOnBothSides()
+        public async Task CSharpOnlyOneDiagnosticForComparisonWithNaNOnBothSides()
         {
             var code = @"
 public class A
@@ -366,11 +371,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(6, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(6, 16));
         }
 
         [Fact]
-        public void BasicOnlyOneDiagnosticForComparisonWithNonNaNOnBothSides()
+        public async Task BasicOnlyOneDiagnosticForComparisonWithNonNaNOnBothSides()
         {
             var code = @"
 Public Class A
@@ -379,7 +384,7 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(4, 16));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(4, 16));
         }
 
         // At @srivatsn's suggestion, here are a few tests that verify that the operation
@@ -390,7 +395,7 @@ End Class
         // than they are about the correctness of our treatment of these expressions once
         // we find them.
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNInFunctionArgument()
+        public async Task CSharpDiagnosticForComparisonWithNaNInFunctionArgument()
         {
             var code = @"
 public class A
@@ -405,11 +410,11 @@ public class A
     public void G(bool comparison) {}
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(8, 11));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(8, 11));
         }
 
         [Fact]
-        public void BasicDiagnosticForComparisonWithNaNInFunctionArgument()
+        public async Task BasicDiagnosticForComparisonWithNaNInFunctionArgument()
         {
             var code = @"
 Public Class A
@@ -423,11 +428,11 @@ Public Class A
     End Sub
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(6, 11));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(6, 11));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNInTernaryOperator()
+        public async Task CSharpDiagnosticForComparisonWithNaNInTernaryOperator()
         {
             var code = @"
 public class A
@@ -440,11 +445,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(8, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(8, 16));
         }
 
         [Fact]
-        public void BasicDiagnosticForComparisonWithNaNInIfOperator()
+        public async Task BasicDiagnosticForComparisonWithNaNInIfOperator()
         {
             // VB doesn't have the ternary operator, but we add this test for symmetry.
             var code = @"
@@ -456,11 +461,11 @@ Public Class A
     End Function
 End Class
 ";
-            VerifyBasic(code, GetBasicResultAt(6, 19));
+            await VerifyVB.VerifyAnalyzerAsync(code, GetBasicResultAt(6, 19));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNInThrowStatement()
+        public async Task CSharpDiagnosticForComparisonWithNaNInThrowStatement()
         {
             var code = @"
 public class A
@@ -473,11 +478,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(8, 15));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(8, 15));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNInCatchFilterClause()
+        public async Task CSharpDiagnosticForComparisonWithNaNInCatchFilterClause()
         {
             var code = @"
 using System;
@@ -497,11 +502,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(13, 36));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(13, 36));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNInYieldReturnStatement()
+        public async Task CSharpDiagnosticForComparisonWithNaNInYieldReturnStatement()
         {
             var code = @"
 using System.Collections.Generic;
@@ -516,11 +521,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(10, 22));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(10, 22));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNInSwitchStatement()
+        public async Task CSharpDiagnosticForComparisonWithNaNInSwitchStatement()
         {
             var code = @"
 public class A
@@ -537,11 +542,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(8, 17));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(8, 17));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNInForLoop()
+        public async Task CSharpDiagnosticForComparisonWithNaNInForLoop()
         {
             var code = @"
 public class A
@@ -557,11 +562,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(8, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(8, 16));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNInWhileLoop()
+        public async Task CSharpDiagnosticForComparisonWithNaNInWhileLoop()
         {
             var code = @"
 public class A
@@ -576,11 +581,11 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(8, 16));
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(8, 16));
         }
 
         [Fact]
-        public void CSharpDiagnosticForComparisonWithNaNInDoWhileLoop()
+        public async Task CSharpDiagnosticForComparisonWithNaNInDoWhileLoop()
         {
             var code = @"
 public class A
@@ -596,27 +601,15 @@ public class A
     }
 }
 ";
-            VerifyCSharp(code, GetCSharpResultAt(11, 16));
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new TestForNaNCorrectlyAnalyzer();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new TestForNaNCorrectlyAnalyzer();
+            await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(11, 16));
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, TestForNaNCorrectlyAnalyzer.Rule);
-        }
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
         private DiagnosticResult GetBasicResultAt(int line, int column)
-        {
-            return GetBasicResultAt(line, column, TestForNaNCorrectlyAnalyzer.Rule);
-        }
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/TestForNaNCorrectlyTests.cs
@@ -606,11 +606,11 @@ public class A
             await VerifyCS.VerifyAnalyzerAsync(code, GetCSharpResultAt(11, 16));
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column)
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/UseOrdinalStringComparisonTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Runtime/UseOrdinalStringComparisonTests.cs
@@ -1,46 +1,37 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.NetCore.CSharp.Analyzers.Runtime;
-using Microsoft.NetCore.VisualBasic.Analyzers.Runtime;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpUseOrdinalStringComparisonAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicUseOrdinalStringComparisonAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public class UseOrdinalStringComparisonTests : DiagnosticAnalyzerTestBase
+    public class UseOrdinalStringComparisonTests
     {
         #region Helper methods
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new CSharpUseOrdinalStringComparisonAnalyzer();
-        }
+        private DiagnosticResult CSharpResult(int line, int column)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new BasicUseOrdinalStringComparisonAnalyzer();
-        }
-
-        private static DiagnosticResult CSharpResult(int line, int column)
-        {
-            return GetCSharpResultAt(line, column, UseOrdinalStringComparisonAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.UseOrdinalStringComparisonTitle);
-        }
-
-        private static DiagnosticResult BasicResult(int line, int column)
-        {
-            return GetBasicResultAt(line, column, UseOrdinalStringComparisonAnalyzer.RuleId, MicrosoftNetCoreAnalyzersResources.UseOrdinalStringComparisonTitle);
-        }
+        private DiagnosticResult BasicResult(int line, int column)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
 
         #endregion
 
-        #region Diagnostic tests 
+        #region Diagnostic tests
 
         [Fact]
-        public void CA1309CompareOverloadTestCSharp()
+        public async Task CA1309CompareOverloadTestCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
 
@@ -84,9 +75,9 @@ class C
         }
 
         [Fact]
-        public void CA1309CompareOverloadTestBasic()
+        public async Task CA1309CompareOverloadTestBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Globalization
 
@@ -131,9 +122,9 @@ End Class
         }
 
         [Fact]
-        public void CA1309EqualsOverloadTestCSharp()
+        public async Task CA1309EqualsOverloadTestCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class C
@@ -157,9 +148,9 @@ class C
         }
 
         [Fact]
-        public void CA1309EqualsOverloadTestBasic()
+        public async Task CA1309EqualsOverloadTestBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class C
@@ -181,9 +172,9 @@ End Class
         }
 
         [Fact]
-        public void CA1309InstanceEqualsTestCSharp()
+        public async Task CA1309InstanceEqualsTestCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class C
@@ -207,9 +198,9 @@ class C
         }
 
         [Fact]
-        public void CA1309InstanceEqualsTestBasic()
+        public async Task CA1309InstanceEqualsTestBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class C
@@ -231,9 +222,9 @@ End Class
         }
 
         [Fact]
-        public void CA1309OperatorOverloadTestCSharp_NoDiagnostic()
+        public async Task CA1309OperatorOverloadTestCSharp_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class C
@@ -251,9 +242,9 @@ class C
         }
 
         [Fact]
-        public void CA1309OperatorOverloadTestBasic_NoDiagnostic()
+        public async Task CA1309OperatorOverloadTestBasic_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Class C
@@ -275,9 +266,9 @@ End Class
         }
 
         [Fact]
-        public void CA1309NotReallyCompareOrEqualsTestCSharp()
+        public async Task CA1309NotReallyCompareOrEqualsTestCSharp()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 class C
 {
     void Method()
@@ -305,9 +296,9 @@ static class Extensions
         }
 
         [Fact]
-        public void CA1309NotReallyCompareOrEqualsTestBasic()
+        public async Task CA1309NotReallyCompareOrEqualsTestBasic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Runtime.CompilerServices
 
 Class C

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ApprovedCipherModeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ApprovedCipherModeTests.cs
@@ -1,17 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.ApprovedCipherModeAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.ApprovedCipherModeAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class ApprovedCipherModeTests : DiagnosticAnalyzerTestBase
+    public class ApprovedCipherModeTests
     {
         [Fact]
-        public void TestECBMode()
+        public async Task TestECBMode()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -22,9 +28,9 @@ class TestClass {
         rijn.Mode  = CipherMode.ECB;
     }
 }",
-            GetCSharpResultAt(9, 22, ApprovedCipherModeAnalyzer.Rule, "ECB"));
+            GetCSharpResultAt(9, 22, "ECB"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Public Module SecurityCenter
@@ -33,13 +39,13 @@ Public Module SecurityCenter
         encripter.Mode = CipherMode.ECB
     End Sub
 End Module",
-            GetBasicResultAt(7, 26, ApprovedCipherModeAnalyzer.Rule, "ECB"));
+            GetBasicResultAt(7, 26, "ECB"));
         }
 
         [Fact]
-        public void TestOFBMode()
+        public async Task TestOFBMode()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -50,9 +56,9 @@ class TestClass {
         rijn.Mode  = CipherMode.OFB;
     }
 }",
-            GetCSharpResultAt(9, 22, ApprovedCipherModeAnalyzer.Rule, "OFB"));
+            GetCSharpResultAt(9, 22, "OFB"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Public Module SecurityCenter
@@ -61,13 +67,13 @@ Public Module SecurityCenter
         encripter.Mode = CipherMode.OFB
     End Sub
 End Module",
-            GetBasicResultAt(7, 26, ApprovedCipherModeAnalyzer.Rule, "OFB"));
+            GetBasicResultAt(7, 26, "OFB"));
         }
 
         [Fact]
-        public void TestCFBMode()
+        public async Task TestCFBMode()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -78,9 +84,9 @@ class TestClass {
         rijn.Mode  = CipherMode.CFB;;
     }
 }",
-            GetCSharpResultAt(9, 22, ApprovedCipherModeAnalyzer.Rule, "CFB"));
+            GetCSharpResultAt(9, 22, "CFB"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Public Module SecurityCenter
@@ -89,13 +95,13 @@ Public Module SecurityCenter
         encripter.Mode = CipherMode.CFB
     End Sub
 End Module",
-            GetBasicResultAt(7, 26, ApprovedCipherModeAnalyzer.Rule, "CFB"));
+            GetBasicResultAt(7, 26, "CFB"));
         }
 
         [Fact]
-        public void TestCBCMode()
+        public async Task TestCBCMode()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -108,7 +114,7 @@ class TestClass {
 }"
             );
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Public Module SecurityCenter
@@ -121,9 +127,9 @@ End Module"
         }
 
         [Fact]
-        public void TestCTSMode()
+        public async Task TestCTSMode()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -136,7 +142,7 @@ class TestClass {
 }"
             );
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Public Module SecurityCenter
@@ -148,14 +154,14 @@ End Module"
             );
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new ApprovedCipherModeAnalyzer();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new ApprovedCipherModeAnalyzer();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ApprovedCipherModeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/ApprovedCipherModeTests.cs
@@ -154,12 +154,12 @@ End Module"
             );
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotAddSchemaByURLTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotAddSchemaByURLTests.cs
@@ -128,11 +128,11 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column)
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotAddSchemaByURLTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotAddSchemaByURLTests.cs
@@ -1,22 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotAddSchemaByURL,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotAddSchemaByURL,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotAddSchemaByURLTests : DiagnosticAnalyzerTestBase
+    public class DoNotAddSchemaByURLTests
     {
         [Fact]
-        public void TestAddWithStringStringParametersDiagnostic()
+        public async Task TestAddWithStringStringParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml.Schema;
 
@@ -28,9 +29,9 @@ class TestClass
         xsc.Add(""urn: bookstore - schema"", ""books.xsd"");
     }
 }",
-            GetCSharpResultAt(10, 9, DoNotAddSchemaByURL.Rule));
+            GetCSharpResultAt(10, 9));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Xml.Schema
 
@@ -40,13 +41,13 @@ class TestClass
         xsc.Add(""urn: bookstore - schema"", ""books.xsd"")
     End Sub
 End Class",
-            GetBasicResultAt(8, 9, DoNotAddSchemaByURL.Rule));
+            GetBasicResultAt(8, 9));
         }
 
         [Fact]
-        public void TestAddWithNullStringParametersDiagnostic()
+        public async Task TestAddWithNullStringParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml.Schema;
 
@@ -58,9 +59,9 @@ class TestClass
         xsc.Add(null, ""books.xsd"");
     }
 }",
-            GetCSharpResultAt(10, 9, DoNotAddSchemaByURL.Rule));
+            GetCSharpResultAt(10, 9));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Xml.Schema
 
@@ -70,13 +71,13 @@ class TestClass
         xsc.Add(Nothing, ""books.xsd"")
     End Sub
 End Class",
-            GetBasicResultAt(8, 9, DoNotAddSchemaByURL.Rule));
+            GetBasicResultAt(8, 9));
         }
 
         [Fact]
-        public void TestAddWithXmlSchemaCollectionParameterNoDiagnostic()
+        public async Task TestAddWithXmlSchemaCollectionParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml.Schema;
 
@@ -91,9 +92,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestAddWithXmlSchemaParameterNoDiagnostic()
+        public async Task TestAddWithXmlSchemaParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml.Schema;
 
@@ -108,9 +109,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestNormalAddMethodNoDiagnostic()
+        public async Task TestNormalAddMethodNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml.Schema;
 
@@ -127,14 +128,12 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotAddSchemaByURL();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotAddSchemaByURL();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
@@ -2499,12 +2499,12 @@ public class TestClass : IDisposable
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
@@ -1327,7 +1327,7 @@ public class TestGenericClass<T>
 {
     private T memberInGeneric;
 
-    public async Task TestGenericMethod()
+    public void TestGenericMethod()
     {
         var path = ""C:\\"";
         var bytes = new byte[] {0x20, 0x20, 0x20};
@@ -1366,7 +1366,7 @@ interface TestInterface
 [Serializable()]
 public class TestInterfaceImplement : TestInterface
 {
-    public async Task TestInterfaceMethod()
+    public void TestInterfaceMethod()
     {
         var path = ""C:\\"";
         var bytes = new byte[] {0x20, 0x20, 0x20};
@@ -2347,7 +2347,7 @@ public class TestGenericClass<T>
 {
     private T memberInGeneric;
 
-    public async Task TestGenericMethod()
+    public void TestGenericMethod()
     {
     }
 }
@@ -2401,7 +2401,7 @@ interface TestInterface
 [Serializable()]
 public class TestInterfaceImplement : TestInterface
 {
-    public async Task TestInterfaceMethod()
+    public void TestInterfaceMethod()
     {
         var path = ""C:\\"";
         var bytes = new byte[] {0x20, 0x20, 0x20};

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
@@ -1,17 +1,23 @@
 ﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotCallDangerousMethodsInDeserialization,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotCallDangerousMethodsInDeserialization,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotCallDangerousMethodsInDeserializationTests : DiagnosticAnalyzerTestBase
+    public class DoNotCallDangerousMethodsInDeserializationTests
     {
         [Fact]
-        public void TestOnDeserializingDiagnostic()
+        public async Task TestOnDeserializingDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -28,9 +34,9 @@ public class TestClass
         File.WriteAllBytes(""C:\\"", bytes);
     }
 }",
-            GetCSharpResultAt(12, 19, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializingMethod", "WriteAllBytes"));
+            GetCSharpResultAt(12, 19, "TestClass", "OnDeserializingMethod", "WriteAllBytes"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -47,13 +53,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 13, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializingMethod", "WriteAllBytes"));
+            GetBasicResultAt(12, 13, "TestClass", "OnDeserializingMethod", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestOnDeserializedDiagnostic()
+        public async Task TestOnDeserializedDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -70,9 +76,9 @@ public class TestClass
         File.WriteAllBytes(""C:\\"", bytes);
     }
 }",
-            GetCSharpResultAt(12, 19, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
+            GetCSharpResultAt(12, 19, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -89,13 +95,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 13, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
+            GetBasicResultAt(12, 13, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestOnMultiAttributesDiagnostic()
+        public async Task TestOnMultiAttributesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -113,9 +119,9 @@ public class TestClass
         File.WriteAllBytes(""C:\\"", bytes);
     }
 }",
-            GetCSharpResultAt(13, 19, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
+            GetCSharpResultAt(13, 19, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -133,13 +139,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 13, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
+            GetBasicResultAt(13, 13, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestOnDeserializedMediateInvocationDiagnostic()
+        public async Task TestOnDeserializedMediateInvocationDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -157,16 +163,16 @@ public class TestClass
         byte[] bytes = new byte[] {0x20, 0x20, 0x20};
         File.WriteAllBytes(""C:\\"", bytes);
     }
-    
+
     private void TestMethod()
     {
         byte[] bytes = new byte[] {0x20, 0x20, 0x20};
         File.WriteAllBytes(""C:\\"", bytes);
     }
 }",
-            GetCSharpResultAt(12, 19, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
+            GetCSharpResultAt(12, 19, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -189,13 +195,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 13, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
+            GetBasicResultAt(12, 13, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestOnDeserializedMultiMediateInvocationsDiagnostic()
+        public async Task TestOnDeserializedMultiMediateInvocationsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -225,9 +231,9 @@ public class TestClass
         }
     }
 }",
-            GetCSharpResultAt(12, 19, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
+            GetCSharpResultAt(12, 19, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -255,13 +261,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 13, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
+            GetBasicResultAt(12, 13, "TestClass", "OnDeserializedMethod", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestOnDeserializationImplicitlyDiagnostic()
+        public async Task TestOnDeserializationImplicitlyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -280,13 +286,13 @@ public class TestClass : IDeserializationCallback
         File.WriteAllBytes(path, bytes);
     }
 }",
-            GetCSharpResultAt(13, 17, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "WriteAllBytes"));
+            GetCSharpResultAt(13, 17, "TestClass", "OnDeserialization", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestOnDeserializationWriteAllBytesDiagnostic()
+        public async Task TestOnDeserializationWriteAllBytesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -305,9 +311,9 @@ public class TestClass : IDeserializationCallback
         File.WriteAllBytes(path, bytes);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -324,13 +330,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserializationExplictlyImplemented", "WriteAllBytes"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserializationExplictlyImplemented", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestOnDeserializationWriteAllLinesDiagnostic()
+        public async Task TestOnDeserializationWriteAllLinesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -349,9 +355,9 @@ public class TestClass : IDeserializationCallback
         File.WriteAllLines(path, strings, Encoding.ASCII);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllLines"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllLines"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -371,13 +377,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "WriteAllLines"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "WriteAllLines"));
         }
 
         [Fact]
-        public void TestOnDeserializationWriteAllTextDiagnostic()
+        public async Task TestOnDeserializationWriteAllTextDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -396,9 +402,9 @@ public class TestClass : IDeserializationCallback
         File.WriteAllText(path, contents);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllText"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllText"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -418,13 +424,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "WriteAllText"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "WriteAllText"));
         }
 
         [Fact]
-        public void TestOnDeserializationCopyDiagnostic()
+        public async Task TestOnDeserializationCopyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -443,9 +449,9 @@ public class TestClass : IDeserializationCallback
         File.Copy(sourceFileName, destFileName);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Copy"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Copy"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -465,13 +471,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "Copy"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "Copy"));
         }
 
         [Fact]
-        public void TestOnDeserializationMoveDiagnostic()
+        public async Task TestOnDeserializationMoveDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -490,9 +496,9 @@ public class TestClass : IDeserializationCallback
         File.Move(sourceFileName, destFileName);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Move"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Move"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -513,13 +519,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "Move"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "Move"));
         }
 
         [Fact]
-        public void TestOnDeserializationAppendAllLinesDiagnostic()
+        public async Task TestOnDeserializationAppendAllLinesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -538,9 +544,9 @@ public class TestClass : IDeserializationCallback
         File.AppendAllLines(path, strings);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "AppendAllLines"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "AppendAllLines"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -559,13 +565,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "AppendAllLines"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "AppendAllLines"));
         }
 
         [Fact]
-        public void TestOnDeserializationAppendAllTextDiagnostic()
+        public async Task TestOnDeserializationAppendAllTextDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -584,9 +590,9 @@ public class TestClass : IDeserializationCallback
         File.AppendAllText(path, contents);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "AppendAllText"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "AppendAllText"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -605,13 +611,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "AppendAllText"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "AppendAllText"));
         }
 
         [Fact]
-        public void TestOnDeserializationAppendTextDiagnostic()
+        public async Task TestOnDeserializationAppendTextDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -629,9 +635,9 @@ public class TestClass : IDeserializationCallback
         File.AppendText(path);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "AppendText"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "AppendText"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -649,13 +655,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "AppendText"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "AppendText"));
         }
 
         [Fact]
-        public void TestOnDeserializationDeleteDiagnostic()
+        public async Task TestOnDeserializationDeleteDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -673,9 +679,9 @@ public class TestClass : IDeserializationCallback
         File.Delete(path);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -693,13 +699,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "Delete"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "Delete"));
         }
 
         [Fact]
-        public void TestOnDeserializationDeleteOfDirectoryDiagnostic()
+        public async Task TestOnDeserializationDeleteOfDirectoryDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -717,9 +723,9 @@ public class TestClass : IDeserializationCallback
         Directory.Delete(path);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -737,13 +743,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "Delete"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "Delete"));
         }
 
         [Fact]
-        public void TestOnDeserializationDeleteOfFileInfoDiagnostic()
+        public async Task TestOnDeserializationDeleteOfFileInfoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -760,9 +766,9 @@ public class TestClass : IDeserializationCallback
         new FileInfo(""fileName"").Delete();
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -779,13 +785,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "Delete"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "Delete"));
         }
 
         [Fact]
-        public void TestOnDeserializationDeleteOfDirectoryInfoDiagnostic()
+        public async Task TestOnDeserializationDeleteOfDirectoryInfoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -802,9 +808,9 @@ public class TestClass : IDeserializationCallback
         new DirectoryInfo(""path"").Delete();
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -821,13 +827,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(12, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "Delete"));
+            GetBasicResultAt(12, 20, "TestClass", "OnDeserialization", "Delete"));
         }
 
         [Fact]
-        public void TestOnDeserializationDeleteOfLogStoreDiagnostic()
+        public async Task TestOnDeserializationDeleteOfLogStoreDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.IO.Log;
@@ -860,9 +866,9 @@ public class TestClass : IDeserializationCallback
         LogStore.Delete(path);
     }
 }",
-            GetCSharpResultAt(28, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
+            GetCSharpResultAt(28, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Delete"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.IO.Log
@@ -892,13 +898,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(24, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "Delete"));
+            GetBasicResultAt(24, 20, "TestClass", "OnDeserialization", "Delete"));
         }
 
         [Fact]
-        public void TestOnDeserializationGetLoadedModulesDiagnostic()
+        public async Task TestOnDeserializationGetLoadedModulesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -916,9 +922,9 @@ public class TestClass : IDeserializationCallback
         var modules = assem.GetLoadedModules();
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "GetLoadedModules"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "GetLoadedModules"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Reflection
@@ -936,13 +942,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "GetLoadedModules"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "GetLoadedModules"));
         }
 
         [Fact]
-        public void TestOnDeserializationLoadDiagnostic()
+        public async Task TestOnDeserializationLoadDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -962,9 +968,9 @@ public class TestClass : IDeserializationCallback
         var assem = Assembly.Load(an);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Load"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "Load"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Reflection
@@ -985,13 +991,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "Load"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "Load"));
         }
 
         [Fact]
-        public void TestOnDeserializationLoadFileDiagnostic()
+        public async Task TestOnDeserializationLoadFileDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1009,9 +1015,9 @@ public class TestClass : IDeserializationCallback
         var assem = Assembly.LoadFile(fileName);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "LoadFile"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "LoadFile"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Reflection
@@ -1030,13 +1036,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "LoadFile"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "LoadFile"));
         }
 
         [Fact]
-        public void TestOnDeserializationLoadFromDiagnostic()
+        public async Task TestOnDeserializationLoadFromDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1054,9 +1060,9 @@ public class TestClass : IDeserializationCallback
         var assem = Assembly.LoadFrom(assemblyName);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "LoadFrom"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "LoadFrom"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Reflection
@@ -1075,13 +1081,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "LoadFrom"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "LoadFrom"));
         }
 
         [Fact]
-        public void TestOnDeserializationLoadModuleDiagnostic()
+        public async Task TestOnDeserializationLoadModuleDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1101,9 +1107,9 @@ public class TestClass : IDeserializationCallback
         var module = assem.LoadModule(moduleName, rawModule);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "LoadModule"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "LoadModule"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Reflection
@@ -1124,13 +1130,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "LoadModule"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "LoadModule"));
         }
 
         [Fact]
-        public void TestOnDeserializationLoadWithPartialNameDiagnostic()
+        public async Task TestOnDeserializationLoadWithPartialNameDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1148,9 +1154,9 @@ public class TestClass : IDeserializationCallback
         var assem = Assembly.LoadWithPartialName(partialName);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "LoadWithPartialName"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "LoadWithPartialName"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Reflection
@@ -1169,13 +1175,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "LoadWithPartialName"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "LoadWithPartialName"));
         }
 
         [Fact]
-        public void TestOnDeserializationReflectionOnlyLoadDiagnostic()
+        public async Task TestOnDeserializationReflectionOnlyLoadDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1193,9 +1199,9 @@ public class TestClass : IDeserializationCallback
         var assem = Assembly.ReflectionOnlyLoad(rawAssembly);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "ReflectionOnlyLoad"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "ReflectionOnlyLoad"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Reflection
@@ -1213,13 +1219,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "ReflectionOnlyLoad"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "ReflectionOnlyLoad"));
         }
 
         [Fact]
-        public void TestOnDeserializationReflectionOnlyLoadFromDiagnostic()
+        public async Task TestOnDeserializationReflectionOnlyLoadFromDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1237,9 +1243,9 @@ public class TestClass : IDeserializationCallback
         var assem = Assembly.ReflectionOnlyLoadFrom(assemblyName);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "ReflectionOnlyLoadFrom"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "ReflectionOnlyLoadFrom"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Reflection
@@ -1258,13 +1264,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "ReflectionOnlyLoadFrom"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "ReflectionOnlyLoadFrom"));
         }
 
         [Fact]
-        public void TestOnDeserializationUnsafeLoadFromDiagnostic()
+        public async Task TestOnDeserializationUnsafeLoadFromDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1282,9 +1288,9 @@ public class TestClass : IDeserializationCallback
         var assem = Assembly.UnsafeLoadFrom(assemblyName);
     }
 }",
-            GetCSharpResultAt(13, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "UnsafeLoadFrom"));
+            GetCSharpResultAt(13, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "UnsafeLoadFrom"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Reflection
@@ -1303,13 +1309,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(13, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "OnDeserialization", "UnsafeLoadFrom"));
+            GetBasicResultAt(13, 20, "TestClass", "OnDeserialization", "UnsafeLoadFrom"));
         }
 
         [Fact]
-        public void TestUsingGenericwithTypeSpecifiedDiagnostic()
+        public async Task TestUsingGenericwithTypeSpecifiedDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1321,7 +1327,7 @@ public class TestGenericClass<T>
 {
     private T memberInGeneric;
 
-    public void TestGenericMethod()
+    public async Task TestGenericMethod()
     {
         var path = ""C:\\"";
         var bytes = new byte[] {0x20, 0x20, 0x20};
@@ -1330,22 +1336,22 @@ public class TestGenericClass<T>
 }
 
 [Serializable()]
-public class TestClass : IDeserializationCallback 
+public class TestClass : IDeserializationCallback
 {
     private TestGenericClass<int> member;
 
-    void IDeserializationCallback.OnDeserialization(Object sender) 
+    void IDeserializationCallback.OnDeserialization(Object sender)
     {
         member.TestGenericMethod();
     }
 }",
-            GetCSharpResultAt(26, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
+            GetCSharpResultAt(26, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestUsingInterfaceDiagnostic()
+        public async Task TestUsingInterfaceDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1360,7 +1366,7 @@ interface TestInterface
 [Serializable()]
 public class TestInterfaceImplement : TestInterface
 {
-    public void TestInterfaceMethod()
+    public async Task TestInterfaceMethod()
     {
         var path = ""C:\\"";
         var bytes = new byte[] {0x20, 0x20, 0x20};
@@ -1369,22 +1375,22 @@ public class TestInterfaceImplement : TestInterface
 }
 
 [Serializable()]
-public class TestClass : IDeserializationCallback 
+public class TestClass : IDeserializationCallback
 {
     private TestInterfaceImplement member;
 
-    void IDeserializationCallback.OnDeserialization(Object sender) 
+    void IDeserializationCallback.OnDeserialization(Object sender)
     {
         member.TestInterfaceMethod();
     }
 }",
-            GetCSharpResultAt(29, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
+            GetCSharpResultAt(29, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestStaticDelegateFieldDiagnostic()
+        public async Task TestStaticDelegateFieldDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1405,20 +1411,20 @@ public class TestAnotherClass
 }
 
 [Serializable()]
-public class TestClass : IDeserializationCallback 
+public class TestClass : IDeserializationCallback
 {
-    void IDeserializationCallback.OnDeserialization(Object sender) 
+    void IDeserializationCallback.OnDeserialization(Object sender)
     {
         TestAnotherClass.staticDelegateField();
     }
 }",
-            GetCSharpResultAt(24, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
+            GetCSharpResultAt(24, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestDelegateFieldDiagnostic()
+        public async Task TestDelegateFieldDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1448,13 +1454,13 @@ public class TestClass : IDeserializationCallback
         testAnotherClass.delegateField();
     }
 }",
-            GetCSharpResultAt(19, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
+            GetCSharpResultAt(19, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestUsingAbstractClassDiagnostic()
+        public async Task TestUsingAbstractClassDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Reflection;
@@ -1478,22 +1484,22 @@ public class TestDerivedClass : TestAbstractClass
 }
 
 [Serializable()]
-public class TestClass : IDeserializationCallback 
+public class TestClass : IDeserializationCallback
 {
     private TestDerivedClass member;
 
-    void IDeserializationCallback.OnDeserialization(Object sender) 
+    void IDeserializationCallback.OnDeserialization(Object sender)
     {
         member.TestAbstractMethod();
     }
 }",
-            GetCSharpResultAt(29, 35, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
+            GetCSharpResultAt(29, 35, "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestFinalizeDiagnostic()
+        public async Task TestFinalizeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1509,9 +1515,9 @@ public class TestClass
         File.WriteAllBytes(""C:\\"", bytes);
     }
 }",
-            GetCSharpResultAt(11, 6, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "Finalize", "WriteAllBytes"));
+            GetCSharpResultAt(11, 6, "TestClass", "Finalize", "WriteAllBytes"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -1527,13 +1533,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(11, 33, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "Finalize", "WriteAllBytes"));
+            GetBasicResultAt(11, 33, "TestClass", "Finalize", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestDisposeDiagnostic()
+        public async Task TestDisposeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -1572,10 +1578,10 @@ public class TestClass : IDisposable
         Dispose(false);
     }
 }",
-            GetCSharpResultAt(13, 17, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "Dispose", "WriteAllBytes"),
-            GetCSharpResultAt(35, 6, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "Finalize", "WriteAllBytes"));
+            GetCSharpResultAt(13, 17, "TestClass", "Dispose", "WriteAllBytes"),
+            GetCSharpResultAt(35, 6, "TestClass", "Finalize", "WriteAllBytes"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -1607,14 +1613,14 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(23, 20, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "Dispose", "WriteAllBytes"),
-            GetBasicResultAt(28, 33, DoNotCallDangerousMethodsInDeserialization.Rule, "TestClass", "Finalize", "WriteAllBytes"));
+            GetBasicResultAt(23, 20, "TestClass", "Dispose", "WriteAllBytes"),
+            GetBasicResultAt(28, 33, "TestClass", "Finalize", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestFinalizeWhenSubClassWithSerializableDiagnostic()
+        public async Task TestFinalizeWhenSubClassWithSerializableDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1640,9 +1646,9 @@ public class SubTestClass : TestClass
         File.WriteAllBytes(""C:\\"", bytes);
     }
 }",
-            GetCSharpResultAt(21, 6, DoNotCallDangerousMethodsInDeserialization.Rule, "SubTestClass", "Finalize", "WriteAllBytes"));
+            GetCSharpResultAt(21, 6, "SubTestClass", "Finalize", "WriteAllBytes"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -1667,13 +1673,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(20, 33, DoNotCallDangerousMethodsInDeserialization.Rule, "SubTestClass", "Finalize", "WriteAllBytes"));
+            GetBasicResultAt(20, 33, "SubTestClass", "Finalize", "WriteAllBytes"));
         }
 
         [Fact]
-        public void TestOnDeserializingNoDiagnostic()
+        public async Task TestOnDeserializingNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.Serialization;
 
@@ -1694,7 +1700,7 @@ public class TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Runtime.Serialization
 
@@ -1716,9 +1722,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestOnDeserializedNoDiagnostic()
+        public async Task TestOnDeserializedNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.Serialization;
 
@@ -1739,7 +1745,7 @@ public class TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Runtime.Serialization
 
@@ -1761,9 +1767,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestOnDeserializationNoDiagnostic()
+        public async Task TestOnDeserializationNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1784,7 +1790,7 @@ public class TestClass : IDeserializationCallback
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Runtime.Serialization
 
@@ -1806,9 +1812,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestOnDeserializingWithoutSerializableNoDiagnostic()
+        public async Task TestOnDeserializingWithoutSerializableNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1825,7 +1831,7 @@ public class TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -1844,9 +1850,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestOnDeserializationWithoutSerializableNoDiagnostic()
+        public async Task TestOnDeserializationWithoutSerializableNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1862,7 +1868,7 @@ public class TestClass : IDeserializationCallback
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -1881,9 +1887,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestOnDeserializationWithoutIDeserializationCallbackNoDiagnostic()
+        public async Task TestOnDeserializationWithoutIDeserializationCallbackNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1902,9 +1908,9 @@ public class TestClass
         }
 
         [Fact]
-        public void TestOnDeserializedWithEmptyMethodBodyNoDiagnostic()
+        public async Task TestOnDeserializedWithEmptyMethodBodyNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.Serialization;
 
@@ -1919,7 +1925,7 @@ public class TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -1937,9 +1943,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestWithoutOnDeserializingAttributesNoDiagnostic()
+        public async Task TestWithoutOnDeserializingAttributesNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1956,7 +1962,7 @@ public class TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -1975,9 +1981,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestOnSerializedNoDiagnostic()
+        public async Task TestOnSerializedNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1995,7 +2001,7 @@ public class TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -2014,9 +2020,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestFinalizeNoDiagnostic()
+        public async Task TestFinalizeNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -2037,7 +2043,7 @@ public class TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -2059,9 +2065,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestFinalizeWhenSubClassWithoutSerializableNoDiagnostic()
+        public async Task TestFinalizeWhenSubClassWithoutSerializableNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -2087,7 +2093,7 @@ public class SubTestClass : TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -2114,9 +2120,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestDisposeNoDiagnostic()
+        public async Task TestDisposeNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -2156,7 +2162,7 @@ public class TestClass : IDisposable
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -2192,9 +2198,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestDisposeWithoutSerializableNoDiagnostic()
+        public async Task TestDisposeWithoutSerializableNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -2209,27 +2215,27 @@ public class TestClass : IDisposable
         byte[] bytes = new byte[] {0x20, 0x20, 0x20};
         File.WriteAllBytes(""C:\\"", bytes);
         Dispose(true);
-        GC.SuppressFinalize(this);           
+        GC.SuppressFinalize(this);
     }
-    
+
     protected virtual void Dispose(bool disposing)
     {
         if (disposed)
         {
-            return; 
+            return;
         }
-      
-        if (disposing) 
+
+        if (disposing)
         {
             byte[] bytes = new byte[] {0x20, 0x20, 0x20};
             File.WriteAllBytes(""C:\\"", bytes);
         }
-      
+
         disposed = true;
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -2243,8 +2249,8 @@ Namespace TestNamespace
         Sub Dispose() Implements IDisposable.Dispose
             Dim bytes(9) As Byte
             File.WriteAllBytes(""C:\\"", bytes)
-            Dispose(True)  
-            GC.SuppressFinalize(Me) 
+            Dispose(True)
+            GC.SuppressFinalize(Me)
         End Sub
 
         Protected Overridable Sub Dispose(ByVal disposing As Boolean)
@@ -2261,9 +2267,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestDisposeNotImplementIDisposableNoDiagnostic()
+        public async Task TestDisposeNotImplementIDisposableNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -2278,27 +2284,27 @@ public class TestClass
         byte[] bytes = new byte[] {0x20, 0x20, 0x20};
         File.WriteAllBytes(""C:\\"", bytes);
         Dispose(true);
-        GC.SuppressFinalize(this);           
+        GC.SuppressFinalize(this);
     }
-    
+
     protected virtual void Dispose(bool disposing)
     {
         if (disposed)
         {
-            return; 
+            return;
         }
-      
-        if (disposing) 
+
+        if (disposing)
         {
             byte[] bytes = new byte[] {0x20, 0x20, 0x20};
             File.WriteAllBytes(""C:\\"", bytes);
         }
-      
+
         disposed = true;
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -2311,8 +2317,8 @@ Namespace TestNamespace
         Sub Dispose()
             Dim bytes(9) As Byte
             File.WriteAllBytes(""C:\\"", bytes)
-            Dispose(True)  
-            GC.SuppressFinalize(Me) 
+            Dispose(True)
+            GC.SuppressFinalize(Me)
         End Sub
 
         Protected Overridable Sub Dispose(ByVal disposing As Boolean)
@@ -2329,9 +2335,9 @@ End Namespace");
         }
 
         [Fact]
-        public void TestUsingGenericwithTypeSpecifiedNoDiagnostic()
+        public async Task TestUsingGenericwithTypeSpecifiedNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -2341,7 +2347,7 @@ public class TestGenericClass<T>
 {
     private T memberInGeneric;
 
-    public void TestGenericMethod()
+    public async Task TestGenericMethod()
     {
     }
 }
@@ -2380,9 +2386,9 @@ public class TestClass : IDisposable
         }
 
         [Fact]
-        public void TestUsingInterfaceNoDiagnostic()
+        public async Task TestUsingInterfaceNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -2395,7 +2401,7 @@ interface TestInterface
 [Serializable()]
 public class TestInterfaceImplement : TestInterface
 {
-    public void TestInterfaceMethod()
+    public async Task TestInterfaceMethod()
     {
         var path = ""C:\\"";
         var bytes = new byte[] {0x20, 0x20, 0x20};
@@ -2412,20 +2418,20 @@ public class TestClass : IDisposable
     public void Dispose()
     {
         Dispose(true);
-        GC.SuppressFinalize(this);           
+        GC.SuppressFinalize(this);
     }
-    
+
     protected virtual void Dispose(bool disposing)
     {
         if (disposed)
         {
-            return; 
+            return;
         }
-      
-        if (disposing) 
+
+        if (disposing)
         {
         }
-      
+
         disposed = true;
     }
 
@@ -2437,9 +2443,9 @@ public class TestClass : IDisposable
         }
 
         [Fact]
-        public void TestUsingAbstractClassNoDiagnostic()
+        public async Task TestUsingAbstractClassNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -2469,20 +2475,20 @@ public class TestClass : IDisposable
     public void Dispose()
     {
         Dispose(true);
-        GC.SuppressFinalize(this);           
+        GC.SuppressFinalize(this);
     }
-    
+
     protected virtual void Dispose(bool disposing)
     {
         if (disposed)
         {
-            return; 
+            return;
         }
-      
-        if (disposing) 
+
+        if (disposing)
         {
         }
-      
+
         disposed = true;
     }
 
@@ -2493,14 +2499,14 @@ public class TestClass : IDisposable
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotCallDangerousMethodsInDeserialization();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotCallDangerousMethodsInDeserialization();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableCertificateValidationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableCertificateValidationTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Security.DoNotDisableCertificateValidation,
@@ -14,12 +12,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotDisableCertificateValidationTests : DiagnosticAnalyzerTestBase
+    public class DoNotDisableCertificateValidationTests
     {
         [Fact]
-        public void TestLambdaDiagnostic()
+        public async Task TestLambdaDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 
 class TestClass
@@ -29,13 +27,13 @@ class TestClass
         ServicePointManager.ServerCertificateValidationCallback += (a, b, c, d) => { return true; };
     }
 }",
-            GetCSharpResultAt(8, 68, DoNotDisableCertificateValidation.Rule));
+            GetCSharpResultAt(8, 68));
         }
 
         [Fact]
-        public void TestLambdaWithLiteralValueDiagnostic()
+        public async Task TestLambdaWithLiteralValueDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 
 class TestClass
@@ -45,13 +43,13 @@ class TestClass
         ServicePointManager.ServerCertificateValidationCallback += (a, b, c, d) => true;
     }
 }",
-            GetCSharpResultAt(8, 68, DoNotDisableCertificateValidation.Rule));
+            GetCSharpResultAt(8, 68));
         }
 
         [Fact]
-        public void TestAnonymousMethodDiagnostic()
+        public async Task TestAnonymousMethodDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 
 class TestClass
@@ -61,13 +59,13 @@ class TestClass
         ServicePointManager.ServerCertificateValidationCallback += delegate { return true; };
     }
 }",
-            GetCSharpResultAt(8, 68, DoNotDisableCertificateValidation.Rule));
+            GetCSharpResultAt(8, 68));
         }
 
         [Fact]
-        public void TestDelegateCreationLocalFunctionDiagnostic()
+        public async Task TestDelegateCreationLocalFunctionDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -88,13 +86,13 @@ class TestClass
         }
     }
 }",
-            GetCSharpResultAt(10, 67, DoNotDisableCertificateValidation.Rule));
+            GetCSharpResultAt(10, 67));
         }
 
         [Fact]
-        public void TestDelegateCreationDiagnostic()
+        public async Task TestDelegateCreationDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -115,9 +113,9 @@ class TestClass
         ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(AcceptAllCertifications);
     }
 }",
-            GetCSharpResultAt(19, 67, DoNotDisableCertificateValidation.Rule));
+            GetCSharpResultAt(19, 67));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Net
 Imports System.Net.Security
 Imports System.Security.Cryptography.X509Certificates
@@ -133,13 +131,13 @@ Namespace TestNamespace
         End Function
     End Class
 End Namespace",
-            GetBasicResultAt(9, 82, DoNotDisableCertificateValidation.Rule));
+            GetBasicResultAt(9, 82));
         }
 
         [Fact]
-        public void TestDelegateCreationNormalMethodWithLambdaDiagnostic()
+        public async Task TestDelegateCreationNormalMethodWithLambdaDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -157,11 +155,11 @@ class TestClass
         ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(AcceptAllCertifications);
     }
 }",
-            GetCSharpResultAt(16, 67, DoNotDisableCertificateValidation.Rule));
+            GetCSharpResultAt(16, 67));
         }
 
         [Fact]
-        public void TestDelegatedMethodFromDifferentAssemblyNoDiagnostic()
+        public async Task TestDelegatedMethodFromDifferentAssemblyNoDiagnostic()
         {
             string source1 = @"
 
@@ -196,11 +194,12 @@ class TestClass
     }
 }";
 
-            VerifyCSharpAcrossTwoAssemblies(source1, source2);
+            // TODO: Amaury - Fix this code
+            //VerifyCSharpAcrossTwoAssemblies(source1, source2);
         }
 
         [Fact]
-        public void TestDelegatedMethodFromLocalFromDifferentAssemblyNoDiagnostic()
+        public async Task TestDelegatedMethodFromLocalFromDifferentAssemblyNoDiagnostic()
         {
             string source1 = @"
 
@@ -246,7 +245,8 @@ class TestClass
     }
 }";
 
-            VerifyCSharpAcrossTwoAssemblies(source1, source2);
+            // TODO: Amaury - Fix this code
+            //VerifyCSharpAcrossTwoAssemblies(source1, source2);
         }
 
         [Fact]
@@ -534,15 +534,5 @@ class TestClass
         private DiagnosticResult GetBasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotDisableCertificateValidation();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotDisableCertificateValidation();
-        }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableCertificateValidationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableCertificateValidationTests.cs
@@ -1,12 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Diagnostics;
-using System.Linq;
-using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotDisableCertificateValidation,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotDisableCertificateValidation,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
@@ -246,9 +250,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestLambdaNoDiagnostic()
+        public async Task TestLambdaNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 
 class TestClass
@@ -261,9 +265,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestLambdaWithLiteralValueNoDiagnostic()
+        public async Task TestLambdaWithLiteralValueNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 
 class TestClass
@@ -276,9 +280,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestAnonymousMethodNoDiagnostic()
+        public async Task TestAnonymousMethodNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 
 class TestClass
@@ -291,9 +295,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDelegateCreationLocalFunctionNoDiagnostic()
+        public async Task TestDelegateCreationLocalFunctionNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -322,9 +326,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDelegateCreationNoDiagnostic()
+        public async Task TestDelegateCreationNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -350,7 +354,7 @@ class TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Net
 Imports System.Net.Security
 Imports System.Security.Cryptography.X509Certificates
@@ -371,9 +375,9 @@ End Module");
         }
 
         [Fact]
-        public void TestDelegateCreationNoDiagnostic2()
+        public async Task TestDelegateCreationNoDiagnostic2()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -396,9 +400,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDelegateCreationNormalMethodWithLambdaNoDiagnostic()
+        public async Task TestDelegateCreationNormalMethodWithLambdaNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -419,9 +423,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDelegateCreationFromLocalFromLocalNoDiagnostic()
+        public async Task TestDelegateCreationFromLocalFromLocalNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -456,7 +460,7 @@ class TestClass
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Net
 Imports System.Net.Security
 Imports System.Security.Cryptography.X509Certificates
@@ -477,9 +481,9 @@ End Module");
         }
 
         [Fact]
-        public void TestDelegateCreationFromLocalFromLocal2NoDiagnostic()
+        public async Task TestDelegateCreationFromLocalFromLocal2NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -522,6 +526,14 @@ class TestClass
     }
 }");
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column);
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableCertificateValidationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableCertificateValidationTests.cs
@@ -527,11 +527,11 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column)
+        private static DiagnosticResult GetBasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableHTTPHeaderCheckingTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableHTTPHeaderCheckingTests.cs
@@ -1,22 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotDisableHTTPHeaderChecking,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotDisableHTTPHeaderCheckingTests : DiagnosticAnalyzerTestBase
+    public class DoNotDisableHTTPHeaderCheckingTests
     {
         [Fact]
-        public void TestLiteralDiagnostic()
+        public async Task TestLiteralDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.Configuration;
 
@@ -28,13 +26,13 @@ class TestClass
         httpRuntimeSection.EnableHeaderChecking = false;
     }
 }",
-            GetCSharpResultAt(10, 9, DoNotDisableHTTPHeaderChecking.Rule));
+            GetCSharpResultAt(10, 9));
         }
 
         [Fact]
-        public void TestConstantDiagnostic()
+        public async Task TestConstantDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.Configuration;
 
@@ -47,13 +45,13 @@ class TestClass
         httpRuntimeSection.EnableHeaderChecking = flag;
     }
 }",
-            GetCSharpResultAt(11, 9, DoNotDisableHTTPHeaderChecking.Rule));
+            GetCSharpResultAt(11, 9));
         }
 
         [Fact]
-        public void TestPropertyInitializerDiagnostic()
+        public async Task TestPropertyInitializerDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.Configuration;
 
@@ -67,14 +65,14 @@ class TestClass
         };
     }
 }",
-            GetCSharpResultAt(11, 13, DoNotDisableHTTPHeaderChecking.Rule));
+            GetCSharpResultAt(11, 13));
         }
 
         //Ideally, we would generate a diagnostic in this case.
         [Fact]
-        public void TestVariableNoDiagnostic()
+        public async Task TestVariableNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.Configuration;
 
@@ -90,9 +88,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestLiteralNoDiagnostic()
+        public async Task TestLiteralNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.Configuration;
 
@@ -107,9 +105,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstantNoDiagnostic()
+        public async Task TestConstantNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.Configuration;
 
@@ -125,9 +123,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestPropertyInitializerNoDiagnostic()
+        public async Task TestPropertyInitializerNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.Configuration;
 
@@ -143,14 +141,8 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotDisableHTTPHeaderChecking();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotDisableHTTPHeaderChecking();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableHTTPHeaderCheckingTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableHTTPHeaderCheckingTests.cs
@@ -141,7 +141,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableHttpClientCRLCheckTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableHttpClientCRLCheckTests.cs
@@ -357,7 +357,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
             => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableHttpClientCRLCheckTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableHttpClientCRLCheckTests.cs
@@ -1,31 +1,42 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Test.Utilities.MinimalImplementations;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotDisableHttpClientCRLCheck,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
-    public class DoNotDisableHttpClientCRLCheckTests : DiagnosticAnalyzerTestBase
+    public class DoNotDisableHttpClientCRLCheckTests
     {
         private static readonly DiagnosticDescriptor DefinitelyRule = DoNotDisableHttpClientCRLCheck.DefinitelyDisableHttpClientCRLCheckRule;
         private static readonly DiagnosticDescriptor MaybeRule = DoNotDisableHttpClientCRLCheck.MaybeDisableHttpClientCRLCheckRule;
 
-        protected void VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
+        private async Task VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
         {
-            this.VerifyCSharp(
-                new[] { source, SystemNetHttpApis.CSharp }.ToFileAndSource(),
-                expected);
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source, SystemNetHttpApis.CSharp }
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_NotSet_DefaultWrong_DefinitelyDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_NotSet_DefaultWrong_DefinitelyDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -40,9 +51,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -58,9 +69,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_HttpClientHandler_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
+        public async Task Test_HttpClientHandler_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -76,9 +87,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_CurlHandler_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
+        public async Task Test_CurlHandler_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -94,9 +105,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_HttpClientWithHttpMessageHandlerAndBooleanParameters_WinHttpHandler_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
+        public async Task Test_HttpClientWithHttpMessageHandlerAndBooleanParameters_WinHttpHandler_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -112,9 +123,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_PropertyInitializer_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
+        public async Task Test_WinHttpHandler_PropertyInitializer_CheckCertificateRevocationList_Wrong_DefinitelyDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -129,9 +140,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_UnknownOrRight_MaybeDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_UnknownOrRight_MaybeDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using System.Net.Http;
 
@@ -155,9 +166,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_Wrong_ServerCertificateValidationCallback_Null_DefinitelyDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_Wrong_ServerCertificateValidationCallback_Null_DefinitelyDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -174,9 +185,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_Wrong_ServerCertificateValidationCallback_MaybeNull_MaybeDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_Wrong_ServerCertificateValidationCallback_MaybeNull_MaybeDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using System.Net.Http;
 
@@ -200,9 +211,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_Wrong_ServerCertificateValidationCallback_NotNull_DefinitelyDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_Wrong_ServerCertificateValidationCallback_NotNull_DefinitelyDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using System.Net.Http;
 
@@ -219,9 +230,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_UnknownOrWrong_MaybeDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_UnknownOrWrong_MaybeDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using System.Net.Http;
 
@@ -245,9 +256,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_WrongOrRight_MaybeDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_WrongOrRight_MaybeDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using System.Net.Http;
 
@@ -271,9 +282,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_DerivedClassOfHttpClient_DefinitelyDiagnostic()
+        public async Task Test_DerivedClassOfHttpClient_DefinitelyDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class DerivedClass : HttpClient
@@ -296,9 +307,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_HttpClientConstructorWithoutParameter_handlerSetByDefault_NoDiagnostic()
+        public async Task Test_HttpClientConstructorWithoutParameter_handlerSetByDefault_NoDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -313,9 +324,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_Right_NoDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_Right_NoDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -330,9 +341,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WinHttpHandler_CheckCertificateRevocationList_Unknown_NoDiagnostic()
+        public async Task Test_WinHttpHandler_CheckCertificateRevocationList_Unknown_NoDiagnostic()
         {
-            this.VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Net.Http;
 
 class TestClass
@@ -346,14 +357,8 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotDisableHttpClientCRLCheck();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotDisableHttpClientCRLCheck();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+            => VerifyCS.Diagnostic(rule)
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableRequestValidationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableRequestValidationTests.cs
@@ -1,15 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotDisableRequestValidation,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotDisableRequestValidationTests : DiagnosticAnalyzerTestBase
+    public class DoNotDisableRequestValidationTests
     {
-        protected void VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
+        private async Task VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
         {
             string validateInputAttributeCSharpSourceCode = @"
 namespace System.Web.Mvc
@@ -22,15 +24,23 @@ namespace System.Web.Mvc
         }
     }
 }";
-            this.VerifyCSharp(
-                new[] { source, validateInputAttributeCSharpSourceCode }.ToFileAndSource(),
-                expected);
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source, validateInputAttributeCSharpSourceCode }
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
         }
 
         [Fact]
-        public void TestLiteralAtActionLevelDiagnostic()
+        public async Task TestLiteralAtActionLevelDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web.Mvc;
 
 class TestControllerClass
@@ -40,13 +50,13 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(7, 17, DoNotDisableRequestValidation.Rule, "TestActionMethod"));
+            GetCSharpResultAt(7, 17, "TestActionMethod"));
         }
 
         [Fact]
-        public void TestConstAtActionLevelDiagnostic()
+        public async Task TestConstAtActionLevelDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web.Mvc;
 
 class TestControllerClass
@@ -58,13 +68,13 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(9, 17, DoNotDisableRequestValidation.Rule, "TestActionMethod"));
+            GetCSharpResultAt(9, 17, "TestActionMethod"));
         }
 
         [Fact]
-        public void TestLiteralAtControllerLevelDiagnostic()
+        public async Task TestLiteralAtControllerLevelDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web.Mvc;
 
 [ValidateInput(false)]
@@ -74,13 +84,13 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(5, 7, DoNotDisableRequestValidation.Rule, "TestControllerClass"));
+            GetCSharpResultAt(5, 7, "TestControllerClass"));
         }
 
         [Fact]
-        public void TestSetBothControllerLevelAndActionLevelDiagnostic()
+        public async Task TestSetBothControllerLevelAndActionLevelDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web.Mvc;
 
 [ValidateInput(true)]
@@ -91,13 +101,13 @@ class TestControllerClass
     {
     }
 }",
-            GetCSharpResultAt(8, 17, DoNotDisableRequestValidation.Rule, "TestActionMethod"));
+            GetCSharpResultAt(8, 17, "TestActionMethod"));
         }
 
         [Fact]
-        public void TestLiteralAtActionLevelNoDiagnostic()
+        public async Task TestLiteralAtActionLevelNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web.Mvc;
 
 class TestControllerClass
@@ -110,9 +120,9 @@ class TestControllerClass
         }
 
         [Fact]
-        public void TestConstAtActionLevelNoDiagnostic()
+        public async Task TestConstAtActionLevelNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web.Mvc;
 
 class TestControllerClass
@@ -127,9 +137,9 @@ class TestControllerClass
         }
 
         [Fact]
-        public void TestLiteralAtControllerLevelNoDiagnostic()
+        public async Task TestLiteralAtControllerLevelNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web.Mvc;
 
 [ValidateInput(true)]
@@ -142,9 +152,9 @@ class TestControllerClass
         }
 
         [Fact]
-        public void TestSetBothControllerLevelAndActionLevelNoDiagnostic()
+        public async Task TestSetBothControllerLevelAndActionLevelNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web.Mvc;
 
 [ValidateInput(false)]
@@ -158,9 +168,9 @@ class TestControllerClass
         }
 
         [Fact]
-        public void TestWithoutValidateInputAttributeNoDiagnostic()
+        public async Task TestWithoutValidateInputAttributeNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web.Mvc;
 
 class TestControllerClass
@@ -171,14 +181,9 @@ class TestControllerClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotDisableRequestValidation();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotDisableRequestValidation();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableRequestValidationTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableRequestValidationTests.cs
@@ -181,7 +181,7 @@ class TestControllerClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -14,12 +13,12 @@ using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotDisableSchUseStrongCryptoTests : DiagnosticAnalyzerTestBase
+    public class DoNotDisableSchUseStrongCryptoTests
     {
         [Fact]
-        public void DocSample1_CSharp_Violation()
+        public async Task DocSample1_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class ExampleClass
@@ -30,13 +29,13 @@ public class ExampleClass
         AppContext.SetSwitch(""Switch.System.Net.DontEnableSchUseStrongCrypto"", true);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch"));
+            GetCSharpResultAt(9, 9, "SetSwitch"));
         }
 
         [Fact]
-        public void DocSample1_VB_Violation()
+        public async Task DocSample1_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class ExampleClass
@@ -45,7 +44,7 @@ Public Class ExampleClass
         AppContext.SetSwitch(""Switch.System.Net.DontEnableSchUseStrongCrypto"", true)
     End Sub
 End Class",
-            GetBasicResultAt(7, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch"));
+            GetBasicResultAt(7, 9, "SetSwitch"));
         }
 
         [Fact]
@@ -77,9 +76,9 @@ End Class");
         }
 
         [Fact]
-        public void TestBoolDiagnostic()
+        public async Task TestBoolDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -89,13 +88,13 @@ class TestClass
         AppContext.SetSwitch(""Switch.System.Net.DontEnableSchUseStrongCrypto"", true);
     }
 }",
-            GetCSharpResultAt(8, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch"));
+            GetCSharpResultAt(8, 9, "SetSwitch"));
         }
 
         [Fact]
-        public void TestEquationDiagnostic()
+        public async Task TestEquationDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -105,7 +104,7 @@ class TestClass
         AppContext.SetSwitch(""Switch.System.Net.DontEnableSchUseStrongCrypto"", 1 + 2 == 3);
     }
 }",
-            GetCSharpResultAt(8, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch"));
+            GetCSharpResultAt(8, 9, "SetSwitch"));
         }
 
         [Fact]
@@ -125,9 +124,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestWithConstantSwitchNameDiagnostic()
+        public async Task TestWithConstantSwitchNameDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -138,7 +137,7 @@ class TestClass
         AppContext.SetSwitch(constSwitchName, true);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch"));
+            GetCSharpResultAt(9, 9, "SetSwitch"));
         }
 
         [Fact]
@@ -203,9 +202,9 @@ class TestClass
 
         [Fact]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
-        public void TestSwitchNameVariableNoDiagnostic()
+        public async Task TestSwitchNameVariableNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -216,7 +215,7 @@ class TestClass
         AppContext.SetSwitch(switchName, true);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch"));
+            GetCSharpResultAt(9, 9, "SetSwitch"));
         }
 
         //Ideally, we would generate a diagnostic in this case.
@@ -280,15 +279,5 @@ class TestClass
             => VerifyVB.Diagnostic(DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotSetSwitch();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotSetSwitch();
-        }
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotSetSwitch,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotSetSwitch,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
@@ -47,9 +49,9 @@ End Class",
         }
 
         [Fact]
-        public void DocSample1_CSharp_Solution()
+        public async Task DocSample1_CSharp_Solution()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class ExampleClass
@@ -62,9 +64,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample1_VB_Solution()
+        public async Task DocSample1_VB_Solution()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class ExampleClass
@@ -107,9 +109,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestConditionalOperatorDiagnostic()
+        public async Task TestConditionalOperatorDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -119,7 +121,7 @@ class TestClass
         AppContext.SetSwitch(""Switch.System.Net.DontEnableSchUseStrongCrypto"", 1 == 1 ? true : false);
     }
 }",
-            GetCSharpResultAt(8, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch"));
+            GetCSharpResultAt(8, 9, "SetSwitch"));
         }
 
         [Fact]
@@ -140,9 +142,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestBoolNoDiagnostic()
+        public async Task TestBoolNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -155,9 +157,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestEquationNoDiagnostic()
+        public async Task TestEquationNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -170,9 +172,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestConditionalOperatorNoDiagnostic()
+        public async Task TestConditionalOperatorNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -185,9 +187,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestSwitchNameNullNoDiagnostic()
+        public async Task TestSwitchNameNullNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -219,9 +221,9 @@ class TestClass
 
         //Ideally, we would generate a diagnostic in this case.
         [Fact]
-        public void TestBoolParseNoDiagnostic()
+        public async Task TestBoolParseNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -238,18 +240,15 @@ class TestClass
         [InlineData("dotnet_code_quality.excluded_symbol_names = TestMethod")]
         [InlineData("dotnet_code_quality.CA5361.excluded_symbol_names = TestMethod")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = TestMethod")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (editorConfigText.Length == 0)
+            var test = new VerifyCS.Test
             {
-                expected = new DiagnosticResult[]
+                TestState =
                 {
-                    GetCSharpResultAt(8, 9, DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule, "SetSwitch")
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 using System;
 
 class TestClass
@@ -258,8 +257,29 @@ class TestClass
     {
         AppContext.SetSwitch(""Switch.System.Net.DontEnableSchUseStrongCrypto"", true);
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}",
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (editorConfigText.Length == 0)
+            {
+                test.ExpectedDiagnostics.Add(GetCSharpResultAt(8, 9, "SetSwitch"));
+            }
+
+            await test.RunAsync();
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic(DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic(DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableSchUseStrongCryptoTests.cs
@@ -270,12 +270,12 @@ class TestClass
             await test.RunAsync();
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic(DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic(DoNotSetSwitch.DoNotDisableSchUseStrongCryptoRule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
@@ -1,19 +1,24 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotSetSwitch,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotSetSwitch,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotDisableUsingServicePointManagerSecurityProtocolsTests : DiagnosticAnalyzerTestBase
+    public class DoNotDisableUsingServicePointManagerSecurityProtocolsTests
     {
         [Fact]
-        public void DocSample1_CSharp_Violation()
+        public async Task DocSample1_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class ExampleClass
@@ -24,13 +29,13 @@ public class ExampleClass
         AppContext.SetSwitch(""Switch.System.ServiceModel.DisableUsingServicePointManagerSecurityProtocols"", true);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch"));
+            GetCSharpResultAt(9, 9, "SetSwitch"));
         }
 
         [Fact]
-        public void DocSample1_VB_Violation()
+        public async Task DocSample1_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class ExampleClass
@@ -39,13 +44,13 @@ Public Class ExampleClass
         AppContext.SetSwitch(""Switch.System.ServiceModel.DisableUsingServicePointManagerSecurityProtocols"", true)
     End Sub
 End Class",
-            GetBasicResultAt(7, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch"));
+            GetBasicResultAt(7, 9, "SetSwitch"));
         }
 
         [Fact]
-        public void DocSample1_CSharp_Solution()
+        public async Task DocSample1_CSharp_Solution()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 public class ExampleClass
@@ -58,9 +63,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample1_VB_Solution()
+        public async Task DocSample1_VB_Solution()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Public Class ExampleClass
@@ -71,9 +76,9 @@ End Class");
         }
 
         [Fact]
-        public void TestBoolDiagnostic()
+        public async Task TestBoolDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -83,13 +88,13 @@ class TestClass
         AppContext.SetSwitch(""Switch.System.ServiceModel.DisableUsingServicePointManagerSecurityProtocols"", true);
     }
 }",
-            GetCSharpResultAt(8, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch"));
+            GetCSharpResultAt(8, 9, "SetSwitch"));
         }
 
         [Fact]
-        public void TestEquationDiagnostic()
+        public async Task TestEquationDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -99,13 +104,13 @@ class TestClass
         AppContext.SetSwitch(""Switch.System.ServiceModel.DisableUsingServicePointManagerSecurityProtocols"", 1 + 2 == 3);
     }
 }",
-            GetCSharpResultAt(8, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch"));
+            GetCSharpResultAt(8, 9, "SetSwitch"));
         }
 
         [Fact]
-        public void TestConditionalOperatorDiagnostic()
+        public async Task TestConditionalOperatorDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -115,13 +120,13 @@ class TestClass
         AppContext.SetSwitch(""Switch.System.ServiceModel.DisableUsingServicePointManagerSecurityProtocols"", 1 == 1 ? true : false);
     }
 }",
-            GetCSharpResultAt(8, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch"));
+            GetCSharpResultAt(8, 9, "SetSwitch"));
         }
 
         [Fact]
-        public void TestWithConstantSwitchNameDiagnostic()
+        public async Task TestWithConstantSwitchNameDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -132,13 +137,13 @@ class TestClass
         AppContext.SetSwitch(constSwitchName, true);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch"));
+            GetCSharpResultAt(9, 9, "SetSwitch"));
         }
 
         [Fact]
-        public void TestBoolNoDiagnostic()
+        public async Task TestBoolNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -151,9 +156,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestEquationNoDiagnostic()
+        public async Task TestEquationNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -166,9 +171,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestConditionalOperatorNoDiagnostic()
+        public async Task TestConditionalOperatorNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -181,9 +186,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestSwitchNameNullNoDiagnostic()
+        public async Task TestSwitchNameNullNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -197,9 +202,9 @@ class TestClass
 
         [Fact]
         [Trait(Traits.DataflowAnalysis, Traits.Dataflow.ValueContentAnalysis)]
-        public void TestSwitchNameVariableNoDiagnostic()
+        public async Task TestSwitchNameVariableNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -210,14 +215,14 @@ class TestClass
         AppContext.SetSwitch(switchName, true);
     }
 }",
-                GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch"));
+                GetCSharpResultAt(9, 9, "SetSwitch"));
         }
 
         //Ideally, we would generate a diagnostic in this case.
         [Fact]
-        public void TestBoolParseNoDiagnostic()
+        public async Task TestBoolParseNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -234,18 +239,15 @@ class TestClass
         [InlineData("dotnet_code_quality.excluded_symbol_names = ExampleMethod")]
         [InlineData("dotnet_code_quality.CA5378.excluded_symbol_names = ExampleMethod")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = ExampleMethod")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (editorConfigText.Length == 0)
+            var test = new VerifyCS.Test
             {
-                expected = new DiagnosticResult[]
+                TestState =
                 {
-                    GetCSharpResultAt(9, 9, DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule, "SetSwitch")
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 using System;
 
 public class ExampleClass
@@ -255,17 +257,28 @@ public class ExampleClass
         // CA5378 violation
         AppContext.SetSwitch(""Switch.System.ServiceModel.DisableUsingServicePointManagerSecurityProtocols"", true);
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (editorConfigText.Length == 0)
+            {
+                test.ExpectedDiagnostics.Add(GetCSharpResultAt(9, 9, "SetSwitch"));
+            }
+
+            await test.RunAsync();
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotSetSwitch();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic(DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotSetSwitch();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic(DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotDisableUsingServicePointManagerSecurityProtocolsTests.cs
@@ -271,12 +271,12 @@ public class ExampleClass
             await test.RunAsync();
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic(DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic(DoNotSetSwitch.DoNotDisableSpmSecurityProtocolsRule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotInstallRootCertTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotInstallRootCertTests.cs
@@ -67,7 +67,7 @@ using System.Security.Cryptography.X509Certificates;
 
 class TestClass
 {
-    public async Task TestMethod(StoreName storeName)
+    public void TestMethod(StoreName storeName)
     {
         Random r = new Random();
 
@@ -202,7 +202,7 @@ class TestClass
         TestMethod2(x509Store); 
     }
 
-    public async Task TestMethod2(X509Store x509Store)
+    public void TestMethod2(X509Store x509Store)
     {
         x509Store.Add(new X509Certificate2());
     }
@@ -320,7 +320,7 @@ using System.Security.Cryptography.X509Certificates;
 
 class TestClass
 {
-    public async Task TestMethod(StoreName storeName)
+    public void TestMethod(StoreName storeName)
     {
         var x509Store = new X509Store(storeName);
         x509Store.Add(new X509Certificate2());
@@ -337,7 +337,7 @@ using System.Security.Cryptography.X509Certificates;
 
 class TestClass
 {
-    public async Task TestMethod(StoreName storeName)
+    public void TestMethod(StoreName storeName)
     {
         Random r = new Random();
 
@@ -367,7 +367,7 @@ class TestClass
         TestMethod2(x509Store); 
     }
 
-    public async Task TestMethod2(X509Store x509Store)
+    public void TestMethod2(X509Store x509Store)
     {
         x509Store.Add(new X509Certificate2());
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotInstallRootCertTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotInstallRootCertTests.cs
@@ -449,7 +449,7 @@ class TestClass
             await test.RunAsync();
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
             => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotInstallRootCertTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotInstallRootCertTests.cs
@@ -1,20 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotInstallRootCert,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
-    public class DoNotInstallRootCertTests : DiagnosticAnalyzerTestBase
+    public class DoNotInstallRootCertTests
     {
         [Fact]
-        public void TestConstructorWithStoreNameParameterDiagnostic()
+        public async Task TestConstructorWithStoreNameParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -30,9 +33,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithStoreNameParameterMaybeChangedDiagnostic()
+        public async Task TestConstructorWithStoreNameParameterMaybeChangedDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography.X509Certificates;
 
@@ -56,15 +59,15 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithStoreNameParameterUnassignedMaybeChangedWithRootDiagnostic()
+        public async Task TestConstructorWithStoreNameParameterUnassignedMaybeChangedWithRootDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
 {
-    public void TestMethod(StoreName storeName)
+    public async Task TestMethod(StoreName storeName)
     {
         Random r = new Random();
 
@@ -81,9 +84,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithStoreNameAndStoreLocationParametersDiagnostic()
+        public async Task TestConstructorWithStoreNameAndStoreLocationParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -99,16 +102,16 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithStringParameterDiagnostic()
+        public async Task TestConstructorWithStringParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
 {
     public void TestMethod()
     {
-        var storeName = ""Root""; 
+        var storeName = ""Root"";
         var x509Store = new X509Store(storeName);
         x509Store.Add(new X509Certificate2());
     }
@@ -117,16 +120,16 @@ class TestClass
         }
 
         [Fact]
-        public void TestStringCaseSensitiveDiagnostic()
+        public async Task TestStringCaseSensitiveDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
 {
     public void TestMethod()
     {
-        var storeName = ""rooT""; 
+        var storeName = ""rooT"";
         var x509Store = new X509Store(storeName);
         x509Store.Add(new X509Certificate2());
     }
@@ -135,16 +138,16 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithStringAndStoreLocationParametersDiagnostic()
+        public async Task TestConstructorWithStringAndStoreLocationParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
 {
     public void TestMethod()
     {
-        var storeName = ""Root""; 
+        var storeName = ""Root"";
         var x509Store = new X509Store(storeName, StoreLocation.CurrentUser);
         x509Store.Add(new X509Certificate2());
     }
@@ -153,9 +156,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithStoreNameParameterWithoutTemporaryObjectDiagnostic()
+        public async Task TestConstructorWithStoreNameParameterWithoutTemporaryObjectDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -169,9 +172,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithStringParameterWithoutTemporaryObjectDiagnostic()
+        public async Task TestConstructorWithStringParameterWithoutTemporaryObjectDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -185,9 +188,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestPassX509StoreAsParameterInterproceduralDiagnostic()
+        public async Task TestPassX509StoreAsParameterInterproceduralDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -199,7 +202,7 @@ class TestClass
         TestMethod2(x509Store); 
     }
 
-    public void TestMethod2(X509Store x509Store)
+    public async Task TestMethod2(X509Store x509Store)
     {
         x509Store.Add(new X509Certificate2());
     }
@@ -208,9 +211,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestGetX509StoreFromLocalFunctionDiagnostic()
+        public async Task TestGetX509StoreFromLocalFunctionDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -226,9 +229,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestReturnX509StoreInterproceduralDiagnostic()
+        public async Task TestReturnX509StoreInterproceduralDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -247,9 +250,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestNotCallAddMethodNoDiagnostic()
+        public async Task TestNotCallAddMethodNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -262,9 +265,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestInstallCertToOtherStoreNoDiagnostic()
+        public async Task TestInstallCertToOtherStoreNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -278,9 +281,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestInstallCertToNullStoreNoDiagnostic()
+        public async Task TestInstallCertToNullStoreNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -294,9 +297,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateAStoreWithoutSettingStoreNameNoDiagnostic()
+        public async Task TestCreateAStoreWithoutSettingStoreNameNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -310,14 +313,14 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithStoreNameParameterUnassignedNoDiagnostic()
+        public async Task TestConstructorWithStoreNameParameterUnassignedNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
 {
-    public void TestMethod(StoreName storeName)
+    public async Task TestMethod(StoreName storeName)
     {
         var x509Store = new X509Store(storeName);
         x509Store.Add(new X509Certificate2());
@@ -326,15 +329,15 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithStoreNameParameterUnassignedMaybeChangedWithMyNoDiagnostic()
+        public async Task TestConstructorWithStoreNameParameterUnassignedMaybeChangedWithMyNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
 {
-    public void TestMethod(StoreName storeName)
+    public async Task TestMethod(StoreName storeName)
     {
         Random r = new Random();
 
@@ -350,9 +353,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestPassX509StoreAsParameterInterproceduralNoDiagnostic()
+        public async Task TestPassX509StoreAsParameterInterproceduralNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -364,7 +367,7 @@ class TestClass
         TestMethod2(x509Store); 
     }
 
-    public void TestMethod2(X509Store x509Store)
+    public async Task TestMethod2(X509Store x509Store)
     {
         x509Store.Add(new X509Certificate2());
     }
@@ -372,9 +375,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestLambdaNoDiagnostic()
+        public async Task TestLambdaNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -389,9 +392,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestReturnX509StoreInterproceduralNoDiagnostic()
+        public async Task TestReturnX509StoreInterproceduralNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -414,18 +417,15 @@ class TestClass
         [InlineData(@"dotnet_code_quality.CA5380.excluded_symbol_names = TestMethod
                       dotnet_code_quality.CA5381.excluded_symbol_names = TestMethod")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = TestMethod")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (editorConfigText.Length == 0)
+            var test = new VerifyCS.Test
             {
-                expected = new DiagnosticResult[]
+                TestState =
                 {
-                    GetCSharpResultAt(10, 9, DoNotInstallRootCert.DefinitelyInstallRootCertRule)
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 using System.Security.Cryptography.X509Certificates;
 
 class TestClass
@@ -436,17 +436,21 @@ class TestClass
         var x509Store = new X509Store(storeName);
         x509Store.Add(new X509Certificate2());
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+                    }
+                }
+            };
+
+            if (editorConfigText.Length == 0)
+            {
+                test.ExpectedDiagnostics.Add(GetCSharpResultAt(10, 9, DoNotInstallRootCert.DefinitelyInstallRootCertRule));
+            }
+
+            await test.RunAsync();
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotInstallRootCert();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotInstallRootCert();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+            => VerifyCS.Diagnostic(rule)
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotReferSelfInSerializableClassTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotReferSelfInSerializableClassTests.cs
@@ -926,12 +926,12 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotReferSelfInSerializableClassTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotReferSelfInSerializableClassTests.cs
@@ -1,22 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotReferSelfInSerializableClass,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotReferSelfInSerializableClass,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotReferSelfInSerializableClassTests : DiagnosticAnalyzerTestBase
+    public class DoNotReferSelfInSerializableClassTests
     {
         [Fact]
-        public void TestSelfReferDirectlyDiagnostic()
+        public async Task TestSelfReferDirectlyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -28,9 +29,9 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(7, 23, DoNotReferSelfInSerializableClass.Rule, "testClass"));
+            GetCSharpResultAt(7, 23, "testClass"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Namespace TestNamespace
@@ -42,13 +43,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(7, 17, DoNotReferSelfInSerializableClass.Rule, "testClass"));
+            GetBasicResultAt(7, 17, "testClass"));
         }
 
         [Fact]
-        public void TestParentChildCircleDiagnostic()
+        public async Task TestParentChildCircleDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -70,14 +71,14 @@ class TestClassB
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "testClassB"),
-            GetCSharpResultAt(17, 24, DoNotReferSelfInSerializableClass.Rule, "testClassA"));
+            GetCSharpResultAt(7, 24, "testClassB"),
+            GetCSharpResultAt(17, 24, "testClassA"));
         }
 
         [Fact]
-        public void TestParentGrandchildCircleDiagnostic()
+        public async Task TestParentGrandchildCircleDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -119,15 +120,15 @@ class TestClassD
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "testClassBInA"),
-            GetCSharpResultAt(19, 24, DoNotReferSelfInSerializableClass.Rule, "testClassCInB"),
-            GetCSharpResultAt(29, 24, DoNotReferSelfInSerializableClass.Rule, "testClassAInC"));
+            GetCSharpResultAt(7, 24, "testClassBInA"),
+            GetCSharpResultAt(19, 24, "testClassCInB"),
+            GetCSharpResultAt(29, 24, "testClassAInC"));
         }
 
         [Fact]
-        public void TestChildCircleDiagnostic()
+        public async Task TestChildCircleDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -149,13 +150,13 @@ class TestClassB
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "testClassAInA"));
+            GetCSharpResultAt(7, 24, "testClassAInA"));
         }
 
         [Fact]
-        public void TestChildGrandchildCircleDiagnostic()
+        public async Task TestChildGrandchildCircleDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -187,14 +188,14 @@ class TestClassC
     {
     }
 }",
-            GetCSharpResultAt(17, 24, DoNotReferSelfInSerializableClass.Rule, "testClassCInB"),
-            GetCSharpResultAt(27, 24, DoNotReferSelfInSerializableClass.Rule, "testClassBInC"));
+            GetCSharpResultAt(17, 24, "testClassCInB"),
+            GetCSharpResultAt(27, 24, "testClassBInC"));
         }
 
         [Fact]
-        public void TestClassReferedInTwoLoopsDiagnostic()
+        public async Task TestClassReferedInTwoLoopsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -258,18 +259,18 @@ class TestClassC2
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "testClassBInA"),
-            GetCSharpResultAt(11, 25, DoNotReferSelfInSerializableClass.Rule, "testClassB2InA"),
-            GetCSharpResultAt(21, 24, DoNotReferSelfInSerializableClass.Rule, "testClassCInB"),
-            GetCSharpResultAt(31, 24, DoNotReferSelfInSerializableClass.Rule, "testClassAInC"),
-            GetCSharpResultAt(49, 25, DoNotReferSelfInSerializableClass.Rule, "testClassC2InB2"),
-            GetCSharpResultAt(59, 24, DoNotReferSelfInSerializableClass.Rule, "testClassAInC2"));
+            GetCSharpResultAt(7, 24, "testClassBInA"),
+            GetCSharpResultAt(11, 25, "testClassB2InA"),
+            GetCSharpResultAt(21, 24, "testClassCInB"),
+            GetCSharpResultAt(31, 24, "testClassAInC"),
+            GetCSharpResultAt(49, 25, "testClassC2InB2"),
+            GetCSharpResultAt(59, 24, "testClassAInC2"));
         }
 
         [Fact]
-        public void TestMultiFieldsWithSameTypeDiagnostic()
+        public async Task TestMultiFieldsWithSameTypeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -295,16 +296,16 @@ class TestClassB
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "testClassBInA"),
-            GetCSharpResultAt(9, 24, DoNotReferSelfInSerializableClass.Rule, "testClassB2InA"),
-            GetCSharpResultAt(19, 24, DoNotReferSelfInSerializableClass.Rule, "testClassAInB"),
-            GetCSharpResultAt(21, 24, DoNotReferSelfInSerializableClass.Rule, "testClassA2InB"));
+            GetCSharpResultAt(7, 24, "testClassBInA"),
+            GetCSharpResultAt(9, 24, "testClassB2InA"),
+            GetCSharpResultAt(19, 24, "testClassAInB"),
+            GetCSharpResultAt(21, 24, "testClassA2InB"));
         }
 
         [Fact]
-        public void TestChildCircleWithParentChildCircleDiagnostic()
+        public async Task TestChildCircleWithParentChildCircleDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -328,15 +329,15 @@ class TestClassB
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "testClassBInA"),
-            GetCSharpResultAt(17, 24, DoNotReferSelfInSerializableClass.Rule, "testClassAInB"),
-            GetCSharpResultAt(19, 24, DoNotReferSelfInSerializableClass.Rule, "testClassBInB"));
+            GetCSharpResultAt(7, 24, "testClassBInA"),
+            GetCSharpResultAt(17, 24, "testClassAInB"),
+            GetCSharpResultAt(19, 24, "testClassBInB"));
         }
 
         [Fact]
-        public void TestTwoIndependentParentChildCirclesDiagnostic()
+        public async Task TestTwoIndependentParentChildCirclesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -378,16 +379,16 @@ class TestClassB2
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "testClassB"),
-            GetCSharpResultAt(17, 24, DoNotReferSelfInSerializableClass.Rule, "testClassA"),
-            GetCSharpResultAt(27, 25, DoNotReferSelfInSerializableClass.Rule, "testClassB2"),
-            GetCSharpResultAt(37, 25, DoNotReferSelfInSerializableClass.Rule, "testClassA2"));
+            GetCSharpResultAt(7, 24, "testClassB"),
+            GetCSharpResultAt(17, 24, "testClassA"),
+            GetCSharpResultAt(27, 25, "testClassB2"),
+            GetCSharpResultAt(37, 25, "testClassA2"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyByPropertyDiagnostic()
+        public async Task TestSelfReferDirectlyByPropertyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -399,13 +400,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(7, 22, DoNotReferSelfInSerializableClass.Rule, "TestClassProperty"));
+            GetCSharpResultAt(7, 22, "TestClassProperty"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithGenericTypeDiagnostic()
+        public async Task TestSelfReferDirectlyWithGenericTypeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [System.Serializable]
@@ -422,13 +423,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(12, 37, DoNotReferSelfInSerializableClass.Rule, "testClasses"));
+            GetCSharpResultAt(12, 37, "testClasses"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithArrayDiagnostic()
+        public async Task TestSelfReferDirectlyWithArrayDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -440,13 +441,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(7, 25, DoNotReferSelfInSerializableClass.Rule, "testClasses"));
+            GetCSharpResultAt(7, 25, "testClasses"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithDoubleDimensionalArrayDiagnostic()
+        public async Task TestSelfReferDirectlyWithDoubleDimensionalArrayDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -458,13 +459,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(7, 27, DoNotReferSelfInSerializableClass.Rule, "testClasses"));
+            GetCSharpResultAt(7, 27, "testClasses"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithListDiagnostic()
+        public async Task TestSelfReferDirectlyWithListDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -477,13 +478,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(8, 29, DoNotReferSelfInSerializableClass.Rule, "testClasses"));
+            GetCSharpResultAt(8, 29, "testClasses"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithListListDiagnostic()
+        public async Task TestSelfReferDirectlyWithListListDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -496,13 +497,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(8, 35, DoNotReferSelfInSerializableClass.Rule, "testClasses"));
+            GetCSharpResultAt(8, 35, "testClasses"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithListListListDiagnostic()
+        public async Task TestSelfReferDirectlyWithListListListDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -515,13 +516,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(8, 41, DoNotReferSelfInSerializableClass.Rule, "testClasses"));
+            GetCSharpResultAt(8, 41, "testClasses"));
         }
 
         [Fact]
-        public void TestGenericChildCircleDiagnostic()
+        public async Task TestGenericChildCircleDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -544,13 +545,13 @@ class TestClassB
     {
     }
 }",
-            GetCSharpResultAt(8, 30, DoNotReferSelfInSerializableClass.Rule, "testClassAInA"));
+            GetCSharpResultAt(8, 30, "testClassAInA"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyByPropertyWithArrayDiagnostic()
+        public async Task TestSelfReferDirectlyByPropertyWithArrayDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -562,13 +563,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "TestClassProperty"));
+            GetCSharpResultAt(7, 24, "TestClassProperty"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithinGenericTypeDiagnostic()
+        public async Task TestSelfReferDirectlyWithinGenericTypeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -580,13 +581,13 @@ class TestClass<T>
     {
     }
 }",
-            GetCSharpResultAt(7, 26, DoNotReferSelfInSerializableClass.Rule, "testClass"));
+            GetCSharpResultAt(7, 26, "testClass"));
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithDictionaryDiagnostic()
+        public async Task TestSelfReferDirectlyWithDictionaryDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -604,13 +605,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(13, 48, DoNotReferSelfInSerializableClass.Rule, "testClasses"));
+            GetCSharpResultAt(13, 48, "testClasses"));
         }
 
         [Fact]
-        public void TestParentClassSubclassCirlceDiagnostic()
+        public async Task TestParentClassSubclassCirlceDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -632,9 +633,9 @@ class TestClassB : TestClassA
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "testClassB"));
+            GetCSharpResultAt(7, 24, "testClassB"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 
 Namespace TestNamespace
@@ -656,13 +657,13 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace",
-            GetBasicResultAt(7, 17, DoNotReferSelfInSerializableClass.Rule, "testClassB"));
+            GetBasicResultAt(7, 17, "testClassB"));
         }
 
         [Fact]
-        public void TestParentClassIndirectSubclassCirlceDiagnostic()
+        public async Task TestParentClassIndirectSubclassCirlceDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -694,15 +695,15 @@ class TestClassC : TestClassB
     {
     }
 }",
-            GetCSharpResultAt(7, 24, DoNotReferSelfInSerializableClass.Rule, "testClassB"),
-            GetCSharpResultAt(17, 24, DoNotReferSelfInSerializableClass.Rule, "testClassC"),
-            GetCSharpResultAt(27, 24, DoNotReferSelfInSerializableClass.Rule, "testClassA"));
+            GetCSharpResultAt(7, 24, "testClassB"),
+            GetCSharpResultAt(17, 24, "testClassC"),
+            GetCSharpResultAt(27, 24, "testClassA"));
         }
 
         [Fact]
-        public void TestWithoutSelfReferNoDiagnostic()
+        public async Task TestWithoutSelfReferNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -727,9 +728,9 @@ class TestClassB
         }
 
         [Fact]
-        public void TestStaticSelfReferNoDiagnostic()
+        public async Task TestStaticSelfReferNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -744,9 +745,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestStaticParentChildCircleNoDiagnostic()
+        public async Task TestStaticParentChildCircleNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -771,9 +772,9 @@ class TestClassB
         }
 
         [Fact]
-        public void TestStaticParentGrandchildCircleNoDiagnostic()
+        public async Task TestStaticParentGrandchildCircleNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -818,9 +819,9 @@ class TestClassD
         }
 
         [Fact]
-        public void TestNonSerializedAttributeSelfReferNoDiagnostic()
+        public async Task TestNonSerializedAttributeSelfReferNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -836,9 +837,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithArrayNoDiagnostic()
+        public async Task TestSelfReferDirectlyWithArrayNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -858,9 +859,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithDoubleDimensionalArrayNoDiagnostic()
+        public async Task TestSelfReferDirectlyWithDoubleDimensionalArrayNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 [Serializable()]
@@ -880,9 +881,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithListNoDiagnostic()
+        public async Task TestSelfReferDirectlyWithListNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -903,9 +904,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestSelfReferDirectlyWithListListNoDiagnostic()
+        public async Task TestSelfReferDirectlyWithListListNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Collections.Generic;
 
@@ -925,14 +926,14 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotReferSelfInSerializableClass();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotReferSelfInSerializableClass();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotSerializeTypeWithPointerFieldsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotSerializeTypeWithPointerFieldsTests.cs
@@ -1,17 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotSerializeTypeWithPointerFields,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotSerializeTypeWithPointerFieldsTests : DiagnosticAnalyzerTestBase
+    public class DoNotSerializeTypeWithPointerFieldsTests
     {
         [Fact]
         public void TestChildPointerToStructureDiagnostic()
@@ -29,7 +26,7 @@ unsafe class TestClassA
 struct TestStructB
 {
 }",
-            GetCSharpResultAt(7, 26, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(7, 26, "pointer"));
         }
 
         [Fact]
@@ -43,7 +40,7 @@ unsafe class TestClassA
 {
     private int* pointer;
 }",
-            GetCSharpResultAt(7, 18, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(7, 18, "pointer"));
         }
 
         [Fact]
@@ -57,7 +54,7 @@ unsafe class TestClassA
 {
     private bool* pointer;
 }",
-            GetCSharpResultAt(7, 19, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(7, 19, "pointer"));
         }
 
         [Fact]
@@ -71,7 +68,7 @@ unsafe class TestClassA
 {
     private int** pointer;
 }",
-            GetCSharpResultAt(7, 19, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(7, 19, "pointer"));
         }
 
         [Fact]
@@ -85,7 +82,7 @@ unsafe class TestClassA
 {
     private int** pointer { get; set; }
 }",
-            GetCSharpResultAt(7, 19, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(7, 19, "pointer"));
         }
 
         [Fact]
@@ -99,7 +96,7 @@ unsafe class TestClassA
 {
     private int*[] pointers;
 }",
-            GetCSharpResultAt(7, 20, DoNotSerializeTypeWithPointerFields.Rule, "pointers"));
+            GetCSharpResultAt(7, 20, "pointers"));
         }
 
         [Fact]
@@ -119,7 +116,7 @@ unsafe class TestClassB
 {
     private int* pointer;
 }",
-            GetCSharpResultAt(13, 18, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(13, 18, "pointer"));
         }
 
         [Fact]
@@ -140,7 +137,7 @@ unsafe class TestClassB
 {
     private int* pointer;
 }",
-            GetCSharpResultAt(14, 18, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(14, 18, "pointer"));
         }
 
         [Fact]
@@ -161,7 +158,7 @@ unsafe class TestClassB
 {
     private int* pointer;
 }",
-            GetCSharpResultAt(14, 18, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(14, 18, "pointer"));
         }
 
         [Fact]
@@ -181,7 +178,7 @@ unsafe class TestClassB
 {
     public int* pointer;
 }",
-            GetCSharpResultAt(13, 17, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(13, 17, "pointer"));
         }
 
         [Fact]
@@ -201,7 +198,7 @@ unsafe class TestClassB
 {
     private int*[] pointers;
 }",
-            GetCSharpResultAt(13, 20, DoNotSerializeTypeWithPointerFields.Rule, "pointers"));
+            GetCSharpResultAt(13, 20, "pointers"));
         }
 
         [Fact]
@@ -221,8 +218,8 @@ unsafe struct TestStructB
 {
     public int* pointer2;
 }",
-            GetCSharpResultAt(7, 26, DoNotSerializeTypeWithPointerFields.Rule, "pointer1"),
-            GetCSharpResultAt(13, 17, DoNotSerializeTypeWithPointerFields.Rule, "pointer2"));
+            GetCSharpResultAt(7, 26, "pointer1"),
+            GetCSharpResultAt(13, 17, "pointer2"));
         }
 
         [Fact]
@@ -238,8 +235,8 @@ unsafe class TestClassA
     
     private int* pointer2;
 }",
-            GetCSharpResultAt(7, 18, DoNotSerializeTypeWithPointerFields.Rule, "pointer1"),
-            GetCSharpResultAt(9, 18, DoNotSerializeTypeWithPointerFields.Rule, "pointer2"));
+            GetCSharpResultAt(7, 18, "pointer1"),
+            GetCSharpResultAt(9, 18, "pointer2"));
         }
 
         [Fact]
@@ -253,7 +250,7 @@ unsafe struct TestStructA
 {
     private TestStructA* pointer;
 }",
-            GetCSharpResultAt(7, 26, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(7, 26, "pointer"));
         }
 
         [Fact]
@@ -273,7 +270,7 @@ unsafe struct TestStructB
 {
     public TestStructB* pointer;
 }",
-            GetCSharpResultAt(13, 25, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(13, 25, "pointer"));
         }
 
         [Fact]
@@ -298,8 +295,8 @@ unsafe class TestClassC : TestClassA
 {
     private int* pointer2;
 }",
-            GetCSharpResultAt(7, 28, DoNotSerializeTypeWithPointerFields.Rule, "pointer1"),
-            GetCSharpResultAt(18, 18, DoNotSerializeTypeWithPointerFields.Rule, "pointer2"));
+            GetCSharpResultAt(7, 28, "pointer1"),
+            GetCSharpResultAt(18, 18, "pointer2"));
         }
 
         [Fact]
@@ -315,7 +312,7 @@ unsafe class TestClassA<T>
 
     private int* pointer;
 }",
-            GetCSharpResultAt(9, 18, DoNotSerializeTypeWithPointerFields.Rule, "pointer"));
+            GetCSharpResultAt(9, 18, "pointer"));
         }
 
         [Fact]
@@ -383,14 +380,14 @@ unsafe class TestClassA
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        private void VerifyCSharpUnsafeCode(string code, params DiagnosticResult[] expected)
         {
-            return new DoNotSerializeTypeWithPointerFields();
+            // TODO: Amaury - Fix this code
         }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotSerializeTypeWithPointerFields();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotSerializeTypeWithPointerFieldsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotSerializeTypeWithPointerFieldsTests.cs
@@ -385,7 +385,7 @@ unsafe class TestClassA
             // TODO: Amaury - Fix this code
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseAccountSASTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseAccountSASTests.cs
@@ -114,7 +114,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
            => VerifyCS.Diagnostic()
                .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseAccountSASTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseAccountSASTests.cs
@@ -1,15 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseAccountSAS,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseAccountSASTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseAccountSASTests
     {
-        protected void VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
+        protected async Task VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
         {
             string microsoftWindowsAzureStorageCSharpSourceCode = @"
 using System;
@@ -47,15 +49,23 @@ namespace NormalNamespace
     {
     }
 }";
-            this.VerifyCSharp(
-                new[] { source, microsoftWindowsAzureStorageCSharpSourceCode }.ToFileAndSource(),
-                expected);
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source, microsoftWindowsAzureStorageCSharpSourceCode }
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
         }
 
         [Fact]
-        public void TestGetSharedAccessSignatureOfCloudStorageAccountDiagnostic()
+        public async Task TestGetSharedAccessSignatureOfCloudStorageAccountDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage;
 
@@ -67,13 +77,13 @@ class TestClass
         cloudStorageAccount.GetSharedAccessSignature(policy);
     }
 }",
-            GetCSharpResultAt(10, 9, DoNotUseAccountSAS.Rule));
+            GetCSharpResultAt(10, 9));
         }
 
         [Fact]
-        public void TestNormalMethodOfCloudStorageAccountNoDiagnostic()
+        public async Task TestNormalMethodOfCloudStorageAccountNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage;
 
@@ -88,9 +98,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestGetSharedAccessSignatureOfCloudStorageAccountOfNormalNamespaceNoDiagnostic()
+        public async Task TestGetSharedAccessSignatureOfCloudStorageAccountOfNormalNamespaceNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using NormalNamespace;
 
@@ -104,14 +114,8 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseAccountSAS();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseAccountSAS();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+           => VerifyCS.Diagnostic()
+               .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseCreateEncryptorWithNonDefaultIVTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseCreateEncryptorWithNonDefaultIVTests.cs
@@ -108,7 +108,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
             => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseCreateEncryptorWithNonDefaultIVTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseCreateEncryptorWithNonDefaultIVTests.cs
@@ -22,7 +22,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] rgbIV)
+    public void TestMethod(byte[] rgbIV)
     {
         var aesCng  = new AesCng();
         aesCng.IV = rgbIV;
@@ -60,7 +60,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] rgbIV)
+    public void TestMethod(byte[] rgbIV)
     {
         var aesCng  = new AesCng();
         Random r = new Random();
@@ -84,7 +84,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] rgbKey, byte[] rgbIV)
+    public void TestMethod(byte[] rgbKey, byte[] rgbIV)
     {
         var aesCng  = new AesCng();
         aesCng.CreateEncryptor(rgbKey, rgbIV);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDSATests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDSATests.cs
@@ -35,7 +35,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(CngKey key)
+    public void TestMethod(CngKey key)
     {
         var dsaCng = new DSACng(key);
     }
@@ -67,7 +67,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(int keySize)
+    public void TestMethod(int keySize)
     {
         var dsaCng = new DSACng(keySize);
     }
@@ -240,7 +240,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(DSA dsa)
+    public void TestMethod(DSA dsa)
     { 
         return;
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDSATests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDSATests.cs
@@ -1,17 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseDSA,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseDSATests : DiagnosticAnalyzerTestBase
+    public class DoNotUseDSATests
     {
         [Fact]
-        public void TestCreateObjectOfDSADerivedClassWithoutParameterDiagnostic()
+        public async Task TestCreateObjectOfDSADerivedClassWithoutParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -21,29 +24,29 @@ class TestClass
         var dsaCng = new DSACng();
     }
 }",
-            GetCSharpResultAt(8, 22, DoNotUseDSA.Rule, "DSACng"));
+            GetCSharpResultAt(8, 22, "DSACng"));
         }
 
         [Fact]
-        public void TestCreateObjectOfDSADerivedClassWithCngKeyParameterDiagnostic()
+        public async Task TestCreateObjectOfDSADerivedClassWithCngKeyParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(CngKey key)
+    public async Task TestMethod(CngKey key)
     {
         var dsaCng = new DSACng(key);
     }
 }",
-            GetCSharpResultAt(8, 22, DoNotUseDSA.Rule, "DSACng"));
+            GetCSharpResultAt(8, 22, "DSACng"));
         }
 
         [Fact]
-        public void TestCreateObjectOfDSADerivedClassWithInt32ParameterAssignedKeySizeDiagnostic()
+        public async Task TestCreateObjectOfDSADerivedClassWithInt32ParameterAssignedKeySizeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -53,29 +56,29 @@ class TestClass
         var dsaCng = new DSACng(2048);
     }
 }",
-            GetCSharpResultAt(8, 22, DoNotUseDSA.Rule, "DSACng"));
+            GetCSharpResultAt(8, 22, "DSACng"));
         }
 
         [Fact]
-        public void TestCreateObjectOfDSADerivedClassWithInt32ParameterUnassignedKeySizeDiagnostic()
+        public async Task TestCreateObjectOfDSADerivedClassWithInt32ParameterUnassignedKeySizeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(int keySize)
+    public async Task TestMethod(int keySize)
     {
         var dsaCng = new DSACng(keySize);
     }
 }",
-            GetCSharpResultAt(8, 22, DoNotUseDSA.Rule, "DSACng"));
+            GetCSharpResultAt(8, 22, "DSACng"));
         }
 
         [Fact]
-        public void TestReturnObjectOfDSADerivedClassDiagnostic()
+        public async Task TestReturnObjectOfDSADerivedClassDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -85,13 +88,13 @@ class TestClass
         return dsa;
     }
 }",
-            GetCSharpResultAt(8, 9, DoNotUseDSA.Rule, "DSA"));
+            GetCSharpResultAt(8, 9, "DSA"));
         }
 
         [Fact]
-        public void TestReturnObjectOfDSADerivedClassLocalFunctionDiagnostic()
+        public async Task TestReturnObjectOfDSADerivedClassLocalFunctionDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -101,13 +104,13 @@ class TestClass
         DSA GetDSA(DSA dsa) => dsa;
     }
 }",
-            GetCSharpResultAt(8, 32, DoNotUseDSA.Rule, "DSA"));
+            GetCSharpResultAt(8, 32, "DSA"));
         }
 
         [Fact]
-        public void TestCreateWithDSAArgDiagnostic()
+        public async Task TestCreateWithDSAArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -117,13 +120,13 @@ class TestClass
         var asymmetricAlgorithm = AsymmetricAlgorithm.Create(""DSA"");
     }
 }",
-            GetCSharpResultAt(8, 35, DoNotUseDSA.Rule, "DSA"));
+            GetCSharpResultAt(8, 35, "DSA"));
         }
 
         [Fact]
-        public void TestCaseSensitiveDiagnostic()
+        public async Task TestCaseSensitiveDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -133,13 +136,13 @@ class TestClass
         var asymmetricAlgorithm = AsymmetricAlgorithm.Create(""dSa"");
     }
 }",
-            GetCSharpResultAt(8, 35, DoNotUseDSA.Rule, "dSa"));
+            GetCSharpResultAt(8, 35, "dSa"));
         }
 
         [Fact]
-        public void TestCreateWithSystemSecurityCryptographyDSAArgDiagnostic()
+        public async Task TestCreateWithSystemSecurityCryptographyDSAArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -149,13 +152,13 @@ class TestClass
         var asymmetricAlgorithm = AsymmetricAlgorithm.Create(""System.Security.Cryptography.DSA"");
     }
 }",
-            GetCSharpResultAt(8, 35, DoNotUseDSA.Rule, "System.Security.Cryptography.DSA"));
+            GetCSharpResultAt(8, 35, "System.Security.Cryptography.DSA"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithDSAArgDiagnostic()
+        public async Task TestCreateFromNameWithDSAArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -165,13 +168,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""DSA"");
     }
 }",
-            GetCSharpResultAt(8, 28, DoNotUseDSA.Rule, "DSA"));
+            GetCSharpResultAt(8, 28, "DSA"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyDSAArgDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyDSAArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -181,13 +184,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""System.Security.Cryptography.DSA"");
     }
 }",
-            GetCSharpResultAt(8, 28, DoNotUseDSA.Rule, "System.Security.Cryptography.DSA"));
+            GetCSharpResultAt(8, 28, "System.Security.Cryptography.DSA"));
         }
 
         [Fact]
-        public void TestCreateWithECDsaArgNoDiagnostic()
+        public async Task TestCreateWithECDsaArgNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -200,9 +203,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithECDsaArgNoDiagnostic()
+        public async Task TestCreateFromNameWithECDsaArgNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -215,9 +218,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithECDsaAndKeySize1024ArgsNoDiagnostic()
+        public async Task TestCreateFromNameWithECDsaAndKeySize1024ArgsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -230,28 +233,23 @@ class TestClass
         }
 
         [Fact]
-        public void TestReturnVoidNoDiagnostic()
+        public async Task TestReturnVoidNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(DSA dsa)
+    public async Task TestMethod(DSA dsa)
     { 
         return;
     }
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseDSA();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseDSA();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDSATests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDSATests.cs
@@ -247,7 +247,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDeprecatedSecurityProtocolsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDeprecatedSecurityProtocolsTests.cs
@@ -2,11 +2,16 @@
 
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Xunit.Abstractions;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseDeprecatedSecurityProtocols,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseDeprecatedSecurityProtocols,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
@@ -33,17 +38,12 @@ namespace Microsoft.NetCore.Analyzers.Security.UnitTests
         }
     }
 
-    public class DoNotUseDeprecatedSecurityProtocolsTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseDeprecatedSecurityProtocolsTests
     {
-        public DoNotUseDeprecatedSecurityProtocolsTests(ITestOutputHelper output)
-            : base(output)
-        {
-        }
-
         [Fact]
-        public void DocSample1_CSharp_Violation()
+        public async Task DocSample1_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -60,9 +60,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample1_VB_Violation()
+        public async Task DocSample1_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Net
 
@@ -78,9 +78,9 @@ End Class
         }
 
         [Fact]
-        public void DocSample2_CSharp_Violation()
+        public async Task DocSample2_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -96,9 +96,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample2_VB_Violation()
+        public async Task DocSample2_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Net
 
@@ -113,9 +113,9 @@ End Class
         }
 
         [Fact]
-        public void DocSample1_CSharp_Solution()
+        public async Task DocSample1_CSharp_Solution()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -130,9 +130,9 @@ public class TestClass
         }
 
         [Fact]
-        public void DocSample1_VB_Solution()
+        public async Task DocSample1_VB_Solution()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Net
 
@@ -146,9 +146,9 @@ End Class
         }
 
         [Fact]
-        public void DocSample3_CSharp_Violation()
+        public async Task DocSample3_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -164,9 +164,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample3_VB_Violation()
+        public async Task DocSample3_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Net
 
@@ -181,9 +181,9 @@ End Class
         }
 
         [Fact]
-        public void DocSample4_CSharp_Violation()
+        public async Task DocSample4_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -199,9 +199,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample4_VB_Violation()
+        public async Task DocSample4_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Net
 
@@ -216,9 +216,9 @@ End Class
         }
 
         [Fact]
-        public void TestUseSsl3Diagnostic()
+        public async Task TestUseSsl3Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -233,9 +233,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUseTlsDiagnostic()
+        public async Task TestUseTlsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -250,9 +250,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUseTls11Diagnostic()
+        public async Task TestUseTls11Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -267,9 +267,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUseSystemDefaultNoDiagnostic()
+        public async Task TestUseSystemDefaultNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -283,9 +283,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUseTls12Diagnostic()
+        public async Task TestUseTls12Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -300,9 +300,9 @@ class TestClass
         }
 
         [FactUnlessTls13Unavailable]
-        public void TestUseTls13Diagnostic()
+        public async Task TestUseTls13Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -317,9 +317,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUseTls12OrdTls11Diagnostic()
+        public async Task TestUseTls12OrdTls11Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -335,9 +335,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUse192CompoundAssignmentDiagnostic()
+        public async Task TestUse192CompoundAssignmentDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -352,10 +352,10 @@ class TestClass
         }
 
         [Fact]
-        public void TestUse384SimpleAssignmentDiagnostic()
+        public async Task TestUse384SimpleAssignmentDiagnostic()
         {
             // 384 = SchProtocols.Tls11Server | SchProtocols.Tls10Client
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -370,9 +370,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUse768SimpleAssignmentOrExpressionDiagnostic()
+        public async Task TestUse768SimpleAssignmentOrExpressionDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -387,9 +387,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUse12288SimpleAssignmentOrExpressionDiagnostic()
+        public async Task TestUse12288SimpleAssignmentOrExpressionDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -404,9 +404,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUseTls12OrTls11Or192Diagnostic()
+        public async Task TestUseTls12OrTls11Or192Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -422,9 +422,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUseTls12Or192Diagnostic()
+        public async Task TestUseTls12Or192Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -440,9 +440,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUse768DeconstructionAssignmentNoDiagnostic()
+        public async Task TestUse768DeconstructionAssignmentNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -458,9 +458,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUse24Plus24SimpleAssignmentDiagnostic()
+        public async Task TestUse24Plus24SimpleAssignmentDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -475,9 +475,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestUse768NotSecurityProtocolTypeNoDiagnostic()
+        public async Task TestUse768NotSecurityProtocolTypeNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -491,9 +491,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestMaskOutUnsafeOnServicePointManagerNoDiagnostic()
+        public async Task TestMaskOutUnsafeOnServicePointManagerNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -507,9 +507,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestMaskOutUnsafeOnVariableDiagnostic()
+        public async Task TestMaskOutUnsafeOnVariableDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net;
 
@@ -527,14 +527,14 @@ class TestClass
                 GetCSharpResultAt(10, 71, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls11"));
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseDeprecatedSecurityProtocols();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+           => VerifyCS.Diagnostic(rule)
+               .WithLocation(line, column)
+               .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseDeprecatedSecurityProtocols();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+           => VerifyVB.Diagnostic(rule)
+               .WithLocation(line, column)
+               .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDeprecatedSecurityProtocolsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseDeprecatedSecurityProtocolsTests.cs
@@ -527,12 +527,12 @@ class TestClass
                 GetCSharpResultAt(10, 71, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls11"));
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyVB.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
@@ -1,19 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureCryptographicAlgorithmsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureCryptographicAlgorithmsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseInsecureCryptographicAlgorithmsTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseInsecureCryptographicAlgorithmsTests
     {
-        #region CA5350 
+        #region CA5350
 
         [Fact]
-        public void CA5350UseMD5CreateInMethodDeclaration()
+        public async Task CA5350UseMD5CreateInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -28,7 +35,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -40,9 +47,9 @@ End Module",
         }
         //NO VB
         [Fact]
-        public void CA5350UseMD5CreateInPropertyDeclaration()
+        public async Task CA5350UseMD5CreateInPropertyDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -55,9 +62,9 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5350UseMD5CreateInGetDeclaration()
+        public async Task CA5350UseMD5CreateInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -71,7 +78,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "get_GetAlg", "MD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -86,9 +93,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350UseMD5CreateInFieldDeclaration()
+        public async Task CA5350UseMD5CreateInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -99,7 +106,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "Alg", "MD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -110,9 +117,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350UseMD5CreateInLambdaExpression()
+        public async Task CA5350UseMD5CreateInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -127,7 +134,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Imports System.Threading.Tasks
 Namespace TestNamespace
@@ -143,9 +150,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350UseMD5CreateInAnonymousMethodExpression()
+        public async Task CA5350UseMD5CreateInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -157,7 +164,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(8, 31, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "d", "MD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -169,9 +176,14 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350CreateObjectFromMD5DerivedClass()
+        public async Task CA5350CreateObjectFromMD5DerivedClass()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
 @"
 using System.Security.Cryptography;
@@ -210,11 +222,21 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-                GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5"));
+}"
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5")
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
-//Test0
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 @"
 Imports System.Security.Cryptography
 
@@ -245,19 +267,24 @@ Namespace TestNamespace
 			Throw New System.NotImplementedException()
 		End Function
 	End Class
-End Namespace"},
-
-                GetBasicResultAt(7, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5"));
+End Namespace"
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicResultAt(7, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5")
+                    }
+                }
+            }.RunAsync();
         }
 
         #endregion
 
-        #region CA5354  
+        #region CA5354
 
         [Fact]
-        public void CA5354UseSHA1CreateInMethodDeclaration()
+        public async Task CA5354UseSHA1CreateInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -272,7 +299,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 24, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -284,9 +311,9 @@ End Module",
         }
         //NO VB
         [Fact]
-        public void CA5354UseSHA1CreateInPropertyDeclaration()
+        public async Task CA5354UseSHA1CreateInPropertyDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -299,9 +326,9 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5354UseSHA1CreateInGetDeclaration()
+        public async Task CA5354UseSHA1CreateInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -315,7 +342,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "get_GetAlg", "SHA1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -330,9 +357,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5354UseSHA1CreateInFieldDeclaration()
+        public async Task CA5354UseSHA1CreateInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -343,7 +370,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "Alg", "SHA1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -354,9 +381,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5354UseSHA1CreateInLambdaExpression()
+        public async Task CA5354UseSHA1CreateInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -371,7 +398,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Imports System.Threading.Tasks
 Namespace TestNamespace
@@ -387,9 +414,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5354UseSHA1CreateInAnonymousMethodExpression()
+        public async Task CA5354UseSHA1CreateInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -401,7 +428,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(8, 31, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "d", "SHA1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -413,9 +440,14 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5354CreateObjectFromSHA1DerivedClass()
+        public async Task CA5354CreateObjectFromSHA1DerivedClass()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
 @"
 using System.Security.Cryptography;
@@ -454,10 +486,21 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-                GetCSharpResultAt(10, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1"));
+}"
+},
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1")
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
 @"
 Imports System.Security.Cryptography
@@ -487,14 +530,20 @@ Namespace TestNamespace
 			Throw New System.NotImplementedException()
 		End Function
 	End Class
-End Namespace" },
-                GetBasicResultAt(6, 17, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1"));
+End Namespace"
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicResultAt(6, 17, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1")
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA5354UseSHA1CryptoServiceProviderInMethodDeclaration()
+        public async Task CA5354UseSHA1CryptoServiceProviderInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -509,7 +558,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 24, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -521,9 +570,9 @@ End Module",
         }
 
         [Fact]
-        public void CA5354CreateHMACSHA1ObjectInMethodDeclaration()
+        public async Task CA5354CreateHMACSHA1ObjectInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -538,7 +587,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 28, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACSHA1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -550,9 +599,9 @@ End Module",
         }
         //No VB
         [Fact]
-        public void CA5354CreateHMACSHA1ObjectInPropertyDeclaration()
+        public async Task CA5354CreateHMACSHA1ObjectInPropertyDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -565,9 +614,9 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5354CreateHMACSHA1ObjectInGetDeclaration()
+        public async Task CA5354CreateHMACSHA1ObjectInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -581,7 +630,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "get_GetAlg", "HMACSHA1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -596,9 +645,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5354CreateHMACSHA1ObjectInFieldDeclaration()
+        public async Task CA5354CreateHMACSHA1ObjectInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -609,7 +658,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 27, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "Alg", "HMACSHA1"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -620,9 +669,9 @@ End Namespace",
         }
         //No VB
         [Fact]
-        public void CA5354CreateHMACSHA1ObjectInLambdaExpression()
+        public async Task CA5354CreateHMACSHA1ObjectInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -639,9 +688,9 @@ namespace TestNamespace
         }
         //No VB
         [Fact]
-        public void CA5354CreateHMACSHA1ObjectInAnonymousMethodExpression()
+        public async Task CA5354CreateHMACSHA1ObjectInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -655,9 +704,14 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5354CreateObjectFromHMACSHA1DerivedClass()
+        public async Task CA5354CreateObjectFromHMACSHA1DerivedClass()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
 @"
 using System.Security.Cryptography;
@@ -696,10 +750,21 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-                GetCSharpResultAt(10, 30, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACSHA1"));
+}"
+},
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 30, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACSHA1")
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
 @"
 Imports System.Security.Cryptography
@@ -731,15 +796,21 @@ Namespace TestNamespace
 		End Function
 	End Class
 End Namespace
-" },
-                GetBasicResultAt(7, 21, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACSHA1"));
+"
+},
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicResultAt(7, 21, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACSHA1")
+                    }
+                }
+            }.RunAsync();
         }
-        #endregion 
+        #endregion
 
         [Fact]
-        public void CA5350UseHMACMD5CreateInMethodDeclaration()
+        public async Task CA5350UseHMACMD5CreateInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -754,7 +825,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "HMACMD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Namespace TestNamespace
@@ -768,9 +839,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350CreateObjectFromHMACMD5DerivedClass()
+        public async Task CA5350CreateObjectFromHMACMD5DerivedClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -787,7 +858,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(12, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "HMACMD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class MyHMACMD5
@@ -804,9 +875,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350UseHMACMD5CreateInGetDeclaration()
+        public async Task CA5350UseHMACMD5CreateInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -820,7 +891,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "get_GetHMACMD5", "HMACMD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -835,9 +906,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350UseHMACMD5InFieldDeclaration()
+        public async Task CA5350UseHMACMD5InFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -848,7 +919,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 30, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "privateMd5", "HMACMD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -859,9 +930,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350UseHMACMD5InLambdaExpression()
+        public async Task CA5350UseHMACMD5InLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -876,7 +947,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "HMACMD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Imports System.Threading.Tasks
 
@@ -891,9 +962,9 @@ End Module",
         }
 
         [Fact]
-        public void CA5350UseHMACMD5InAnonymousMethodExpression()
+        public async Task CA5350UseHMACMD5InAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -905,7 +976,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(8, 31, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "d", "HMACMD5"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass 
@@ -916,9 +987,9 @@ End Module",
         }
 
         [Fact]
-        public void CA5351UseDESCreateInMethodDeclaration()
+        public async Task CA5351UseDESCreateInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -933,7 +1004,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -945,9 +1016,9 @@ End Module",
         }
 
         [Fact]
-        public void CA5351UseDESCreateInGetDeclaration()
+        public async Task CA5351UseDESCreateInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -961,7 +1032,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "get_GetDES", "DES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -977,9 +1048,9 @@ End Namespace
         }
 
         [Fact]
-        public void CA5351UseDESCreateInFieldDeclaration()
+        public async Task CA5351UseDESCreateInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -990,7 +1061,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "privateDES", "DES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1001,9 +1072,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5351UseDESCreateInLambdaExpression()
+        public async Task CA5351UseDESCreateInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -1018,7 +1089,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Imports System.Threading.Tasks
 Namespace TestNamespace
@@ -1034,9 +1105,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5351UseDESCreateInAnonymousMethodExpression()
+        public async Task CA5351UseDESCreateInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1048,7 +1119,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(8, 31, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "d", "DES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1060,9 +1131,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5351UseDESCryptoServiceProviderCreateInMethodDeclaration()
+        public async Task CA5351UseDESCryptoServiceProviderCreateInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -1077,7 +1148,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1090,9 +1161,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5351UseDESCryptoServiceProviderCreateInGetDeclaration()
+        public async Task CA5351UseDESCryptoServiceProviderCreateInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1106,7 +1177,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "get_GetDES", "DES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1121,9 +1192,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5351UseDESCryptoServiceProviderCreateInFieldDeclaration()
+        public async Task CA5351UseDESCryptoServiceProviderCreateInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1134,7 +1205,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 47, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "privateDES", "DES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1143,11 +1214,11 @@ Namespace TestNamespace
 End Namespace",
                 GetBasicResultAt(5, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "privateDES", "DES"));
         }
-        //No VB        
+        //No VB
         [Fact]
-        public void CA5351UseDESCryptoServiceProviderInLambdaExpression()
+        public async Task CA5351UseDESCryptoServiceProviderInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -1162,11 +1233,11 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"));
         }
-        //No VB        
+        //No VB
         [Fact]
-        public void CA5351UseDESCryptoServiceProviderInAnonymousMethodExpression()
+        public async Task CA5351UseDESCryptoServiceProviderInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1180,9 +1251,14 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5351CreateObjectFromDESDerivedClass()
+        public async Task CA5351CreateObjectFromDESDerivedClass()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 using System.Security.Cryptography;
@@ -1227,11 +1303,22 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-                GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"),
-                GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"));
+}"
+},
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"),
+                        GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES")
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 Imports System.Security.Cryptography
@@ -1267,15 +1354,21 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace
-" },
-                GetBasicResultAt(6, 15, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"),
-                GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"));
+"
+},
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicResultAt(6, 15, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"),
+                        GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES")
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA5352UseRC2CryptoServiceProviderInMethodDeclaration()
+        public async Task CA5352UseRC2CryptoServiceProviderInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -1290,7 +1383,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -1302,9 +1395,9 @@ End Module",
         }
 
         [Fact]
-        public void CA5352UseRC2CryptoServiceProviderInGetDeclaration()
+        public async Task CA5352UseRC2CryptoServiceProviderInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1318,7 +1411,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "get_GetRC2", "RC2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1333,9 +1426,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5352UseRC2CryptoServiceProviderInFieldDeclaration()
+        public async Task CA5352UseRC2CryptoServiceProviderInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1346,7 +1439,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 47, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "privateRC2", "RC2"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1356,11 +1449,11 @@ End Namespace
 ",
                 GetBasicResultAt(5, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "privateRC2", "RC2"));
         }
-        //No VB            
+        //No VB
         [Fact]
-        public void CA5352UseRC2CryptoServiceProviderInLambdaExpression()
+        public async Task CA5352UseRC2CryptoServiceProviderInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -1375,11 +1468,11 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2"));
         }
-        //No VB        
+        //No VB
         [Fact]
-        public void CA5352UseRC2CryptoServiceProviderInAnonymousMethodExpression()
+        public async Task CA5352UseRC2CryptoServiceProviderInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1393,9 +1486,14 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5352CreateObjectFromRC2DerivedClass()
+        public async Task CA5352CreateObjectFromRC2DerivedClass()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
 @"
 using System.Security.Cryptography;
@@ -1439,10 +1537,21 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-                GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2"));
+}"
+},
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2")
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
 @"
 Imports System.Security.Cryptography
@@ -1477,14 +1586,20 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace
-" },
-                GetBasicResultAt(6, 14, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2"));
+"
+},
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicResultAt(6, 14, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2")
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA5353TripleDESCreateInMethodDeclaration()
+        public async Task CA5353TripleDESCreateInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -1493,13 +1608,13 @@ namespace TestNamespace
     {
         private static void TestMethod()
         {
-            var tripleDES = TripleDES.Create(""TripleDES"");  
+            var tripleDES = TripleDES.Create(""TripleDES"");
         }
     }
 }",
                 GetCSharpResultAt(10, 29, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1512,9 +1627,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5353TripleDESCreateInGetDeclaration()
+        public async Task CA5353TripleDESCreateInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1528,7 +1643,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "get_GetTripleDES", "TripleDES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1543,9 +1658,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5353TripleDESCreateInFieldDeclaration()
+        public async Task CA5353TripleDESCreateInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1556,7 +1671,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 32, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "privateDES", "TripleDES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1567,9 +1682,9 @@ End Namespace",
         }
         //No VB
         [Fact]
-        public void CA5353TripleDESCreateInLambdaExpression()
+        public async Task CA5353TripleDESCreateInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -1586,9 +1701,9 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5353TripleDESCreateInAnonymousMethodExpression()
+        public async Task CA5353TripleDESCreateInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1600,7 +1715,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(8, 31, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "d", "TripleDES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1612,9 +1727,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5353TripleDESCryptoServiceProviderInMethodDeclaration()
+        public async Task CA5353TripleDESCryptoServiceProviderInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -1629,7 +1744,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 56, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -1641,9 +1756,9 @@ End Module",
         }
 
         [Fact]
-        public void CA5353TripleDESCryptoServiceProviderInGetDeclaration()
+        public async Task CA5353TripleDESCryptoServiceProviderInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1657,7 +1772,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "get_GetDES", "TripleDES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1672,9 +1787,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5353TripleDESCryptoServiceProviderInFieldDeclaration()
+        public async Task CA5353TripleDESCryptoServiceProviderInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1685,7 +1800,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 53, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "privateDES", "TripleDES"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1694,11 +1809,11 @@ Namespace TestNamespace
 End Namespace",
                 GetBasicResultAt(5, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "privateDES", "TripleDES"));
         }
-        //No VB       
+        //No VB
         [Fact]
-        public void CA5353TripleDESCryptoServiceProviderInLambdaExpression()
+        public async Task CA5353TripleDESCryptoServiceProviderInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -1713,11 +1828,11 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"));
         }
-        //No VB        
+        //No VB
         [Fact]
-        public void CA5353TripleDESCryptoServiceProviderInAnonymousMethodExpression()
+        public async Task CA5353TripleDESCryptoServiceProviderInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1731,9 +1846,14 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5353CreateObjectFromTripleDESDerivedClass()
+        public async Task CA5353CreateObjectFromTripleDESDerivedClass()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 using System.Security.Cryptography;
@@ -1778,11 +1898,22 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-                GetCSharpResultAt(10, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"),
-                GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"));
+}"
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"),
+                        GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES")
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 Imports System.Security.Cryptography
@@ -1820,15 +1951,21 @@ Namespace TestNamespace
 		End Sub
 	End Class
 End Namespace
-" },
-                GetBasicResultAt(6, 17, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"),
-                GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"));
+"
+                },
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicResultAt(6, 17, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"),
+                        GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES")
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA5350RIPEMD160ManagedInMethodDeclaration()
+        public async Task CA5350RIPEMD160ManagedInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -1843,7 +1980,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -1855,9 +1992,9 @@ End Module",
         }
 
         [Fact]
-        public void CA5350RIPEMD160ManagedInGetDeclaration()
+        public async Task CA5350RIPEMD160ManagedInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1871,7 +2008,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "get_GetRIPEMD160", "RIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -1886,9 +2023,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350RIPEMD160ManagedInFieldDeclaration()
+        public async Task CA5350RIPEMD160ManagedInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1899,7 +2036,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 45, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "privateRIPEMD160", "RIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1909,11 +2046,11 @@ End Namespace
 ",
                 GetBasicResultAt(5, 31, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "privateRIPEMD160", "RIPEMD160"));
         }
-        //No VB               
+        //No VB
         [Fact]
-        public void CA5350RIPEMD160ManagedInLambdaExpression()
+        public async Task CA5350RIPEMD160ManagedInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -1928,11 +2065,11 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"));
         }
-        //No VB        
+        //No VB
         [Fact]
-        public void CA5350RIPEMD160ManagedInAnonymousMethodExpression()
+        public async Task CA5350RIPEMD160ManagedInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1946,9 +2083,9 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5350RIPEMD160CreateInMethodDeclaration()
+        public async Task CA5350RIPEMD160CreateInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -1963,7 +2100,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 31, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -1976,9 +2113,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350RIPEMD160CreateInGetDeclaration()
+        public async Task CA5350RIPEMD160CreateInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -1992,7 +2129,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "get_GetRIPEMD160", "RIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -2007,9 +2144,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350RIPEMD160CreateInFieldDeclaration()
+        public async Task CA5350RIPEMD160CreateInFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -2020,7 +2157,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 38, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "privateRIPEMD160", "RIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -2029,11 +2166,11 @@ Namespace TestNamespace
 End Namespace",
                 GetBasicResultAt(5, 43, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "privateRIPEMD160", "RIPEMD160"));
         }
-        //No VB                
+        //No VB
         [Fact]
-        public void CA5350RIPEMD160CreateInLambdaExpression()
+        public async Task CA5350RIPEMD160CreateInLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -2050,9 +2187,9 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5350RIPEMD160CreateInAnonymousMethodExpression()
+        public async Task CA5350RIPEMD160CreateInAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -2064,7 +2201,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(8, 31, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "d", "RIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
     Class TestClass
@@ -2076,9 +2213,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350HMACRIPEMD160InMethodDeclaration()
+        public async Task CA5350HMACRIPEMD160InMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -2093,7 +2230,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACRIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -2106,9 +2243,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350HMACRIPEMD160InGetDeclaration()
+        public async Task CA5350HMACRIPEMD160InGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -2122,7 +2259,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(9, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "get_GetHMARIPEMD160", "HMACRIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -2137,9 +2274,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5350HMACRIPEMD160InFieldDeclaration()
+        public async Task CA5350HMACRIPEMD160InFieldDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -2150,7 +2287,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(7, 45, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "privateHMARIPEMD160", "HMACRIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -2159,11 +2296,11 @@ Namespace TestNamespace
 End Namespace",
                 GetBasicResultAt(5, 34, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "privateHMARIPEMD160", "HMACRIPEMD160"));
         }
-        //No VB        
+        //No VB
         [Fact]
-        public void CA5350HMACRIPEMD160InLambdaExpression()
+        public async Task CA5350HMACRIPEMD160InLambdaExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -2178,11 +2315,11 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 36, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACRIPEMD160"));
         }
-        //No VB        
+        //No VB
         [Fact]
-        public void CA5350HMACRIPEMD160InAnonymousMethodExpression()
+        public async Task CA5350HMACRIPEMD160InAnonymousMethodExpression()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -2196,9 +2333,14 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5350CreateObjectFromRIPEMD160DerivedClass()
+        public async Task CA5350CreateObjectFromRIPEMD160DerivedClass()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 using System.Security.Cryptography;
@@ -2237,10 +2379,21 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-                GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"));
+}"
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160")
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 Imports System.Security.Cryptography
@@ -2271,14 +2424,25 @@ Namespace TestNamespace
 			Throw New NotImplementedException()
 		End Function
 	End Class
-End Namespace" },
-                GetBasicResultAt(6, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"));
+End Namespace"
+                },
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicResultAt(6, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160")
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA5350CreateObjectFromRIPEMD160ManagedDerivedClass()
+        public async Task CA5350CreateObjectFromRIPEMD160ManagedDerivedClass()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 using System.Security.Cryptography;
@@ -2317,10 +2481,21 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-                GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"));
+}"
+                },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160")
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 Imports System.Security.Cryptography
@@ -2351,14 +2526,20 @@ Namespace TestNamespace
 		End Function
 	End Class
 End Namespace
-" },
-                GetBasicResultAt(6, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"));
+"
+                },
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicResultAt(6, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160")
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA5350CreateObjectFromHMACRIPEMD160DerivedClass()
+        public async Task CA5350CreateObjectFromHMACRIPEMD160DerivedClass()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -2375,7 +2556,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(12, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACRIPEMD160"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class MyHMACRIPEMD160
@@ -2392,9 +2573,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5356DSACreateSignatureInMethodDeclaration()
+        public async Task CA5356DSACreateSignatureInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -2409,7 +2590,7 @@ namespace TestNamespace
 }",
                 GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -2422,9 +2603,9 @@ End Module",
         }
 
         [Fact]
-        public void CA5356UseDSACreateSignatureInGetDeclaration()
+        public async Task CA5356UseDSACreateSignatureInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -2441,7 +2622,7 @@ class TestClass
 }",
                 GetCSharpResultAt(12, 20, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "get_MyProperty", "DSA"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Class TestClass
@@ -2457,9 +2638,9 @@ End Class",
         }
 
         [Fact]
-        public void CA5356DSASignatureFormatterInMethodDeclaration()
+        public async Task CA5356DSASignatureFormatterInMethodDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -2476,7 +2657,7 @@ namespace TestNamespace
                 GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA"),
                 GetCSharpResultAt(11, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Namespace TestNamespace
@@ -2492,9 +2673,9 @@ End Namespace",
         }
 
         [Fact]
-        public void CA5356UseDSACreateSignatureFormatterInGetDeclaration()
+        public async Task CA5356UseDSACreateSignatureFormatterInGetDeclaration()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -2513,7 +2694,7 @@ class TestClass
                 GetCSharpResultAt(12, 43, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "get_MyProperty", "DSA"),
                 GetCSharpResultAt(13, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "get_MyProperty", "DSA"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Class TestClass
 	Private dsa1 As DSA = Nothing
@@ -2533,9 +2714,14 @@ End Class",
         }
 
         [Fact]
-        public void CA5356CreateSignatureFromDSADerivedClass()
+        public async Task CA5356CreateSignatureFromDSADerivedClass()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
                 //Test0
                 @"
 using System.Security.Cryptography;
@@ -2596,10 +2782,21 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" },
-                GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA"));
+}"
+                },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA")
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 Imports System.Security.Cryptography
@@ -2647,14 +2844,20 @@ Namespace TestNamespace
 			Throw New NotImplementedException()
 		End Function
 	End Class
-End Namespace" },
-                GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA"));
+End Namespace"
+                },
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA")
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void CA5357RijndaelManagedInMethodDeclarationShouldNotGenerateDiagnostics()
+        public async Task CA5357RijndaelManagedInMethodDeclarationShouldNotGenerateDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 namespace TestNamespace
@@ -2669,7 +2872,7 @@ namespace TestNamespace
 }"
             );
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 
 Module TestClass
@@ -2681,9 +2884,9 @@ End Module"
         }
 
         [Fact]
-        public void CA5357RijndaelManagedInGetDeclarationShouldNotGenerateDiagnostics()
+        public async Task CA5357RijndaelManagedInGetDeclarationShouldNotGenerateDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -2697,7 +2900,7 @@ namespace TestNamespace
 }"
             );
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass1
@@ -2712,9 +2915,9 @@ End Namespace"
         }
 
         [Fact]
-        public void CA5357RijndaelManagedInFieldDeclarationShouldNotGenerateDiagnostics()
+        public async Task CA5357RijndaelManagedInFieldDeclarationShouldNotGenerateDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -2725,7 +2928,7 @@ namespace TestNamespace
 }"
             );
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Security.Cryptography
 Namespace TestNamespace
 	Class TestClass
@@ -2734,11 +2937,11 @@ Namespace TestNamespace
 End Namespace"
             );
         }
-        //No VB                    
+        //No VB
         [Fact]
-        public void CA5357RijndaelManagedInLambdaExpressionShouldNotGenerateDiagnostics()
+        public async Task CA5357RijndaelManagedInLambdaExpressionShouldNotGenerateDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 namespace TestNamespace
@@ -2753,11 +2956,11 @@ namespace TestNamespace
 }"
             );
         }
-        //No VB        
+        //No VB
         [Fact]
-        public void CA5357RijndaelManagedInAnonymousMethodExpressionShouldNotGenerateDiagnostics()
+        public async Task CA5357RijndaelManagedInAnonymousMethodExpressionShouldNotGenerateDiagnostics()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 namespace TestNamespace
 {
@@ -2771,9 +2974,14 @@ namespace TestNamespace
         }
 
         [Fact]
-        public void CA5357CreateObjectFromRijndaelDerivedClassShouldNotGenerateDiagnostics()
+        public async Task CA5357CreateObjectFromRijndaelDerivedClassShouldNotGenerateDiagnostics()
         {
-            VerifyCSharp(new[] {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 using System.Security.Cryptography;
@@ -2817,10 +3025,17 @@ namespace TestNamespace
             throw new NotImplementedException();
         }
     }
-}" }
-            );
+}"
+                    }
+                }
+            }.RunAsync();
 
-            VerifyBasic(new[] {
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
 //Test0
                 @"
 Imports System.Security.Cryptography
@@ -2854,18 +3069,20 @@ Namespace TestNamespace
 			Throw New NotImplementedException()
 		End Sub
 	End Class
-End Namespace" }
-            );
+End Namespace"
+                    }
+                }
+            }.RunAsync();
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureCryptographicAlgorithmsAnalyzer();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => VerifyCS.Diagnostic(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureCryptographicAlgorithmsAnalyzer();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => VerifyVB.Diagnostic(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
@@ -3075,12 +3075,12 @@ End Namespace"
             }.RunAsync();
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
             => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
             => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureCryptographicAlgorithmsTests.cs
@@ -226,7 +226,7 @@ namespace TestNamespace
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5")
+                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5"),
                     }
                 }
             }.RunAsync();
@@ -271,7 +271,7 @@ End Namespace"
                     },
                     ExpectedDiagnostics =
                     {
-                        GetBasicResultAt(7, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5")
+                        GetBasicResultAt(7, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "MD5"),
                     }
                 }
             }.RunAsync();
@@ -490,7 +490,7 @@ namespace TestNamespace
 },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(10, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1")
+                        GetCSharpResultAt(10, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1"),
                     }
                 }
             }.RunAsync();
@@ -534,7 +534,7 @@ End Namespace"
                     },
                     ExpectedDiagnostics =
                     {
-                        GetBasicResultAt(6, 17, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1")
+                        GetBasicResultAt(6, 17, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "SHA1"),
                     }
                 }
             }.RunAsync();
@@ -754,7 +754,7 @@ namespace TestNamespace
 },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(10, 30, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACSHA1")
+                        GetCSharpResultAt(10, 30, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACSHA1"),
                     }
                 }
             }.RunAsync();
@@ -800,7 +800,7 @@ End Namespace
 },
                     ExpectedDiagnostics =
                     {
-                        GetBasicResultAt(7, 21, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACSHA1")
+                        GetBasicResultAt(7, 21, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "HMACSHA1"),
                     }
                 }
             }.RunAsync();
@@ -1308,7 +1308,7 @@ namespace TestNamespace
                     ExpectedDiagnostics =
                     {
                         GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"),
-                        GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES")
+                        GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"),
                     }
                 }
             }.RunAsync();
@@ -1359,7 +1359,7 @@ End Namespace
                     ExpectedDiagnostics =
                     {
                         GetBasicResultAt(6, 15, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"),
-                        GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES")
+                        GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DES"),
                     }
                 }
             }.RunAsync();
@@ -1541,7 +1541,7 @@ namespace TestNamespace
 },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2")
+                        GetCSharpResultAt(10, 23, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2"),
                     }
                 }
             }.RunAsync();
@@ -1590,7 +1590,7 @@ End Namespace
 },
                     ExpectedDiagnostics =
                     {
-                        GetBasicResultAt(6, 14, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2")
+                        GetBasicResultAt(6, 14, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "RC2"),
                     }
                 }
             }.RunAsync();
@@ -1903,7 +1903,7 @@ namespace TestNamespace
                     ExpectedDiagnostics =
                     {
                         GetCSharpResultAt(10, 26, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"),
-                        GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES")
+                        GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"),
                     }
                 }
             }.RunAsync();
@@ -1956,7 +1956,7 @@ End Namespace
                     ExpectedDiagnostics =
                     {
                         GetBasicResultAt(6, 17, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"),
-                        GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES")
+                        GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "TripleDES"),
                     }
                 }
             }.RunAsync();
@@ -2383,7 +2383,7 @@ namespace TestNamespace
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160")
+                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"),
                     }
                 }
             }.RunAsync();
@@ -2428,7 +2428,7 @@ End Namespace"
                 },
                     ExpectedDiagnostics =
                     {
-                        GetBasicResultAt(6, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160")
+                        GetBasicResultAt(6, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"),
                     }
                 }
             }.RunAsync();
@@ -2485,7 +2485,7 @@ namespace TestNamespace
                 },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160")
+                        GetCSharpResultAt(10, 25, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"),
                     }
                 }
             }.RunAsync();
@@ -2530,7 +2530,7 @@ End Namespace
                 },
                     ExpectedDiagnostics =
                     {
-                        GetBasicResultAt(6, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160")
+                        GetBasicResultAt(6, 16, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseWeakCryptographyRule, "TestMethod", "RIPEMD160"),
                     }
                 }
             }.RunAsync();
@@ -2786,7 +2786,7 @@ namespace TestNamespace
                 },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA")
+                        GetCSharpResultAt(11, 13, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA"),
                     }
                 }
             }.RunAsync();
@@ -2848,7 +2848,7 @@ End Namespace"
                 },
                     ExpectedDiagnostics =
                     {
-                        GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA")
+                        GetBasicResultAt(7, 4, DoNotUseInsecureCryptographicAlgorithmsAnalyzer.DoNotUseBrokenCryptographyRule, "TestMethod", "DSA"),
                     }
                 }
             }.RunAsync();

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializationLosFormatterTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializationLosFormatterTests.cs
@@ -176,12 +176,12 @@ namespace Blah
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializationObjectStateFormatterTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializationObjectStateFormatterTests.cs
@@ -1,30 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerObjectStateFormatter,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerObjectStateFormatter,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseInsecureDeserializerObjectStateFormatterTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseInsecureDeserializerObjectStateFormatterTests
     {
-        private static readonly DiagnosticDescriptor Rule = DoNotUseInsecureDeserializerObjectStateFormatter.RealMethodUsedDescriptor;
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerObjectStateFormatter();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerObjectStateFormatter();
-        }
-
         [Fact]
-        public void DocSample1_CSharp_Violation_Diagnostic()
+        public async Task DocSample1_CSharp_Violation_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.UI;
 
@@ -36,13 +29,13 @@ public class ExampleClass
         return formatter.Deserialize(new MemoryStream(bytes));
     }
 }",
-                GetCSharpResultAt(10, 16, Rule, "object ObjectStateFormatter.Deserialize(Stream inputStream)"));
+                GetCSharpResultAt(10, 16, "object ObjectStateFormatter.Deserialize(Stream inputStream)"));
         }
 
         [Fact]
-        public void DocSample1_VB_Violation_Diagnostic()
+        public async Task DocSample1_VB_Violation_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.IO
 Imports System.Web.UI
 
@@ -52,13 +45,13 @@ Public Class ExampleClass
         Return formatter.Deserialize(New MemoryStream(bytes))
     End Function
 End Class",
-                GetBasicResultAt(8, 16, Rule, "Function ObjectStateFormatter.Deserialize(inputStream As Stream) As Object"));
+                GetBasicResultAt(8, 16, "Function ObjectStateFormatter.Deserialize(inputStream As Stream) As Object"));
         }
 
         [Fact]
-        public void DeserializeStream_Diagnostic()
+        public async Task DeserializeStream_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.UI;
 
@@ -73,13 +66,13 @@ namespace Blah
         }
     }
 }",
-            GetCSharpResultAt(12, 20, Rule, "object ObjectStateFormatter.Deserialize(Stream inputStream)"));
+            GetCSharpResultAt(12, 20, "object ObjectStateFormatter.Deserialize(Stream inputStream)"));
         }
 
         [Fact]
-        public void DeserializeString_Diagnostic()
+        public async Task DeserializeString_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.UI;
 
@@ -94,13 +87,13 @@ namespace Blah
         }
     }
 }",
-            GetCSharpResultAt(12, 20, Rule, "object ObjectStateFormatter.Deserialize(string inputString)"));
+            GetCSharpResultAt(12, 20, "object ObjectStateFormatter.Deserialize(string inputString)"));
         }
 
         [Fact]
-        public void Deserialize_Reference_Diagnostic()
+        public async Task Deserialize_Reference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.UI;
 
@@ -116,13 +109,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(13, 20, Rule, "object ObjectStateFormatter.Deserialize(string inputString)"));
+                GetCSharpResultAt(13, 20, "object ObjectStateFormatter.Deserialize(string inputString)"));
         }
 
         [Fact]
-        public void Serialize_NoDiagnostic()
+        public async Task Serialize_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.UI;
 
@@ -142,9 +135,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Serialize_Reference_NoDiagnostic()
+        public async Task Serialize_Reference_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.UI;
 
@@ -161,5 +154,15 @@ namespace Blah
     }
 }");
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializationObjectStateFormatterTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializationObjectStateFormatterTests.cs
@@ -155,12 +155,12 @@ namespace Blah
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterMethodsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterMethodsTests.cs
@@ -1,31 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.NetCore.Analyzers.Security;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerBinaryFormatterMethods,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseInsecureDeserializerBinaryFormatterMethodsTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseInsecureDeserializerBinaryFormatterMethodsTests
     {
-        private static readonly DiagnosticDescriptor Rule = DoNotUseInsecureDeserializerBinaryFormatterMethods.RealMethodUsedDescriptor;
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerBinaryFormatterMethods();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerBinaryFormatterMethods();
-        }
-
         [Fact]
-        public void UnsafeDeserialize_Diagnostic()
+        public async Task UnsafeDeserialize_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -40,13 +29,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(12, 20, Rule, "object BinaryFormatter.UnsafeDeserialize(Stream serializationStream, HeaderHandler handler)"));
+                GetCSharpResultAt(12, 20, "object BinaryFormatter.UnsafeDeserialize(Stream serializationStream, HeaderHandler handler)"));
         }
 
         [Fact]
-        public void UnsafeDeserializeMethodResponse_Diagnostic()
+        public async Task UnsafeDeserializeMethodResponse_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -61,13 +50,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(12, 20, Rule, "object BinaryFormatter.UnsafeDeserializeMethodResponse(Stream serializationStream, HeaderHandler handler, IMethodCallMessage methodCallMessage)"));
+                GetCSharpResultAt(12, 20, "object BinaryFormatter.UnsafeDeserializeMethodResponse(Stream serializationStream, HeaderHandler handler, IMethodCallMessage methodCallMessage)"));
         }
 
         [Fact]
-        public void Deserialize_Diagnostic()
+        public async Task Deserialize_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -82,13 +71,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(12, 20, Rule, "object BinaryFormatter.Deserialize(Stream serializationStream)"));
+                GetCSharpResultAt(12, 20, "object BinaryFormatter.Deserialize(Stream serializationStream)"));
         }
 
         [Fact]
-        public void Deserialize_HeaderHandler_Diagnostic()
+        public async Task Deserialize_HeaderHandler_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -103,13 +92,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(12, 20, Rule, "object BinaryFormatter.Deserialize(Stream serializationStream, HeaderHandler handler)"));
+                GetCSharpResultAt(12, 20, "object BinaryFormatter.Deserialize(Stream serializationStream, HeaderHandler handler)"));
         }
 
         [Fact]
-        public void DeserializeMethodResponse_Diagnostic()
+        public async Task DeserializeMethodResponse_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -124,13 +113,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(12, 20, Rule, "object BinaryFormatter.DeserializeMethodResponse(Stream serializationStream, HeaderHandler handler, IMethodCallMessage methodCallMessage)"));
+                GetCSharpResultAt(12, 20, "object BinaryFormatter.DeserializeMethodResponse(Stream serializationStream, HeaderHandler handler, IMethodCallMessage methodCallMessage)"));
         }
 
         [Fact]
-        public void Deserialize_Reference_Diagnostic()
+        public async Task Deserialize_Reference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -146,13 +135,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(13, 20, Rule, "object BinaryFormatter.Deserialize(Stream serializationStream)"));
+                GetCSharpResultAt(13, 20, "object BinaryFormatter.Deserialize(Stream serializationStream)"));
         }
 
         [Fact]
-        public void Serialize_NoDiagnostic()
+        public async Task Serialize_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -172,9 +161,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Serialize_Reference_NoDiagnostic()
+        public async Task Serialize_Reference_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -191,5 +180,10 @@ namespace Blah
     }
 }");
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic(DoNotUseInsecureDeserializerBinaryFormatterMethods.RealMethodUsedDescriptor)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterMethodsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterMethodsTests.cs
@@ -181,7 +181,7 @@ namespace Blah
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic(DoNotUseInsecureDeserializerBinaryFormatterMethods.RealMethodUsedDescriptor)
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterWithoutBinderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterWithoutBinderTests.cs
@@ -1493,12 +1493,12 @@ namespace Blah
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyVB.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterWithoutBinderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerBinaryFormatterWithoutBinderTests.cs
@@ -1,32 +1,27 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerBinaryFormatterWithoutBinder,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerBinaryFormatterWithoutBinder,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
-    public class DoNotUseInsecureDeserializerBinaryFormatterWithoutBinderTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseInsecureDeserializerBinaryFormatterWithoutBinderTests
     {
         private static readonly DiagnosticDescriptor BinderNotSetRule = DoNotUseInsecureDeserializerBinaryFormatterWithoutBinder.RealBinderDefinitelyNotSetDescriptor;
 
         private static readonly DiagnosticDescriptor BinderMaybeNotSetRule = DoNotUseInsecureDeserializerBinaryFormatterWithoutBinder.RealBinderMaybeNotSetDescriptor;
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerBinaryFormatterWithoutBinder();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerBinaryFormatterWithoutBinder();
-        }
-
-        protected void VerifyCSharpWithMyBinderDefined(string source, params DiagnosticResult[] expected)
+        private async Task VerifyCSharpWithMyBinderDefined(string source, params DiagnosticResult[] expected)
         {
             string myBinderCSharpSourceCode = @"
 using System;
@@ -52,15 +47,23 @@ namespace Blah
 }
             ";
 
-            this.VerifyCSharp(
-                new[] { source, myBinderCSharpSourceCode }.ToFileAndSource(),
-                expected);
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source, myBinderCSharpSourceCode }
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
         }
 
         [Fact]
-        public void DocSample1_CSharp_Violation_Diagnostic()
+        public async Task DocSample1_CSharp_Violation_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -94,9 +97,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample1_VB_Violation_Diagnostic()
+        public async Task DocSample1_VB_Violation_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization.Formatters.Binary
@@ -125,9 +128,9 @@ End Class",
         }
 
         [Fact]
-        public void DocSample1_CSharp_Solution_NoDiagnostic()
+        public async Task DocSample1_CSharp_Solution_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -182,9 +185,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample1_VB_Solution_NoDiagnostic()
+        public async Task DocSample1_VB_Solution_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -231,9 +234,9 @@ End Class");
         }
 
         [Fact]
-        public void DocSample2_CSharp_Violation_Diagnostic()
+        public async Task DocSample2_CSharp_Violation_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -268,9 +271,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample2_VB_Violation_Diagnostic()
+        public async Task DocSample2_VB_Violation_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization.Formatters.Binary
@@ -300,9 +303,9 @@ End Class",
         }
 
         [Fact]
-        public void DocSample3_CSharp_Violation_Diagnostic()
+        public async Task DocSample3_CSharp_Violation_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -364,9 +367,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample3_VB_Violation_Diagnostic()
+        public async Task DocSample3_VB_Violation_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -419,9 +422,9 @@ End Class",
 
 
         [Fact]
-        public void DocSample3_CSharp_Solution_NoDiagnostic()
+        public async Task DocSample3_CSharp_Solution_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -485,9 +488,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample3_VB_Solution_NoDiagnostic()
+        public async Task DocSample3_VB_Solution_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -541,9 +544,9 @@ End Class");
         }
 
         [Fact]
-        public void Deserialize_Diagnostic()
+        public async Task Deserialize_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -562,9 +565,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_OptionalParameters_Diagnostic()
+        public async Task Deserialize_OptionalParameters_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -584,9 +587,9 @@ namespace Blah
 
         // Ideally, we'd detect that formatter.Binder is always null.
         [Fact]
-        public void DeserializeWithInstanceField_Diagnostic_NotIdeal()
+        public async Task DeserializeWithInstanceField_Diagnostic_NotIdeal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -606,9 +609,9 @@ namespace Blah
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/1851")]
-        public void DeserializeWithInstanceField_NoDiagnostic()
+        public async Task DeserializeWithInstanceField_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -629,9 +632,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_BinderMaybeSet_Diagnostic()
+        public async Task Deserialize_BinderMaybeSet_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -656,9 +659,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_BinderSet_NoDiagnostic()
+        public async Task Deserialize_BinderSet_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -678,9 +681,9 @@ namespace Blah
         }
 
         [Fact]
-        public void TwoDeserializersOneBinderOnFirst_Diagnostic()
+        public async Task TwoDeserializersOneBinderOnFirst_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -708,9 +711,9 @@ namespace Blah
         }
 
         [Fact]
-        public void TwoDeserializersOneBinderOnSecond_Diagnostic()
+        public async Task TwoDeserializersOneBinderOnSecond_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -737,9 +740,9 @@ namespace Blah
         }
 
         [Fact]
-        public void TwoDeserializersNoBinder_Diagnostic()
+        public async Task TwoDeserializersNoBinder_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -767,9 +770,9 @@ namespace Blah
         }
 
         [Fact]
-        public void BinderSetInline_NoDiagnostic()
+        public async Task BinderSetInline_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -787,9 +790,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Serialize_NoDiagnostic()
+        public async Task Serialize_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -809,9 +812,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_LoopBinderSetAfter_Diagnostic()
+        public async Task Deserialize_LoopBinderSetAfter_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -835,9 +838,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_LoopBinderSetBefore_NoDiagnostic()
+        public async Task Deserialize_LoopBinderSetBefore_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -860,9 +863,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_LoopBinderSetBeforeMaybe_Diagnostic()
+        public async Task Deserialize_LoopBinderSetBeforeMaybe_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -889,9 +892,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_InvokedAsDelegate_Diagnostic()
+        public async Task Deserialize_InvokedAsDelegate_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -913,9 +916,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_BranchInvokedAsDelegate_Diagnostic()
+        public async Task Deserialize_BranchInvokedAsDelegate_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -945,9 +948,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_BranchInvokedAsDelegate_NoDiagnostic()
+        public async Task Deserialize_BranchInvokedAsDelegate_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -975,9 +978,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_Property_Diagnostic()
+        public async Task Deserialize_Property_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -1005,9 +1008,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_Constructor_Diagnostic()
+        public async Task Deserialize_Constructor_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -1029,9 +1032,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_FieldInitializer_Diagnostic()
+        public async Task Deserialize_FieldInitializer_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -1049,9 +1052,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_InConstructorAndMethod_Diagnostics()
+        public async Task Deserialize_InConstructorAndMethod_Diagnostics()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -1095,9 +1098,9 @@ class Derived : Base
         }
 
         [Fact]
-        public void BinderVariableSetInAllBranches_NoDiagnostic()
+        public async Task BinderVariableSetInAllBranches_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1123,9 +1126,9 @@ namespace Blah
         }
 
         [Fact]
-        public void BinderParameter_NoDiagnostic()
+        public async Task BinderParameter_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1148,9 +1151,9 @@ namespace Blah
         }
 
         [Fact]
-        public void BinderNotNullInsideIf_NoDiagnostic()
+        public async Task BinderNotNullInsideIf_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1177,9 +1180,9 @@ namespace Blah
         }
 
         [Fact]
-        public void SomeOtherSerializer_NoDiagnostic()
+        public async Task SomeOtherSerializer_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1202,9 +1205,9 @@ namespace Blah
         }
 
         [Fact]
-        public void OtherMethodInstantiatesWithoutBinder_Diagnostic()
+        public async Task OtherMethodInstantiatesWithoutBinder_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1230,9 +1233,9 @@ namespace Blah
         }
 
         [Fact]
-        public void OtherMethodInstantiatesWithBinderMaybe_Diagnostic()
+        public async Task OtherMethodInstantiatesWithBinderMaybe_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1261,9 +1264,9 @@ namespace Blah
         }
 
         [Fact]
-        public void OtherMethodInstantiatesWithBinder_NoDiagnostic()
+        public async Task OtherMethodInstantiatesWithBinder_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1288,9 +1291,9 @@ namespace Blah
         }
 
         [Fact]
-        public void OtherMethodDeserializesWithoutBinder_Diagnostic()
+        public async Task OtherMethodDeserializesWithoutBinder_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1318,9 +1321,9 @@ namespace Blah
         }
 
         [Fact]
-        public void OtherMethodDeserializesWithoutBinderUsingDelegate_Diagnostic()
+        public async Task OtherMethodDeserializesWithoutBinderUsingDelegate_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1349,9 +1352,9 @@ namespace Blah
         }
 
         [Fact]
-        public void OtherMethodDeserializesWithoutBinderUsingBinaryFormatter_Diagnostic()
+        public async Task OtherMethodDeserializesWithoutBinderUsingBinaryFormatter_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1384,18 +1387,15 @@ namespace Blah
         [InlineData(@"dotnet_code_quality.CA2301.excluded_symbol_names = DeserializeBookRecord
                       dotnet_code_quality.CA2302.excluded_symbol_names = DeserializeBookRecord")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = DeserializeBookRecord")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (editorConfigText.Length == 0)
+            var csharpTest = new VerifyCS.Test
             {
-                expected = new DiagnosticResult[]
+                TestState =
                 {
-                    GetCSharpResultAt(29, 33, BinderNotSetRule, "object BinaryFormatter.Deserialize(Stream serializationStream)")
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -1426,13 +1426,24 @@ public class ExampleClass
             return (BookRecord) formatter.Deserialize(ms);
         }
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (editorConfigText.Length == 0)
+            {
+                csharpTest.ExpectedDiagnostics.Add(GetCSharpResultAt(29, 33, BinderNotSetRule, "object BinaryFormatter.Deserialize(Stream serializationStream)"));
+            }
+
+            await csharpTest.RunAsync();
         }
 
         [Fact]
-        public void Deserialize_SharedBinderInstance_NoDiagnostic()
+        public async Task Deserialize_SharedBinderInstance_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1456,9 +1467,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_SharedBinderInstanceIntermediate_NoDiagnostic()
+        public async Task Deserialize_SharedBinderInstanceIntermediate_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1481,5 +1492,15 @@ namespace Blah
     }
 }");
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+           => VerifyCS.Diagnostic(rule)
+               .WithLocation(line, column)
+               .WithArguments(arguments);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+           => VerifyVB.Diagnostic(rule)
+               .WithLocation(line, column)
+               .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolverTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolverTests.cs
@@ -1,34 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerJavaScriptSerializerWithSimpleTypeResolver,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
-    public class DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolverTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolverTests
     {
         private static readonly DiagnosticDescriptor DefinitelyRule = DoNotUseInsecureDeserializerJavaScriptSerializerWithSimpleTypeResolver.DefinitelyWithSimpleTypeResolver;
         private static readonly DiagnosticDescriptor MaybeRule = DoNotUseInsecureDeserializerJavaScriptSerializerWithSimpleTypeResolver.MaybeWithSimpleTypeResolver;
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerJavaScriptSerializerWithSimpleTypeResolver();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerJavaScriptSerializerWithSimpleTypeResolver();
-        }
-
         [Fact]
-        public void Deserialize_Generic_DefinitelyDiagnostic()
+        public async Task Deserialize_Generic_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -47,9 +39,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_DefinitelyDiagnostic()
+        public async Task Deserialize_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -68,9 +60,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_DefinitelyDiagnostic()
+        public async Task DeserializeObject_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -89,9 +81,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_AnyPath_DefinitelyDiagnostic()
+        public async Task DeserializeObject_AnyPath_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -114,9 +106,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_FromArgument_MaybeDiagnostic()
+        public async Task Deserialize_FromArgument_MaybeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -134,9 +126,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_TypeResolver_Unknown_MaybeDiagnostic()
+        public async Task Deserialize_TypeResolver_Unknown_MaybeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -156,9 +148,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_TypeResolver_UnknownNotNull_MaybeDiagnostic()
+        public async Task Deserialize_TypeResolver_UnknownNotNull_MaybeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -179,9 +171,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_TypeResolver_UnknownNull_NoDiagnostic()
+        public async Task Deserialize_TypeResolver_UnknownNull_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -201,9 +193,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_FromField_MaybeDiagnostic()
+        public async Task Deserialize_FromField_MaybeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -223,9 +215,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_FromStaticField_MaybeDiagnostic()
+        public async Task Deserialize_FromStaticField_MaybeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -245,9 +237,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_NoTypeResolver_NoDiagnostic()
+        public async Task Deserialize_NoTypeResolver_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -264,9 +256,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_CustomTypeResolver_NoDiagnostic()
+        public async Task Deserialize_CustomTypeResolver_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -297,9 +289,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_FromLocalFunction_DefinitelyDiagnostic()
+        public async Task DeserializeObject_FromLocalFunction_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -319,9 +311,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_SimpleTypeResolverFromParameter_DefinitelyDiagnostic()
+        public async Task DeserializeObject_SimpleTypeResolverFromParameter_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -341,9 +333,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_JavaScriptTypeResolverFromParameter_MaybeDiagnostic()
+        public async Task DeserializeObject_JavaScriptTypeResolverFromParameter_MaybeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -363,9 +355,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_SimpleTypeResolverFromLocalFunction_DefinitelyDiagnostic()
+        public async Task DeserializeObject_SimpleTypeResolverFromLocalFunction_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -386,9 +378,9 @@ namespace Blah
 
 
         [Fact]
-        public void Deserialize_InLocalFunction_SimpleTypeResolverFromLocalFunction_DefinitelyDiagnostic()
+        public async Task Deserialize_InLocalFunction_SimpleTypeResolverFromLocalFunction_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -411,9 +403,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_InLambda_DefinitelyDiagnostic()
+        public async Task DeserializeObject_InLambda_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -435,9 +427,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_InLambda_CustomTypeResolver_NoDiagnostic()
+        public async Task DeserializeObject_InLambda_CustomTypeResolver_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -471,9 +463,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_InOtherMethod_DefinitelyDiagnostic()
+        public async Task DeserializeObject_InOtherMethod_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -499,9 +491,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_InOtherMethodThrice_DefinitelyDiagnostic()
+        public async Task DeserializeObject_InOtherMethodThrice_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -530,9 +522,9 @@ namespace Blah
         }
 
         [Fact]
-        public void DeserializeObject_InOtherMethod_OnceDefinitely_OnceMaybe_DefinitelyDiagnostic()
+        public async Task DeserializeObject_InOtherMethod_OnceDefinitely_OnceMaybe_DefinitelyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -563,9 +555,9 @@ namespace Blah
 
 
         [Fact]
-        public void DeserializeObject_InOtherMethod_CustomTypeResolver_MaybeDiagnostic()
+        public async Task DeserializeObject_InOtherMethod_CustomTypeResolver_MaybeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Web.Script.Serialization;
@@ -609,18 +601,15 @@ namespace Blah
         [InlineData(@"dotnet_code_quality.CA2321.excluded_symbol_names = D
                       dotnet_code_quality.CA2322.excluded_symbol_names = D")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = D")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (editorConfigText.Length == 0)
+            var test = new VerifyCS.Test
             {
-                expected = new DiagnosticResult[]
+                TestState =
                 {
-                    GetCSharpResultAt(12, 20, DefinitelyRule, "T JavaScriptSerializer.Deserialize<T>(string input)")
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 using System.IO;
 using System.Web.Script.Serialization;
 
@@ -634,7 +623,24 @@ namespace Blah
             return s.Deserialize<T>(str);
         }
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (editorConfigText.Length == 0)
+            {
+                test.ExpectedDiagnostics.Add(GetCSharpResultAt(12, 20, DefinitelyRule, "T JavaScriptSerializer.Deserialize<T>(string input)"));
+            }
+
+            await test.RunAsync();
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => VerifyCS.Diagnostic(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolverTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolverTests.cs
@@ -638,7 +638,7 @@ namespace Blah
             await test.RunAsync();
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
             => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerJsonNetWithoutBinderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerJsonNetWithoutBinderTests.cs
@@ -2,16 +2,17 @@
 
 using System;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
-using Test.Utilities.MinimalImplementations;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerJsonNetWithoutBinder,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
-    public class DoNotUseInsecureDeserializerJsonNetWithoutBinderTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseInsecureDeserializerJsonNetWithoutBinderTests
     {
         private static readonly DiagnosticDescriptor DefinitelyRule =
             DoNotUseInsecureDeserializerJsonNetWithoutBinder.DefinitelyInsecureSerializer;
@@ -715,42 +716,43 @@ class Blah
                 };
             }
 
-            VerifyCSharpAcrossTwoAssemblies(
-                NewtonsoftJsonNetApis.CSharp,
-                @"
-using Newtonsoft.Json;
+            // TODO: Amaury - Fix this code
+            //            VerifyCSharpAcrossTwoAssemblies(
+            //                NewtonsoftJsonNetApis.CSharp,
+            //                @"
+            //using Newtonsoft.Json;
 
-class Blah
-{
-    object Method(JsonReader jr)
-    {
-        JsonSerializer serializer = new JsonSerializer();
-        serializer.TypeNameHandling = TypeNameHandling.All;
-        return serializer.Deserialize(jr);
-    }
-}",
-                GetEditorConfigAdditionalFile(editorConfigText),
-                expected);
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerJsonNetWithoutBinder();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerJsonNetWithoutBinder();
+            //class Blah
+            //{
+            //    object Method(JsonReader jr)
+            //    {
+            //        JsonSerializer serializer = new JsonSerializer();
+            //        serializer.TypeNameHandling = TypeNameHandling.All;
+            //        return serializer.Deserialize(jr);
+            //    }
+            //}",
+            //                GetEditorConfigAdditionalFile(editorConfigText),
+            //                expected);
         }
 
         private void VerifyCSharpWithJsonNet(string source, params DiagnosticResult[] expected)
         {
-            this.VerifyCSharpAcrossTwoAssemblies(NewtonsoftJsonNetApis.CSharp, source, expected);
+            // TODO: Amaury - Fix this code
+            //this.VerifyCSharpAcrossTwoAssemblies(NewtonsoftJsonNetApis.CSharp, source, expected);
         }
 
         private void VerifyBasicWithJsonNet(string source, params DiagnosticResult[] expected)
         {
-            this.VerifyBasicAcrossTwoAssemblies(NewtonsoftJsonNetApis.VisualBasic, source, expected);
+            // TODO: Amaury - Fix this code
+            //this.VerifyBasicAcrossTwoAssemblies(NewtonsoftJsonNetApis.VisualBasic, source, expected);
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+           => VerifyCS.Diagnostic(rule)
+               .WithLocation(line, column);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
+           => VerifyCS.Diagnostic(rule)
+               .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerJsonNetWithoutBinderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerJsonNetWithoutBinderTests.cs
@@ -747,11 +747,11 @@ class Blah
             //this.VerifyBasicAcrossTwoAssemblies(NewtonsoftJsonNetApis.VisualBasic, source, expected);
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethodsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethodsTests.cs
@@ -1,30 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerNetDataContractSerializerMethods,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerNetDataContractSerializerMethods,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseInsecureDeserializerNetDataContractSerializerMethodsTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseInsecureDeserializerNetDataContractSerializerMethodsTests
     {
-        private static readonly DiagnosticDescriptor Rule = DoNotUseInsecureDeserializerNetDataContractSerializerMethods.RealMethodUsedDescriptor;
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerNetDataContractSerializerMethods();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerNetDataContractSerializerMethods();
-        }
-
         [Fact]
-        public void DocSample1_CSharp_Violation_Diagnostic()
+        public async Task DocSample1_CSharp_Violation_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -36,13 +29,13 @@ public class ExampleClass
         return serializer.Deserialize(new MemoryStream(bytes));
     }
 }",
-                GetCSharpResultAt(10, 16, Rule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+                GetCSharpResultAt(10, 16, "object NetDataContractSerializer.Deserialize(Stream stream)"));
         }
 
         [Fact]
-        public void DocSample1_VB_Violation_Diagnostic()
+        public async Task DocSample1_VB_Violation_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.IO
 Imports System.Runtime.Serialization
 
@@ -52,13 +45,13 @@ Public Class ExampleClass
         Return serializer.Deserialize(New MemoryStream(bytes))
     End Function
 End Class",
-                GetBasicResultAt(8, 16, Rule, "Function NetDataContractSerializer.Deserialize(stream As Stream) As Object"));
+                GetBasicResultAt(8, 16, "Function NetDataContractSerializer.Deserialize(stream As Stream) As Object"));
         }
 
         [Fact]
-        public void Deserialize_Diagnostic()
+        public async Task Deserialize_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -73,13 +66,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(12, 20, Rule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+                GetCSharpResultAt(12, 20, "object NetDataContractSerializer.Deserialize(Stream stream)"));
         }
 
         [Fact]
-        public void Deserialize_Reference_Diagnostic()
+        public async Task Deserialize_Reference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -95,13 +88,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(13, 20, Rule, "object NetDataContractSerializer.Deserialize(Stream stream)"));
+                GetCSharpResultAt(13, 20, "object NetDataContractSerializer.Deserialize(Stream stream)"));
         }
 
         [Fact]
-        public void ReadObject_Stream_Diagnostic()
+        public async Task ReadObject_Stream_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -116,13 +109,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(12, 20, Rule, "object XmlObjectSerializer.ReadObject(Stream stream)"));
+                GetCSharpResultAt(12, 20, "object XmlObjectSerializer.ReadObject(Stream stream)"));
         }
 
         [Fact]
-        public void ReadObject_Stream_Reference_Diagnostic()
+        public async Task ReadObject_Stream_Reference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -138,13 +131,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(13, 20, Rule, "object XmlObjectSerializer.ReadObject(Stream stream)"));
+                GetCSharpResultAt(13, 20, "object XmlObjectSerializer.ReadObject(Stream stream)"));
         }
 
         [Fact]
-        public void ReadObject_XmlReader_Diagnostic()
+        public async Task ReadObject_XmlReader_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 using System.Xml;
@@ -160,13 +153,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(13, 20, Rule, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
+                GetCSharpResultAt(13, 20, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
         }
 
         [Fact]
-        public void ReadObject_XmlReader_Reference_Diagnostic()
+        public async Task ReadObject_XmlReader_Reference_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 using System.Xml;
@@ -183,13 +176,13 @@ namespace Blah
         }
     }
 }",
-                GetCSharpResultAt(14, 20, Rule, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
+                GetCSharpResultAt(14, 20, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
         }
 
         [Fact]
-        public void Serialize_NoDiagnostic()
+        public async Task Serialize_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -209,9 +202,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Serialize_Reference_NoDiagnostic()
+        public async Task Serialize_Reference_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -228,5 +221,15 @@ namespace Blah
     }
 }");
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethodsTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerMethodsTests.cs
@@ -222,12 +222,12 @@ namespace Blah
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinderTests.cs
@@ -1036,12 +1036,12 @@ namespace Blah
                 GetCSharpResultAt(16, 20, BinderNotSetRule, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyVB.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinderTests.cs
@@ -1,31 +1,27 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
-    public class DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinderTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinderTests
     {
         private static readonly DiagnosticDescriptor BinderNotSetRule = DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder.RealBinderDefinitelyNotSetDescriptor;
 
         private static readonly DiagnosticDescriptor BinderMaybeNotSetRule = DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder.RealBinderMaybeNotSetDescriptor;
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureDeserializerNetDataContractSerializerWithoutBinder();
-        }
-
-        protected void VerifyCSharpWithMyBinderDefined(string source, params DiagnosticResult[] expected)
+        protected async Task VerifyCSharpWithMyBinderDefined(string source, params DiagnosticResult[] expected)
         {
             string myBinderCSharpSourceCode = @"
 using System;
@@ -51,15 +47,23 @@ namespace Blah
 }
             ";
 
-            this.VerifyCSharp(
-                new[] { source, myBinderCSharpSourceCode }.ToFileAndSource(),
-                expected);
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source, myBinderCSharpSourceCode }
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
         }
 
         [Fact]
-        public void DocSample1_CSharp_Violation_Diagnostic()
+        public async Task DocSample1_CSharp_Violation_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -99,9 +103,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample1_VB_Violation_Diagnostic()
+        public async Task DocSample1_VB_Violation_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -136,9 +140,9 @@ End Class",
         }
 
         [Fact]
-        public void DocSample1_CSharp_Solution_NoDiagnostic()
+        public async Task DocSample1_CSharp_Solution_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -198,9 +202,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample1_VB_Solution_NoDiagnostic()
+        public async Task DocSample1_VB_Solution_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -252,9 +256,9 @@ End Class");
         }
 
         [Fact]
-        public void DocSample2_CSharp_Violation_Diagnostic()
+        public async Task DocSample2_CSharp_Violation_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -295,9 +299,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample2_VB_Violation_Diagnostic()
+        public async Task DocSample2_VB_Violation_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -333,9 +337,9 @@ End Class",
         }
 
         [Fact]
-        public void DocSample3_CSharp_Violation_Diagnostic()
+        public async Task DocSample3_CSharp_Violation_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -401,9 +405,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample3_VB_Violation_Diagnostic()
+        public async Task DocSample3_VB_Violation_Diagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -461,9 +465,9 @@ End Class",
         }
 
         [Fact]
-        public void DocSample3_CSharp_Solution_NoDiagnostic()
+        public async Task DocSample3_CSharp_Solution_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -531,9 +535,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample3_VB_Solution_NoDiagnostic()
+        public async Task DocSample3_VB_Solution_NoDiagnostic()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Runtime.Serialization
@@ -592,9 +596,9 @@ End Class");
         }
 
         [Fact]
-        public void Deserialize_Diagnostic()
+        public async Task Deserialize_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -614,9 +618,9 @@ namespace Blah
 
         // Ideally, we'd detect that serializer.Binder is always null.
         [Fact]
-        public void DeserializeWithInstanceField_Diagnostic_NotIdeal()
+        public async Task DeserializeWithInstanceField_Diagnostic_NotIdeal()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -636,9 +640,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_BinderMaybeSet_Diagnostic()
+        public async Task Deserialize_BinderMaybeSet_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -663,9 +667,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Deserialize_BinderSet_NoDiagnostic()
+        public async Task Deserialize_BinderSet_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -685,9 +689,9 @@ namespace Blah
         }
 
         [Fact]
-        public void TwoDeserializersOneBinderOnFirst_Diagnostic()
+        public async Task TwoDeserializersOneBinderOnFirst_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -715,9 +719,9 @@ namespace Blah
         }
 
         [Fact]
-        public void TwoDeserializersOneBinderOnSecond_Diagnostic()
+        public async Task TwoDeserializersOneBinderOnSecond_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -744,9 +748,9 @@ namespace Blah
         }
 
         [Fact]
-        public void TwoDeserializersNoBinder_Diagnostic()
+        public async Task TwoDeserializersNoBinder_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -774,9 +778,9 @@ namespace Blah
         }
 
         [Fact]
-        public void BinderSetInline_NoDiagnostic()
+        public async Task BinderSetInline_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -794,9 +798,9 @@ namespace Blah
         }
 
         [Fact]
-        public void Serialize_NoDiagnostic()
+        public async Task Serialize_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -817,9 +821,9 @@ namespace Blah
 
 
         [Fact]
-        public void Deserialize_InvokedAsDelegate_Diagnostic()
+        public async Task Deserialize_InvokedAsDelegate_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -841,9 +845,9 @@ namespace Blah
         }
 
         [Fact]
-        public void ReadObject_Stream_Diagnostic()
+        public async Task ReadObject_Stream_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -862,9 +866,9 @@ namespace Blah
         }
 
         [Fact]
-        public void ReadObject_Stream_BinderMaybeSet_Diagnostic()
+        public async Task ReadObject_Stream_BinderMaybeSet_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -889,9 +893,9 @@ namespace Blah
         }
 
         [Fact]
-        public void ReadObject_Stream_BinderSet_NoDiagnostic()
+        public async Task ReadObject_Stream_BinderSet_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -911,9 +915,9 @@ namespace Blah
         }
 
         [Fact]
-        public void ReadObject_Stream_InvokedAsDelegate_Diagnostic()
+        public async Task ReadObject_Stream_InvokedAsDelegate_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -935,9 +939,9 @@ namespace Blah
         }
 
         [Fact]
-        public void ReadObject_XmlReader_Diagnostic()
+        public async Task ReadObject_XmlReader_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 using System.Xml;
@@ -957,9 +961,9 @@ namespace Blah
         }
 
         [Fact]
-        public void ReadObject_XmlReader_BinderMaybeSet_Diagnostic()
+        public async Task ReadObject_XmlReader_BinderMaybeSet_Diagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -985,9 +989,9 @@ namespace Blah
         }
 
         [Fact]
-        public void ReadObject_XmlReader_BinderSet_NoDiagnostic()
+        public async Task ReadObject_XmlReader_BinderSet_NoDiagnostic()
         {
-            VerifyCSharpWithMyBinderDefined(@"
+            await VerifyCSharpWithMyBinderDefined(@"
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -1008,9 +1012,9 @@ namespace Blah
         }
 
         [Fact]
-        public void ReadObject_XmlReader_InvokedAsDelegate_Diagnostic()
+        public async Task ReadObject_XmlReader_InvokedAsDelegate_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.IO;
 using System.Runtime.Serialization;
 using System.Xml;
@@ -1031,5 +1035,15 @@ namespace Blah
 }",
                 GetCSharpResultAt(16, 20, BinderNotSetRule, "object NetDataContractSerializer.ReadObject(XmlReader reader)"));
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+           => VerifyCS.Diagnostic(rule)
+               .WithLocation(line, column)
+               .WithArguments(arguments);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+           => VerifyVB.Diagnostic(rule)
+               .WithLocation(line, column)
+               .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureRandomnessTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureRandomnessTests.cs
@@ -22,7 +22,7 @@ using System;
 
 class TestClass
 {
-    public async Task TestMethod(Random random)
+    public void TestMethod(Random random)
     {
         var sensitiveVariable = random.Next();
     }
@@ -49,7 +49,7 @@ using System;
 
 class TestClass
 {
-    public async Task TestMethod(Random random)
+    public void TestMethod(Random random)
     {
         var sensitiveVariable = random.NextDouble();
     }
@@ -76,7 +76,7 @@ using System;
 
 class TestClass
 {
-    public async Task TestMethod(Random random)
+    public void TestMethod(Random random)
     {
         var hashCode = random.GetHashCode();
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureRandomnessTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureRandomnessTests.cs
@@ -117,12 +117,12 @@ class TestClass
 End Class");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureSettingsForJsonNetTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureSettingsForJsonNetTests.cs
@@ -1328,11 +1328,11 @@ class Blah
             //this.VerifyBasicAcrossTwoAssemblies(NewtonsoftJsonNetApis.VisualBasic, source, expected);
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
            => VerifyVB.Diagnostic(rule)
                .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureSettingsForJsonNetTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseInsecureSettingsForJsonNetTests.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
-using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
-using Test.Utilities.MinimalImplementations;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureSettingsForJsonNet,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureSettingsForJsonNet,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
     [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PropertySetAnalysis)]
-    public class DoNotUseInsecureSettingsForJsonNetTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseInsecureSettingsForJsonNetTests
     {
         private static readonly DiagnosticDescriptor DefinitelyRule = DoNotUseInsecureSettingsForJsonNet.DefinitelyInsecureSettings;
         private static readonly DiagnosticDescriptor MaybeRule = DoNotUseInsecureSettingsForJsonNet.MaybeInsecureSettings;
@@ -1293,43 +1295,45 @@ class Blah
                 };
             }
 
-            this.VerifyCSharpWithJsonNet(@"
-using Newtonsoft.Json;
+            // TODO: Amaury - Fix this code
+//            this.VerifyCSharpWithJsonNet(@"
+//using Newtonsoft.Json;
 
-class Blah
-{
-    object Method(string s)
-    {
-        JsonSerializerSettings settings = new JsonSerializerSettings();
-        settings.TypeNameHandling = TypeNameHandling.All;
-        return JsonConvert.DeserializeObject(s, settings);
-    }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
-        }
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureSettingsForJsonNet();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseInsecureSettingsForJsonNet();
+//class Blah
+//{
+//    object Method(string s)
+//    {
+//        JsonSerializerSettings settings = new JsonSerializerSettings();
+//        settings.TypeNameHandling = TypeNameHandling.All;
+//        return JsonConvert.DeserializeObject(s, settings);
+//    }
+//}", GetEditorConfigAdditionalFile(editorConfigText), expected);
         }
 
         private void VerifyCSharpWithJsonNet(string source, params DiagnosticResult[] expected)
         {
-            this.VerifyCSharpAcrossTwoAssemblies(NewtonsoftJsonNetApis.CSharp, source, expected);
+            // TODO: Amaury - Fix this code
+            //this.VerifyCSharpAcrossTwoAssemblies(NewtonsoftJsonNetApis.CSharp, source, expected);
         }
 
         private void VerifyCSharpWithJsonNet(string source, FileAndSource additionalFile, params DiagnosticResult[] expected)
         {
-            this.VerifyCSharpAcrossTwoAssemblies(NewtonsoftJsonNetApis.CSharp, source, additionalFile, expected);
+            // TODO: Amaury - Fix this code
+            //this.VerifyCSharpAcrossTwoAssemblies(NewtonsoftJsonNetApis.CSharp, source, additionalFile, expected);
         }
 
         private void VerifyBasicWithJsonNet(string source, params DiagnosticResult[] expected)
         {
-            this.VerifyBasicAcrossTwoAssemblies(NewtonsoftJsonNetApis.VisualBasic, source, expected);
+            // TODO: Amaury - Fix this code
+            //this.VerifyBasicAcrossTwoAssemblies(NewtonsoftJsonNetApis.VisualBasic, source, expected);
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+           => VerifyCS.Diagnostic(rule)
+               .WithLocation(line, column);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
+           => VerifyVB.Diagnostic(rule)
+               .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseObsoleteKDFAlgorithmTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseObsoleteKDFAlgorithmTests.cs
@@ -20,7 +20,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(PasswordDeriveBytes passwordDeriveBytes)
+    public void TestMethod(PasswordDeriveBytes passwordDeriveBytes)
     {
         passwordDeriveBytes.GetBytes(1);
     }
@@ -44,7 +44,7 @@ class DerivedClass : PasswordDeriveBytes
 
 class TestClass
 {
-    public async Task TestMethod(DerivedClass derivedClass, string algname, string alghashname, int keySize, byte[] rgbIV)
+    public void TestMethod(DerivedClass derivedClass, string algname, string alghashname, int keySize, byte[] rgbIV)
     {
         derivedClass.CryptDeriveKey(algname, alghashname, keySize, rgbIV);
     }
@@ -61,7 +61,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(Rfc2898DeriveBytes rfc2898DeriveBytes, string algname, string alghashname, int keySize, byte[] rgbIV)
+    public void TestMethod(Rfc2898DeriveBytes rfc2898DeriveBytes, string algname, string alghashname, int keySize, byte[] rgbIV)
     {
         rfc2898DeriveBytes.CryptDeriveKey(algname, alghashname, keySize, rgbIV);
     }
@@ -85,7 +85,7 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public async Task TestMethod(DerivedClass derivedClass, string algname, string alghashname, int keySize, byte[] rgbIV)
+    public void TestMethod(DerivedClass derivedClass, string algname, string alghashname, int keySize, byte[] rgbIV)
     {
         derivedClass.CryptDeriveKey(algname, alghashname, keySize, rgbIV);
     }
@@ -102,7 +102,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(Rfc2898DeriveBytes rfc2898DeriveBytes)
+    public void TestMethod(Rfc2898DeriveBytes rfc2898DeriveBytes)
     {
         rfc2898DeriveBytes.GetBytes(1);
     }
@@ -118,7 +118,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt)
+    public void TestMethod(string password, byte[] salt)
     {
         new Rfc2898DeriveBytes(password, salt);
     }
@@ -134,7 +134,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt)
+    public void TestMethod(string password, byte[] salt)
     {
         new PasswordDeriveBytes(password, salt);
     }
@@ -162,7 +162,7 @@ class DerivedClass : PasswordDeriveBytes
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         new DerivedClass(password, salt).GetBytes(cb);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseObsoleteKDFAlgorithmTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseObsoleteKDFAlgorithmTests.cs
@@ -1,34 +1,37 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseObsoleteKDFAlgorithm,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseObsoleteKDFAlgorithmTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseObsoleteKDFAlgorithmTests
     {
         [Fact]
-        public void TestNormalMethodOfPasswordDeriveBytesDiagnostic()
+        public async Task TestNormalMethodOfPasswordDeriveBytesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(PasswordDeriveBytes passwordDeriveBytes)
+    public async Task TestMethod(PasswordDeriveBytes passwordDeriveBytes)
     {
         passwordDeriveBytes.GetBytes(1);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseObsoleteKDFAlgorithm.Rule, "PasswordDeriveBytes", "GetBytes"));
+            GetCSharpResultAt(9, 9, "PasswordDeriveBytes", "GetBytes"));
         }
 
         [Fact]
-        public void TestCryptDeriveKeyOfClassDerivedFromPasswordDeriveBytesDiagnostic()
+        public async Task TestCryptDeriveKeyOfClassDerivedFromPasswordDeriveBytesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -41,35 +44,35 @@ class DerivedClass : PasswordDeriveBytes
 
 class TestClass
 {
-    public void TestMethod(DerivedClass derivedClass, string algname, string alghashname, int keySize, byte[] rgbIV)
+    public async Task TestMethod(DerivedClass derivedClass, string algname, string alghashname, int keySize, byte[] rgbIV)
     {
         derivedClass.CryptDeriveKey(algname, alghashname, keySize, rgbIV);
     }
 }",
-            GetCSharpResultAt(16, 9, DoNotUseObsoleteKDFAlgorithm.Rule, "PasswordDeriveBytes", "CryptDeriveKey"));
+            GetCSharpResultAt(16, 9, "PasswordDeriveBytes", "CryptDeriveKey"));
         }
 
         [Fact]
-        public void TestCryptDeriveKeyOfRfc2898DeriveBytesDiagnostic()
+        public async Task TestCryptDeriveKeyOfRfc2898DeriveBytesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(Rfc2898DeriveBytes rfc2898DeriveBytes, string algname, string alghashname, int keySize, byte[] rgbIV)
+    public async Task TestMethod(Rfc2898DeriveBytes rfc2898DeriveBytes, string algname, string alghashname, int keySize, byte[] rgbIV)
     {
         rfc2898DeriveBytes.CryptDeriveKey(algname, alghashname, keySize, rgbIV);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseObsoleteKDFAlgorithm.Rule, "Rfc2898DeriveBytes", "CryptDeriveKey"));
+            GetCSharpResultAt(9, 9, "Rfc2898DeriveBytes", "CryptDeriveKey"));
         }
 
         [Fact]
-        public void TestCryptDeriveKeyOfClassDerivedFromRfc2898DeriveBytesDiagnostic()
+        public async Task TestCryptDeriveKeyOfClassDerivedFromRfc2898DeriveBytesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -82,24 +85,24 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public void TestMethod(DerivedClass derivedClass, string algname, string alghashname, int keySize, byte[] rgbIV)
+    public async Task TestMethod(DerivedClass derivedClass, string algname, string alghashname, int keySize, byte[] rgbIV)
     {
         derivedClass.CryptDeriveKey(algname, alghashname, keySize, rgbIV);
     }
 }",
-            GetCSharpResultAt(16, 9, DoNotUseObsoleteKDFAlgorithm.Rule, "Rfc2898DeriveBytes", "CryptDeriveKey"));
+            GetCSharpResultAt(16, 9, "Rfc2898DeriveBytes", "CryptDeriveKey"));
         }
 
         [Fact]
-        public void TestNormalMethodOfRfc2898DeriveBytesNoDiagnostic()
+        public async Task TestNormalMethodOfRfc2898DeriveBytesNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(Rfc2898DeriveBytes rfc2898DeriveBytes)
+    public async Task TestMethod(Rfc2898DeriveBytes rfc2898DeriveBytes)
     {
         rfc2898DeriveBytes.GetBytes(1);
     }
@@ -107,15 +110,15 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorOfRfc2898DeriveBytesNoDiagnostic()
+        public async Task TestConstructorOfRfc2898DeriveBytesNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt)
+    public async Task TestMethod(string password, byte[] salt)
     {
         new Rfc2898DeriveBytes(password, salt);
     }
@@ -123,15 +126,15 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorOfPasswordDeriveBytesNoDiagnostic()
+        public async Task TestConstructorOfPasswordDeriveBytesNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt)
+    public async Task TestMethod(string password, byte[] salt)
     {
         new PasswordDeriveBytes(password, salt);
     }
@@ -139,9 +142,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestGetBytesOfClassDerivedFromPasswordDeriveBytesNoDiagnostic()
+        public async Task TestGetBytesOfClassDerivedFromPasswordDeriveBytesNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -159,21 +162,16 @@ class DerivedClass : PasswordDeriveBytes
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         new DerivedClass(password, salt).GetBytes(cb);
     }
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseObsoleteKDFAlgorithm();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseObsoleteKDFAlgorithm();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseObsoleteKDFAlgorithmTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseObsoleteKDFAlgorithmTests.cs
@@ -169,7 +169,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFAlgorithmTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFAlgorithmTests.cs
@@ -189,7 +189,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFAlgorithmTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFAlgorithmTests.cs
@@ -1,65 +1,68 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseWeakKDFAlgorithm,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseWeakKDFAlgorithmTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseWeakKDFAlgorithmTests
     {
         [Fact]
-        public void TestMD5Diagnostic()
+        public async Task TestMD5Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.MD5);
     }
 }",
-            GetCSharpResultAt(8, 34, DoNotUseWeakKDFAlgorithm.Rule, "Rfc2898DeriveBytes"));
+            GetCSharpResultAt(8, 34, "Rfc2898DeriveBytes"));
         }
 
         [Fact]
-        public void TestSHA1Diagnostic()
+        public async Task TestSHA1Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA1);
     }
 }",
-            GetCSharpResultAt(8, 34, DoNotUseWeakKDFAlgorithm.Rule, "Rfc2898DeriveBytes"));
+            GetCSharpResultAt(8, 34, "Rfc2898DeriveBytes"));
         }
 
         [Fact]
-        public void TestNoHashAlgorithmNameDiagnostic()
+        public async Task TestNoHashAlgorithmNameDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt)
+    public async Task TestMethod(string password, byte[] salt)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
     }
 }",
-            GetCSharpResultAt(8, 34, DoNotUseWeakKDFAlgorithm.Rule, "Rfc2898DeriveBytes"));
+            GetCSharpResultAt(8, 34, "Rfc2898DeriveBytes"));
         }
 
         [Fact]
-        public void TestDerivedClassOfRfc2898DeriveBytesDiagnostic()
+        public async Task TestDerivedClassOfRfc2898DeriveBytesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class DerivedClass : Rfc2898DeriveBytes
@@ -71,18 +74,18 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var derivedClass = new DerivedClass(password, salt, iterations, HashAlgorithmName.MD5);
     }
 }",
-            GetCSharpResultAt(15, 28, DoNotUseWeakKDFAlgorithm.Rule, "DerivedClass"));
+            GetCSharpResultAt(15, 28, "DerivedClass"));
         }
 
         [Fact]
-        public void TestDerivedClassOfRfc2898DeriveBytesNewPropertyDiagnostic()
+        public async Task TestDerivedClassOfRfc2898DeriveBytesNewPropertyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class DerivedClass : Rfc2898DeriveBytes
@@ -96,19 +99,19 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var derivedClass = new DerivedClass(password, salt, iterations, HashAlgorithmName.MD5);
         derivedClass.HashAlgorithm = HashAlgorithmName.SHA256;
     }
 }",
-            GetCSharpResultAt(17, 28, DoNotUseWeakKDFAlgorithm.Rule, "DerivedClass"));
+            GetCSharpResultAt(17, 28, "DerivedClass"));
         }
 
         [Fact]
-        public void TestNormalClassNoDiagnostic()
+        public async Task TestNormalClassNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -117,7 +120,7 @@ class TestClass
     {
     }
 
-    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var subClass = new TestClass(password, salt, iterations, HashAlgorithmName.MD5);
     }
@@ -125,14 +128,14 @@ class TestClass
         }
 
         [Fact]
-        public void TestSHA256NoDiagnostic()
+        public async Task TestSHA256NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256);
     }
@@ -140,9 +143,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDerivedClassOfRfc2898DeriveBytesNoDiagnostic()
+        public async Task TestDerivedClassOfRfc2898DeriveBytesNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class DerivedClass : Rfc2898DeriveBytes
@@ -154,7 +157,7 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var derivedClass = new DerivedClass(password, salt, iterations, HashAlgorithmName.SHA256);
     }
@@ -162,9 +165,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDerivedClassOfRfc2898DeriveBytesNewPropertyNoDiagnostic()
+        public async Task TestDerivedClassOfRfc2898DeriveBytesNewPropertyNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class DerivedClass : Rfc2898DeriveBytes
@@ -178,7 +181,7 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var derivedClass = new DerivedClass(password, salt, iterations, HashAlgorithmName.SHA256);
         derivedClass.HashAlgorithm = HashAlgorithmName.MD5;
@@ -186,14 +189,9 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseWeakKDFAlgorithm();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseWeakKDFAlgorithm();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFAlgorithmTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFAlgorithmTests.cs
@@ -19,7 +19,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.MD5);
     }
@@ -35,7 +35,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA1);
     }
@@ -51,7 +51,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt)
+    public void TestMethod(string password, byte[] salt)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
     }
@@ -74,7 +74,7 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var derivedClass = new DerivedClass(password, salt, iterations, HashAlgorithmName.MD5);
     }
@@ -99,7 +99,7 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var derivedClass = new DerivedClass(password, salt, iterations, HashAlgorithmName.MD5);
         derivedClass.HashAlgorithm = HashAlgorithmName.SHA256;
@@ -120,7 +120,7 @@ class TestClass
     {
     }
 
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var subClass = new TestClass(password, salt, iterations, HashAlgorithmName.MD5);
     }
@@ -135,7 +135,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256);
     }
@@ -157,7 +157,7 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var derivedClass = new DerivedClass(password, salt, iterations, HashAlgorithmName.SHA256);
     }
@@ -181,7 +181,7 @@ class DerivedClass : Rfc2898DeriveBytes
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
     {
         var derivedClass = new DerivedClass(password, salt, iterations, HashAlgorithmName.SHA256);
         derivedClass.HashAlgorithm = HashAlgorithmName.MD5;

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFInsufficientIterationCountTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFInsufficientIterationCountTests.cs
@@ -1,62 +1,64 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseWeakKDFInsufficientIterationCount,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseWeakKDFInsufficientIterationCountTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseWeakKDFInsufficientIterationCountTests
     {
         private const int SufficientIterationCount = 100000;
 
         [Fact]
-        public void TestConstructorWithStringAndByteArrayParametersDiagnostic()
+        public async Task TestConstructorWithStringAndByteArrayParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestAssignIterationCountDiagnostic()
+        public async Task TestAssignIterationCountDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100;
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(10, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(10, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestAssignIterationsParameterMaybeChangedDiagnostic()
+        public async Task TestAssignIterationsParameterMaybeChangedDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var iterations = 100;
         Random r = new Random();
@@ -70,19 +72,19 @@ class TestClass
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(18, 9, DoNotUseWeakKDFInsufficientIterationCount.MaybeUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(18, 9, DoNotUseWeakKDFInsufficientIterationCount.MaybeUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestAssignIterationCountPropertyMaybeChangedDiagnostic()
+        public async Task TestAssignIterationCountPropertyMaybeChangedDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100;
@@ -96,18 +98,18 @@ class TestClass
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(18, 9, DoNotUseWeakKDFInsufficientIterationCount.MaybeUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(18, 9, DoNotUseWeakKDFInsufficientIterationCount.MaybeUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestPassRfc2898DeriveBytesAsParameterInterproceduralDiagnostic()
+        public async Task TestPassRfc2898DeriveBytesAsParameterInterproceduralDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100;
@@ -119,18 +121,18 @@ class TestClass
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(15, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(15, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestReturnRfc2898DeriveBytesInterproceduralDiagnostic()
+        public async Task TestReturnRfc2898DeriveBytesInterproceduralDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = GetRfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -144,137 +146,137 @@ class TestClass
         return rfc2898DeriveBytes;
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestConstructorWithStringAndIntParametersDiagnostic()
+        public async Task TestConstructorWithStringAndIntParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, int saltSize, int cb)
+    public async Task TestMethod(string password, int saltSize, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, saltSize);
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestConstructorWithStringAndByteArrayAndIntParametersDiagnostic()
+        public async Task TestConstructorWithStringAndByteArrayAndIntParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100);
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestConstructorWithByteArrayAndByteArrayAndIntParametersLowIterationsDiagnostic()
+        public async Task TestConstructorWithByteArrayAndByteArrayAndIntParametersLowIterationsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int cb)
+    public async Task TestMethod(byte[] password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100);
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestConstructorWithStringAndIntAndIntParametersDiagnostic()
+        public async Task TestConstructorWithStringAndIntAndIntParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, int saltSize, int cb)
+    public async Task TestMethod(string password, int saltSize, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, saltSize, 100);
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestConstructorWithByteArrayAndByteArrayAndIntAndHashAlgorithmNameParametersDiagnostic()
+        public async Task TestConstructorWithByteArrayAndByteArrayAndIntAndHashAlgorithmNameParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, HashAlgorithmName hashAlgorithm, int cb)
+    public async Task TestMethod(byte[] password, byte[] salt, HashAlgorithmName hashAlgorithm, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100, hashAlgorithm);
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestConstructorWithStringAndByteArrayAndIntAndHashAlgorithmNameParametersDiagnostic()
+        public async Task TestConstructorWithStringAndByteArrayAndIntAndHashAlgorithmNameParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, HashAlgorithmName hashAlgorithm, int cb)
+    public async Task TestMethod(string password, byte[] salt, HashAlgorithmName hashAlgorithm, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100, hashAlgorithm);
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestConstructorWithStringAndIntAndIntAndHashAlgorithmNameParametersDiagnostic()
+        public async Task TestConstructorWithStringAndIntAndIntAndHashAlgorithmNameParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, int saltSize, HashAlgorithmName hashAlgorithm, int cb)
+    public async Task TestMethod(string password, int saltSize, HashAlgorithmName hashAlgorithm, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, saltSize, 100, hashAlgorithm);
         rfc2898DeriveBytes.GetBytes(cb);
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount));
+            GetCSharpResultAt(9, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
         }
 
         [Fact]
-        public void TestAssignIterationCountNoDiagnostic()
+        public async Task TestAssignIterationCountNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100000;
@@ -284,14 +286,14 @@ class TestClass
         }
 
         [Fact]
-        public void TestPassRfc2898DeriveBytesAsParameterInterproceduralNoDiagnostic()
+        public async Task TestPassRfc2898DeriveBytesAsParameterInterproceduralNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100000;
@@ -306,14 +308,14 @@ class TestClass
         }
 
         [Fact]
-        public void TestReturnRfc2898DeriveBytesInterproceduralNoDiagnostic()
+        public async Task TestReturnRfc2898DeriveBytesInterproceduralNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = GetRfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -330,14 +332,14 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithByteArrayAndByteArrayAndIntParametersUnassignedIterationsNoDiagnostic()
+        public async Task TestConstructorWithByteArrayAndByteArrayAndIntParametersUnassignedIterationsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int iterations, int cb)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, iterations);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -346,14 +348,14 @@ class TestClass
         }
 
         [Fact]
-        public void TestConstructorWithByteArrayAndByteArrayAndIntParametersHighIterationsNoDiagnostic()
+        public async Task TestConstructorWithByteArrayAndByteArrayAndIntParametersHighIterationsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(byte[] password, byte[] salt, int iterations, int cb)
+    public async Task TestMethod(byte[] password, byte[] salt, int iterations, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100000);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -367,39 +369,43 @@ class TestClass
         [InlineData(@"dotnet_code_quality.CA5387.excluded_symbol_names = TestMethod
                       dotnet_code_quality.CA5388.excluded_symbol_names = TestMethod")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = TestMethod")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
-            var expected = Array.Empty<DiagnosticResult>();
-            if (editorConfigText.Length == 0)
+            var test = new VerifyCS.Test
             {
-                expected = new DiagnosticResult[]
+                TestState =
                 {
-                    GetCSharpResultAt(10, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule, SufficientIterationCount)
-                };
-            }
-
-            VerifyCSharp(@"
+                    Sources =
+                    {
+                        @"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(string password, byte[] salt, int cb)
+    public async Task TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100;
         rfc2898DeriveBytes.GetBytes(cb);
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}"
+
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            if (editorConfigText.Length == 0)
+            {
+                test.ExpectedDiagnostics.Add(GetCSharpResultAt(10, 9, DoNotUseWeakKDFInsufficientIterationCount.DefinitelyUseWeakKDFInsufficientIterationCountRule));
+            }
+
+            await test.RunAsync();
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseWeakKDFInsufficientIterationCount();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseWeakKDFInsufficientIterationCount();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+            => VerifyCS.Diagnostic(rule)
+                .WithLocation(line, column)
+                .WithArguments(SufficientIterationCount);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFInsufficientIterationCountTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFInsufficientIterationCountTests.cs
@@ -22,7 +22,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -39,7 +39,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100;
@@ -58,7 +58,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var iterations = 100;
         Random r = new Random();
@@ -84,7 +84,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100;
@@ -109,7 +109,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100;
@@ -132,7 +132,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = GetRfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -157,7 +157,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, int saltSize, int cb)
+    public void TestMethod(string password, int saltSize, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, saltSize);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -174,7 +174,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -191,7 +191,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int cb)
+    public void TestMethod(byte[] password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -208,7 +208,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, int saltSize, int cb)
+    public void TestMethod(string password, int saltSize, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, saltSize, 100);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -225,7 +225,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, HashAlgorithmName hashAlgorithm, int cb)
+    public void TestMethod(byte[] password, byte[] salt, HashAlgorithmName hashAlgorithm, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100, hashAlgorithm);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -242,7 +242,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, HashAlgorithmName hashAlgorithm, int cb)
+    public void TestMethod(string password, byte[] salt, HashAlgorithmName hashAlgorithm, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100, hashAlgorithm);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -259,7 +259,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, int saltSize, HashAlgorithmName hashAlgorithm, int cb)
+    public void TestMethod(string password, int saltSize, HashAlgorithmName hashAlgorithm, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, saltSize, 100, hashAlgorithm);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -276,7 +276,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100000;
@@ -293,7 +293,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100000;
@@ -315,7 +315,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = GetRfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -339,7 +339,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, int cb)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, iterations);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -355,7 +355,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(byte[] password, byte[] salt, int iterations, int cb)
+    public void TestMethod(byte[] password, byte[] salt, int iterations, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt, 100000);
         rfc2898DeriveBytes.GetBytes(cb);
@@ -382,7 +382,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(string password, byte[] salt, int cb)
+    public void TestMethod(string password, byte[] salt, int cb)
     {
         var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, salt);
         rfc2898DeriveBytes.IterationCount = 100;

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFInsufficientIterationCountTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseWeakKDFInsufficientIterationCountTests.cs
@@ -403,7 +403,7 @@ class TestClass
             await test.RunAsync();
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
             => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(SufficientIterationCount);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseXslTransformTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseXslTransformTests.cs
@@ -60,7 +60,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseXslTransformTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseXslTransformTests.cs
@@ -1,17 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.DoNotUseXslTransform,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotUseXslTransformTests : DiagnosticAnalyzerTestBase
+    public class DoNotUseXslTransformTests
     {
         [Fact]
-        public void TestConstructXslTransformDiagnostic()
+        public async Task TestConstructXslTransformDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml.Xsl;
 
@@ -22,13 +25,13 @@ class TestClass
         new XslTransform();
     }
 }",
-            GetCSharpResultAt(9, 9, DoNotUseXslTransform.Rule));
+            GetCSharpResultAt(9, 9));
         }
 
         [Fact]
-        public void TestConstructNormalClassNoDiagnostic()
+        public async Task TestConstructNormalClassNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml.Xsl;
 
@@ -42,29 +45,23 @@ class TestClass
         }
 
         [Fact]
-        public void TestInvokeMethodOfXslTransformNoDiagnostic()
+        public async Task TestInvokeMethodOfXslTransformNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml.Xsl;
 
 class TestClass
 {
-    public void TestMethod(XslTransform xslTransform)
+    public async Task TestMethod(XslTransform xslTransform)
     {
         xslTransform.Load(""url"");
     }
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new DoNotUseXslTransform();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new DoNotUseXslTransform();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseXslTransformTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/DoNotUseXslTransformTests.cs
@@ -53,7 +53,7 @@ using System.Xml.Xsl;
 
 class TestClass
 {
-    public async Task TestMethod(XslTransform xslTransform)
+    public void TestMethod(XslTransform xslTransform)
     {
         xslTransform.Load(""url"");
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/JsonNetTypeNameHandlingTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/JsonNetTypeNameHandlingTests.cs
@@ -215,11 +215,11 @@ class Blah
             //this.VerifyBasicAcrossTwoAssemblies(NewtonsoftJsonNetApis.VisualBasic, source, expected);
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
            => VerifyVB.Diagnostic(rule)
                .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/JsonNetTypeNameHandlingTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/JsonNetTypeNameHandlingTests.cs
@@ -1,27 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
-using Test.Utilities.MinimalImplementations;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.JsonNetTypeNameHandling,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.JsonNetTypeNameHandling,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class JsonNetTypeNameHandlingTests : DiagnosticAnalyzerTestBase
+    public class JsonNetTypeNameHandlingTests
     {
         private static readonly DiagnosticDescriptor Rule = JsonNetTypeNameHandling.Rule;
-
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new JsonNetTypeNameHandling();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new JsonNetTypeNameHandling();
-        }
 
         [Fact]
         public void DocSample1_CSharp_Violation_Diagnostic()
@@ -212,12 +205,22 @@ class Blah
 
         private void VerifyCSharpWithJsonNet(string source, params DiagnosticResult[] expected)
         {
-            this.VerifyCSharpAcrossTwoAssemblies(NewtonsoftJsonNetApis.CSharp, source, expected);
+            // TODO: Amaury - Fix this code
+            //this.VerifyCSharpAcrossTwoAssemblies(NewtonsoftJsonNetApis.CSharp, source, expected);
         }
 
         private void VerifyBasicWithJsonNet(string source, params DiagnosticResult[] expected)
         {
-            this.VerifyBasicAcrossTwoAssemblies(NewtonsoftJsonNetApis.VisualBasic, source, expected);
+            // TODO: Amaury - Fix this code
+            //this.VerifyBasicAcrossTwoAssemblies(NewtonsoftJsonNetApis.VisualBasic, source, expected);
         }
+
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+           => VerifyCS.Diagnostic(rule)
+               .WithLocation(line, column);
+
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule)
+           => VerifyVB.Diagnostic(rule)
+               .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetHttpOnlyForHttpCookieTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetHttpOnlyForHttpCookieTests.cs
@@ -374,7 +374,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
            => VerifyCS.Diagnostic()
                .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetHttpOnlyForHttpCookieTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetHttpOnlyForHttpCookieTests.cs
@@ -1,15 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.SetHttpOnlyForHttpCookie,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class SetHttpOnlyForHttpCookieTests : DiagnosticAnalyzerTestBase
+    public class SetHttpOnlyForHttpCookieTests
     {
-        protected void VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
+        protected async Task VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
         {
             string httpCookieCSharpSourceCode = @"
 namespace System.Web
@@ -27,15 +29,23 @@ namespace System.Web
         public bool HttpOnly { get; set; }
     }
 }";
-            this.VerifyCSharp(
-                new[] { source, httpCookieCSharpSourceCode }.ToFileAndSource(),
-                expected);
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source, httpCookieCSharpSourceCode }
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
         }
 
         [Fact]
-        public void Test_AssignHttpOnlyWithFalse_Diagnostic()
+        public async Task Test_AssignHttpOnlyWithFalse_Diagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -46,13 +56,13 @@ class TestClass
         httpCookie.HttpOnly = false;
     }
 }",
-            GetCSharpResultAt(9, 9, SetHttpOnlyForHttpCookie.Rule));
+            GetCSharpResultAt(9, 9));
         }
 
         [Fact]
-        public void Test_AssignHttpOnlyWithFalsePossibly_Diagnostic()
+        public async Task Test_AssignHttpOnlyWithFalsePossibly_Diagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using System.Web;
 
@@ -69,13 +79,13 @@ class TestClass
         }
     }
 }",
-            GetCSharpResultAt(14, 13, SetHttpOnlyForHttpCookie.Rule));
+            GetCSharpResultAt(14, 13));
         }
 
         [Fact]
-        public void Test_ReturnHttpCookieWithFalseHttpOnly_Diagnostic()
+        public async Task Test_ReturnHttpCookieWithFalseHttpOnly_Diagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -87,13 +97,13 @@ class TestClass
         return httpCookie;
     }
 }",
-            GetCSharpResultAt(8, 9, SetHttpOnlyForHttpCookie.Rule));
+            GetCSharpResultAt(8, 9));
         }
 
         [Fact]
-        public void Test_ReturnHttpCookie_WithoutSettingHttpOnly_Diagnostic()
+        public async Task Test_ReturnHttpCookie_WithoutSettingHttpOnly_Diagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -105,13 +115,13 @@ class TestClass
         return httpCookie;
     }
 }",
-            GetCSharpResultAt(10, 16, SetHttpOnlyForHttpCookie.Rule));
+            GetCSharpResultAt(10, 16));
         }
 
         [Fact]
-        public void Test_PassHttpCookieAsAParamter_WithoutSettingHttpOnly_Diagnostic()
+        public async Task Test_PassHttpCookieAsAParamter_WithoutSettingHttpOnly_Diagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -126,13 +136,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(9, 21, SetHttpOnlyForHttpCookie.Rule));
+            GetCSharpResultAt(9, 21));
         }
 
         [Fact]
-        public void Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsFalse_Diagnostic()
+        public async Task Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsFalse_Diagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -148,13 +158,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(9, 9, SetHttpOnlyForHttpCookie.Rule));
+            GetCSharpResultAt(9, 9));
         }
 
         [Fact]
-        public void Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsFalsePossibly_Diagnostic()
+        public async Task Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsFalsePossibly_Diagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using System.Web;
 
@@ -177,13 +187,13 @@ class TestClass
     {
     }
 }",
-            GetCSharpResultAt(14, 13, SetHttpOnlyForHttpCookie.Rule));
+            GetCSharpResultAt(14, 13));
         }
 
         [Fact]
-        public void Test_CreateHttpCookieWithNullArguments_NoDiagnostic()
+        public async Task Test_CreateHttpCookieWithNullArguments_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -196,9 +206,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_AssignHttpOnlyWithTrue_NoDiagnostic()
+        public async Task Test_AssignHttpOnlyWithTrue_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -212,9 +222,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_JustObjectCreation_NoDiagnostic()
+        public async Task Test_JustObjectCreation_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -227,9 +237,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_AssignHttpOnlyWithTruePossibly_NoDiagnostic()
+        public async Task Test_AssignHttpOnlyWithTruePossibly_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using System.Web;
 
@@ -249,9 +259,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_ReturnHttpCookieWithUnkownHttpOnly_NoDiagnostic()
+        public async Task Test_ReturnHttpCookieWithUnkownHttpOnly_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -264,9 +274,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_ReturnHttpCookieWithTrueHttpOnly_NoDiagnostic()
+        public async Task Test_ReturnHttpCookieWithTrueHttpOnly_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -281,9 +291,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsTrue_NoDiagnostic()
+        public async Task Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsTrue_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -303,9 +313,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsTruePossibly_NoDiagnostic()
+        public async Task Test_PassHttpCookieAsAParamter_WithSettingHttpOnlyAsTruePossibly_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using System.Web;
 
@@ -331,9 +341,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_PassHttpCookieWithNullValue_NoDiagnostic()
+        public async Task Test_PassHttpCookieWithNullValue_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -350,9 +360,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_ReturnNull_NoDiagnostic()
+        public async Task Test_ReturnNull_NoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System.Web;
 
 class TestClass
@@ -364,14 +374,8 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new SetHttpOnlyForHttpCookie();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new SetHttpOnlyForHttpCookie();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+           => VerifyCS.Diagnostic()
+               .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetViewStateUserKeyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetViewStateUserKeyTests.cs
@@ -1,22 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.SetViewStateUserKey,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.SetViewStateUserKey,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class SetViewStateUserKeyTests : DiagnosticAnalyzerTestBase
+    public class SetViewStateUserKeyTests
     {
         [Fact]
-        public void TestSubclassWithoutOnInitMethodDiagnostic()
+        public async Task TestSubclassWithoutOnInitMethodDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -27,9 +28,9 @@ class TestClass : Page
         ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Web.UI
 
@@ -39,13 +40,13 @@ class TestClass
         ViewStateUserKey = ""ViewStateUserKey""
     End Sub
 End Class",
-            GetBasicResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetBasicResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestOverrideModifierWithoutSettingViewStateUserKeyDiagnostic()
+        public async Task TestOverrideModifierWithoutSettingViewStateUserKeyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -55,9 +56,9 @@ class TestClass : Page
     {
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Web.UI
 
@@ -66,13 +67,13 @@ class TestClass
     protected Sub OnInit (ByVal e As EventArgs)
     End Sub
 End Class",
-            GetBasicResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetBasicResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestNewModifierWithoutSettingViewStateUserKeyDiagnostic()
+        public async Task TestNewModifierWithoutSettingViewStateUserKeyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -82,13 +83,13 @@ class TestClass : Page
     {
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestNoModifierWithoutSettingViewStateUserKeyDiagnostic()
+        public async Task TestNoModifierWithoutSettingViewStateUserKeyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -98,13 +99,13 @@ class TestClass : Page
     {
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestOverloadOnInitWithSettingViewStateUserKeyDiagnostic()
+        public async Task TestOverloadOnInitWithSettingViewStateUserKeyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -115,13 +116,13 @@ class TestClass : Page
         ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestStaticMethodWithSettingViewStateUserKeyDiagnostic()
+        public async Task TestStaticMethodWithSettingViewStateUserKeyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -133,13 +134,13 @@ class TestClass : Page
         testClass.ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestSubclassWithSettingPropertyOfLocalObjectDiagnostic()
+        public async Task TestSubclassWithSettingPropertyOfLocalObjectDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -151,13 +152,13 @@ class TestClass : Page
         testClass.ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestSubclassWithSettingPropertyOfWrongClassDiagnostic()
+        public async Task TestSubclassWithSettingPropertyOfWrongClassDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -175,13 +176,13 @@ class TestClass : Page
         _field.ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(10, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(10, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestSubclassWithSettingWrongPropertyDiagnostic()
+        public async Task TestSubclassWithSettingWrongPropertyDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -194,13 +195,13 @@ class TestClass : Page
         ViewStateUserKey = 123;
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestSettingPropertyOfLocalObjectInPage_InitDiagnostic()
+        public async Task TestSettingPropertyOfLocalObjectInPage_InitDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -212,13 +213,13 @@ class TestClass : Page
         testClass.ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TesthSettingPropertyOfWrongClassInPage_InitDiagnostic()
+        public async Task TesthSettingPropertyOfWrongClassInPage_InitDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -236,13 +237,13 @@ class TestClass : Page
         _field.ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(10, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(10, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestWithSettingWrongPropertyInPage_InitDiagnostic()
+        public async Task TestWithSettingWrongPropertyInPage_InitDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -255,13 +256,13 @@ class TestClass : Page
         ViewStateUserKey = 123;
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestInPage_InitWithObjectParameterDiagnostic()
+        public async Task TestInPage_InitWithObjectParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -272,13 +273,13 @@ class TestClass : Page
         ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestInPage_InitWithStringReturnTypeDiagnostic()
+        public async Task TestInPage_InitWithStringReturnTypeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -290,13 +291,13 @@ class TestClass : Page
         return ViewStateUserKey;
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestNeitherOnInitNorInPage_InitNoDiagnostic()
+        public async Task TestNeitherOnInitNorInPage_InitNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -310,13 +311,13 @@ class TestClass : Page
     {
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestNewPageDiagnostic()
+        public async Task TestNewPageDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -329,13 +330,13 @@ class TestClass : Page
         Page.ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestOverridePageDiagnostic()
+        public async Task TestOverridePageDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -348,13 +349,13 @@ class TestClass : Page
         Page.ViewStateUserKey = ""ViewStateUserKey"";
     }
 }",
-            GetCSharpResultAt(5, 7, SetViewStateUserKey.Rule, "TestClass"));
+            GetCSharpResultAt(5, 7, "TestClass"));
         }
 
         [Fact]
-        public void TestSubclassWithSettingViewStateUserKeyNoDiagnostic()
+        public async Task TestSubclassWithSettingViewStateUserKeyNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -368,9 +369,9 @@ class TestClass : Page
         }
 
         [Fact]
-        public void TestNewModifierNoDiagnostic()
+        public async Task TestNewModifierNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -384,9 +385,9 @@ class TestClass : Page
         }
 
         [Fact]
-        public void TestWithoutModifierNoDiagnostic()
+        public async Task TestWithoutModifierNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -400,9 +401,9 @@ class TestClass : Page
         }
 
         [Fact]
-        public void TestOrdinaryClassWithSettingViewStateUserKeyNoDiagnostic()
+        public async Task TestOrdinaryClassWithSettingViewStateUserKeyNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 
 class TestClass
@@ -417,9 +418,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestSettingViewStateUserKeyInPage_InitNoDiagnostic()
+        public async Task TestSettingViewStateUserKeyInPage_InitNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -433,9 +434,9 @@ class TestClass : Page
         }
 
         [Fact]
-        public void TestBothOnInitAndInPage_InitNoDiagnostic()
+        public async Task TestBothOnInitAndInPage_InitNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -454,9 +455,9 @@ class TestClass : Page
         }
 
         [Fact]
-        public void TestNotAPage_NoDiagnostic()
+        public async Task TestNotAPage_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -475,9 +476,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestInterface_NoDiagnostic()
+        public async Task TestInterface_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -492,9 +493,9 @@ interface ITestInterface
         }
 
         [Fact]
-        public void TestSettingViewStateUserKeyOfPageNoDiagnostic()
+        public async Task TestSettingViewStateUserKeyOfPageNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Web.UI;
 
@@ -507,14 +508,14 @@ class TestClass : Page
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new SetViewStateUserKey();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new SetViewStateUserKey();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetViewStateUserKeyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SetViewStateUserKeyTests.cs
@@ -508,12 +508,12 @@ class TestClass : Page
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SslProtocolsAnalyzerTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SslProtocolsAnalyzerTests.cs
@@ -536,12 +536,12 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
             => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
             => VerifyVB.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SslProtocolsAnalyzerTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/SslProtocolsAnalyzerTests.cs
@@ -1,23 +1,24 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Xunit.Abstractions;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.SslProtocolsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.SslProtocolsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class SslProtocolsAnalyzerTests : DiagnosticAnalyzerTestBase
+    public class SslProtocolsAnalyzerTests
     {
-        public SslProtocolsAnalyzerTests(ITestOutputHelper output)
-            : base(output)
-        {
-        }
-
         [Fact]
-        public void DocSample1_CSharp_Violation()
+        public async Task DocSample1_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -34,9 +35,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample1_VB_Violation()
+        public async Task DocSample1_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Security.Authentication
 
@@ -52,9 +53,9 @@ End Class
         }
 
         [Fact]
-        public void DocSample2_CSharp_Violation()
+        public async Task DocSample2_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -70,9 +71,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample2_VB_Violation()
+        public async Task DocSample2_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Security.Authentication
 
@@ -87,9 +88,9 @@ End Class
         }
 
         [Fact]
-        public void DocSample1_CSharp_Solution()
+        public async Task DocSample1_CSharp_Solution()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -105,9 +106,9 @@ public class TestClass
         }
 
         [Fact]
-        public void DocSample1_VB_Solution()
+        public async Task DocSample1_VB_Solution()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Security.Authentication
 
@@ -122,9 +123,9 @@ End Class
         }
 
         [Fact]
-        public void DocSample3_CSharp_Violation()
+        public async Task DocSample3_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -140,9 +141,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample3_VB_Violation()
+        public async Task DocSample3_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Security.Authentication
 
@@ -157,9 +158,9 @@ End Class
         }
 
         [Fact]
-        public void DocSample4_CSharp_Violation()
+        public async Task DocSample4_CSharp_Violation()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -175,9 +176,9 @@ public class ExampleClass
         }
 
         [Fact]
-        public void DocSample4_VB_Violation()
+        public async Task DocSample4_VB_Violation()
         {
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Security.Authentication
 
@@ -192,9 +193,9 @@ End Class
         }
 
         [Fact]
-        public void Argument_Ssl2_Diagnostic()
+        public async Task Argument_Ssl2_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net.Security;
 using System.Security.Authentication;
@@ -211,9 +212,9 @@ class TestClass
         }
 
         [Fact]
-        public void Argument_Tls12_Diagnostic()
+        public async Task Argument_Tls12_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net.Security;
 using System.Security.Authentication;
@@ -230,9 +231,9 @@ class TestClass
         }
 
         [Fact]
-        public void Argument_None_Diagnostic()
+        public async Task Argument_None_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Net.Security;
 using System.Security.Authentication;
@@ -248,9 +249,9 @@ class TestClass
         }
 
         [Fact]
-        public void UseSsl3_Diagnostic()
+        public async Task UseSsl3_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -265,9 +266,9 @@ class TestClass
         }
 
         [Fact]
-        public void UseTls_Diagnostic()
+        public async Task UseTls_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -282,9 +283,9 @@ class TestClass
         }
 
         [Fact]
-        public void UseTls11_Diagnostic()
+        public async Task UseTls11_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -299,9 +300,9 @@ class TestClass
         }
 
         [Fact]
-        public void UseSystemDefault_NoDiagnostic()
+        public async Task UseSystemDefault_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -316,9 +317,9 @@ class TestClass
         }
 
         [Fact]
-        public void UseTls12_Diagnostic()
+        public async Task UseTls12_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -333,9 +334,9 @@ class TestClass
         }
 
         [FactUnlessTls13Unavailable]
-        public void UseTls13_Diagnostic()
+        public async Task UseTls13_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -350,9 +351,9 @@ class TestClass
         }
 
         [Fact]
-        public void UseTls12OrdTls11_Diagnostic()
+        public async Task UseTls12OrdTls11_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -368,9 +369,9 @@ class TestClass
         }
 
         [Fact]
-        public void Use192CompoundAssignment_Diagnostic()
+        public async Task Use192CompoundAssignment_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -387,10 +388,10 @@ class TestClass
         }
 
         [Fact]
-        public void Use384SimpleAssignment_Diagnostic()
+        public async Task Use384SimpleAssignment_Diagnostic()
         {
             // 384 = SchProtocols.Tls11Server | SchProtocols.Tls10Client
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -407,9 +408,9 @@ class TestClass
         }
 
         [Fact]
-        public void Use768SimpleAssignmentOrExpression_Diagnostic()
+        public async Task Use768SimpleAssignmentOrExpression_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -426,9 +427,9 @@ class TestClass
         }
 
         [Fact]
-        public void Use12288SimpleAssignmentOrExpression_Diagnostic()
+        public async Task Use12288SimpleAssignmentOrExpression_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -445,9 +446,9 @@ class TestClass
         }
 
         [Fact]
-        public void UseTls12OrTls11Or192_Diagnostic()
+        public async Task UseTls12OrTls11Or192_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -465,9 +466,9 @@ class TestClass
         }
 
         [Fact]
-        public void UseTls12Or192_Diagnostic()
+        public async Task UseTls12Or192_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -483,9 +484,9 @@ class TestClass
         }
 
         [Fact]
-        public void Use768DeconstructionAssignment_NoDiagnostic()
+        public async Task Use768DeconstructionAssignment_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -503,9 +504,9 @@ class TestClass
         }
 
         [Fact]
-        public void Use24Plus24SimpleAssignment_Diagnostic()
+        public async Task Use24Plus24SimpleAssignment_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -520,9 +521,9 @@ class TestClass
         }
 
         [Fact]
-        public void Use768NotSslProtocols_NoDiagnostic()
+        public async Task Use768NotSslProtocols_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Authentication;
 
@@ -535,14 +536,14 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new SslProtocolsAnalyzer();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => VerifyCS.Diagnostic(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new SslProtocolsAnalyzer();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => VerifyVB.Diagnostic(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseAutoValidateAntiforgeryTokenTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseAutoValidateAntiforgeryTokenTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
     public class UseAutoValidateAntiforgeryTokenTests
     {
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column)
                .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseContainerLevelAccessPolicyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseContainerLevelAccessPolicyTests.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseContainerLevelAccessPolicy,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class UseContainerLevelAccessPolicyTests : DiagnosticAnalyzerTestBase
+    public class UseContainerLevelAccessPolicyTests
     {
         private const string MicrosoftWindowsAzureStorageCSharpSourceCode = @"
 using System;
@@ -125,26 +127,41 @@ namespace Microsoft.WindowsAzure.Storage
     }
 }";
 
-        protected void VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
+        private async Task VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
         {
-            this.VerifyCSharp(
-                new[] { source, MicrosoftWindowsAzureStorageCSharpSourceCode }.ToFileAndSource(),
-                expected);
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source, MicrosoftWindowsAzureStorageCSharpSourceCode  }
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
         }
 
-        protected void VerifyCSharpWithDependencies(string source, FileAndSource additionalFile, params DiagnosticResult[] expected)
+        private async Task VerifyCSharpWithDependencies(string source, string editorConfigText, params DiagnosticResult[] expected)
         {
-            this.VerifyCSharp(
-                new[] { source, MicrosoftWindowsAzureStorageCSharpSourceCode },
-                additionalFile,
-                ReferenceFlags.None,
-                expected);
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source, MicrosoftWindowsAzureStorageCSharpSourceCode  },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.AddRange(expected);
+
+            await csharpTest.RunAsync();
         }
 
         [Fact]
-        public void TestGroupPolicyIdentifierOfBlobNamespaceIsNullDiagnostic()
+        public async Task TestGroupPolicyIdentifierOfBlobNamespaceIsNullDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -158,32 +175,32 @@ class TestClass
         cloudAppendBlob.GetSharedAccessSignature(policy, headers, groupPolicyIdentifier, protocols, ipAddressOrRange);
     }
 }",
-            GetCSharpResultAt(12, 9, UseContainerLevelAccessPolicy.Rule));
+            GetCSharpResultAt(12, 9));
         }
 
         [Fact]
-        public void TestAccessPolicyIdentifierOfTableNamespaceIsNullDiagnostic()
+        public async Task TestAccessPolicyIdentifierOfTableNamespaceIsNullDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.Table;
 
 class TestClass
 {
-    public void TestMethod(SharedAccessTablePolicy policy, string startPartitionKey, string startRowKey, string endPartitionKey, string endRowKey)
+    public async Task TestMethod(SharedAccessTablePolicy policy, string startPartitionKey, string startRowKey, string endPartitionKey, string endRowKey)
     {
         var cloudTable = new CloudTable();
         string accessPolicyIdentifier = null;
         cloudTable.GetSharedAccessSignature(policy, accessPolicyIdentifier, startPartitionKey, startRowKey, endPartitionKey, endRowKey);
     }
 }",
-            GetCSharpResultAt(11, 9, UseContainerLevelAccessPolicy.Rule));
+            GetCSharpResultAt(11, 9));
         }
 
         [Fact]
-        public void TestGroupPolicyIdentifierOfFileNamespaceIsNullDiagnostic()
+        public async Task TestGroupPolicyIdentifierOfFileNamespaceIsNullDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.File;
 
@@ -196,13 +213,13 @@ class TestClass
         cloudFile.GetSharedAccessSignature(policy, groupPolicyIdentifier);
     }
 }",
-            GetCSharpResultAt(11, 9, UseContainerLevelAccessPolicy.Rule));
+            GetCSharpResultAt(11, 9));
         }
 
         [Fact]
-        public void TestAccessPolicyIdentifierOfQueueNamespaceIsNullDiagnostic()
+        public async Task TestAccessPolicyIdentifierOfQueueNamespaceIsNullDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.Queue;
 
@@ -216,13 +233,13 @@ class TestClass
         cloudQueue.GetSharedAccessSignature(policy, accessPolicyIdentifier);
     }
 }",
-            GetCSharpResultAt(12, 9, UseContainerLevelAccessPolicy.Rule));
+            GetCSharpResultAt(12, 9));
         }
 
         [Fact]
-        public void TestWithoutGroupPolicyIdentifierParameterOfBlobNamespaceDiagnostic()
+        public async Task TestWithoutGroupPolicyIdentifierParameterOfBlobNamespaceDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -235,13 +252,13 @@ class TestClass
         cloudAppendBlob.GetSharedAccessSignature(policy);
     }
 }",
-            GetCSharpResultAt(11, 9, UseContainerLevelAccessPolicy.Rule));
+            GetCSharpResultAt(11, 9));
         }
 
         [Fact]
-        public void TestWithoutAccessPolicyIdentifierParameterOfTableNamespaceDiagnostic()
+        public async Task TestWithoutAccessPolicyIdentifierParameterOfTableNamespaceDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.Table;
 
@@ -253,13 +270,13 @@ class TestClass
         cloudTable.GetSharedAccessSignature(policy);
     }
 }",
-            GetCSharpResultAt(10, 9, UseContainerLevelAccessPolicy.Rule));
+            GetCSharpResultAt(10, 9));
         }
 
         [Fact]
-        public void TestWithoutGroupPolicyIdentifierParameterOfFileNamespaceDiagnostic()
+        public async Task TestWithoutGroupPolicyIdentifierParameterOfFileNamespaceDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.File;
 
@@ -271,13 +288,13 @@ class TestClass
         cloudFile.GetSharedAccessSignature(policy);
     }
 }",
-            GetCSharpResultAt(10, 9, UseContainerLevelAccessPolicy.Rule));
+            GetCSharpResultAt(10, 9));
         }
 
         [Fact]
-        public void TestWithoutAccessPolicyIdentifierParameterOfQueueNamespaceDiagnostic()
+        public async Task TestWithoutAccessPolicyIdentifierParameterOfQueueNamespaceDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.Queue;
 
@@ -290,13 +307,13 @@ class TestClass
         cloudQueue.GetSharedAccessSignature(policy);
     }
 }",
-            GetCSharpResultAt(11, 9, UseContainerLevelAccessPolicy.Rule));
+            GetCSharpResultAt(11, 9));
         }
 
         [Fact]
-        public void TestGroupPolicyIdentifierOfBlobNamespaceIsNotNullNoDiagnostic()
+        public async Task TestGroupPolicyIdentifierOfBlobNamespaceIsNotNullNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -313,9 +330,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestGroupPolicyIdentifierOfFileNamespaceIsNotNullNoDiagnostic()
+        public async Task TestGroupPolicyIdentifierOfFileNamespaceIsNotNullNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.File;
 
@@ -331,9 +348,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestGetSharedAccessSignatureOfANormalTypeNoDiagnostic()
+        public async Task TestGetSharedAccessSignatureOfANormalTypeNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage;
 
@@ -352,9 +369,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestAccessPolicyIdentifierOfQueueNamespaceIsNotNullNoDiagnostic()
+        public async Task TestAccessPolicyIdentifierOfQueueNamespaceIsNotNullNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.Queue;
 
@@ -370,9 +387,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestAccessPolicyIdentifierOfTableNamespaceIsNotNullNoDiagnostic()
+        public async Task TestAccessPolicyIdentifierOfTableNamespaceIsNotNullNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.Table;
 
@@ -392,18 +409,18 @@ class TestClass
         [InlineData("dotnet_code_quality.excluded_symbol_names = TestMethod")]
         [InlineData("dotnet_code_quality." + UseContainerLevelAccessPolicy.DiagnosticId + ".excluded_symbol_names = TestMethod")]
         [InlineData("dotnet_code_quality.dataflow.excluded_symbol_names = TestMethod")]
-        public void EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
+        public async Task EditorConfigConfiguration_ExcludedSymbolNamesOption(string editorConfigText)
         {
             var expected = Array.Empty<DiagnosticResult>();
             if (editorConfigText.Length == 0)
             {
                 expected = new DiagnosticResult[]
                 {
-                    GetCSharpResultAt(11, 9, UseContainerLevelAccessPolicy.Rule)
+                    GetCSharpResultAt(11, 9)
                 };
             }
 
-            VerifyCSharpWithDependencies(@"
+            await VerifyCSharpWithDependencies(@"
 using System;
 using Microsoft.WindowsAzure.Storage.Table;
 
@@ -415,17 +432,11 @@ class TestClass
         string accessPolicyIdentifier = null;
         cloudTable.GetSharedAccessSignature(policy, accessPolicyIdentifier, startPartitionKey, startRowKey, endPartitionKey, endRowKey);
     }
-}", GetEditorConfigAdditionalFile(editorConfigText), expected);
+}", editorConfigText, expected);
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseContainerLevelAccessPolicy();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseContainerLevelAccessPolicy();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column)
+           => VerifyCS.Diagnostic()
+               .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseContainerLevelAccessPolicyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseContainerLevelAccessPolicyTests.cs
@@ -435,7 +435,7 @@ class TestClass
 }", editorConfigText, expected);
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
            => VerifyCS.Diagnostic()
                .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseDefaultDllImportSearchPathsAttributeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseDefaultDllImportSearchPathsAttributeTests.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using System;
-using Test.Utilities;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseDefaultDllImportSearchPathsAttribute,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
@@ -13,13 +15,13 @@ namespace Microsoft.NetCore.Analyzers.Security.UnitTests
     // which will ignore all the configuration about the search algorithm.
     // Fow now, this rule didn't take Known Dlls into consideration.
     // If it is needed in the future, we can recover this rule.
-    public class UseDefaultDllImportSearchPathsAttributeTests : DiagnosticAnalyzerTestBase
+    public class UseDefaultDllImportSearchPathsAttributeTests
     {
         // It will try to retrieve the MessageBox from user32.dll, which will be searched in a default order.
         [Fact]
-        public void Test_DllImportAttribute_Diagnostic()
+        public async Task Test_DllImportAttribute_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -37,9 +39,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_DllInUpperCase_Diagnostic()
+        public async Task Test_DllInUpperCase_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -57,9 +59,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_WithoutDllExtension_Diagnostic()
+        public async Task Test_WithoutDllExtension_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -77,9 +79,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_DllImportSearchPathAssemblyDirectory_Diagnostic()
+        public async Task Test_DllImportSearchPathAssemblyDirectory_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -98,9 +100,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_UnsafeDllImportSearchPathBits_BitwiseCombination_OneValueIsBad_Diagnostic()
+        public async Task Test_UnsafeDllImportSearchPathBits_BitwiseCombination_OneValueIsBad_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -119,9 +121,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_UnsafeDllImportSearchPathBits_BitwiseCombination_BothIsBad_Diagnostic()
+        public async Task Test_UnsafeDllImportSearchPathBits_BitwiseCombination_BothIsBad_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -140,9 +142,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_DllImportSearchPathLegacyBehavior_Diagnostic()
+        public async Task Test_DllImportSearchPathLegacyBehavior_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -161,9 +163,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_DllImportSearchPathUseDllDirectoryForDependencies_Diagnostic()
+        public async Task Test_DllImportSearchPathUseDllDirectoryForDependencies_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -182,9 +184,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_DllImportSearchPathAssemblyDirectory_Assembly_Diagnostic()
+        public async Task Test_DllImportSearchPathAssemblyDirectory_Assembly_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -204,9 +206,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_AssemblyDirectory_ApplicationDirectory_Diagnostic()
+        public async Task Test_AssemblyDirectory_ApplicationDirectory_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -227,9 +229,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_ApplicationDirectory_AssemblyDirectory_Diagnostic()
+        public async Task Test_ApplicationDirectory_AssemblyDirectory_Diagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -253,9 +255,15 @@ class TestClass
         [InlineData("")]
         [InlineData("dotnet_code_quality.CA5393.unsafe_DllImportSearchPath_bits = 2 | 256 | 512")]
         [InlineData("dotnet_code_quality.CA5393.unsafe_DllImportSearchPath_bits = 770")]
-        public void EditorConfigConfiguration_UnsafeDllImportSearchPathBits_DefaultValue_Diagnostic(string editorConfigText)
+        public async Task EditorConfigConfiguration_UnsafeDllImportSearchPathBits_DefaultValue_Diagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 using System.Runtime.InteropServices;
 
@@ -269,16 +277,28 @@ class TestClass
     {
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
-}",
-            GetEditorConfigAdditionalFile(editorConfigText),
-            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory, ApplicationDirectory"));
+}"
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory, ApplicationDirectory")
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         [Theory]
         [InlineData("dotnet_code_quality.CA5393.unsafe_DllImportSearchPath_bits = 2048")]
-        public void EditorConfigConfiguration_UnsafeDllImportSearchPathBits_NonDefaultValue_Diagnostic(string editorConfigText)
+        public async Task EditorConfigConfiguration_UnsafeDllImportSearchPathBits_NonDefaultValue_Diagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 using System.Runtime.InteropServices;
 
@@ -292,16 +312,28 @@ class TestClass
     {
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
-}",
-            GetEditorConfigAdditionalFile(editorConfigText),
-            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "System32"));
+}"
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "System32")
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         [Theory]
         [InlineData("dotnet_code_quality.CA5393.unsafe_DllImportSearchPath_bits = 1026")]
-        public void EditorConfigConfiguration_UnsafeDllImportSearchPathBits_BitwiseCombination_Diagnostic(string editorConfigText)
+        public async Task EditorConfigConfiguration_UnsafeDllImportSearchPathBits_BitwiseCombination_Diagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 using System.Runtime.InteropServices;
 
@@ -315,15 +347,21 @@ class TestClass
     {
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
-}",
-            GetEditorConfigAdditionalFile(editorConfigText),
-            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "UserDirectories"));
+}"
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "UserDirectories")
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void Test_NoAttribute_NoDiagnostic()
+        public async Task Test_NoAttribute_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -340,9 +378,9 @@ class TestClass
 
         // user32.dll will be searched in UserDirectories, which is specified by DllImportSearchPath and is good.
         [Fact]
-        public void Test_DllImportAndDefaultDllImportSearchPathsAttributes_NoDiagnostic()
+        public async Task Test_DllImportAndDefaultDllImportSearchPathsAttributes_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -362,9 +400,15 @@ class TestClass
         [Theory]
         [InlineData("dotnet_code_quality.CA5392.unsafe_DllImportSearchPath_bits = 2 | 1024")]
         [InlineData("dotnet_code_quality.CA5392.unsafe_DllImportSearchPath_bits = DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.UserDirectories")]
-        public void EditorConfigConfiguration_UnsafeDllImportSearchPathBits_BitwiseCombination_NoDiagnostic(string editorConfigText)
+        public async Task EditorConfigConfiguration_UnsafeDllImportSearchPathBits_BitwiseCombination_NoDiagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
 using System;
 using System.Runtime.InteropServices;
 
@@ -378,16 +422,24 @@ class TestClass
     {
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
-}",
-            GetEditorConfigAdditionalFile(editorConfigText),
-            Array.Empty<DiagnosticResult>());
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                }
+            }.RunAsync();
         }
 
         [Theory]
         [InlineData("dotnet_code_quality.CA5393.unsafe_DllImportSearchPath_bits = 2048")]
-        public void EditorConfigConfiguration_UnsafeDllImportSearchPathBits_NonDefaultValue_NoDiagnostic(string editorConfigText)
+        public async Task EditorConfigConfiguration_UnsafeDllImportSearchPathBits_NonDefaultValue_NoDiagnostic(string editorConfigText)
         {
-            VerifyCSharp(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+            @"
 using System;
 using System.Runtime.InteropServices;
 
@@ -401,17 +453,19 @@ class TestClass
     {
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
-}",
-            GetEditorConfigAdditionalFile(editorConfigText),
-            Array.Empty<DiagnosticResult>());
+}"
+                    },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
+                    }
+            }.RunAsync();
         }
 
         // In this case, [DefaultDllImportSearchPaths] is applied to the assembly.
         // So, this attribute specifies the paths that are used by default to search for any DLL that provides a function for a platform invoke, in any code in the assembly.
         [Fact]
-        public void Test_DllImportAndAssemblyDefaultDllImportSearchPathsAttributes_NoDiagnostic()
+        public async Task Test_DllImportAndAssemblyDefaultDllImportSearchPathsAttributes_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -431,9 +485,9 @@ class TestClass
 
         // It will have a compiler warning and recommend to use [DllImport] also.
         [Fact]
-        public void Test_DefaultDllImportSearchPaths_NoDiagnostic()
+        public async Task Test_DefaultDllImportSearchPaths_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -450,9 +504,9 @@ class TestClass
 
         // It will have a compiler warning and recommend to use [DllImport] also.
         [Fact]
-        public void Test_AssemblyDefaultDllImportSearchPaths_NoDiagnostic()
+        public async Task Test_AssemblyDefaultDllImportSearchPaths_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -470,9 +524,9 @@ class TestClass
 
         // [DllImport] is set with an absolute path, which will let the [DefaultDllImportSearchPaths] be ignored.
         [Fact]
-        public void Test_DllImportAttributeWithAbsolutePath_DefaultDllImportSearchPaths_NoDiagnostic()
+        public async Task Test_DllImportAttributeWithAbsolutePath_DefaultDllImportSearchPaths_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -491,9 +545,9 @@ class TestClass
 
         // [DllImport] is set with an absolute path.
         [Fact]
-        public void Test_DllImportAttributeWithAbsolutePath_NoDiagnostic()
+        public async Task Test_DllImportAttributeWithAbsolutePath_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -510,9 +564,9 @@ class TestClass
         }
 
         [Fact]
-        public void Test_UsingNonexistentAbsolutePath_NoDiagnostic()
+        public async Task Test_UsingNonexistentAbsolutePath_NoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Runtime.InteropServices;
 
@@ -529,14 +583,9 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseDefaultDllImportSearchPathsAttribute();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseDefaultDllImportSearchPathsAttribute();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+            => VerifyCS.Diagnostic(rule)
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseDefaultDllImportSearchPathsAttributeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseDefaultDllImportSearchPathsAttributeTests.cs
@@ -281,7 +281,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory, ApplicationDirectory")
+                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory, ApplicationDirectory"),
                     },
                     AdditionalFiles = { (".editorconfig", editorConfigText) }
                 }
@@ -316,7 +316,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "System32")
+                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "System32"),
                     },
                     AdditionalFiles = { (".editorconfig", editorConfigText) }
                 }
@@ -351,7 +351,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "UserDirectories")
+                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "UserDirectories"),
                     },
                     AdditionalFiles = { (".editorconfig", editorConfigText) }
                 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseDefaultDllImportSearchPathsAttributeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseDefaultDllImportSearchPathsAttributeTests.cs
@@ -583,7 +583,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)
             => VerifyCS.Diagnostic(rule)
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseRSAWithSufficientKeySizeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseRSAWithSufficientKeySizeTests.cs
@@ -548,7 +548,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseRSAWithSufficientKeySizeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseRSAWithSufficientKeySizeTests.cs
@@ -1,17 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseRSAWithSufficientKeySize,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class UseRSAWithSufficientKeySizeTests : DiagnosticAnalyzerTestBase
+    public class UseRSAWithSufficientKeySizeTests
     {
         [Fact]
-        public void Issue2697()
+        public async Task Issue2697()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -26,9 +29,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateObjectOfRSADerivedClassWithInt32ParameterDiagnostic()
+        public async Task TestCreateObjectOfRSADerivedClassWithInt32ParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -38,13 +41,13 @@ class TestClass
         var rsaCng = new RSACng(1024);
     }
 }",
-            GetCSharpResultAt(8, 22, UseRSAWithSufficientKeySize.Rule, "RSACng"));
+            GetCSharpResultAt(8, 22, "RSACng"));
         }
 
         [Fact]
-        public void TestConstantDiagnostic()
+        public async Task TestConstantDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -55,13 +58,13 @@ class TestClass
         var rsaCng = new RSACng(keySize);
     }
 }",
-            GetCSharpResultAt(9, 22, UseRSAWithSufficientKeySize.Rule, "RSACng"));
+            GetCSharpResultAt(9, 22, "RSACng"));
         }
 
         [Fact]
-        public void TestCreateWithoutParameterDiagnostic()
+        public async Task TestCreateWithoutParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -71,13 +74,13 @@ class TestClass
         var asymmetricAlgorithm = AsymmetricAlgorithm.Create();
     }
 }",
-            GetCSharpResultAt(8, 35, UseRSAWithSufficientKeySize.Rule, "RSA"));
+            GetCSharpResultAt(8, 35, "RSA"));
         }
 
         [Fact]
-        public void TestCreateWithRSAArgDiagnostic()
+        public async Task TestCreateWithRSAArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -87,13 +90,13 @@ class TestClass
         var asymmetricAlgorithm = AsymmetricAlgorithm.Create(""RSA"");
     }
 }",
-            GetCSharpResultAt(8, 35, UseRSAWithSufficientKeySize.Rule, "RSA"));
+            GetCSharpResultAt(8, 35, "RSA"));
         }
 
         [Fact]
-        public void TestCreateWithSystemSecurityCryptographyRSAArgDiagnostic()
+        public async Task TestCreateWithSystemSecurityCryptographyRSAArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -103,13 +106,13 @@ class TestClass
         var asymmetricAlgorithm = AsymmetricAlgorithm.Create(""System.Security.Cryptography.RSA"");
     }
 }",
-            GetCSharpResultAt(8, 35, UseRSAWithSufficientKeySize.Rule, "System.Security.Cryptography.RSA"));
+            GetCSharpResultAt(8, 35, "System.Security.Cryptography.RSA"));
         }
 
         [Fact]
-        public void TestCreateWithSystemSecurityCryptographyAsymmetricAlgorithmArgDiagnostic()
+        public async Task TestCreateWithSystemSecurityCryptographyAsymmetricAlgorithmArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -119,13 +122,13 @@ class TestClass
         var asymmetricAlgorithm = AsymmetricAlgorithm.Create(""System.Security.Cryptography.AsymmetricAlgorithm"");
     }
 }",
-            GetCSharpResultAt(8, 35, UseRSAWithSufficientKeySize.Rule, "System.Security.Cryptography.AsymmetricAlgorithm"));
+            GetCSharpResultAt(8, 35, "System.Security.Cryptography.AsymmetricAlgorithm"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithRSAArgDiagnostic()
+        public async Task TestCreateFromNameWithRSAArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -135,13 +138,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""RSA"");
     }
 }",
-            GetCSharpResultAt(8, 28, UseRSAWithSufficientKeySize.Rule, "RSA"));
+            GetCSharpResultAt(8, 28, "RSA"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyRSAArgDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyRSAArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -151,13 +154,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""System.Security.Cryptography.RSA"");
     }
 }",
-            GetCSharpResultAt(8, 28, UseRSAWithSufficientKeySize.Rule, "System.Security.Cryptography.RSA"));
+            GetCSharpResultAt(8, 28, "System.Security.Cryptography.RSA"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmArgDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmArgDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -167,13 +170,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""System.Security.Cryptography.AsymmetricAlgorithm"");
     }
 }",
-            GetCSharpResultAt(8, 28, UseRSAWithSufficientKeySize.Rule, "System.Security.Cryptography.AsymmetricAlgorithm"));
+            GetCSharpResultAt(8, 28, "System.Security.Cryptography.AsymmetricAlgorithm"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithRSAAndKeySize1024ArgsDiagnostic()
+        public async Task TestCreateFromNameWithRSAAndKeySize1024ArgsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -183,13 +186,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""RSA"", 1024);
     }
 }",
-            GetCSharpResultAt(8, 28, UseRSAWithSufficientKeySize.Rule, "RSA"));
+            GetCSharpResultAt(8, 28, "RSA"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyRSAAndKeySize1024ArgsDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyRSAAndKeySize1024ArgsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -199,13 +202,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""System.Security.Cryptography.RSA"", 1024);
     }
 }",
-            GetCSharpResultAt(8, 28, UseRSAWithSufficientKeySize.Rule, "System.Security.Cryptography.RSA"));
+            GetCSharpResultAt(8, 28, "System.Security.Cryptography.RSA"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmAndKeySize1024ArgsDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmAndKeySize1024ArgsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -215,13 +218,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""System.Security.Cryptography.AsymmetricAlgorithm"", 1024);
     }
 }",
-            GetCSharpResultAt(8, 28, UseRSAWithSufficientKeySize.Rule, "System.Security.Cryptography.AsymmetricAlgorithm"));
+            GetCSharpResultAt(8, 28, "System.Security.Cryptography.AsymmetricAlgorithm"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithRSAAndObjectArray1024ArgsDiagnostic()
+        public async Task TestCreateFromNameWithRSAAndObjectArray1024ArgsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -232,13 +235,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""RSA"", new Object[]{1024});
     }
 }",
-            GetCSharpResultAt(9, 28, UseRSAWithSufficientKeySize.Rule, "RSA"));
+            GetCSharpResultAt(9, 28, "RSA"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyRSAAndObjectArray1024ArgsDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyRSAAndObjectArray1024ArgsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -249,13 +252,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""System.Security.Cryptography.RSA"", new Object[]{1024});
     }
 }",
-            GetCSharpResultAt(9, 28, UseRSAWithSufficientKeySize.Rule, "System.Security.Cryptography.RSA"));
+            GetCSharpResultAt(9, 28, "System.Security.Cryptography.RSA"));
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmAndObjectArray1024ArgsDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmAndObjectArray1024ArgsDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -266,13 +269,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""System.Security.Cryptography.AsymmetricAlgorithm"", new Object[]{1024});
     }
 }",
-            GetCSharpResultAt(9, 28, UseRSAWithSufficientKeySize.Rule, "System.Security.Cryptography.AsymmetricAlgorithm"));
+            GetCSharpResultAt(9, 28, "System.Security.Cryptography.AsymmetricAlgorithm"));
         }
 
         [Fact]
-        public void TestCaseSensitiveDiagnostic()
+        public async Task TestCaseSensitiveDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -283,13 +286,13 @@ class TestClass
         var cryptoConfig = CryptoConfig.CreateFromName(""system.security.cryptography.asymmetricalgorithm"", new Object[]{1024});
     }
 }",
-            GetCSharpResultAt(9, 28, UseRSAWithSufficientKeySize.Rule, "system.security.cryptography.asymmetricalgorithm"));
+            GetCSharpResultAt(9, 28, "system.security.cryptography.asymmetricalgorithm"));
         }
 
         [Fact]
-        public void TestReturnObjectOfRSADerivedClassNoDiagnostic()
+        public async Task TestReturnObjectOfRSADerivedClassNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -302,9 +305,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateObjectOfRSADerivedClassWithInt32ParameterNoDiagnostic()
+        public async Task TestCreateObjectOfRSADerivedClassWithInt32ParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -317,9 +320,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateObjectOfRSADerivedClassWithoutParameterNoDiagnostic()
+        public async Task TestCreateObjectOfRSADerivedClassWithoutParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -332,14 +335,14 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateObjectOfRSADerivedClassWithCngKeyParameterNoDiagnostic()
+        public async Task TestCreateObjectOfRSADerivedClassWithCngKeyParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(CngKey key)
+    public async Task TestMethod(CngKey key)
     {
         var rsaCng = new RSACng(key);
     }
@@ -347,14 +350,14 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateObjectOfRSADerivedClassWithInt32ParameterUnassignedKeySizeDiagnostic()
+        public async Task TestCreateObjectOfRSADerivedClassWithInt32ParameterUnassignedKeySizeDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(int keySize)
+    public async Task TestMethod(int keySize)
     {
         var rsaCng = new RSACng(keySize);
     }
@@ -362,9 +365,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateWithECDsaArgNoDiagnostic()
+        public async Task TestCreateWithECDsaArgNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -377,9 +380,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithECDsaArgNoDiagnostic()
+        public async Task TestCreateFromNameWithECDsaArgNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -392,9 +395,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithECDsaAndKeySize1024ArgsNoDiagnostic()
+        public async Task TestCreateFromNameWithECDsaAndKeySize1024ArgsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -407,9 +410,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithRSAAndKeySize2048ArgsNoDiagnostic()
+        public async Task TestCreateFromNameWithRSAAndKeySize2048ArgsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -422,14 +425,14 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithRSAAndKeySizeArgsUnassignedKeySizeNoDiagnostic()
+        public async Task TestCreateFromNameWithRSAAndKeySizeArgsUnassignedKeySizeNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(int keySize)
+    public async Task TestMethod(int keySize)
     {
         var cryptoConfig = CryptoConfig.CreateFromName(""RSA"", keySize);
     }
@@ -437,9 +440,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyRSAAndKeySize2048ArgsNoDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyRSAAndKeySize2048ArgsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -452,9 +455,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmAndKeySize2048ArgsNoDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmAndKeySize2048ArgsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
@@ -467,9 +470,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithECDsaAndObjectArray1024ArgsNoDiagnostic()
+        public async Task TestCreateFromNameWithECDsaAndObjectArray1024ArgsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -483,9 +486,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithRSAAndObjectArray2048ArgsNoDiagnostic()
+        public async Task TestCreateFromNameWithRSAAndObjectArray2048ArgsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -499,9 +502,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyRSAAndObjectArray2048ArgsNoDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyRSAAndObjectArray2048ArgsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -515,9 +518,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmAndObjectArray2048ArgsNoDiagnostic()
+        public async Task TestCreateFromNameWithSystemSecurityCryptographyAsymmetricAlgorithmAndObjectArray2048ArgsNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Security.Cryptography;
 
@@ -531,28 +534,23 @@ class TestClass
         }
 
         [Fact]
-        public void TestReturnVoidNoDiagnostic()
+        public async Task TestReturnVoidNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System.Security.Cryptography;
 
 class TestClass
 {
-    public void TestMethod(RSA rsa)
+    public async Task TestMethod(RSA rsa)
     {
         return;
     }
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseRSAWithSufficientKeySize();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseRSAWithSufficientKeySize();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseRSAWithSufficientKeySizeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseRSAWithSufficientKeySizeTests.cs
@@ -342,7 +342,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(CngKey key)
+    public void TestMethod(CngKey key)
     {
         var rsaCng = new RSACng(key);
     }
@@ -357,7 +357,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(int keySize)
+    public void TestMethod(int keySize)
     {
         var rsaCng = new RSACng(keySize);
     }
@@ -432,7 +432,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(int keySize)
+    public void TestMethod(int keySize)
     {
         var cryptoConfig = CryptoConfig.CreateFromName(""RSA"", keySize);
     }
@@ -541,7 +541,7 @@ using System.Security.Cryptography;
 
 class TestClass
 {
-    public async Task TestMethod(RSA rsa)
+    public void TestMethod(RSA rsa)
     {
         return;
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSecureCookiesASPNetCoreTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSecureCookiesASPNetCoreTests.cs
@@ -468,7 +468,7 @@ class TestClass
             }.RunAsync();
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
            => VerifyCS.Diagnostic(rule)
                .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSecureCookiesASPNetCoreTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSecureCookiesASPNetCoreTests.cs
@@ -1,26 +1,28 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using Test.Utilities;
 using Test.Utilities.MinimalImplementations;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseSecureCookiesASPNetCore,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class UseSecureCookiesASPNetCoreTests : DiagnosticAnalyzerTestBase
+    public class UseSecureCookiesASPNetCoreTests
     {
-        protected void VerifyCSharpWithDependencies(string source, params DiagnosticResult[] expected)
-        {
-            this.VerifyCSharp(
-                new[] { source, ASPNetCoreApis.CSharp }.ToFileAndSource(),
-                expected);
-        }
-
         [Fact]
-        public void TestHasWrongSecurePropertyAssignmentDiagnostic()
+        public async Task TestHasWrongSecurePropertyAssignmentDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -34,13 +36,25 @@ class TestClass
         responseCookies.Append(key, value, cookieOptions);
     }
 }",
-            GetCSharpResultAt(12, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(12, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestHasWrongSecurePropertyAssignmentMaybeChangedRightDiagnostic()
+        public async Task TestHasWrongSecurePropertyAssignmentMaybeChangedRightDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -62,13 +76,25 @@ class TestClass
         responseCookies.Append(key, value, cookieOptions);
     }
 }",
-            GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestHasRightSecurePropertyAssignmentMaybeChangedWrongDiagnostic()
+        public async Task TestHasRightSecurePropertyAssignmentMaybeChangedWrongDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -90,13 +116,25 @@ class TestClass
         responseCookies.Append(key, value, cookieOptions);
     }
 }",
-            GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestAssignSecurePropertyAnUnassignedVariableMaybeChangedWrongDiagnostic()
+        public async Task TestAssignSecurePropertyAnUnassignedVariableMaybeChangedWrongDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -118,13 +156,25 @@ class TestClass
         responseCookies.Append(key, value, cookieOptions);
     }
 }",
-            GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestAssignSecurePropertyAnUnassignedVariableMaybeChangedRightDiagnostic()
+        public async Task TestAssignSecurePropertyAnUnassignedVariableMaybeChangedRightDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -146,13 +196,25 @@ class TestClass
         responseCookies.Append(key, value, cookieOptions);
     }
 }",
-            GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestAssignSecurePropertyAnAssignedVariableMaybeChangedDiagnostic()
+        public async Task TestAssignSecurePropertyAnAssignedVariableMaybeChangedDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -175,13 +237,25 @@ class TestClass
         responseCookies.Append(key, value, cookieOptions);
     }
 }",
-            GetCSharpResultAt(21, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(21, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestHasWrongSecurePropertyInitializerDiagnostic()
+        public async Task TestHasWrongSecurePropertyInitializerDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -194,13 +268,25 @@ class TestClass
         responseCookies.Append(key, value, cookieOptions);
     }
 }",
-            GetCSharpResultAt(11, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(11, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestWithoutSecurePropertyAssignmentDiagnostic()
+        public async Task TestWithoutSecurePropertyAssignmentDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -213,13 +299,25 @@ class TestClass
         responseCookies.Append(key, value, cookieOptions);
     }
 }",
-            GetCSharpResultAt(11, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(11, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestParamterLengthLessThan3TrueDiagnostic()
+        public async Task TestParamterLengthLessThan3TrueDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -231,13 +329,25 @@ class TestClass
         responseCookies.Append(key, value);
     }
 }",
-            GetCSharpResultAt(10, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestGetCookieOptionsFromOtherMethodInterproceduralDiagnostic()
+        public async Task TestGetCookieOptionsFromOtherMethodInterproceduralDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -257,13 +367,25 @@ class TestClass
         return cookieOptions;
     }
 }",
-            GetCSharpResultAt(10, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(10, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestPassCookieOptionsAsParameterInterproceduralDiagnostic()
+        public async Task TestPassCookieOptionsAsParameterInterproceduralDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -282,13 +404,25 @@ class TestClass
         responseCookies.Append(key, value, cookieOptions);
     }
 }",
-            GetCSharpResultAt(17, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule));
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(17, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestHasRightSecurePropertyAssignmentNoDiagnostic()
+        public async Task TestHasRightSecurePropertyAssignmentNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -301,13 +435,22 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}");
+}"
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
-        public void TestHasRightSecurePropertyInitializerNoDiagnostic()
+        public async Task TestHasRightSecurePropertyInitializerNoDiagnostic()
         {
-            VerifyCSharpWithDependencies(@"
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        ASPNetCoreApis.CSharp, @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -319,17 +462,14 @@ class TestClass
         var responseCookies = new ResponseCookies();
         responseCookies.Append(key, value, cookieOptions);
     }
-}");
+}"
+                    }
+                }
+            }.RunAsync();
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseSecureCookiesASPNetCore();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseSecureCookiesASPNetCore();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule)
+           => VerifyCS.Diagnostic(rule)
+               .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSecureCookiesASPNetCoreTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSecureCookiesASPNetCoreTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NetCore.Analyzers.Security.UnitTests
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -35,7 +35,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -54,7 +54,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -75,7 +75,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -94,7 +94,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -115,7 +115,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -134,7 +134,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -155,7 +155,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -174,7 +174,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -195,7 +195,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -214,7 +214,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -236,7 +236,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -255,7 +255,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -267,7 +267,7 @@ class TestClass
         var responseCookies = new ResponseCookies();
         responseCookies.Append(key, value, cookieOptions);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -286,7 +286,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -298,7 +298,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -317,7 +317,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -328,7 +328,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -347,7 +347,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -366,7 +366,7 @@ class TestClass
 
         return cookieOptions;
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -385,7 +385,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -403,7 +403,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}",
+}", ASPNetCoreApis.CSharp,
                     },
                     ExpectedDiagnostics =
                     {
@@ -422,7 +422,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -435,7 +435,7 @@ class TestClass
         var responseCookies = new ResponseCookies(); 
         responseCookies.Append(key, value, cookieOptions);
     }
-}"
+}", ASPNetCoreApis.CSharp,
                     }
                 }
             }.RunAsync();
@@ -450,7 +450,7 @@ class TestClass
                 {
                     Sources =
                     {
-                        ASPNetCoreApis.CSharp, @"
+                        @"
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 
@@ -462,7 +462,7 @@ class TestClass
         var responseCookies = new ResponseCookies();
         responseCookies.Append(key, value, cookieOptions);
     }
-}"
+}",  ASPNetCoreApis.CSharp,
                     }
                 }
             }.RunAsync();

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSecureCookiesASPNetCoreTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSecureCookiesASPNetCoreTests.cs
@@ -39,7 +39,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(12, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(12, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -79,7 +79,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -119,7 +119,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -159,7 +159,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -199,7 +199,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(20, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -240,7 +240,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(21, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(21, 9, UseSecureCookiesASPNetCore.MaybeUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -271,7 +271,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(11, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(11, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -302,7 +302,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(11, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(11, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -332,7 +332,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(10, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(10, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -370,7 +370,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(10, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(10, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();
@@ -407,7 +407,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(17, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule)
+                        GetCSharpResultAt(17, 9, UseSecureCookiesASPNetCore.DefinitelyUseSecureCookiesASPNetCoreRule),
                     }
                 }
             }.RunAsync();

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
@@ -266,7 +266,7 @@ class TestClass
 }", editorConfigText, expected);
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
            => VerifyCS.Diagnostic()
                .WithLocation(line, column);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDataSetReadXmlTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDataSetReadXmlTests.cs
@@ -1,17 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDataSetReadXml,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDataSetReadXml,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class UseXmlReaderForDataSetReadXmlTests : DiagnosticAnalyzerTestBase
+    public class UseXmlReaderForDataSetReadXmlTests
     {
         [Fact]
-        public void TestReadXmlWithStreamParameterDiagnostic()
+        public async Task TestReadXmlWithStreamParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -23,9 +29,9 @@ class TestClass
         new DataSet().ReadXml(new FileStream(""xmlFilename"", FileMode.Open));
     }
 }",
-            GetCSharpResultAt(10, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXml"));
+            GetCSharpResultAt(10, 9, "DataSet", "ReadXml"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Data
 Imports System.IO
@@ -36,13 +42,13 @@ Class TestClass
         dataSet.ReadXml(new FileStream(""xmlFilename"", FileMode.Open))
     End Sub
 End Class",
-            GetBasicResultAt(9, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXml"));
+            GetBasicResultAt(9, 9, "DataSet", "ReadXml"));
         }
 
         [Fact]
-        public void TestReadXmlWithStreamAndXmlReadModeParametersDiagnostic()
+        public async Task TestReadXmlWithStreamAndXmlReadModeParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Data;
@@ -54,13 +60,13 @@ class TestClass
         new DataSet().ReadXml(new FileStream(""xmlFilename"", FileMode.Open), XmlReadMode.Auto);
     }
 }",
-            GetCSharpResultAt(10, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXml"));
+            GetCSharpResultAt(10, 9, "DataSet", "ReadXml"));
         }
 
         [Fact]
-        public void TestReadXmlWithStringParameterDiagnostic()
+        public async Task TestReadXmlWithStringParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 
@@ -71,13 +77,13 @@ class TestClass
         new DataSet().ReadXml(""Filename"");
     }
 }",
-            GetCSharpResultAt(9, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXml"));
+            GetCSharpResultAt(9, 9, "DataSet", "ReadXml"));
         }
 
         [Fact]
-        public void TestReadXmlWithStringXmlReadModeParametersDiagnostic()
+        public async Task TestReadXmlWithStringXmlReadModeParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 
@@ -88,13 +94,13 @@ class TestClass
         new DataSet().ReadXml(""Filename"", XmlReadMode.Auto);
     }
 }",
-            GetCSharpResultAt(9, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXml"));
+            GetCSharpResultAt(9, 9, "DataSet", "ReadXml"));
         }
 
         [Fact]
-        public void TestReadXmlWithTextReaderParameterDiagnostic()
+        public async Task TestReadXmlWithTextReaderParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -106,13 +112,13 @@ class TestClass
         new DataSet().ReadXml(new StreamReader(""TestFile.txt""));
     }
 }",
-            GetCSharpResultAt(10, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXml"));
+            GetCSharpResultAt(10, 9, "DataSet", "ReadXml"));
         }
 
         [Fact]
-        public void TestReadXmlWithTextReaderAndXmlReadModeParametersDiagnostic()
+        public async Task TestReadXmlWithTextReaderAndXmlReadModeParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -124,13 +130,13 @@ class TestClass
         new DataSet().ReadXml(new StreamReader(""TestFile.txt""), XmlReadMode.Auto);
     }
 }",
-            GetCSharpResultAt(10, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXml"));
+            GetCSharpResultAt(10, 9, "DataSet", "ReadXml"));
         }
 
         [Fact]
-        public void TestReadXmlSchemaWithStreamParameterDiagnostic()
+        public async Task TestReadXmlSchemaWithStreamParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -142,13 +148,13 @@ class TestClass
         new DataSet().ReadXmlSchema(new FileStream(""xmlFilename"", FileMode.Open));
     }
 }",
-            GetCSharpResultAt(10, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXmlSchema"));
+            GetCSharpResultAt(10, 9, "DataSet", "ReadXmlSchema"));
         }
 
         [Fact]
-        public void TestReadXmlSchemaWithStringParameterDiagnostic()
+        public async Task TestReadXmlSchemaWithStringParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 
@@ -159,13 +165,13 @@ class TestClass
         new DataSet().ReadXmlSchema(""Filename"");
     }
 }",
-            GetCSharpResultAt(9, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXmlSchema"));
+            GetCSharpResultAt(9, 9, "DataSet", "ReadXmlSchema"));
         }
 
         [Fact]
-        public void TestReadXmlSchemaWithTextReaderParameterDiagnostic()
+        public async Task TestReadXmlSchemaWithTextReaderParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -177,13 +183,13 @@ class TestClass
         new DataSet().ReadXmlSchema(new StreamReader(""TestFile.txt""));
     }
 }",
-            GetCSharpResultAt(10, 9, UseXmlReaderForDataSetReadXml.RealRule, "DataSet", "ReadXmlSchema"));
+            GetCSharpResultAt(10, 9, "DataSet", "ReadXmlSchema"));
         }
 
         [Fact]
-        public void TestReadXmlWithXmlReaderParameterNoDiagnostic()
+        public async Task TestReadXmlWithXmlReaderParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -199,9 +205,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestReadXmlWithXmlReaderAndXmlReadModeParametersNoDiagnostic()
+        public async Task TestReadXmlWithXmlReaderAndXmlReadModeParametersNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -217,9 +223,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestReadXmlSchemaWithXmlReaderParameterNoDiagnostic()
+        public async Task TestReadXmlSchemaWithXmlReaderParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -235,9 +241,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestReadXmlSerializableWithXmlReaderParameterNoDiagnostic()
+        public async Task TestReadXmlSerializableWithXmlReaderParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -255,7 +261,7 @@ class TestClass : DataSet
     }
 }");
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.Data
 Imports System.IO
@@ -273,9 +279,9 @@ End Class");
         }
 
         [Fact]
-        public void TestDerivedFromANormalClassNoDiagnostic()
+        public async Task TestDerivedFromANormalClassNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -302,9 +308,9 @@ class SubTestClass : TestClass
         }
 
         [Fact]
-        public void TestTwoLevelsOfInheritanceAndOverridesNoDiagnostic()
+        public async Task TestTwoLevelsOfInheritanceAndOverridesNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -331,9 +337,9 @@ class SubTestClass : TestClass
         }
 
         [Fact]
-        public void TestNormalClassReadXmlWithXmlReaderParameterNoDiagnostic()
+        public async Task TestNormalClassReadXmlWithXmlReaderParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -353,14 +359,14 @@ class TestClass
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseXmlReaderForDataSetReadXml();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseXmlReaderForDataSetReadXml();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDataSetReadXmlTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDataSetReadXmlTests.cs
@@ -359,12 +359,12 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDeserializeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDeserializeTests.cs
@@ -281,12 +281,12 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);
 
-        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDeserializeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDeserializeTests.cs
@@ -24,7 +24,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public async Task TestMethod(Stream stream)
+    public void TestMethod(Stream stream)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(stream);
     }
@@ -42,7 +42,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public async Task TestMethod(TextReader textReader)
+    public void TestMethod(TextReader textReader)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(textReader);
     }
@@ -96,7 +96,7 @@ class TestClass : XmlSerializer
         return new TestClass();
     }
 
-    public async Task TestMethod(XmlSerializationReader xmlSerializationReader)
+    public void TestMethod(XmlSerializationReader xmlSerializationReader)
     {
         Deserialize(xmlSerializationReader);
     }
@@ -144,7 +144,7 @@ class SubTestClass : TestClass
         return new TestClass();
     }
 
-    public async Task TestMethod(XmlSerializationReader xmlSerializationReader)
+    public void TestMethod(XmlSerializationReader xmlSerializationReader)
     {
         Deserialize(xmlSerializationReader);
     }
@@ -163,7 +163,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public async Task TestMethod(XmlReader xmlReader)
+    public void TestMethod(XmlReader xmlReader)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(xmlReader);
     }
@@ -181,7 +181,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public async Task TestMethod(XmlReader xmlReader, string str)
+    public void TestMethod(XmlReader xmlReader, string str)
     {
         var xmlSerializer = new XmlSerializer(typeof(TestClass));
         new XmlSerializer(typeof(TestClass)).Deserialize(xmlReader, str);
@@ -200,7 +200,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public async Task TestMethod(XmlReader xmlReader, XmlDeserializationEvents xmlDeserializationEvents)
+    public void TestMethod(XmlReader xmlReader, XmlDeserializationEvents xmlDeserializationEvents)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(xmlReader, xmlDeserializationEvents);
     }
@@ -218,7 +218,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public async Task TestMethod(XmlReader xmlReader, string str, XmlDeserializationEvents xmlDeserializationEvents)
+    public void TestMethod(XmlReader xmlReader, string str, XmlDeserializationEvents xmlDeserializationEvents)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(xmlReader, str, xmlDeserializationEvents);
     }
@@ -250,7 +250,7 @@ class SubTestClass : TestClass
         return new SubTestClass();
     }
 
-    public async Task TestMethod(XmlSerializationReader xmlSerializationReader)
+    public void TestMethod(XmlSerializationReader xmlSerializationReader)
     {
         Deserialize(xmlSerializationReader);
     }
@@ -274,7 +274,7 @@ class TestClass
         return new TestClass();
     }
 
-    public async Task TestMethod(XmlSerializationReader xmlSerializationReader)
+    public void TestMethod(XmlSerializationReader xmlSerializationReader)
     {
         new TestClass().Deserialize(xmlSerializationReader);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDeserializeTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForDeserializeTests.cs
@@ -1,53 +1,59 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDeserialize,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDeserialize,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class UseXmlReaderForDeserializeTests : DiagnosticAnalyzerTestBase
+    public class UseXmlReaderForDeserializeTests
     {
         [Fact]
-        public void TestDeserializeWithStreamParameterDiagnostic()
+        public async Task TestDeserializeWithStreamParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml.Serialization;
 
 class TestClass
 {
-    public void TestMethod(Stream stream)
+    public async Task TestMethod(Stream stream)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(stream);
     }
 }",
-            GetCSharpResultAt(10, 9, UseXmlReaderForDeserialize.RealRule, "XmlSerializer", "Deserialize"));
+            GetCSharpResultAt(10, 9, "XmlSerializer", "Deserialize"));
         }
 
         [Fact]
-        public void TestDeserializeWithTextReaderParameterDiagnostic()
+        public async Task TestDeserializeWithTextReaderParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml.Serialization;
 
 class TestClass
 {
-    public void TestMethod(TextReader textReader)
+    public async Task TestMethod(TextReader textReader)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(textReader);
     }
 }",
-            GetCSharpResultAt(10, 9, UseXmlReaderForDeserialize.RealRule, "XmlSerializer", "Deserialize"));
+            GetCSharpResultAt(10, 9, "XmlSerializer", "Deserialize"));
         }
 
         [Fact]
-        public void TestBaseClassInvokesDeserializeWithXmlSerializationReaderParameterDiagnostic()
+        public async Task TestBaseClassInvokesDeserializeWithXmlSerializationReaderParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml.Serialization;
@@ -59,9 +65,9 @@ class TestClass : XmlSerializer
         return base.Deserialize(xmlSerializationReader);
     }
 }",
-            GetCSharpResultAt(10, 16, UseXmlReaderForDeserialize.RealRule, "XmlSerializer", "Deserialize"));
+            GetCSharpResultAt(10, 16, "XmlSerializer", "Deserialize"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Xml.Serialization
@@ -72,13 +78,13 @@ Class TestClass
         Deserialize = MyBase.Deserialize(xmlSerializationReader)
     End Function
 End Class",
-            GetBasicResultAt(9, 23, UseXmlReaderForDeserialize.RealRule, "XmlSerializer", "Deserialize"));
+            GetBasicResultAt(9, 23, "XmlSerializer", "Deserialize"));
         }
 
         [Fact]
-        public void TesDerivedClassInvokesDeserializeWithXmlSerializationReaderParameterDiagnostic()
+        public async Task TesDerivedClassInvokesDeserializeWithXmlSerializationReaderParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml.Serialization;
@@ -90,14 +96,14 @@ class TestClass : XmlSerializer
         return new TestClass();
     }
 
-    public void TestMethod(XmlSerializationReader xmlSerializationReader)
+    public async Task TestMethod(XmlSerializationReader xmlSerializationReader)
     {
         Deserialize(xmlSerializationReader);
     }
 }",
-            GetCSharpResultAt(15, 9, UseXmlReaderForDeserialize.RealRule, "TestClass", "Deserialize"));
+            GetCSharpResultAt(15, 9, "TestClass", "Deserialize"));
 
-            VerifyBasic(@"
+            await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Xml.Serialization
@@ -112,13 +118,13 @@ Class TestClass
         Deserialize(xmlSerializationReader)
     End Sub
 End Class",
-            GetBasicResultAt(13, 9, UseXmlReaderForDeserialize.RealRule, "TestClass", "Deserialize"));
+            GetBasicResultAt(13, 9, "TestClass", "Deserialize"));
         }
 
         [Fact]
-        public void TestWithTwoLevelsOfInheritanceAndOverridesDiagnostic()
+        public async Task TestWithTwoLevelsOfInheritanceAndOverridesDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml.Serialization;
@@ -138,18 +144,18 @@ class SubTestClass : TestClass
         return new TestClass();
     }
 
-    public void TestMethod(XmlSerializationReader xmlSerializationReader)
+    public async Task TestMethod(XmlSerializationReader xmlSerializationReader)
     {
         Deserialize(xmlSerializationReader);
     }
 }",
-            GetCSharpResultAt(23, 9, UseXmlReaderForDeserialize.RealRule, "SubTestClass", "Deserialize"));
+            GetCSharpResultAt(23, 9, "SubTestClass", "Deserialize"));
         }
 
         [Fact]
-        public void TestDeserializeWithXmlReaderParameterNoDiagnostic()
+        public async Task TestDeserializeWithXmlReaderParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml;
@@ -157,7 +163,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public void TestMethod(XmlReader xmlReader)
+    public async Task TestMethod(XmlReader xmlReader)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(xmlReader);
     }
@@ -165,9 +171,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDeserializeWithXmlReaderAndStringParametersNoDiagnostic()
+        public async Task TestDeserializeWithXmlReaderAndStringParametersNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml;
@@ -175,7 +181,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public void TestMethod(XmlReader xmlReader, string str)
+    public async Task TestMethod(XmlReader xmlReader, string str)
     {
         var xmlSerializer = new XmlSerializer(typeof(TestClass));
         new XmlSerializer(typeof(TestClass)).Deserialize(xmlReader, str);
@@ -184,9 +190,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDeserializeWithXmlReaderAndXmlDeserializationEventsParametersNoDiagnostic()
+        public async Task TestDeserializeWithXmlReaderAndXmlDeserializationEventsParametersNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml;
@@ -194,7 +200,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public void TestMethod(XmlReader xmlReader, XmlDeserializationEvents xmlDeserializationEvents)
+    public async Task TestMethod(XmlReader xmlReader, XmlDeserializationEvents xmlDeserializationEvents)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(xmlReader, xmlDeserializationEvents);
     }
@@ -202,9 +208,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDeserializeWithXmlReaderAndStringAndXmlDeserializationEventsParametersNoDiagnostic()
+        public async Task TestDeserializeWithXmlReaderAndStringAndXmlDeserializationEventsParametersNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml;
@@ -212,7 +218,7 @@ using System.Xml.Serialization;
 
 class TestClass
 {
-    public void TestMethod(XmlReader xmlReader, string str, XmlDeserializationEvents xmlDeserializationEvents)
+    public async Task TestMethod(XmlReader xmlReader, string str, XmlDeserializationEvents xmlDeserializationEvents)
     {
         new XmlSerializer(typeof(TestClass)).Deserialize(xmlReader, str, xmlDeserializationEvents);
     }
@@ -220,9 +226,9 @@ class TestClass
         }
 
         [Fact]
-        public void TestDerivedFromANormalClassNoDiagnostic()
+        public async Task TestDerivedFromANormalClassNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -244,7 +250,7 @@ class SubTestClass : TestClass
         return new SubTestClass();
     }
 
-    public void TestMethod(XmlSerializationReader xmlSerializationReader)
+    public async Task TestMethod(XmlSerializationReader xmlSerializationReader)
     {
         Deserialize(xmlSerializationReader);
     }
@@ -252,9 +258,9 @@ class SubTestClass : TestClass
         }
 
         [Fact]
-        public void TestNormalClassReadXmlWithXmlReaderParameterNoDiagnostic()
+        public async Task TestNormalClassReadXmlWithXmlReaderParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Data;
 using System.IO;
@@ -268,21 +274,21 @@ class TestClass
         return new TestClass();
     }
 
-    public void TestMethod(XmlSerializationReader xmlSerializationReader)
+    public async Task TestMethod(XmlSerializationReader xmlSerializationReader)
     {
         new TestClass().Deserialize(xmlSerializationReader);
     }
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseXmlReaderForDeserialize();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseXmlReaderForDeserialize();
-        }
+        private DiagnosticResult GetBasicResultAt(int line, int column, params string[] arguments)
+            => VerifyVB.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForSchemaReadTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForSchemaReadTests.cs
@@ -21,7 +21,7 @@ using System.Xml.Schema;
 
 class TestClass
 {
-    public async Task TestMethod(Stream stream, ValidationEventHandler validationEventHandler)
+    public void TestMethod(Stream stream, ValidationEventHandler validationEventHandler)
     {
         XmlSchema.Read(stream, validationEventHandler);
     }
@@ -39,7 +39,7 @@ using System.Xml.Schema;
 
 class TestClass
 {
-    public async Task TestMethod(TextReader reader, ValidationEventHandler validationEventHandler)
+    public void TestMethod(TextReader reader, ValidationEventHandler validationEventHandler)
     {
         XmlSchema.Read(reader, validationEventHandler);
     }
@@ -57,7 +57,7 @@ using System.Xml.Schema;
 
 class TestClass
 {
-    public async Task TestMethod(XmlReader reader, ValidationEventHandler validationEventHandler)
+    public void TestMethod(XmlReader reader, ValidationEventHandler validationEventHandler)
     {
         XmlSchema.Read(reader, validationEventHandler);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForSchemaReadTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForSchemaReadTests.cs
@@ -88,7 +88,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForValidatingReaderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForValidatingReaderTests.cs
@@ -21,7 +21,7 @@ using System.Xml;
 
 class TestClass
 {
-    public async Task TestMethod(Stream xmlFragment, XmlNodeType fragType, XmlParserContext context)
+    public void TestMethod(Stream xmlFragment, XmlNodeType fragType, XmlParserContext context)
     {
         var obj = new XmlValidatingReader(xmlFragment, fragType, context);
     }
@@ -38,7 +38,7 @@ using System.Xml;
 
 class TestClass
 {
-    public async Task TestMethod(string xmlFragment, XmlNodeType fragType, XmlParserContext context)
+    public void TestMethod(string xmlFragment, XmlNodeType fragType, XmlParserContext context)
     {
         var obj = new XmlValidatingReader(xmlFragment, fragType, context);
     }
@@ -55,7 +55,7 @@ using System.Xml;
 
 class TestClass
 {
-    public async Task TestMethod(XmlReader xmlReader)
+    public void TestMethod(XmlReader xmlReader)
     {
         var obj = new XmlValidatingReader(xmlReader);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForValidatingReaderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForValidatingReaderTests.cs
@@ -62,7 +62,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForValidatingReaderTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForValidatingReaderTests.cs
@@ -1,77 +1,70 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForValidatingReader,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class UseXmlReaderForValidatingReaderTests : DiagnosticAnalyzerTestBase
+    public class UseXmlReaderForValidatingReaderTests
     {
         [Fact]
-        public void TestStreamAndXmlNodeTypeAndXmlParseContextParametersDiagnostic()
+        public async Task TestStreamAndXmlNodeTypeAndXmlParseContextParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml;
 
 class TestClass
 {
-    public void TestMethod(Stream xmlFragment, XmlNodeType fragType, XmlParserContext context)
+    public async Task TestMethod(Stream xmlFragment, XmlNodeType fragType, XmlParserContext context)
     {
         var obj = new XmlValidatingReader(xmlFragment, fragType, context);
     }
 }",
-            GetCSharpResultAt(10, 19, UseXmlReaderForValidatingReader.RealRule, "XmlValidatingReader", "XmlValidatingReader"));
+            GetCSharpResultAt(10, 19, "XmlValidatingReader", "XmlValidatingReader"));
         }
 
         [Fact]
-        public void TestStringAndXmlNodeTypeAndXmlParseContextParametersDiagnostic()
+        public async Task TestStringAndXmlNodeTypeAndXmlParseContextParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml;
 
 class TestClass
 {
-    public void TestMethod(string xmlFragment, XmlNodeType fragType, XmlParserContext context)
+    public async Task TestMethod(string xmlFragment, XmlNodeType fragType, XmlParserContext context)
     {
         var obj = new XmlValidatingReader(xmlFragment, fragType, context);
     }
 }",
-            GetCSharpResultAt(9, 19, UseXmlReaderForValidatingReader.RealRule, "XmlValidatingReader", "XmlValidatingReader"));
+            GetCSharpResultAt(9, 19, "XmlValidatingReader", "XmlValidatingReader"));
         }
 
         [Fact]
-        public void TestXmlReaderParameterNoDiagnostic()
+        public async Task TestXmlReaderParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml;
 
 class TestClass
 {
-    public void TestMethod(XmlReader xmlReader)
+    public async Task TestMethod(XmlReader xmlReader)
     {
         var obj = new XmlValidatingReader(xmlReader);
     }
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseXmlReaderForValidatingReader();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseXmlReaderForValidatingReader();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForXPathDocumentTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForXPathDocumentTests.cs
@@ -1,95 +1,98 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForXPathDocument,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class UseXmlReaderForXPathDocumentTests : DiagnosticAnalyzerTestBase
+    public class UseXmlReaderForXPathDocumentTests
     {
         [Fact]
-        public void TestStreamParameterDiagnostic()
+        public async Task TestStreamParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml.XPath;
 
 class TestClass
 {
-    public void TestMethod(Stream stream)
+    public async Task TestMethod(Stream stream)
     {
         var obj = new XPathDocument(stream);
     }
 }",
-            GetCSharpResultAt(10, 19, UseXmlReaderForXPathDocument.RealRule, "XPathDocument", "XPathDocument"));
+            GetCSharpResultAt(10, 19, "XPathDocument", "XPathDocument"));
         }
 
         [Fact]
-        public void TestStringParameterDiagnostic()
+        public async Task TestStringParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml.XPath;
 
 class TestClass
 {
-    public void TestMethod(string uri)
+    public async Task TestMethod(string uri)
     {
         var obj = new XPathDocument(uri);
     }
 }",
-            GetCSharpResultAt(9, 19, UseXmlReaderForXPathDocument.RealRule, "XPathDocument", "XPathDocument"));
+            GetCSharpResultAt(9, 19, "XPathDocument", "XPathDocument"));
         }
 
         [Fact]
-        public void TestStringAndXmlSpaceParametersDiagnostic()
+        public async Task TestStringAndXmlSpaceParametersDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml;
 using System.Xml.XPath;
 
 class TestClass
 {
-    public void TestMethod(string uri, XmlSpace space)
+    public async Task TestMethod(string uri, XmlSpace space)
     {
         var obj = new XPathDocument(uri, space);
     }
 }",
-            GetCSharpResultAt(10, 19, UseXmlReaderForXPathDocument.RealRule, "XPathDocument", "XPathDocument"));
+            GetCSharpResultAt(10, 19, "XPathDocument", "XPathDocument"));
         }
 
         [Fact]
-        public void TestTextReaderParameterDiagnostic()
+        public async Task TestTextReaderParameterDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Xml.XPath;
 
 class TestClass
 {
-    public void TestMethod(TextReader reader)
+    public async Task TestMethod(TextReader reader)
     {
         var obj = new XPathDocument(reader);
     }
 }",
-            GetCSharpResultAt(10, 19, UseXmlReaderForXPathDocument.RealRule, "XPathDocument", "XPathDocument"));
+            GetCSharpResultAt(10, 19, "XPathDocument", "XPathDocument"));
         }
 
         [Fact]
-        public void TestXmlReaderParameterNoDiagnostic()
+        public async Task TestXmlReaderParameterNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml;
 using System.Xml.XPath;
 
 class TestClass
 {
-    public void TestMethod(XmlReader reader)
+    public async Task TestMethod(XmlReader reader)
     {
         var obj = new XPathDocument(reader);
     }
@@ -97,30 +100,25 @@ class TestClass
         }
 
         [Fact]
-        public void TestXmlReaderAndXmlSpaceParametersNoDiagnostic()
+        public async Task TestXmlReaderAndXmlSpaceParametersNoDiagnostic()
         {
-            VerifyCSharp(@"
+            await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Xml;
 using System.Xml.XPath;
 
 class TestClass
 {
-    public void TestMethod(XmlReader reader, XmlSpace space)
+    public async Task TestMethod(XmlReader reader, XmlSpace space)
     {
         var obj = new XPathDocument(reader, space);
     }
 }");
         }
 
-        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return new UseXmlReaderForXPathDocument();
-        }
-
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new UseXmlReaderForXPathDocument();
-        }
+        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+            => VerifyCS.Diagnostic()
+                .WithLocation(line, column)
+                .WithArguments(arguments);
     }
 }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForXPathDocumentTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForXPathDocumentTests.cs
@@ -21,7 +21,7 @@ using System.Xml.XPath;
 
 class TestClass
 {
-    public async Task TestMethod(Stream stream)
+    public void TestMethod(Stream stream)
     {
         var obj = new XPathDocument(stream);
     }
@@ -38,7 +38,7 @@ using System.Xml.XPath;
 
 class TestClass
 {
-    public async Task TestMethod(string uri)
+    public void TestMethod(string uri)
     {
         var obj = new XPathDocument(uri);
     }
@@ -56,7 +56,7 @@ using System.Xml.XPath;
 
 class TestClass
 {
-    public async Task TestMethod(string uri, XmlSpace space)
+    public void TestMethod(string uri, XmlSpace space)
     {
         var obj = new XPathDocument(uri, space);
     }
@@ -74,7 +74,7 @@ using System.Xml.XPath;
 
 class TestClass
 {
-    public async Task TestMethod(TextReader reader)
+    public void TestMethod(TextReader reader)
     {
         var obj = new XPathDocument(reader);
     }
@@ -92,7 +92,7 @@ using System.Xml.XPath;
 
 class TestClass
 {
-    public async Task TestMethod(XmlReader reader)
+    public void TestMethod(XmlReader reader)
     {
         var obj = new XPathDocument(reader);
     }
@@ -109,7 +109,7 @@ using System.Xml.XPath;
 
 class TestClass
 {
-    public async Task TestMethod(XmlReader reader, XmlSpace space)
+    public void TestMethod(XmlReader reader, XmlSpace space)
     {
         var obj = new XPathDocument(reader, space);
     }

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForXPathDocumentTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Security/UseXmlReaderForXPathDocumentTests.cs
@@ -116,7 +116,7 @@ class TestClass
 }");
         }
 
-        private DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
+        private static DiagnosticResult GetCSharpResultAt(int line, int column, params string[] arguments)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)
                 .WithArguments(arguments);

--- a/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCreateTasksWithoutPassingATaskSchedulerTests.cs
+++ b/src/Microsoft.NetCore.Analyzers/UnitTests/Tasks/DoNotCreateTasksWithoutPassingATaskSchedulerTests.cs
@@ -229,13 +229,11 @@ End Class
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-            => new DiagnosticResult(DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftNetCoreAnalyzersResources.DoNotCreateTasksWithoutPassingATaskSchedulerMessage);
+            => VerifyCS.Diagnostic(DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer.Rule)
+                .WithLocation(line, column);
 
         private static DiagnosticResult GetBasicResultAt(int line, int column)
-            => new DiagnosticResult(DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer.Rule)
-                .WithLocation(line, column)
-                .WithMessage(MicrosoftNetCoreAnalyzersResources.DoNotCreateTasksWithoutPassingATaskSchedulerMessage);
+            => VerifyVB.Diagnostic(DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer.Rule)
+                .WithLocation(line, column);
     }
 }

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingDoNotUseLoadXmlTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingDoNotUseLoadXmlTests.cs
@@ -15,12 +15,12 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
 {
     public partial class DoNotUseInsecureDtdProcessingAnalyzerTests
     {
-        private DiagnosticResult GetCA3075LoadXmlCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCA3075LoadXmlCSharpResultAt(int line, int column)
         {
             return new DiagnosticResult(DoNotUseInsecureDtdProcessingAnalyzer.RuleDoNotUseInsecureDtdProcessing).WithLocation(line, column).WithArguments(string.Format(CultureInfo.CurrentCulture, MicrosoftNetFrameworkAnalyzersResources.DoNotUseDtdProcessingOverloadsMessage, "LoadXml"));
         }
 
-        private DiagnosticResult GetCA3075LoadXmlBasicResultAt(int line, int column)
+        private static DiagnosticResult GetCA3075LoadXmlBasicResultAt(int line, int column)
         {
             return new DiagnosticResult(DoNotUseInsecureDtdProcessingAnalyzer.RuleDoNotUseInsecureDtdProcessing).WithLocation(line, column).WithArguments(string.Format(CultureInfo.CurrentCulture, MicrosoftNetFrameworkAnalyzersResources.DoNotUseDtdProcessingOverloadsMessage, "LoadXml"));
         }

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingDoNotUseSetInnerXmlTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingDoNotUseSetInnerXmlTests.cs
@@ -811,12 +811,12 @@ End Namespace",
             );
         }
 
-        private DiagnosticResult GetCA3075InnerXmlCSharpResultAt(int line, int column)
+        private static DiagnosticResult GetCA3075InnerXmlCSharpResultAt(int line, int column)
         {
             return new DiagnosticResult(DoNotUseInsecureDtdProcessingAnalyzer.RuleDoNotUseInsecureDtdProcessing).WithLocation(line, column).WithArguments(MicrosoftNetFrameworkAnalyzersResources.DoNotUseSetInnerXmlMessage);
         }
 
-        private DiagnosticResult GetCA3075InnerXmlBasicResultAt(int line, int column)
+        private static DiagnosticResult GetCA3075InnerXmlBasicResultAt(int line, int column)
         {
             return new DiagnosticResult(DoNotUseInsecureDtdProcessingAnalyzer.RuleDoNotUseInsecureDtdProcessing).WithLocation(line, column).WithArguments(MicrosoftNetFrameworkAnalyzersResources.DoNotUseSetInnerXmlMessage);
         }

--- a/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingUseXmlReaderForDataTableReadXmlTests.cs
+++ b/src/Microsoft.NetFramework.Analyzers/UnitTests/DoNotUseInsecureDtdProcessingUseXmlReaderForDataTableReadXmlTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
             return new DiagnosticResult(DoNotUseInsecureDtdProcessingAnalyzer.RuleDoNotUseInsecureDtdProcessing).WithLocation(line, column).WithArguments(string.Format(CultureInfo.CurrentCulture, MicrosoftNetFrameworkAnalyzersResources.DoNotUseDtdProcessingOverloadsMessage, "ReadXml"));
         }
 
-        private DiagnosticResult GetCA3075DataTableReadXmlBasicResultAt(int line, int column)
+        private static DiagnosticResult GetCA3075DataTableReadXmlBasicResultAt(int line, int column)
         {
             return new DiagnosticResult(DoNotUseInsecureDtdProcessingAnalyzer.RuleDoNotUseInsecureDtdProcessing).WithLocation(line, column).WithArguments(string.Format(CultureInfo.CurrentCulture, MicrosoftNetFrameworkAnalyzersResources.DoNotUseDtdProcessingOverloadsMessage, "ReadXml"));
         }

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
@@ -24,14 +24,10 @@ namespace Test.Utilities
             => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
 
         public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
-            => await VerifyAnalyzerAsync(source, CompilerDiagnostics.Errors, expected);
-
-        public static async Task VerifyAnalyzerAsync(string source, CompilerDiagnostics compilerDiagnostics, params DiagnosticResult[] expected)
         {
             var test = new Test
             {
-                TestCode = source,
-                CompilerDiagnostics = compilerDiagnostics
+                TestCode = source
             };
 
             test.ExpectedDiagnostics.AddRange(expected);

--- a/src/Test.Utilities/VisualBasicCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/VisualBasicCodeFixVerifier`2.cs
@@ -24,14 +24,10 @@ namespace Test.Utilities
             => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
 
         public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
-            => await VerifyAnalyzerAsync(source, CompilerDiagnostics.Errors, expected);
-
-        public static async Task VerifyAnalyzerAsync(string source, CompilerDiagnostics compilerDiagnostics, params DiagnosticResult[] expected)
         {
             var test = new Test
             {
-                TestCode = source,
-                CompilerDiagnostics = compilerDiagnostics
+                TestCode = source
             };
 
             test.ExpectedDiagnostics.AddRange(expected);


### PR DESCRIPTION
### Description

I am trying to convert the remaining tests to the new test framework.

This PR is currently based upon #3005 to avoid duplicated work but as soon as the other PR is merge I will adjust the base.

### Problems

I am facing some issues with the migration and would be grateful for some help/input from your side (cc @sharwell).

~~1. Some tests are failing with a weird error about issues not being listed as expected while they are. Because of the error message I suspect this is linked to generated code but I haven't yet found how the test needs to be tweaked to work.~~

```
Microsoft.CodeAnalysis.Testing.Verifiers.EqualWithMessageException : Context: Diagnostics of test state
    Context: Verifying exclusions in <auto-generated> code
    Mismatch between number of diagnostics returned, expected "0" actual "1"
```

2. Some of the tests need a reference toward the ASP.NET dlls. I have seen that I need to use the package reference helper but I am not sure which version I shall be using for the tests.

3. ~~I am facing some `InvalidOperationException` issue with the new test framework when not specifying the `DiagnosticDescriptor` because the `SupportedDiagnostics` property is empty for `DisposeMethodsShouldCallBaseClassDispose` (see https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.NetCore.Analyzers/Core/Runtime/DisposeMethodsShouldCallBaseClassDispose.cs#L39). I am not sure whether I can safely change this empty array to an array with the rule.~~

4. ~~I don't know how to translate the tests using `VerifyCSharpAcrossTwoAssemblies`. The `Sources` property of the new test framework allows to provide multiple files not assemblies.~~

~~5. I am not sure how to translate the `VerifyUnsafe` calls.~~