### PR TITLE
Update CA1305 to report on TryParse methods

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -409,3 +409,14 @@ Option Values:
 Default Value: `Heuristic`.
 
 Example: `dotnet_code_quality.CA1712.enum_values_prefix_trigger = AnyEnumValue`
+
+### Specify IFormatProvider
+Option Name: `exclude_tryparse_methods`
+
+Configurable Rules: [CA1305](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1305)
+
+Option Values: `true` or `false`
+
+Default Value: `true`
+
+Example: `dotnet_code_quality.CA1305.exclude_tryparse_methods = false`

--- a/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
+++ b/src/Microsoft.NetCore.Analyzers/Core/Runtime/SpecifyIFormatProvider.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -123,6 +124,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 var installedUICulturePropertyOfComputerInfoType = computerInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
 
                 var obsoleteAttributeType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemObsoleteAttribute);
+
+                var excludeTryParseMethods = csaContext.Options.GetBoolOptionValue(EditorConfigOptionNames.ExcludeTryParseMethods, IFormatProviderAlternateRule,
+                    defaultValue: true, cancellationToken: csaContext.CancellationToken);
                 #endregion
 
                 csaContext.RegisterOperationAction(oaContext =>
@@ -175,6 +179,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         // If there are two matching overloads, one with CultureInfo as the first parameter and one with CultureInfo as the last parameter,
                         // report the diagnostic on the overload with CultureInfo as the last parameter, to match the behavior of FxCop.
                         var correctOverload = correctOverloads.FirstOrDefault(overload => overload.Parameters.Last().Type.Equals(iformatProviderType)) ?? correctOverloads.FirstOrDefault();
+
+                        // Use a different mechanism for TryParse methods as they usually have more than 1 extra parameter and
+                        // the IFormatProvider parameter is neither first nor last.
+                        if (correctOverload == null && targetMethod.Name.Equals("TryParse", StringComparison.Ordinal) && !excludeTryParseMethods)
+                        {
+                            correctOverload = methodsWithSameNameAsTargetMethod.FirstOrDefault(x => HasCorrectTryMethodParameters(x, targetMethod));
+                        }
 
                         // Sample message for IFormatProviderAlternateRule: Because the behavior of Convert.ToInt64(string) could vary based on the current user's locale settings,
                         // replace this call in IFormatProviderStringTest.TestMethod() with a call to Convert.ToInt64(string, IFormatProvider).
@@ -245,6 +256,35 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         private static ParameterInfo GetParameterInfo(INamedTypeSymbol type, bool isArray = false, int arrayRank = 0, bool isParams = false)
         {
             return ParameterInfo.GetParameterInfo(type, isArray, arrayRank, isParams);
+        }
+
+        private static bool HasCorrectTryMethodParameters(IMethodSymbol candidateMethod, IMethodSymbol referenceMethod)
+        {
+            if (candidateMethod.Parameters.Length <= referenceMethod.Parameters.Length)
+            {
+                return false;
+            }
+
+            var remainingCandidateMethodParameters = candidateMethod.Parameters.ToList();
+            for (int i = 0; i < referenceMethod.Parameters.Length; i++)
+            {
+                for (int j = 0; j < remainingCandidateMethodParameters.Count; j++)
+                {
+                    if (remainingCandidateMethodParameters[j].Type.Equals(referenceMethod.Parameters[i].Type))
+                    {
+                        remainingCandidateMethodParameters.RemoveAt(i);
+                        continue;
+                    }
+
+                    if (j == remainingCandidateMethodParameters.Count)
+                    {
+                        // Cannot find any parameter of the expected type.
+                        return false;
+                    }
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -119,5 +119,10 @@ namespace Analyzer.Utilities
         ///   3. Default FxCop heuristic (75% of enum values)
         /// </summary>
         public const string EnumValuesPrefixTrigger = "enum_values_prefix_trigger";
+
+        /// <summary>
+        /// Boolean option to configure if TryParse methods are flagged for CA1305 (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1305).
+        /// </summary>
+        public const string ExcludeTryParseMethods = "exclude_tryparse_methods";
     }
 }


### PR DESCRIPTION
Update the behavior of CA1305 to allow reporting on all `TryParse` methods when the related option is activated.

Fix #1848 
