### PR TITLE
Use fully qualified name for types in generated xml metrics

### DIFF
--- a/src/Tools/Metrics/MetricsOutputWriter.cs
+++ b/src/Tools/Metrics/MetricsOutputWriter.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeMetrics;
@@ -61,7 +62,16 @@ namespace Metrics
                 switch (data.Symbol.Kind)
                 {
                     case SymbolKind.NamedType:
-                        writer.WriteAttributeString("Name", data.Symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                        var minimalTypeName = new StringBuilder(data.Symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+
+                        var containingType = data.Symbol.ContainingType;
+                        while (containingType != null)
+                        {
+                            minimalTypeName.Insert(0, ".");
+                            minimalTypeName.Insert(0, containingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                        }
+
+                        writer.WriteAttributeString("Name", minimalTypeName.ToString());
                         break;
 
                     case SymbolKind.Method:

--- a/src/Tools/Metrics/MetricsOutputWriter.cs
+++ b/src/Tools/Metrics/MetricsOutputWriter.cs
@@ -61,7 +61,7 @@ namespace Metrics
                 switch (data.Symbol.Kind)
                 {
                     case SymbolKind.NamedType:
-                        writer.WriteAttributeString("Name", data.Symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                        writer.WriteAttributeString("Name", data.Symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
                         break;
 
                     case SymbolKind.Method:

--- a/src/Tools/Metrics/MetricsOutputWriter.cs
+++ b/src/Tools/Metrics/MetricsOutputWriter.cs
@@ -69,6 +69,7 @@ namespace Metrics
                         {
                             minimalTypeName.Insert(0, ".");
                             minimalTypeName.Insert(0, containingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                            containingType = containingType.ContainingType;
                         }
 
                         writer.WriteAttributeString("Name", minimalTypeName.ToString());


### PR DESCRIPTION
The class doesn't have any test so there is no test to update.

Fix #2804 
