### PR TITLE
Add nullability to shipped API files

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
 
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>3.0.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisForShippedApisVersion>3.5.0-beta2-19619-02</MicrosoftCodeAnalysisForShippedApisVersion>
+    <MicrosoftCodeAnalysisForShippedApisVersion>3.5.0-beta2-20056-01</MicrosoftCodeAnalysisForShippedApisVersion>
     <MicrosoftNetCompilersVersion>3.4.0-beta2-final</MicrosoftNetCompilersVersion>
     <DogfoodAnalyzersVersion>3.0.0-beta2.19529.2+e119d9cf</DogfoodAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,8 +20,8 @@
     <ReportGeneratorVersion>4.3.6</ReportGeneratorVersion>
 
     <!-- Roslyn -->
-    <MicrosoftCodeAnalysisVersion>3.5.0-beta2-19619-02</MicrosoftCodeAnalysisVersion>
-    <MicrosoftNetCompilersVersion>3.5.0-beta2-19619-02</MicrosoftNetCompilersVersion>
+    <MicrosoftCodeAnalysisVersion>3.0.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftNetCompilersVersion>3.4.0-beta2-final</MicrosoftNetCompilersVersion>
     <DogfoodAnalyzersVersion>3.0.0-beta2.19529.2+e119d9cf</DogfoodAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisFXCopAnalyersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,8 @@
     <ReportGeneratorVersion>4.3.6</ReportGeneratorVersion>
 
     <!-- Roslyn -->
-    <MicrosoftCodeAnalysisVersion>3.5.0-beta2-19619-02</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>3.0.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisForShippedApisVersion>3.5.0-beta2-19619-02</MicrosoftCodeAnalysisForShippedApisVersion>
     <MicrosoftNetCompilersVersion>3.4.0-beta2-final</MicrosoftNetCompilersVersion>
     <DogfoodAnalyzersVersion>3.0.0-beta2.19529.2+e119d9cf</DogfoodAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,8 +20,8 @@
     <ReportGeneratorVersion>4.3.6</ReportGeneratorVersion>
 
     <!-- Roslyn -->
-    <MicrosoftCodeAnalysisVersion>3.0.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftNetCompilersVersion>3.4.0-beta2-final</MicrosoftNetCompilersVersion>
+    <MicrosoftCodeAnalysisVersion>3.5.0-beta2-19619-02</MicrosoftCodeAnalysisVersion>
+    <MicrosoftNetCompilersVersion>3.5.0-beta2-19619-02</MicrosoftNetCompilersVersion>
     <DogfoodAnalyzersVersion>3.0.0-beta2.19529.2+e119d9cf</DogfoodAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisFXCopAnalyersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,7 @@
     <ReportGeneratorVersion>4.3.6</ReportGeneratorVersion>
 
     <!-- Roslyn -->
-    <MicrosoftCodeAnalysisVersion>3.0.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>3.5.0-beta2-19619-02</MicrosoftCodeAnalysisVersion>
     <MicrosoftNetCompilersVersion>3.4.0-beta2-final</MicrosoftNetCompilersVersion>
     <DogfoodAnalyzersVersion>3.0.0-beta2.19529.2+e119d9cf</DogfoodAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -238,7 +238,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                         }
                         else
                         {
-                            // TODO2
                             reportAnnotateApi(symbol, reportDiagnostic, isImplicitlyDeclaredConstructor, publicApiName, foundApiLine.IsShippedApi, locationsToReport);
                         }
                     }
@@ -318,8 +317,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                                 else if (!overloadHasOptionalParams)
                                 {
                                     var overloadPublicApiName = GetPublicApiName(overload);
-                                    ApiLine overloadPublicApiLine;
-                                    var isOverloadUnshipped = !lookupPublicApi(overloadPublicApiName, out overloadPublicApiLine) ||
+                                    var isOverloadUnshipped = !lookupPublicApi(overloadPublicApiName, out ApiLine overloadPublicApiLine) ||
                                         !overloadPublicApiLine.IsShippedApi;
                                     if (isOverloadUnshipped)
                                     {
@@ -448,7 +446,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                             continue;
                         }
 
-                        if (!ContainsPublicApiName(apiLineText, containingSymbolPublicApiName + "."))
+                        if (!ContainsPublicApiName(apiLineText, containingSymbolPublicApiName.Name + "."))
                         {
                             // Doesn't contain containingSymbol public API name - not a sibling of symbol.
                             continue;
@@ -505,11 +503,10 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
             private ApiName GetPublicApiName(ISymbol symbol)
             {
-                return new ApiName(getPublicApiString(withNullability: false), getPublicApiString(withNullability: true));
+                return new ApiName(getPublicApiString(s_publicApiFormat), getPublicApiString(s_publicApiFormatWithNullability));
 
-                string getPublicApiString(bool withNullability)
+                string getPublicApiString(SymbolDisplayFormat format)
                 {
-                    var format = withNullability ? s_publicApiFormatWithNullability : s_publicApiFormat;
                     string publicApiName = symbol.ToDisplayString(format);
 
                     ITypeSymbol? memberType = null;
@@ -578,7 +575,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 foreach (ApiLine cur in deletedApiList)
                 {
                     LinePositionSpan linePositionSpan = cur.SourceText.Lines.GetLinePositionSpan(cur.Span);
-                    var location = Location.Create(cur.Path, cur.Span, linePositionSpan);
+                    Location location = Location.Create(cur.Path, cur.Span, linePositionSpan);
                     ImmutableDictionary<string, string> propertyBag = ImmutableDictionary<string, string>.Empty.Add(PublicApiNamePropertyBagKey, cur.Text);
                     context.ReportDiagnostic(Diagnostic.Create(RemoveDeletedApiRule, location, propertyBag, cur.Text));
                 }
@@ -701,7 +698,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 // not internal, private or protected&internal
                 return !type.IsSealed &&
                     type.GetMembers(WellKnownMemberNames.InstanceConstructorName).Any(
-(Func<ISymbol, bool>)(m => m.DeclaredAccessibility != Accessibility.Internal && m.DeclaredAccessibility != Accessibility.Private && m.DeclaredAccessibility != Accessibility.ProtectedAndInternal)
+                        m => m.DeclaredAccessibility != Accessibility.Internal && m.DeclaredAccessibility != Accessibility.Private && m.DeclaredAccessibility != Accessibility.ProtectedAndInternal
                     );
             }
         }

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -238,6 +238,12 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     {
                         reportDeclareNewApi(symbol, isImplicitlyDeclaredConstructor, publicApiName.Name);
                     }
+
+                    if (publicApiName.Name != publicApiName.NameWithNullability)
+                    {
+                        // '#nullable enable' would be useful and should be set
+                        reportDiagnosticAtLocations(ShouldAnnotateApiFilesRule, ImmutableDictionary<string, string>.Empty);
+                    }
                 }
 
                 if (symbol.Kind == SymbolKind.Method)

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -234,11 +234,11 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                         var hasPublicApiEntryWithoutNullability = _publicApiMap.TryGetValue(publicApiName.Name, out foundApiLine);
                         if (!hasPublicApiEntryWithoutNullability)
                         {
-                            reportDeclareNewApi(symbol, reportDiagnostic, isImplicitlyDeclaredConstructor, publicApiName.NameWithNullability, locationsToReport);
+                            reportDeclareNewApi(symbol, isImplicitlyDeclaredConstructor, publicApiName.NameWithNullability);
                         }
                         else
                         {
-                            reportAnnotateApi(symbol, reportDiagnostic, isImplicitlyDeclaredConstructor, publicApiName, foundApiLine.IsShippedApi, locationsToReport);
+                            reportAnnotateApi(symbol, isImplicitlyDeclaredConstructor, publicApiName, foundApiLine.IsShippedApi);
                         }
                     }
                 }
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     var hasPublicApiEntryWithoutNullability = _publicApiMap.TryGetValue(publicApiName.Name, out foundApiLine);
                     if (!hasPublicApiEntryWithoutNullability)
                     {
-                        reportDeclareNewApi(symbol, reportDiagnostic, isImplicitlyDeclaredConstructor, publicApiName.Name, locationsToReport);
+                        reportDeclareNewApi(symbol, isImplicitlyDeclaredConstructor, publicApiName.Name);
                     }
                 }
 
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     }
                 }
 
-                void reportDeclareNewApi(ISymbol symbol, Action<Diagnostic> reportDiagnostic, bool isImplicitlyDeclaredConstructor, string publicApiName, List<Location> locationsToReport)
+                void reportDeclareNewApi(ISymbol symbol, bool isImplicitlyDeclaredConstructor, string publicApiName)
                 {
                     // Unshipped public API with no entry in public API file - report diagnostic.
                     string errorMessageName = GetErrorMessageName(symbol, isImplicitlyDeclaredConstructor);
@@ -356,7 +356,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     reportDiagnosticAtLocations(DeclareNewApiRule, propertyBag, errorMessageName);
                 }
 
-                void reportAnnotateApi(ISymbol symbol, Action<Diagnostic> reportDiagnostic, bool isImplicitlyDeclaredConstructor, ApiName publicApiName, bool isShipped, List<Location> locationsToReport)
+                void reportAnnotateApi(ISymbol symbol, bool isImplicitlyDeclaredConstructor, ApiName publicApiName, bool isShipped)
                 {
                     // Public API missing annotations in public API file - report diagnostic.
                     string errorMessageName = GetErrorMessageName(symbol, isImplicitlyDeclaredConstructor);
@@ -371,7 +371,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
                 bool lookupPublicApi(ApiName overloadPublicApiName, out ApiLine overloadPublicApiLine)
                 {
-                    // TODO2 test scenario for this
                     if (_useNullability)
                     {
                         return _publicApiMap.TryGetValue(overloadPublicApiName.NameWithNullability, out overloadPublicApiLine) ||
@@ -432,7 +431,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     var nestedNamespaceOrTypesPublicApiNames = new List<string>(nestedNamespaceOrTypeMembers.Length);
                     foreach (var nestedNamespaceOrType in nestedNamespaceOrTypeMembers)
                     {
-                        var nestedNamespaceOrTypePublicApiName = GetPublicApiName(nestedNamespaceOrType).Name; // TODO2
+                        var nestedNamespaceOrTypePublicApiName = GetPublicApiName(nestedNamespaceOrType).Name;
                         nestedNamespaceOrTypesPublicApiNames.Add(nestedNamespaceOrTypePublicApiName);
                     }
 
@@ -440,7 +439,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     foreach (var apiLine in _unshippedData.ApiList)
                     {
                         var apiLineText = apiLine.Text;
-                        if (apiLineText == containingSymbolPublicApiName.Name) // TODO2
+                        if (apiLineText == containingSymbolPublicApiName.Name)
                         {
                             // Not a sibling of symbol.
                             continue;
@@ -490,7 +489,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                             }
 
                             var siblingPublicApiName = GetPublicApiName(sibling);
-                            publicApiLinesForSiblingsOfSymbol.Remove(siblingPublicApiName.Name); // TODO2
+                            publicApiLinesForSiblingsOfSymbol.Remove(siblingPublicApiName.Name);
                         }
 
                         // Join all the symbols names with a special separator.

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -51,18 +51,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         }
 
 #pragma warning disable CA1815 // Override equals and operator equals on value types
-        private readonly struct NullableLine
-#pragma warning restore CA1815 // Override equals and operator equals on value types
-        {
-            public int Rank { get; }
-
-            internal NullableLine(int rank)
-            {
-                Rank = rank;
-            }
-        }
-
-#pragma warning disable CA1815 // Override equals and operator equals on value types
         private struct ApiName
 #pragma warning restore CA1815 // Override equals and operator equals on value types
         {
@@ -82,13 +70,14 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         {
             public ImmutableArray<ApiLine> ApiList { get; }
             public ImmutableArray<RemovedApiLine> RemovedApiList { get; }
-            public ImmutableArray<NullableLine> NullableLines { get; }
+            // Number for the max line where #nullable enable was found (-1 otherwise)
+            public int NullableRank { get; }
 
-            internal ApiData(ImmutableArray<ApiLine> apiList, ImmutableArray<RemovedApiLine> removedApiList, ImmutableArray<NullableLine> nullableLines)
+            internal ApiData(ImmutableArray<ApiLine> apiList, ImmutableArray<RemovedApiLine> removedApiList, int nullableRank)
             {
                 ApiList = apiList;
                 RemovedApiList = removedApiList;
-                NullableLines = nullableLines;
+                NullableRank = nullableRank;
             }
         }
 
@@ -107,7 +96,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             internal Impl(Compilation compilation, ApiData shippedData, ApiData unshippedData)
             {
                 _compilation = compilation;
-                _useNullability = shippedData.NullableLines.Length > 0;
+                _useNullability = shippedData.NullableRank >= 0 || unshippedData.NullableRank >= 0;
                 _unshippedData = unshippedData;
 
                 var publicApiMap = new Dictionary<string, ApiLine>(StringComparer.Ordinal);

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -111,6 +111,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 miscellaneousOptions:
                     SymbolDisplayMiscellaneousOptions.None);
 
+        private const int IncludeNullableReferenceTypeModifier = 1 << 6;
+
         private static readonly SymbolDisplayFormat s_publicApiFormat =
             new SymbolDisplayFormat(
                 globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
@@ -130,7 +132,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     SymbolDisplayParameterOptions.IncludeName |
                     SymbolDisplayParameterOptions.IncludeDefaultValue,
                 miscellaneousOptions:
-                    SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+                    SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
+                    (SymbolDisplayMiscellaneousOptions)IncludeNullableReferenceTypeModifier);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(DeclareNewApiRule, RemoveDeletedApiRule, ExposedNoninstantiableType,

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -114,6 +114,17 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             helpLinkUri: @"https://github.com/dotnet/roslyn/blob/master/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md",
             customTags: WellKnownDiagnosticTags.Telemetry);
 
+        internal static readonly DiagnosticDescriptor ShouldAnnotateApiFilesRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.ShouldAnnotateApiFilesRuleId,
+            title: PublicApiAnalyzerResources.ShouldAnnotateApiFilesTitle,
+            messageFormat: PublicApiAnalyzerResources.ShouldAnnotateApiFilesMessage,
+            category: "ApiDesign",
+            defaultSeverity: DiagnosticHelpers.DefaultDiagnosticSeverity,
+            isEnabledByDefault: DiagnosticHelpers.EnabledByDefaultIfNotBuildingVSIX,
+            description: PublicApiAnalyzerResources.ShouldAnnotateApiFilesDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
         internal static readonly SymbolDisplayFormat ShortSymbolNameFormat =
             new SymbolDisplayFormat(
                 globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
@@ -160,7 +171,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(DeclareNewApiRule, AnnotateApiRule, RemoveDeletedApiRule, ExposedNoninstantiableType,
                 PublicApiFilesInvalid, DuplicateSymbolInApiFiles, AvoidMultipleOverloadsWithOptionalParameters,
-                OverloadWithOptionalParametersShouldHaveMostParameters);
+                OverloadWithOptionalParametersShouldHaveMostParameters, ShouldAnnotateApiFilesRule);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -300,13 +311,13 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
             if (shippedData.NullableRank > 0)
             {
-                // #nullable enable must be on the first line
+                // '#nullable enable' must be on the first line
                 errors.Add(Diagnostic.Create(PublicApiFilesInvalid, Location.None, InvalidReasonMisplacedNullableEnable));
             }
 
             if (unshippedData.NullableRank > 0)
             {
-                // #nullable enable must be on the first line
+                // '#nullable enable' must be on the first line
                 errors.Add(Diagnostic.Create(PublicApiFilesInvalid, Location.None, InvalidReasonMisplacedNullableEnable));
             }
 

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -128,6 +128,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     SymbolDisplayMiscellaneousOptions.None);
 
         private const int IncludeNullableReferenceTypeModifier = 1 << 6;
+        private const int IncludeNonNullableReferenceTypeModifier = 1 << 8;
 
         private static readonly SymbolDisplayFormat s_publicApiFormat =
             new SymbolDisplayFormat(
@@ -153,7 +154,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         private static readonly SymbolDisplayFormat s_publicApiFormatWithNullability =
             s_publicApiFormat.WithMiscellaneousOptions(
                 SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
-                (SymbolDisplayMiscellaneousOptions)IncludeNullableReferenceTypeModifier);
+                (SymbolDisplayMiscellaneousOptions)IncludeNullableReferenceTypeModifier |
+                (SymbolDisplayMiscellaneousOptions)IncludeNonNullableReferenceTypeModifier);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(DeclareNewApiRule, AnnotateApiRule, RemoveDeletedApiRule, ExposedNoninstantiableType,

--- a/src/PublicApiAnalyzers/Core/Analyzers/PublicApiAnalyzerResources.resx
+++ b/src/PublicApiAnalyzers/Core/Analyzers/PublicApiAnalyzerResources.resx
@@ -218,4 +218,10 @@
   <data name="AnnotateAllItemsInTheSolutionToThePublicApiTitle" xml:space="preserve">
     <value>Annotate all items in the solution in the public API</value>
   </data>
+  <data name="EnableNullableInProjectToThePublicApiTitle" xml:space="preserve">
+    <value>Enable nullability annotations in the public API for project '{0}'</value>
+  </data>
+  <data name="EnableNullableInTheSolutionToThePublicApiTitle" xml:space="preserve">
+    <value>Enable nullability annotations in the public API for the solution</value>
+  </data>
 </root>

--- a/src/PublicApiAnalyzers/Core/Analyzers/PublicApiAnalyzerResources.resx
+++ b/src/PublicApiAnalyzers/Core/Analyzers/PublicApiAnalyzerResources.resx
@@ -127,13 +127,13 @@
     <value>All public types and members should be declared in PublicAPI.txt. This draws attention to API changes in the code reviews and source control history, and helps prevent breaking changes.</value>
   </data>
   <data name="AnnotatePublicApiTitle" xml:space="preserve">
-    <value>Annotate public types and members in the declared API</value>
+    <value>Annotate nullability of public types and members in the declared API</value>
   </data>
   <data name="AnnotatePublicApiMessage" xml:space="preserve">
-    <value>Symbol '{0}' is not annotated in the declared API.</value>
+    <value>Symbol '{0}' is missing nullability annotations in the declared API.</value>
   </data>
   <data name="AnnotatePublicApiDescription" xml:space="preserve">
-    <value>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</value>
+    <value>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</value>
   </data>
   <data name="RemoveDeletedApiTitle" xml:space="preserve">
     <value>Remove deleted types and members from the declared API</value>

--- a/src/PublicApiAnalyzers/Core/Analyzers/PublicApiAnalyzerResources.resx
+++ b/src/PublicApiAnalyzers/Core/Analyzers/PublicApiAnalyzerResources.resx
@@ -135,6 +135,17 @@
   <data name="AnnotatePublicApiDescription" xml:space="preserve">
     <value>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</value>
   </data>
+
+  <data name="ShouldAnnotateApiFilesTitle" xml:space="preserve">
+    <value>Annotate nullability of types and members in the declared API</value>
+  </data>
+  <data name="ShouldAnnotateApiFilesMessage" xml:space="preserve">
+    <value>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</value>
+  </data>
+  <data name="ShouldAnnotateApiFilesDescription" xml:space="preserve">
+    <value>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</value>
+  </data>
+  
   <data name="RemoveDeletedApiTitle" xml:space="preserve">
     <value>Remove deleted types and members from the declared API</value>
   </data>

--- a/src/PublicApiAnalyzers/Core/Analyzers/PublicApiAnalyzerResources.resx
+++ b/src/PublicApiAnalyzers/Core/Analyzers/PublicApiAnalyzerResources.resx
@@ -126,6 +126,15 @@
   <data name="DeclarePublicApiDescription" xml:space="preserve">
     <value>All public types and members should be declared in PublicAPI.txt. This draws attention to API changes in the code reviews and source control history, and helps prevent breaking changes.</value>
   </data>
+  <data name="AnnotatePublicApiTitle" xml:space="preserve">
+    <value>Annotate public types and members in the declared API</value>
+  </data>
+  <data name="AnnotatePublicApiMessage" xml:space="preserve">
+    <value>Symbol '{0}' is not annotated in the declared API.</value>
+  </data>
+  <data name="AnnotatePublicApiDescription" xml:space="preserve">
+    <value>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</value>
+  </data>
   <data name="RemoveDeletedApiTitle" xml:space="preserve">
     <value>Remove deleted types and members from the declared API</value>
   </data>
@@ -188,5 +197,14 @@
   </data>
   <data name="AddAllItemsInTheSolutionToThePublicApiTitle" xml:space="preserve">
     <value>Add all items in the solution to the public API</value>
+  </data>
+  <data name="AnnotateAllItemsInDocumentToThePublicApiTitle" xml:space="preserve">
+    <value>Annotate all items in document '{0}' in the public API</value>
+  </data>
+  <data name="AnnotateAllItemsInProjectToThePublicApiTitle" xml:space="preserve">
+    <value>Annotate all items in project '{0}' in the public API</value>
+  </data>
+  <data name="AnnotateAllItemsInTheSolutionToThePublicApiTitle" xml:space="preserve">
+    <value>Annotate all items in the solution in the public API</value>
   </data>
 </root>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.cs.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.cs.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Neduplikovat symboly v souborech veřejných rozhraní API</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">Konstruktor nastavuje základní třídu, ze které se nedá dědit, na třídu, ze které se dědit dá, čímž zpřístupňuje své chráněné členy.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.cs.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.cs.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.cs.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.cs.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Odebrat odstraněné typy a členy z deklarovaného rozhraní API</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.cs.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.cs.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">Symbol {0} porušuje požadavek na zpětnou kompatibilitu: Nepřidávat více přetížení s nepovinnými parametry. Podrobnosti najdete tady: {1}</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.de.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.de.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Symbole in öffentlichen API-Dateien nicht duplizieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">Der Konstruktor legt die nicht vererbbare Basisklasse als vererbbar fest und macht damit deren geschützte Member verfügbar.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.de.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.de.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.de.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.de.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">Das Symbol "{0}" verletzt die backcompat-Anforderung: Nicht mehrere Überladungen mit optionalen Parametern hinzufügen. Details finden Sie unter "{1}".</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.de.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.de.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Gelöschte Typen und Member aus der deklarierten API entfernen</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.es.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.es.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.es.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.es.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">El símbolo "{0}" infringe el requisito de compatibilidad con versiones anteriores: "No agregar varias sobrecargas con los parámetros opcionales". Consulte "{1}" para obtener más detalles.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.es.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.es.xlf
@@ -82,6 +82,16 @@
         <target state="translated">No duplicar símbolos en los archivos de la API pública</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">El constructor convierte su clase base no heredable en heredable, por lo que expone sus miembros protegidos.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.es.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.es.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Quitar tipos y miembros eliminados de la API declarada</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.fr.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.fr.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Ne pas dupliquer les symboles dans les fichiers d'une API publique</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">Le constructeur fait de sa classe de base non héritable une classe héritable, exposant ainsi ses membres protégés.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.fr.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.fr.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.fr.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.fr.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">Le symbole '{0}' viole l'exigence de compatibilité descendante : 'Ne pas ajouter plusieurs surcharges publiques avec des paramètres optionnels'. Pour plus d'informations, consultez '{1}'.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.fr.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.fr.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Enlever les types et membres supprimés de l'API déclarée</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.it.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.it.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Rimuovere tipi e membri eliminati dall'API dichiarata</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.it.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.it.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Non duplicare simboli nei file dell'API pubblica</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">Il costruttore rende ereditabile la relativa classe di base non ereditabile, esponendone in tal modo i membri protetti.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.it.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.it.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">Il simbolo '{0}' viola il requisito di compatibilità con le versioni precedenti: 'Non aggiungere più overload public con parametri facoltativi'. Per dettagli, vedere '{1}'.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.it.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.it.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ja.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ja.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">シンボル '{0}' は下位互換性の要件、「省略可能なパラメーターを持つ複数のオーバーロードを追加しない」に違反しています。詳細は '{1}' を参照してください。</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ja.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ja.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ja.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ja.xlf
@@ -152,6 +152,21 @@
         <target state="translated">削除された型とメンバーを、宣言された API から削除する</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ja.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ja.xlf
@@ -82,6 +82,16 @@
         <target state="translated">パブリック API ファイル内でシンボルを重複させない</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">コンストラクターは、その継承不可能な基底クラスを継承可能にすることで、保護されたメンバーを公開します。</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ko.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ko.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ko.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ko.xlf
@@ -152,6 +152,21 @@
         <target state="translated">선언된 API에서 삭제된 형식 및 멤버 제거</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ko.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ko.xlf
@@ -82,6 +82,16 @@
         <target state="translated">공용 API 파일에서 기호를 복제하지 마세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">생성자는 해당 상속할 수 없는 기본 클래스를 상속할 수 있도록 만들어 보호된 멤버가 공개됩니다.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ko.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ko.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">'{0}' 기호가 backcompat 요구 사항인 '선택적 매개 변수가 있는 여러 오버로드를 추가하지 마세요.'를 위반합니다. 자세한 내용은 '{1}'을(를) 참조하세요.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pl.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pl.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">Symbol „{0}” narusza wymaganie wstecznej zgodności: „Nie dodawaj wielu przeciążeń z opcjonalnymi parametrami”. Zobacz „{1}”, aby uzyskać szczegółowe informacje.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pl.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pl.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Nie duplikuj symboli w plikach publicznego interfejsu API</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">Konstruktor umożliwia dziedziczenie klasy podstawowej nieprzeznaczonej do dziedziczenia, tym samym ujawniając jej chronione składowe.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pl.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pl.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Usuń usunięte typy i składowe z zadeklarowanego interfejsu API</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pl.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pl.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pt-BR.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pt-BR.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Remova os tipos e membros excluídos da API declarada</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pt-BR.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pt-BR.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">O símbolo '{0}' viola o requisito de backcompat: 'Não adicione várias sobrecargas com parâmetros opcionais'. Confira '{1}' para obter detalhes.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pt-BR.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pt-BR.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pt-BR.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.pt-BR.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Não duplique símbolos em arquivos de API pública</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">O construtor faz com que sua classe base não herdável seja herdável, expondo seus membros protegidos.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ru.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ru.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Удалите удаленные типы и элементы из объявленного API</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ru.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ru.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Не дублируйте символы в файлах открытого API</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">Конструктор делает свой ненаследуемый базовый класс наследуемым, ставя под угрозу его защищенные элементы.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ru.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ru.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ru.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.ru.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">Символ "{0}" нарушает требование обратной совместимости: "Не добавляйте несколько перегрузок с необязательными параметрами". Дополнительные сведения см. в "{1}" .</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.tr.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.tr.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">'{0}' sembolü geriye dönük uyumluluk gereksinimini ihlal ediyor: 'İsteğe bağlı parametreleri olan birden fazla aşırı yükleme eklemeyin'. Ayrıntılar için bkz. '{1}'.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.tr.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.tr.xlf
@@ -152,6 +152,21 @@
         <target state="translated">Silinen türleri ve üyeleri bildirilen API'den kaldırın</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.tr.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.tr.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.tr.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.tr.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Genel API dosyalarında sembolleri yinelemeyin</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">Oluşturucu devralınamaz temel sınıfını devralınabilir hale getirir, böylece korumalı üyelerini açığa çıkarır.</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hans.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hans.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hans.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hans.xlf
@@ -152,6 +152,21 @@
         <target state="translated">从已声明 API 中删除已删除的类型和成员</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hans.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hans.xlf
@@ -82,6 +82,16 @@
         <target state="translated">请勿在公共 API 文件中复制符号</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">构造函数使其不可继承的基类变为可继承，从而暴露其受保护的成员。</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hans.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hans.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">符号“{0}”违反了 backcompat 要求:“请勿添加具有可选参数的多个重载”。有关详细信息，请参阅“{1}”。</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hant.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hant.xlf
@@ -152,6 +152,21 @@
         <target state="translated">從宣告的 API 移除已刪除的類型與成員</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesDescription">
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesMessage">
+        <source>PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</source>
+        <target state="new">PublicAPI.txt is missing '#nullable enable', so the nullability annotations of API isn't recorded. It is recommended to enable this tracking.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldAnnotateApiFilesTitle">
+        <source>Annotate nullability of types and members in the declared API</source>
+        <target state="new">Annotate nullability of types and members in the declared API</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hant.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hant.xlf
@@ -33,18 +33,18 @@
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiDescription">
-        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
-        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <source>All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with nullability annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiMessage">
-        <source>Symbol '{0}' is not annotated in the declared API.</source>
-        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <source>Symbol '{0}' is missing nullability annotations in the declared API.</source>
+        <target state="new">Symbol '{0}' is missing nullability annotations in the declared API.</target>
         <note />
       </trans-unit>
       <trans-unit id="AnnotatePublicApiTitle">
-        <source>Annotate public types and members in the declared API</source>
-        <target state="new">Annotate public types and members in the declared API</target>
+        <source>Annotate nullability of public types and members in the declared API</source>
+        <target state="new">Annotate nullability of public types and members in the declared API</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hant.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hant.xlf
@@ -17,6 +17,36 @@
         <target state="new">Add all items in the solution to the public API</target>
         <note />
       </trans-unit>
+      <trans-unit id="AnnotateAllItemsInDocumentToThePublicApiTitle">
+        <source>Annotate all items in document '{0}' in the public API</source>
+        <target state="new">Annotate all items in document '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInProjectToThePublicApiTitle">
+        <source>Annotate all items in project '{0}' in the public API</source>
+        <target state="new">Annotate all items in project '{0}' in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotateAllItemsInTheSolutionToThePublicApiTitle">
+        <source>Annotate all items in the solution in the public API</source>
+        <target state="new">Annotate all items in the solution in the public API</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiDescription">
+        <source>All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</source>
+        <target state="new">All public types and members should be declared with annotations in PublicAPI.txt. This draws attention to API nullability changes in the code reviews and source control history, and helps prevent breaking changes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiMessage">
+        <source>Symbol '{0}' is not annotated in the declared API.</source>
+        <target state="new">Symbol '{0}' is not annotated in the declared API.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AnnotatePublicApiTitle">
+        <source>Annotate public types and members in the declared API</source>
+        <target state="new">Annotate public types and members in the declared API</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AvoidMultipleOverloadsWithOptionalParametersMessage">
         <source>Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.</source>
         <target state="translated">符號 '{0}' 違反回溯相容性需求:「請勿新增具備選擇性參數的多項多載」。請參閱 '{1}' 以取得詳細資料。</target>

--- a/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hant.xlf
+++ b/src/PublicApiAnalyzers/Core/Analyzers/xlf/PublicApiAnalyzerResources.zh-Hant.xlf
@@ -82,6 +82,16 @@
         <target state="translated">請勿在公用 API 檔案中使用重複的符號</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnableNullableInProjectToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for project '{0}'</source>
+        <target state="new">Enable nullability annotations in the public API for project '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableNullableInTheSolutionToThePublicApiTitle">
+        <source>Enable nullability annotations in the public API for the solution</source>
+        <target state="new">Enable nullability annotations in the public API for the solution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExposedNoninstantiableTypeMessage">
         <source>Constructor makes its noninheritable base class inheritable, thereby exposing its protected members.</source>
         <target state="translated">建構函式會使無法繼承的基底類別變成可繼承，進而公開其受保護的成員。</target>

--- a/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
@@ -39,13 +39,15 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 bool isShippedDocument = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiIsShippedPropertyBagKey] == "true";
 
                 TextDocument? document = isShippedDocument ? GetShippedDocument(project) : DeclarePublicApiFix.GetUnshippedDocument(project);
-                Debug.Assert(document is object);
 
-                context.RegisterCodeFix(
-                        new DeclarePublicApiFix.AdditionalDocumentChangeAction(
-                            $"Annotate {minimalSymbolName} in public API",
-                            c => GetFix(document, publicSymbolName, publicSymbolNameWithNullability, c)),
-                        diagnostic);
+                if (document != null)
+                {
+                    context.RegisterCodeFix(
+                            new DeclarePublicApiFix.AdditionalDocumentChangeAction(
+                                $"Annotate {minimalSymbolName} in public API",
+                                c => GetFix(document, publicSymbolName, publicSymbolNameWithNullability, c)),
+                            diagnostic);
+                }
             }
 
             return Task.CompletedTask;

--- a/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
@@ -1,0 +1,220 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+using DiagnosticIds = Roslyn.Diagnostics.Analyzers.RoslynDiagnosticIds;
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = "AnnotatePublicApiFix"), Shared]
+    public sealed class AnnotatePublicApiFix : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(DiagnosticIds.AnnotatePublicApiRuleId);
+
+        public sealed override FixAllProvider GetFixAllProvider()
+            => new PublicSurfaceAreaFixAllProvider();
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            Project project = context.Document.Project;
+
+            foreach (Diagnostic diagnostic in context.Diagnostics)
+            {
+                string minimalSymbolName = diagnostic.Properties[DeclarePublicApiAnalyzer.MinimalNamePropertyBagKey];
+                string publicSymbolName = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiNamePropertyBagKey];
+                string publicSymbolNameWithNullability = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiNameWithNullabilityPropertyBagKey];
+                bool isShippedDocument = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiIsShippedPropertyBagKey] == "true";
+
+                TextDocument? document = isShippedDocument ? GetShippedDocument(project) : DeclarePublicApiFix.GetUnshippedDocument(project);
+                Debug.Assert(document is object);
+
+                context.RegisterCodeFix(
+                        new DeclarePublicApiFix.AdditionalDocumentChangeAction(
+                            $"Annotate {minimalSymbolName} in public API",
+                            c => GetFix(document, publicSymbolName, publicSymbolNameWithNullability, c)),
+                        diagnostic);
+            }
+
+            return Task.CompletedTask;
+
+            static async Task<Solution> GetFix(TextDocument publicSurfaceAreaDocument, string oldSymbolName, string newSymbolName, CancellationToken cancellationToken)
+            {
+                SourceText sourceText = await publicSurfaceAreaDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                SourceText newSourceText = AnnotateSymbolNamesInSourceText(sourceText, new Dictionary<string, string> { [oldSymbolName] = newSymbolName });
+
+                return publicSurfaceAreaDocument.Project.Solution.WithAdditionalDocumentText(publicSurfaceAreaDocument.Id, newSourceText);
+            }
+        }
+
+        private static TextDocument? GetShippedDocument(Project project)
+        {
+            return project.AdditionalDocuments.FirstOrDefault(doc => doc.Name.Equals(DeclarePublicApiAnalyzer.ShippedFileName, StringComparison.Ordinal));
+        }
+
+        private static SourceText AnnotateSymbolNamesInSourceText(SourceText sourceText, Dictionary<string, string> changes)
+        {
+            if (changes.Count == 0)
+            {
+                return sourceText;
+            }
+
+            List<string> lines = DeclarePublicApiFix.GetLinesFromSourceText(sourceText);
+
+            for (int i = 0; i < lines.Count; i++)
+            {
+                if (changes.TryGetValue(lines[i], out string newLine))
+                {
+                    lines.Insert(i, newLine);
+                    lines.RemoveAt(i + 1);
+                }
+            }
+
+            SourceText newSourceText = sourceText.Replace(new TextSpan(0, sourceText.Length), string.Join(Environment.NewLine, lines) + DeclarePublicApiFix.GetEndOfFileText(sourceText));
+            return newSourceText;
+        }
+
+        private class FixAllAdditionalDocumentChangeAction : CodeAction
+        {
+            private readonly List<KeyValuePair<Project, ImmutableArray<Diagnostic>>> _diagnosticsToFix;
+            private readonly Solution _solution;
+
+            public FixAllAdditionalDocumentChangeAction(string title, Solution solution, List<KeyValuePair<Project, ImmutableArray<Diagnostic>>> diagnosticsToFix)
+            {
+                this.Title = title;
+                _solution = solution;
+                _diagnosticsToFix = diagnosticsToFix;
+            }
+
+            public override string Title { get; }
+
+            protected override async Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
+            {
+                var updatedPublicSurfaceAreaText = new List<KeyValuePair<DocumentId, SourceText>>();
+
+                foreach (KeyValuePair<Project, ImmutableArray<Diagnostic>> pair in _diagnosticsToFix)
+                {
+                    Project project = pair.Key;
+                    ImmutableArray<Diagnostic> diagnostics = pair.Value;
+
+                    TextDocument? unshippedDocument = DeclarePublicApiFix.GetUnshippedDocument(project);
+                    TextDocument? shippedDocument = GetShippedDocument(project);
+
+                    SourceText? unshippedSourceText = unshippedDocument is null ? null : await unshippedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                    SourceText? shippedSourceText = shippedDocument is null ? null : await shippedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                    IEnumerable<IGrouping<SyntaxTree, Diagnostic>> groupedDiagnostics =
+                        diagnostics
+                            .Where(d => d.Location.IsInSource)
+                            .GroupBy(d => d.Location.SourceTree);
+
+                    var shippedChanges = new Dictionary<string, string>();
+                    var unshippedChanges = new Dictionary<string, string>();
+
+                    foreach (IGrouping<SyntaxTree, Diagnostic> grouping in groupedDiagnostics)
+                    {
+                        Document document = project.GetDocument(grouping.Key);
+
+                        if (document == null)
+                        {
+                            continue;
+                        }
+
+                        SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+                        foreach (Diagnostic diagnostic in grouping)
+                        {
+                            string oldName = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiNamePropertyBagKey];
+                            string newName = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiNameWithNullabilityPropertyBagKey];
+                            bool isShipped = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiIsShippedPropertyBagKey] == "true";
+                            (isShipped ? shippedChanges : unshippedChanges).Add(oldName, newName);
+                        }
+                    }
+
+                    if (shippedSourceText is object)
+                    {
+                        SourceText newShippedSourceText = AnnotateSymbolNamesInSourceText(shippedSourceText, shippedChanges);
+                        updatedPublicSurfaceAreaText.Add(new KeyValuePair<DocumentId, SourceText>(shippedDocument!.Id, newShippedSourceText));
+                    }
+
+                    if (unshippedSourceText is object)
+                    {
+                        SourceText newUnshippedSourceText = AnnotateSymbolNamesInSourceText(unshippedSourceText, unshippedChanges);
+                        updatedPublicSurfaceAreaText.Add(new KeyValuePair<DocumentId, SourceText>(unshippedDocument!.Id, newUnshippedSourceText));
+                    }
+                }
+
+                Solution newSolution = _solution;
+
+                foreach (KeyValuePair<DocumentId, SourceText> pair in updatedPublicSurfaceAreaText)
+                {
+                    newSolution = newSolution.WithAdditionalDocumentText(pair.Key, pair.Value);
+                }
+
+                return newSolution;
+            }
+        }
+
+        private class PublicSurfaceAreaFixAllProvider : FixAllProvider
+        {
+            public override async Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
+            {
+                var diagnosticsToFix = new List<KeyValuePair<Project, ImmutableArray<Diagnostic>>>();
+                string? title;
+                switch (fixAllContext.Scope)
+                {
+                    case FixAllScope.Document:
+                        {
+                            ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(fixAllContext.Document).ConfigureAwait(false);
+                            diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(fixAllContext.Project, diagnostics));
+                            title = string.Format(CultureInfo.InvariantCulture, PublicApiAnalyzerResources.AddAllItemsInDocumentToThePublicApiTitle, fixAllContext.Document.Name);
+                            break;
+                        }
+
+                    case FixAllScope.Project:
+                        {
+                            Project project = fixAllContext.Project;
+                            ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+                            diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(fixAllContext.Project, diagnostics));
+                            title = string.Format(CultureInfo.InvariantCulture, PublicApiAnalyzerResources.AddAllItemsInProjectToThePublicApiTitle, fixAllContext.Project.Name);
+                            break;
+                        }
+
+                    case FixAllScope.Solution:
+                        {
+                            foreach (Project project in fixAllContext.Solution.Projects)
+                            {
+                                ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+                                diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(project, diagnostics));
+                            }
+
+                            title = PublicApiAnalyzerResources.AddAllItemsInTheSolutionToThePublicApiTitle;
+                            break;
+                        }
+
+                    case FixAllScope.Custom:
+                        return null;
+
+                    default:
+                        Debug.Fail($"Unknown FixAllScope '{fixAllContext.Scope}'");
+                        return null;
+                }
+
+                return new FixAllAdditionalDocumentChangeAction(title, fixAllContext.Solution, diagnosticsToFix);
+            }
+        }
+    }
+}

--- a/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 string publicSymbolNameWithNullability = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiNameWithNullabilityPropertyBagKey];
                 bool isShippedDocument = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiIsShippedPropertyBagKey] == "true";
 
-                TextDocument? document = isShippedDocument ? GetShippedDocument(project) : DeclarePublicApiFix.GetUnshippedDocument(project);
+                TextDocument? document = isShippedDocument ? DeclarePublicApiFix.GetShippedDocument(project) : DeclarePublicApiFix.GetUnshippedDocument(project);
 
                 if (document != null)
                 {
@@ -59,11 +59,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
                 return publicSurfaceAreaDocument.Project.Solution.WithAdditionalDocumentText(publicSurfaceAreaDocument.Id, newSourceText);
             }
-        }
-
-        private static TextDocument? GetShippedDocument(Project project)
-        {
-            return project.AdditionalDocuments.FirstOrDefault(doc => doc.Name.Equals(DeclarePublicApiAnalyzer.ShippedFileName, StringComparison.Ordinal));
         }
 
         private static SourceText AnnotateSymbolNamesInSourceText(SourceText sourceText, Dictionary<string, string> changes)
@@ -112,7 +107,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     ImmutableArray<Diagnostic> diagnostics = pair.Value;
 
                     TextDocument? unshippedDocument = DeclarePublicApiFix.GetUnshippedDocument(project);
-                    TextDocument? shippedDocument = GetShippedDocument(project);
+                    TextDocument? shippedDocument = DeclarePublicApiFix.GetShippedDocument(project);
 
                     SourceText? unshippedSourceText = unshippedDocument is null ? null : await unshippedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
                     SourceText? shippedSourceText = shippedDocument is null ? null : await shippedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
@@ -28,17 +28,15 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             return new PublicSurfaceAreaFixAllProvider();
         }
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             Project project = context.Document.Project;
             TextDocument publicSurfaceAreaDocument = GetPublicSurfaceAreaDocument(project);
             if (publicSurfaceAreaDocument == null)
             {
-                return;
+                return Task.CompletedTask;
             }
 
-            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            SemanticModel semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 string minimalSymbolName = diagnostic.Properties[DeclarePublicApiAnalyzer.MinimalNamePropertyBagKey];
@@ -53,6 +51,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                             c => GetFix(publicSurfaceAreaDocument, publicSurfaceAreaSymbolName, siblingSymbolNamesToRemove, c)),
                         diagnostic);
             }
+
+            return Task.CompletedTask;
         }
 
         private static TextDocument GetPublicSurfaceAreaDocument(Project project)

--- a/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             Project project = context.Document.Project;
-            TextDocument publicSurfaceAreaDocument = GetPublicSurfaceAreaDocument(project);
+            TextDocument publicSurfaceAreaDocument = GetUnshippedDocument(project);
             if (publicSurfaceAreaDocument == null)
             {
                 return Task.CompletedTask;
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             return Task.CompletedTask;
         }
 
-        private static TextDocument GetPublicSurfaceAreaDocument(Project project)
+        internal static TextDocument GetUnshippedDocument(Project project)
         {
             return project.AdditionalDocuments.FirstOrDefault(doc => doc.Name.Equals(DeclarePublicApiAnalyzer.UnshippedFileName, StringComparison.Ordinal));
         }
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             return newSourceText;
         }
 
-        private static List<string> GetLinesFromSourceText(SourceText sourceText)
+        internal static List<string> GetLinesFromSourceText(SourceText sourceText)
         {
             var lines = new List<string>();
 
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             return lastLine.Span.IsEmpty ? Environment.NewLine : string.Empty;
         }
 
-        private class AdditionalDocumentChangeAction : CodeAction
+        internal class AdditionalDocumentChangeAction : CodeAction
         {
             private readonly Func<CancellationToken, Task<Solution>> _createChangedAdditionalDocument;
 
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     Project project = pair.Key;
                     ImmutableArray<Diagnostic> diagnostics = pair.Value;
 
-                    TextDocument publicSurfaceAreaAdditionalDocument = GetPublicSurfaceAreaDocument(project);
+                    TextDocument publicSurfaceAreaAdditionalDocument = GetUnshippedDocument(project);
 
                     if (publicSurfaceAreaAdditionalDocument == null)
                     {

--- a/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
@@ -60,6 +60,11 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             return project.AdditionalDocuments.FirstOrDefault(doc => doc.Name.Equals(DeclarePublicApiAnalyzer.UnshippedFileName, StringComparison.Ordinal));
         }
 
+        internal static TextDocument? GetShippedDocument(Project project)
+        {
+            return project.AdditionalDocuments.FirstOrDefault(doc => doc.Name.Equals(DeclarePublicApiAnalyzer.ShippedFileName, StringComparison.Ordinal));
+        }
+
         private static async Task<Solution> GetFix(TextDocument publicSurfaceAreaDocument, string newSymbolName, ImmutableHashSet<string> siblingSymbolNamesToRemove, CancellationToken cancellationToken)
         {
             SourceText sourceText = await publicSurfaceAreaDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
@@ -218,6 +223,11 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
                         foreach (Diagnostic diagnostic in grouping)
                         {
+                            if (diagnostic.Id == DeclarePublicApiAnalyzer.ShouldAnnotateApiFilesRule.Id)
+                            {
+                                continue;
+                            }
+
                             string publicSurfaceAreaSymbolName = diagnostic.Properties[DeclarePublicApiAnalyzer.PublicApiNamePropertyBagKey];
 
                             newSymbolNames.Add(publicSurfaceAreaSymbolName);

--- a/src/PublicApiAnalyzers/Core/CodeFixes/NullableEnablePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/NullableEnablePublicApiFix.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                             Project project = fixAllContext.Project;
                             ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
                             diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(fixAllContext.Project, diagnostics));
-                            title = string.Format(CultureInfo.InvariantCulture, PublicApiAnalyzerResources.AddAllItemsInProjectToThePublicApiTitle, fixAllContext.Project.Name);
+                            title = string.Format(CultureInfo.InvariantCulture, PublicApiAnalyzerResources.EnableNullableInProjectToThePublicApiTitle, fixAllContext.Project.Name);
                             break;
                         }
 
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                                 diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(project, diagnostics));
                             }
 
-                            title = PublicApiAnalyzerResources.AddAllItemsInTheSolutionToThePublicApiTitle;
+                            title = PublicApiAnalyzerResources.EnableNullableInTheSolutionToThePublicApiTitle;
                             break;
                         }
 

--- a/src/PublicApiAnalyzers/Core/CodeFixes/NullableEnablePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/NullableEnablePublicApiFix.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+using DiagnosticIds = Roslyn.Diagnostics.Analyzers.RoslynDiagnosticIds;
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = "NullableEnablePublicApiFix"), Shared]
+    public sealed class NullableEnablePublicApiFix : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(DiagnosticIds.ShouldAnnotateApiFilesRuleId);
+
+        public sealed override FixAllProvider GetFixAllProvider()
+            => new PublicSurfaceAreaFixAllProvider();
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            Project project = context.Document.Project;
+
+            foreach (Diagnostic diagnostic in context.Diagnostics)
+            {
+                TextDocument? document = DeclarePublicApiFix.GetShippedDocument(project);
+
+                if (document != null)
+                {
+                    context.RegisterCodeFix(
+                            new DeclarePublicApiFix.AdditionalDocumentChangeAction(
+                                $"Add '#nullable enable' to public API",
+                                c => GetFix(document, c)),
+                            diagnostic);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static async Task<Solution> GetFix(TextDocument publicSurfaceAreaDocument, CancellationToken cancellationToken)
+        {
+            SourceText sourceText = await publicSurfaceAreaDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            SourceText newSourceText = AddNullableEnable(sourceText);
+
+            return publicSurfaceAreaDocument.Project.Solution.WithAdditionalDocumentText(publicSurfaceAreaDocument.Id, newSourceText);
+        }
+
+        private static SourceText AddNullableEnable(SourceText sourceText)
+        {
+            string extraLine = "#nullable enable" + Environment.NewLine;
+            SourceText newSourceText = sourceText.WithChanges(new TextChange(new TextSpan(0, 0), extraLine));
+            return newSourceText;
+        }
+
+        private class FixAllAdditionalDocumentChangeAction : CodeAction
+        {
+            private readonly List<KeyValuePair<Project, ImmutableArray<Diagnostic>>> _diagnosticsToFix;
+            private readonly Solution _solution;
+
+            public FixAllAdditionalDocumentChangeAction(string title, Solution solution, List<KeyValuePair<Project, ImmutableArray<Diagnostic>>> diagnosticsToFix)
+            {
+                this.Title = title;
+                _solution = solution;
+                _diagnosticsToFix = diagnosticsToFix;
+            }
+
+            public override string Title { get; }
+
+            protected override async Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
+            {
+                var updatedPublicSurfaceAreaText = new List<KeyValuePair<DocumentId, SourceText>>();
+
+                foreach (KeyValuePair<Project, ImmutableArray<Diagnostic>> pair in _diagnosticsToFix)
+                {
+                    Project project = pair.Key;
+                    TextDocument? shippedDocument = DeclarePublicApiFix.GetShippedDocument(project);
+                    SourceText? shippedSourceText = shippedDocument is null ? null : await shippedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                    if (shippedSourceText is object)
+                    {
+                        SourceText newShippedSourceText = AddNullableEnable(shippedSourceText);
+                        updatedPublicSurfaceAreaText.Add(new KeyValuePair<DocumentId, SourceText>(shippedDocument!.Id, newShippedSourceText));
+                    }
+                }
+
+                Solution newSolution = _solution;
+                foreach (KeyValuePair<DocumentId, SourceText> pair in updatedPublicSurfaceAreaText)
+                {
+                    newSolution = newSolution.WithAdditionalDocumentText(pair.Key, pair.Value);
+                }
+
+                return newSolution;
+            }
+        }
+
+        private class PublicSurfaceAreaFixAllProvider : FixAllProvider
+        {
+            public override async Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
+            {
+                var diagnosticsToFix = new List<KeyValuePair<Project, ImmutableArray<Diagnostic>>>();
+                string? title;
+                switch (fixAllContext.Scope)
+                {
+                    case FixAllScope.Document:
+                    case FixAllScope.Project:
+                        {
+                            Project project = fixAllContext.Project;
+                            ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+                            diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(fixAllContext.Project, diagnostics));
+                            title = string.Format(CultureInfo.InvariantCulture, PublicApiAnalyzerResources.AddAllItemsInProjectToThePublicApiTitle, fixAllContext.Project.Name);
+                            break;
+                        }
+
+                    case FixAllScope.Solution:
+                        {
+                            foreach (Project project in fixAllContext.Solution.Projects)
+                            {
+                                ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+                                diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(project, diagnostics));
+                            }
+
+                            title = PublicApiAnalyzerResources.AddAllItemsInTheSolutionToThePublicApiTitle;
+                            break;
+                        }
+
+                    case FixAllScope.Custom:
+                        return null;
+
+                    default:
+                        Debug.Fail($"Unknown FixAllScope '{fixAllContext.Scope}'");
+                        return null;
+                }
+
+                return new FixAllAdditionalDocumentChangeAction(title, fixAllContext.Solution, diagnosticsToFix);
+            }
+        }
+    }
+}

--- a/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
@@ -61,6 +61,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
 
         #region Fix tests
 
+        // TODO2 test fix all
         [Fact]
         public async Task DoNotAnnotateMemberInUnannotatedUnshippedAPI()
         {

--- a/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
@@ -64,21 +64,38 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
         #region Fix tests
 
         [Fact]
-        public async Task DoNotAnnotateMemberInUnannotatedUnshippedAPI()
+        public async Task DoNotAnnotateMemberInUnannotatedUnshippedAPI_Nullable()
         {
             var source = @"
 #nullable enable
 public class C
 {
-    public string? Field;
-    public string Field2;
+    public string? {|RS0037:Field|};
 }
 ";
 
             var shippedText = @"";
             var unshippedText = @"C
 C.C() -> void
-C.Field -> string
+C.Field -> string";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText, System.Array.Empty<DiagnosticResult>());
+        }
+
+        [Fact]
+        public async Task DoNotAnnotateMemberInUnannotatedUnshippedAPI_NonNullable()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string {|RS0037:Field2|};
+}
+";
+
+            var shippedText = @"";
+            var unshippedText = @"C
+C.C() -> void
 C.Field2 -> string";
 
             await VerifyCSharpAsync(source, shippedText, unshippedText, System.Array.Empty<DiagnosticResult>());
@@ -91,8 +108,8 @@ C.Field2 -> string";
 #nullable enable
 public class C
 {
-    public string? Field;
-    public string Field2;
+    public string? {|RS0037:Field|};
+    public string {|RS0037:Field2|};
 }
 ";
 

--- a/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
@@ -61,7 +61,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
 
         #region Fix tests
 
-        // TODO2 test fix all
         [Fact]
         public async Task DoNotAnnotateMemberInUnannotatedUnshippedAPI()
         {

--- a/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
@@ -69,14 +69,15 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
 public class C
 {
     public string? Field;
-    //public string Field2; // TODO2
+    public string Field2;
 }
 ";
 
             var shippedText = @"";
             var unshippedText = @"C
 C.C() -> void
-C.Field -> string";
+C.Field -> string
+C.Field2 -> string";
 
             await VerifyCSharpAsync(source, shippedText, unshippedText, System.Array.Empty<DiagnosticResult>());
         }
@@ -89,13 +90,14 @@ C.Field -> string";
 public class C
 {
     public string? Field;
-    //public string Field2; // TODO2
+    public string Field2;
 }
 ";
 
             var shippedText = @"C
 C.C() -> void
-C.Field -> string";
+C.Field -> string
+C.Field2 -> string";
             var unshippedText = @"";
 
             await VerifyCSharpAsync(source, shippedText, unshippedText, System.Array.Empty<DiagnosticResult>());
@@ -110,7 +112,7 @@ public class C
 {
     public string? OldField;
     public string? {|RS0036:Field|};
-    //public string Field2; // TODO2
+    public string {|RS0036:Field2|};
 }
 ";
 
@@ -118,7 +120,8 @@ public class C
 C
 C.C() -> void
 C.OldField -> string?
-C.Field -> string";
+C.Field -> string
+C.Field2 -> string";
 
             var unshippedText = @"";
 
@@ -126,7 +129,8 @@ C.Field -> string";
 C
 C.C() -> void
 C.OldField -> string?
-C.Field -> string?";
+C.Field -> string?
+C.Field2 -> string!";
 
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedShippedText, newUnshippedApiText: unshippedText);
         }
@@ -140,7 +144,7 @@ public class C
 {
     public string? OldField;
     public string? {|RS0036:Field|};
-    //public string Field2; // TODO2
+    public string {|RS0036:Field2|};
 }
 ";
 
@@ -148,12 +152,14 @@ public class C
             var unshippedText = @"C
 C.C() -> void
 C.OldField -> string?
-C.Field -> string";
+C.Field -> string
+C.Field2 -> string";
 
             var fixedUnshippedText = @"C
 C.C() -> void
 C.OldField -> string?
-C.Field -> string?";
+C.Field -> string?
+C.Field2 -> string!";
 
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, newShippedApiText: shippedText, fixedUnshippedText);
         }

--- a/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#pragma warning disable CA1305
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
+{
+    public class AnnotatePublicApiAnalyzerTests
+    {
+        private async Task VerifyCSharpAsync(string source, string shippedApiText, string unshippedApiText, params DiagnosticResult[] expected)
+        {
+            var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, AnnotatePublicApiFix, XUnitVerifier>
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { },
+                },
+                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
+            };
+
+            if (shippedApiText != null)
+            {
+                test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.ShippedFileName, shippedApiText));
+            }
+
+            if (unshippedApiText != null)
+            {
+                test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.UnshippedFileName, unshippedApiText));
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync();
+        }
+
+        private async Task VerifyCSharpAdditionalFileFixAsync(string source, string oldShippedApiText, string oldUnshippedApiText, string newShippedApiText, string newUnshippedApiText)
+        {
+            await VerifyAdditionalFileFixAsync(source, oldShippedApiText, oldUnshippedApiText, newShippedApiText, newUnshippedApiText);
+        }
+
+        private async Task VerifyAdditionalFileFixAsync(string source, string oldShippedApiText, string oldUnshippedApiText, string newShippedApiText, string newUnshippedApiText)
+        {
+            var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, AnnotatePublicApiFix, XUnitVerifier>();
+
+            test.TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
+
+            test.TestState.Sources.Add(source);
+            test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.ShippedFileName, oldShippedApiText));
+            test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.UnshippedFileName, oldUnshippedApiText));
+
+            test.FixedState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.ShippedFileName, newShippedApiText));
+            test.FixedState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.UnshippedFileName, newUnshippedApiText));
+
+            await test.RunAsync();
+        }
+
+        #region Fix tests
+
+        [Fact]
+        public async Task DoNotAnnotateMemberInUnannotatedUnshippedAPI()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? Field;
+    //public string Field2; // TODO2
+}
+";
+
+            var shippedText = @"";
+            var unshippedText = @"C
+C.C() -> void
+C.Field -> string";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText, System.Array.Empty<DiagnosticResult>());
+        }
+
+        [Fact]
+        public async Task DoNotAnnotateMemberInUnannotatedShippedAPI()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? Field;
+    //public string Field2; // TODO2
+}
+";
+
+            var shippedText = @"C
+C.C() -> void
+C.Field -> string";
+            var unshippedText = @"";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText, System.Array.Empty<DiagnosticResult>());
+        }
+
+        [Fact]
+        public async Task AnnotatedMemberInAnnotatedShippedAPI()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? OldField;
+    public string? {|RS0036:Field|};
+    //public string Field2; // TODO2
+}
+";
+
+            var shippedText = @"#nullable enable
+C
+C.C() -> void
+C.OldField -> string?
+C.Field -> string";
+
+            var unshippedText = @"";
+
+            var fixedShippedText = @"#nullable enable
+C
+C.C() -> void
+C.OldField -> string?
+C.Field -> string?";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedShippedText, newUnshippedApiText: unshippedText);
+        }
+
+        [Fact]
+        public async Task AnnotatedMemberInAnnotatedUnshippedAPI()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? OldField;
+    public string? {|RS0036:Field|};
+    //public string Field2; // TODO2
+}
+";
+
+            var shippedText = @"#nullable enable";
+            var unshippedText = @"C
+C.C() -> void
+C.OldField -> string?
+C.Field -> string";
+
+            var fixedUnshippedText = @"C
+C.C() -> void
+C.OldField -> string?
+C.Field -> string?";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, newShippedApiText: shippedText, fixedUnshippedText);
+        }
+
+        #endregion
+    }
+}

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -1008,7 +1008,7 @@ public class C
         }
 
         [Fact]
-        public async Task ApiFileUnshippedWithNullableEnable()
+        public async Task ApiFileUnshippedWithDuplicateNullableEnable()
         {
             var source = @"
 public class C
@@ -1019,6 +1019,7 @@ public class C
             string shippedText = $@"";
 
             string unshippedText = $@"
+{DeclarePublicApiAnalyzer.NullableEnable}
 {DeclarePublicApiAnalyzer.NullableEnable}
 ";
 

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -967,6 +967,26 @@ C.NewField -> string?";
         }
 
         [Fact]
+        public async Task TestAddAndRemoveMembers_CSharp_Fix_WithRemovedNullability()
+        {
+            var source = @"
+public class C
+{
+    public string {|RS0016:ChangedField|}; // oblivious
+}
+";
+            var shippedText = $@"{DeclarePublicApiAnalyzer.NullableEnable}";
+            var unshippedText = @"C
+C.C() -> void
+{|RS0017:C.ChangedField -> string?|}";
+            var fixedUnshippedText = @"C
+C.C() -> void
+C.ChangedField -> string";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [Fact]
         public async Task ApiFileShippedWithDuplicateNullableEnable()
         {
             var source = @"
@@ -1086,7 +1106,6 @@ C2.C2() -> void";
         [Fact]
         public async Task TestChangingMethodSignatureForAnUnshippedMethod_Fix()
         {
-            // TODO2 test this with nullability
             var source = @"
 public class C
 {
@@ -1099,6 +1118,26 @@ public class C
             // previously method had no params, so the fix should remove the previous overload.
             var unshippedText = @"{|RS0017:C.Method() -> void|}";
             var fixedUnshippedText = @"C.Method(int p1) -> void";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [Fact]
+        public async Task TestChangingMethodSignatureForAnUnshippedMethod_Fix_WithNullability()
+        {
+            var source = @"
+public class C
+{
+    private C() { }
+    public void {|RS0016:Method|}(object? p1){ }
+}
+";
+
+            var shippedText = $@"{DeclarePublicApiAnalyzer.NullableEnable}
+C";
+            // previously method had no params, so the fix should remove the previous overload.
+            var unshippedText = @"{|RS0017:C.Method(string p1) -> void|}";
+            var fixedUnshippedText = @"C.Method(object? p1) -> void";
 
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
         }

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -927,7 +927,6 @@ C.Property.set -> void";
         [Fact]
         public async Task TestSimpleMissingMember_Fix_WithoutNullability()
         {
-            // TODO2
             var source = @"
 #nullable enable
 public class C
@@ -1026,27 +1025,6 @@ public class C
 
             var expected = new DiagnosticResult(DeclarePublicApiAnalyzer.PublicApiFilesInvalid)
                 .WithArguments(DeclarePublicApiAnalyzer.InvalidReasonMisplacedNullableEnable);
-            await VerifyCSharpAsync(source, shippedText, unshippedText, expected);
-        }
-
-        [Fact]
-        public async Task ApiFileShippedWithoutNullableEnable()
-        {
-            var source = @"
-#nullable enable
-public class C
-{
-    public string? {|RS0037:NewField|}; // Should add '#nullable enable' to PublicAPI.txt
-    public string {|RS0037:NewField2|}; // Should add '#nullable enable' to PublicAPI.txt
-}
-";
-
-            string shippedText = $@"";
-
-            string unshippedText = $@"";
-
-            // TODO2
-            var expected = new DiagnosticResult(DeclarePublicApiAnalyzer.ShouldAnnotateApiFilesRule);
             await VerifyCSharpAsync(source, shippedText, unshippedText, expected);
         }
 

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -925,6 +925,27 @@ C.Property.set -> void";
         }
 
         [Fact]
+        public async Task TestSimpleMissingMember_Fix_WithNullability()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? {|RS0016:NewField|}; // Newly added field, not in current public API.
+}
+";
+
+            var shippedText = @"";
+            var unshippedText = @"C
+C.C() -> void";
+            var fixedUnshippedText = @"C
+C.C() -> void
+C.NewField -> string?";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [Fact]
         public async Task TestAddAndRemoveMembers_CSharp_Fix()
         {
             // Unshipped file has a state 'ObsoleteField' entry and a missing 'NewField' entry.
@@ -956,6 +977,46 @@ C.Method() -> void
 C.NewField -> int
 C.Property.get -> int
 C.Property.set -> void";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [Fact]
+        public async Task TestAddAndRemoveMembers_CSharp_Fix_WithRemovedNullability()
+        {
+            var source = @"
+public class C
+{
+    public string {|RS0016:ChangedField|};
+}
+";
+            var shippedText = @"";
+            var unshippedText = @"C
+C.C() -> void
+{|RS0017:C.ChangedField -> string?|}";
+            var fixedUnshippedText = @"C
+C.C() -> void
+C.ChangedField -> string";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [Fact]
+        public async Task TestAddAndRemoveMembers_CSharp_Fix_WithAddedNullability()
+        {
+            var source = @"
+public class C
+{
+    public string? {|RS0016:ChangedField|};
+}
+";
+            var shippedText = @"";
+            var unshippedText = @"C
+C.C() -> void
+{|RS0017:C.ChangedField -> string|}";
+            var fixedUnshippedText = @"C
+C.C() -> void
+C.ChangedField -> string?";
 
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
         }

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -1086,6 +1086,7 @@ C2.C2() -> void";
         [Fact]
         public async Task TestChangingMethodSignatureForAnUnshippedMethod_Fix()
         {
+            // TODO2 test this with nullability
             var source = @"
 public class C
 {

--- a/src/PublicApiAnalyzers/UnitTests/Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests.csproj
+++ b/src/PublicApiAnalyzers/UnitTests/Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.5.0-beta2-19619-02" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Test.Utilities\Test.Utilities.csproj" />

--- a/src/PublicApiAnalyzers/UnitTests/Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests.csproj
+++ b/src/PublicApiAnalyzers/UnitTests/Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.5.0-beta2-19619-02" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Test.Utilities\Test.Utilities.csproj" />

--- a/src/PublicApiAnalyzers/UnitTests/Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests.csproj
+++ b/src/PublicApiAnalyzers/UnitTests/Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisForShippedApisVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Test.Utilities\Test.Utilities.csproj" />

--- a/src/PublicApiAnalyzers/UnitTests/NullableEnablePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/NullableEnablePublicApiAnalyzerTests.cs
@@ -1,0 +1,207 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#pragma warning disable CA1305
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
+{
+    public class NullableEnablePublicApiAnalyzerTests
+    {
+        #region Utilities
+        private async Task VerifyCSharpAsync(string source, string shippedApiText, string unshippedApiText, params DiagnosticResult[] expected)
+        {
+            var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, NullableEnablePublicApiFix, XUnitVerifier>
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { },
+                },
+                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
+            };
+
+            if (shippedApiText != null)
+            {
+                test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.ShippedFileName, shippedApiText));
+            }
+
+            if (unshippedApiText != null)
+            {
+                test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.UnshippedFileName, unshippedApiText));
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync();
+        }
+
+        private async Task VerifyCSharpAdditionalFileFixAsync(string source, string oldShippedApiText, string oldUnshippedApiText, string newSource, string newShippedApiText, string newUnshippedApiText)
+        {
+            await VerifyAdditionalFileFixAsync(source, oldShippedApiText, oldUnshippedApiText, newSource, newShippedApiText, newUnshippedApiText);
+        }
+
+        private async Task VerifyAdditionalFileFixAsync(string source, string oldShippedApiText, string oldUnshippedApiText, string newSource, string newShippedApiText, string newUnshippedApiText)
+        {
+            var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, NullableEnablePublicApiFix, XUnitVerifier>();
+
+            test.TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
+
+            test.TestState.Sources.Add(source);
+            test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.ShippedFileName, oldShippedApiText));
+            test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.UnshippedFileName, oldUnshippedApiText));
+
+            test.FixedState.Sources.Add(newSource);
+            test.FixedState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.ShippedFileName, newShippedApiText));
+            test.FixedState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.UnshippedFileName, newUnshippedApiText));
+
+            await test.RunAsync();
+        }
+        #endregion
+
+        #region Fix tests
+
+        [Fact]
+        public async Task NullableEnableShippedAPI_NullableMember()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? {|RS0037:Field|};
+}
+";
+
+            var shippedText = @"";
+            var unshippedText = @"C
+C.C() -> void
+C.Field -> string";
+
+            // The source is unchanged, but a new diagnostic appears
+            var newSource = @"
+#nullable enable
+public class C
+{
+    public string? {|RS0036:Field|};
+}
+";
+            var fixedShippedText = @"#nullable enable
+";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, newSource, fixedShippedText, newUnshippedApiText: unshippedText);
+        }
+
+        [Fact]
+        public async Task NullableEnableShippedAPI_NonNullableMember()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string {|RS0037:Field2|};
+}
+";
+
+            var shippedText = @"";
+            var unshippedText = @"C
+C.C() -> void
+C.Field2 -> string";
+
+            // The source is unchanged, but a new diagnostic appears
+            var newSource = @"
+#nullable enable
+public class C
+{
+    public string {|RS0036:Field2|};
+}
+";
+
+            var fixedShippedText = @"#nullable enable
+";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, newSource, fixedShippedText, newUnshippedApiText: unshippedText);
+        }
+
+        [Fact]
+        public async Task NullableEnableShippedAPI_NonEmptyFile()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? {|RS0037:Field|};
+}
+";
+
+            var shippedText = @"C
+C.C() -> void
+C.Field -> string";
+            var unshippedText = @"";
+
+            var newSource = @"
+#nullable enable
+public class C
+{
+    public string? {|RS0036:Field|};
+}
+";
+
+            var fixedShippedText = @"#nullable enable
+C
+C.C() -> void
+C.Field -> string";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, newSource, fixedShippedText, newUnshippedApiText: unshippedText);
+        }
+
+        [Fact]
+        public async Task DoNotWarnIfAlreadyEnabled_ViaUnshippedFile()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? {|RS0036:Field|};
+    public string {|RS0036:Field2|};
+}
+";
+
+            var shippedText = @"C
+C.C() -> void
+C.Field -> string
+C.Field2 -> string";
+
+            var unshippedText = @"#nullable enable";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        [Fact]
+        public async Task DoNotWarnIfAlreadyEnabled_ViaShippedFile()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? {|RS0036:Field|};
+    public string {|RS0036:Field2|};
+}
+";
+
+            var shippedText = @"#nullable enable
+C
+C.C() -> void
+C.Field -> string
+C.Field2 -> string";
+
+            var unshippedText = @"";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        #endregion
+    }
+}

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
@@ -39,5 +39,6 @@ namespace Roslyn.Diagnostics.Analyzers
         public const string ImportingConstructorShouldBeObsoleteRuleId = "RS0033";
         public const string ExportedPartsShouldHaveImportingConstructorRuleId = "RS0034";
         public const string RestrictedInternalsVisibleToRuleId = "RS0035";
+        public const string AnnotatePublicApiRuleId = "RS0036";
     }
 }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
@@ -40,5 +40,6 @@ namespace Roslyn.Diagnostics.Analyzers
         public const string ExportedPartsShouldHaveImportingConstructorRuleId = "RS0034";
         public const string RestrictedInternalsVisibleToRuleId = "RS0035";
         public const string AnnotatePublicApiRuleId = "RS0036";
+        public const string ShouldAnnotateApiFilesRuleId = "RS0037";
     }
 }


### PR DESCRIPTION
This PR adds `?` annotations to public APIs.
Before we can add `!` annotations, we need the compiler to expose an internal flag. I'll get that going.

I didn't manage to update the reference to `CodeAnalysis.Common`, so couldn't use `SymbolDisplayMiscellaneousOptions)IncludeNullableReferenceTypeModifier` enum value.


Relates to https://github.com/dotnet/roslyn/issues/40502 (Shipped APIs files should include nullable annotations)