### PR TITLE
Update CA1822: Do not report for web specific methods

### DIFF
--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -156,7 +157,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 return false;
             }
 
-            if (IsSkippedMethod(methodSymbol))
+            if (IsSkippedMethod(methodSymbol, wellKnownTypeProvider))
             {
                 return false;
             }
@@ -284,7 +285,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             return builder?.ToImmutable() ?? ImmutableArray<INamedTypeSymbol>.Empty;
         }
 
-        private static bool IsSkippedMethod(IMethodSymbol methodSymbol)
+        private static bool IsSkippedMethod(IMethodSymbol methodSymbol, WellKnownTypeProvider wellKnownTypeProvider)
         {
             if (methodSymbol.IsConstructor() || methodSymbol.IsFinalizer())
             {
@@ -293,7 +294,8 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
             if (methodSymbol.ReturnsVoid &&
                 methodSymbol.Parameters.IsEmpty &&
-                (methodSymbol.Name == "Application_Start" || methodSymbol.Name == "Application_End"))
+                (methodSymbol.Name == "Application_Start" || methodSymbol.Name == "Application_End") &&
+                methodSymbol.ContainingType.Inherits(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebHttpApplication)))
             {
                 return true;
             }

--- a/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/Core/QualityGuidelines/MarkMembersAsStatic.cs
@@ -62,12 +62,14 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 var internalCandidates = new HashSet<IMethodSymbol>();
                 var invokedInternalMethods = new HashSet<IMethodSymbol>();
 
-                // Get all the possible attributes for a test method
-                ImmutableArray<INamedTypeSymbol> skippedAttributes = GetSkippedAttributes(compilationContext.Compilation);
+                var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(compilationContext.Compilation);
+
+                // Get the list of all method' attributes for which the rule shall not be triggered.
+                ImmutableArray<INamedTypeSymbol> skippedAttributes = GetSkippedAttributes(wellKnownTypeProvider);
 
                 compilationContext.RegisterOperationBlockStartAction(blockStartContext =>
                 {
-                    if (!(blockStartContext.OwningSymbol is IMethodSymbol methodSymbol) || !ShouldAnalyze(methodSymbol, blockStartContext.Compilation, skippedAttributes))
+                    if (!(blockStartContext.OwningSymbol is IMethodSymbol methodSymbol) || !ShouldAnalyze(methodSymbol, wellKnownTypeProvider, skippedAttributes))
                     {
                         return;
                     }
@@ -145,7 +147,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             });
         }
 
-        private static bool ShouldAnalyze(IMethodSymbol methodSymbol, Compilation compilation, ImmutableArray<INamedTypeSymbol> skippedAttributes)
+        private static bool ShouldAnalyze(IMethodSymbol methodSymbol, WellKnownTypeProvider wellKnownTypeProvider, ImmutableArray<INamedTypeSymbol> skippedAttributes)
         {
             // Modifiers that we don't care about
             if (methodSymbol.IsStatic || methodSymbol.IsOverride || methodSymbol.IsVirtual ||
@@ -154,7 +156,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 return false;
             }
 
-            if (methodSymbol.IsConstructor() || methodSymbol.IsFinalizer())
+            if (IsSkippedMethod(methodSymbol))
             {
                 return false;
             }
@@ -176,13 +178,13 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             // so we can flag the associated event if none of it's accessors need instance reference.
             if (methodSymbol.Parameters.Length == 2 &&
                 methodSymbol.Parameters[0].Type.SpecialType == SpecialType.System_Object &&
-                IsEventArgs(methodSymbol.Parameters[1].Type, compilation) &&
+                IsEventArgs(methodSymbol.Parameters[1].Type, wellKnownTypeProvider) &&
                 methodSymbol.MethodKind != MethodKind.EventRaise)
             {
                 return false;
             }
 
-            if (IsExplicitlyVisibleFromCom(methodSymbol, compilation))
+            if (IsExplicitlyVisibleFromCom(methodSymbol, wellKnownTypeProvider))
             {
                 return false;
             }
@@ -190,9 +192,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             return true;
         }
 
-        private static bool IsEventArgs(ITypeSymbol type, Compilation compilation)
+        private static bool IsEventArgs(ITypeSymbol type, WellKnownTypeProvider wellKnownTypeProvider)
         {
-            if (type.DerivesFrom(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemEventArgs)))
+            if (type.DerivesFrom(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemEventArgs)))
             {
                 return true;
             }
@@ -205,14 +207,14 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             return false;
         }
 
-        private static bool IsExplicitlyVisibleFromCom(IMethodSymbol methodSymbol, Compilation compilation)
+        private static bool IsExplicitlyVisibleFromCom(IMethodSymbol methodSymbol, WellKnownTypeProvider wellKnownTypeProvider)
         {
             if (!methodSymbol.IsExternallyVisible() || methodSymbol.IsGenericMethod)
             {
                 return false;
             }
 
-            var comVisibleAttribute = compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeInteropServicesComVisibleAttribute);
+            var comVisibleAttribute = wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeInteropServicesComVisibleAttribute);
             if (comVisibleAttribute == null)
             {
                 return false;
@@ -227,7 +229,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             return false;
         }
 
-        private static ImmutableArray<INamedTypeSymbol> GetSkippedAttributes(Compilation compilation)
+        private static ImmutableArray<INamedTypeSymbol> GetSkippedAttributes(WellKnownTypeProvider wellKnownTypeProvider)
         {
             ImmutableArray<INamedTypeSymbol>.Builder? builder = null;
 
@@ -240,28 +242,63 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 }
             }
 
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebServicesWebMethodAttribute));
+            // Web attributes
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebServicesWebMethodAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebMvcHttpGetAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebMvcHttpPostAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebMvcHttpPutAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebMvcHttpDeleteAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebMvcHttpPatchAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebMvcHttpHeadAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebMvcHttpOptionsAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemWebHttpRouteAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcHttpDeleteAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcHttpGetAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcHttpPostAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcHttpPutAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcHttpHeadAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcHttpPatchAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcHttpOptionsAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcRouteAttribute));
+
 
             // MSTest attributes
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestInitializeAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestMethodAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingDataTestMethodAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestCleanupAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestInitializeAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestMethodAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingDataTestMethodAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestCleanupAttribute));
 
             // XUnit attributes
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.XunitFactAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.XunitFactAttribute));
 
             // NUnit Attributes
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkSetUpAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkOneTimeSetUpAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkOneTimeTearDownAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTestAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTestCaseAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTestCaseSourceAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTheoryAttribute));
-            Add(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTearDownAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkSetUpAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkOneTimeSetUpAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkOneTimeTearDownAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTestAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTestCaseAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTestCaseSourceAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTheoryAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkTearDownAttribute));
 
             return builder?.ToImmutable() ?? ImmutableArray<INamedTypeSymbol>.Empty;
+        }
+
+        private static bool IsSkippedMethod(IMethodSymbol methodSymbol)
+        {
+            if (methodSymbol.IsConstructor() || methodSymbol.IsFinalizer())
+            {
+                return true;
+            }
+
+            if (methodSymbol.ReturnsVoid &&
+                methodSymbol.Parameters.IsEmpty &&
+                (methodSymbol.Name == "Application_Start" || methodSymbol.Name == "Application_End"))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -915,6 +915,45 @@ public class C
     protected void Application_Start() { }
     protected void Application_End() { }
 }");
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Imports System
+
+Public Class C
+    Protected Sub Application_Start(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+
+    Protected Sub Application_AuthenticateRequest(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+
+    Protected Sub Application_BeginRequest(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+
+    Protected Sub Application_EndRequest(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+
+    Protected Sub Application_Error(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+
+    Protected Sub Application_End(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+
+    Protected Sub Application_Init(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+
+    Protected Sub Session_End(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+
+    Protected Sub Session_Start(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+
+    Protected Sub Application_Start()
+    End Sub
+
+    Protected Sub Application_End()
+    End Sub
+End Class
+");
         }
 
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)

--- a/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/Microsoft.CodeQuality.Analyzers/UnitTests/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -735,6 +735,188 @@ namespace Foo
 }");
         }
 
+        [Theory, WorkItem(3123, "https://github.com/dotnet/roslyn-analyzers/issues/3123")]
+        [InlineData("System.Web.Mvc.HttpGetAttribute")]
+        [InlineData("System.Web.Mvc.HttpPostAttribute")]
+        [InlineData("System.Web.Mvc.HttpPutAttribute")]
+        [InlineData("System.Web.Mvc.HttpDeleteAttribute")]
+        [InlineData("System.Web.Mvc.HttpPatchAttribute")]
+        [InlineData("System.Web.Mvc.HttpHeadAttribute")]
+        [InlineData("System.Web.Mvc.HttpOptionsAttribute")]
+        [InlineData("System.Web.Http.RouteAttribute")]
+        [InlineData("Microsoft.AspNetCore.Mvc.HttpGetAttribute")]
+        [InlineData("Microsoft.AspNetCore.Mvc.HttpPostAttribute")]
+        [InlineData("Microsoft.AspNetCore.Mvc.HttpPutAttribute")]
+        [InlineData("Microsoft.AspNetCore.Mvc.HttpDeleteAttribute")]
+        [InlineData("Microsoft.AspNetCore.Mvc.HttpPatchAttribute")]
+        [InlineData("Microsoft.AspNetCore.Mvc.HttpHeadAttribute")]
+        [InlineData("Microsoft.AspNetCore.Mvc.HttpOptionsAttribute")]
+        [InlineData("Microsoft.AspNetCore.Mvc.RouteAttribute")]
+        public async Task NoDiagnostic_WebAttributes(string webAttribute)
+        {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
+public class C
+{{
+    [{webAttribute}]
+    public void Method1()
+    {{
+    }}
+}}",
+                        @"
+using System;
+
+namespace System.Web.Mvc
+{
+    public class HttpGetAttribute : Attribute {}
+    public class HttpPostAttribute : Attribute {}
+    public class HttpPutAttribute : Attribute {}
+    public class HttpDeleteAttribute : Attribute {}
+    public class HttpPatchAttribute : Attribute {}
+    public class HttpHeadAttribute : Attribute {}
+    public class HttpOptionsAttribute : Attribute {}
+}
+
+namespace System.Web.Http
+{
+    public class RouteAttribute : Attribute {}
+}
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    public class HttpGetAttribute : Attribute {}
+    public class HttpPostAttribute : Attribute {}
+    public class HttpPutAttribute : Attribute {}
+    public class HttpDeleteAttribute : Attribute {}
+    public class HttpPatchAttribute : Attribute {}
+    public class HttpHeadAttribute : Attribute {}
+    public class HttpOptionsAttribute : Attribute {}
+    public class RouteAttribute : Attribute {}
+}"
+                    }
+                }
+            }.RunAsync();
+
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        $@"
+Public Class C
+    <{webAttribute}>
+    Public Sub Method1()
+    End Sub
+End Class",
+                        @"
+Imports System
+
+Namespace System.Web.Mvc
+    Public Class HttpGetAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpPostAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpPutAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpDeleteAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpPatchAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpHeadAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpOptionsAttribute
+        Inherits Attribute
+    End Class
+End Namespace
+
+Namespace System.Web.Http
+    Public Class RouteAttribute
+        Inherits Attribute
+    End Class
+End Namespace
+
+Namespace Microsoft.AspNetCore.Mvc
+    Public Class HttpGetAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpPostAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpPutAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpDeleteAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpPatchAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpHeadAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class HttpOptionsAttribute
+        Inherits Attribute
+    End Class
+
+    Public Class RouteAttribute
+        Inherits Attribute
+    End Class
+End Namespace"
+                    }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task WebSpecificControllerMethods_NoDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+
+public class C
+{
+    // The following methods are detected as event handler and so won't
+    // trigger a diagnostic
+    protected void Application_Start(object sender, EventArgs e) { }
+    protected void Application_AuthenticateRequest(object sender, EventArgs e) { }
+    protected void Application_BeginRequest(object sender, EventArgs e) { }
+    protected void Application_EndRequest(object sender, EventArgs e) { }
+    protected void Application_Error(object sender, EventArgs e) { }
+    protected void Application_End(object sender, EventArgs e) { }
+    protected void Application_Init(object sender, EventArgs e) { }
+    protected void Session_End(object sender, EventArgs e) { }
+    protected void Session_Start(object sender, EventArgs e) { }
+
+    // The following controller methods can't be made static
+    protected void Application_Start() { }
+    protected void Application_End() { }
+}");
+        }
+
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
         {
             return VerifyCS.Diagnostic().WithLocation(line, column).WithArguments(symbolName);

--- a/src/Test.Utilities/AdditionalMetadataReferences.cs
+++ b/src/Test.Utilities/AdditionalMetadataReferences.cs
@@ -26,9 +26,6 @@ namespace Test.Utilities
         public static ReferenceAssemblies DefaultWithNewtonsoftJson { get; } = Default
             .AddPackages(ImmutableArray.Create(new PackageIdentity("Newtonsoft.Json", "10.0.1")));
 
-        public static ReferenceAssemblies DefaultWithAspNetCoreMvc { get; } = Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.AspNetCore.Mvc", "2.2.0")));
-
         public static MetadataReference SystemCollectionsImmutableReference { get; } = MetadataReference.CreateFromFile(typeof(ImmutableHashSet<>).Assembly.Location);
         public static MetadataReference SystemComponentModelCompositionReference { get; } = MetadataReference.CreateFromFile(typeof(System.ComponentModel.Composition.ExportAttribute).Assembly.Location);
         public static MetadataReference SystemCompositionReference { get; } = MetadataReference.CreateFromFile(typeof(System.Composition.ExportAttribute).Assembly.Location);

--- a/src/Test.Utilities/AdditionalMetadataReferences.cs
+++ b/src/Test.Utilities/AdditionalMetadataReferences.cs
@@ -26,6 +26,9 @@ namespace Test.Utilities
         public static ReferenceAssemblies DefaultWithNewtonsoftJson { get; } = Default
             .AddPackages(ImmutableArray.Create(new PackageIdentity("Newtonsoft.Json", "10.0.1")));
 
+        public static ReferenceAssemblies DefaultWithAspNetCoreMvc { get; } = Default
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.AspNetCore.Mvc", "2.2.0")));
+
         public static MetadataReference SystemCollectionsImmutableReference { get; } = MetadataReference.CreateFromFile(typeof(ImmutableHashSet<>).Assembly.Location);
         public static MetadataReference SystemComponentModelCompositionReference { get; } = MetadataReference.CreateFromFile(typeof(System.ComponentModel.Composition.ExportAttribute).Assembly.Location);
         public static MetadataReference SystemCompositionReference { get; } = MetadataReference.CreateFromFile(typeof(System.Composition.ExportAttribute).Assembly.Location);

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -459,5 +459,6 @@ namespace Analyzer.Utilities
         public const string MicrosoftAspNetCoreMvcHttpHeadAttribute = "Microsoft.AspNetCore.Mvc.HttpHeadAttribute";
         public const string MicrosoftAspNetCoreMvcHttpOptionsAttribute = "Microsoft.AspNetCore.Mvc.HttpOptionsAttribute";
         public const string MicrosoftAspNetCoreMvcRouteAttribute = "Microsoft.AspNetCore.Mvc.RouteAttribute";
+        public const string SystemWebHttpApplication = "System.Web.HttpApplication";
     }
 }

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -452,5 +452,12 @@ namespace Analyzer.Utilities
         public const string SystemRuntimeInteropServicesCoClassAttribute = "System.Runtime.InteropServices.CoClassAttribute";
         public const string SystemIProgress1 = "System.IProgress`1";
         public const string SystemComponentModelDesignerAttribute = "System.ComponentModel.DesignerAttribute";
+        public const string SystemWebHttpRouteAttribute = "System.Web.Http.RouteAttribute";
+        public const string SystemWebMvcHttpHeadAttribute = "System.Web.Mvc.HttpHeadAttribute";
+        public const string SystemWebMvcHttpOptionsAttribute = "System.Web.Mvc.HttpOptionsAttribute";
+        public const string MicrosoftAspNetCoreMvcHttpGetAttribute = "Microsoft.AspNetCore.Mvc.HttpGetAttribute";
+        public const string MicrosoftAspNetCoreMvcHttpHeadAttribute = "Microsoft.AspNetCore.Mvc.HttpHeadAttribute";
+        public const string MicrosoftAspNetCoreMvcHttpOptionsAttribute = "Microsoft.AspNetCore.Mvc.HttpOptionsAttribute";
+        public const string MicrosoftAspNetCoreMvcRouteAttribute = "Microsoft.AspNetCore.Mvc.RouteAttribute";
     }
 }


### PR DESCRIPTION
Fix #3123 and also handles `Application_Start` and `Application_End` special methods.