### PR TITLE
Fix typos in AnalyzerConfiguration.md

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -211,8 +211,8 @@ Examples:
 | --- | --- |
 |`dotnet_code_quality.excluded_type_names_with_derived_types = MyType` | Matches all types named 'MyType' and all of its derived types in the compilation
 |`dotnet_code_quality.excluded_type_names_with_derived_types = MyType1\|MyType2` | Matches all types named either 'MyType1' or 'MyType2' and all of their derived types in the compilation
-|`dotnet_code_quality.excluded_type_names_with_derived_types = M:NS.MyType` | Matches specific type 'MyType' with given fully qualified name and all of its derived types
-|`dotnet_code_quality.excluded_type_names_with_derived_types = M:NS1.MyType1\|M:NS2.MyType2` | Matches specific types 'MyType1' and 'MyType2' with respective fully qualified names and all of their derived types
+|`dotnet_code_quality.excluded_type_names_with_derived_types = T:NS.MyType` | Matches specific type 'MyType' with given fully qualified name and all of its derived types
+|`dotnet_code_quality.excluded_type_names_with_derived_types = T:NS1.MyType1\|M:NS2.MyType2` | Matches specific types 'MyType1' and 'MyType2' with respective fully qualified names and all of their derived types
 
 ### Unsafe DllImportSearchPath bits when using DefaultDllImportSearchPaths attribute
 Option Name: `unsafe_DllImportSearchPath_bits`


### PR DESCRIPTION
Fix typos: The option prefix in the example should be `T:` not `M:` for type name specification.