### PR TITLE
CA1822: Update rule to flag more cases

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -577,6 +577,70 @@ End Class
             }.RunAsync();
         }
 
+        [Fact, WorkItem(3019, "https://github.com/dotnet/roslyn-analyzers/issues/3019")]
+        public async Task PrivateMethodOnlyCalledByASkippedMethod_Diagnostic()
+        {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
+using Xunit;
+
+public class Program
+{
+    [Fact]
+    private void M()
+    {
+        N();
+    }
+
+    private void N()
+    {
+    }
+}",
+                        XunitApis.CSharp,
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(12, 18, "N")
+                    }
+                }
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(3019, "https://github.com/dotnet/roslyn-analyzers/issues/3019")]
+        public async Task PrivateMethodOnlyReferencedByASkippedMethod_NoDiagnostic()
+        {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
+using Xunit;
+
+public class Program
+{
+    [Fact]
+    private void M()
+    {
+        var x = nameof(N);
+    }
+
+    private void N()
+    {
+    }
+}",
+                        XunitApis.CSharp,
+                    }
+                }
+            }.RunAsync();
+        }
+
         [Fact, WorkItem(1865, "https://github.com/dotnet/roslyn-analyzers/issues/1865")]
         public async Task CSharp_InstanceReferenceInObjectInitializer_Diagnostic()
         {


### PR DESCRIPTION
Fix #3019 

With this change the analyzer will look for invocations located in _ALL_ methods but will keep raising issues only on correct ones. Thanks to this change we shall be able to report a lot more cases where the method could be made `static`.