### PR TITLE
PublicAPI: Keep found APIs regardless of nullability

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -485,6 +485,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
                             var siblingPublicApiName = GetPublicApiName(sibling);
                             publicApiLinesForSiblingsOfSymbol.Remove(siblingPublicApiName.Name);
+                            publicApiLinesForSiblingsOfSymbol.Remove(siblingPublicApiName.NameWithNullability);
                         }
 
                         // Join all the symbols names with a special separator.

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -967,6 +967,51 @@ C.NewField -> string?";
         }
 
         [Fact]
+        public async Task TestSimpleMissingMember_Fix_WithNullability2()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? OldField;
+    public string? {|RS0016:NewField|}; // Newly added field, not in current public API.
+}
+";
+            var shippedText = $@"{DeclarePublicApiAnalyzer.NullableEnable}";
+            var unshippedText = @"C
+C.C() -> void
+C.OldField -> string?";
+            var fixedUnshippedText = @"C
+C.C() -> void
+C.NewField -> string?
+C.OldField -> string?";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [Fact]
+        public async Task TestSimpleMissingMember_Fix_WithNullability3()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? OldField;
+    public string? NewField;
+}
+";
+            var shippedText = $@"{DeclarePublicApiAnalyzer.NullableEnable}
+C
+C.C() -> void
+C.NewField -> string?
+C.OldField -> string?";
+
+            var unshippedText = "";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        [Fact]
         public async Task TestAddAndRemoveMembers_CSharp_Fix_WithRemovedNullability()
         {
             var source = @"


### PR DESCRIPTION
The test added in this PR was running into an issue with the test framework iterating on fixes. That's because the fixer was incorrectly removing APIs already marked with nullability information.

This PR adjusts the logic for recognizing APIs (to decide whether they were removed or not) to account for nullability format.