### PR TITLE
Port "DiagnosticDescriptor id fix"

### DIFF
--- a/src/PerformanceSensitiveAnalyzers/CSharp/TypeConversionAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/TypeConversionAllocationAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
         public const string ValueTypeToReferenceTypeConversionRuleId = "HAA0601";
         public const string DelegateOnStructInstanceRuleId = "HAA0602";
         public const string MethodGroupAllocationRuleId = "HAA0603";
-        public const string ReadonlyMethodGroupAllocationRuleId = "HeapAnalyzerReadonlyMethodGroupAllocationRule";
+        public const string ReadonlyMethodGroupAllocationRuleId = "HAA0604";
 
         private static readonly LocalizableString s_localizableValueTypeToReferenceTypeConversionRuleTitle = new LocalizableResourceString(nameof(AnalyzersResources.ValueTypeToReferenceTypeConversionRuleTitle), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
         private static readonly LocalizableString s_localizableValueTypeToReferenceTypeConversionRuleMessage = new LocalizableResourceString(nameof(AnalyzersResources.ValueTypeToReferenceTypeConversionRuleMessage), AnalyzersResources.ResourceManager, typeof(AnalyzersResources));


### PR DESCRIPTION
ReadonlyMethodGroupAllocationRule is using a name in the DiagnosticDescriptor id field, this corrects it to use an actual id.

This is ported from https://github.com/microsoft/RoslynClrHeapAllocationAnalyzer/pull/76. Originally commited by @nnpcYvIVl 

FYI @mjsabby 