### PR TITLE
Port "Prevent reporting HAA0101 when no value for params is provided"

### DIFF
--- a/src/PerformanceSensitiveAnalyzers/CSharp/AnalyzersResources.resx
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/AnalyzersResources.resx
@@ -148,7 +148,7 @@
     <value>Delegate allocation from a method group</value>
   </data>
   <data name="ParamsParameterRuleMessage" xml:space="preserve">
-    <value>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</value>
+    <value>This call site is calling into a function with a 'params' parameter. This results in an array allocation</value>
   </data>
   <data name="ParamsParameterRuleTitle" xml:space="preserve">
     <value>Array allocation for params parameter</value>

--- a/src/PerformanceSensitiveAnalyzers/CSharp/CallSiteImplicitAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/CallSiteImplicitAllocationAnalyzer.cs
@@ -77,6 +77,11 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
         private static void CheckParam(InvocationExpressionSyntax invocationExpression, IMethodSymbol methodInfo, SemanticModel semanticModel, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
         {
             var arguments = invocationExpression.ArgumentList.Arguments;
+            if (arguments.Count == methodInfo.Parameters.Length - 1)
+            {
+                return;
+            }
+
             if (arguments.Count != methodInfo.Parameters.Length)
             {
                 reportDiagnostic(Diagnostic.Create(ParamsParameterRule, invocationExpression.GetLocation(), EmptyMessageArgs));

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.cs.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.cs.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">Tato lokalita volání volá funkci s parametrem params. Výsledkem je přidělení pole i v případě, že se pro parametr params nepředá žádný parametr.</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">Tato lokalita volání volá funkci s parametrem params. Výsledkem je přidělení pole i v případě, že se pro parametr params nepředá žádný parametr.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.de.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.de.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">Diese Aufrufsite ruft eine Funktion mit einem params-Parameter auf. Dies führt auch dann zu einer Arrayzuordnung, wenn für den params-Parameter kein Parameter übergeben wird.</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">Diese Aufrufsite ruft eine Funktion mit einem params-Parameter auf. Dies führt auch dann zu einer Arrayzuordnung, wenn für den params-Parameter kein Parameter übergeben wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.es.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.es.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">Este sitio de llamada invoca a una función con un parámetro "params". Esto da como resultado una asignación de matriz, aunque no se haya pasado ningún parámetro para "params".</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">Este sitio de llamada invoca a una función con un parámetro "params". Esto da como resultado una asignación de matriz, aunque no se haya pasado ningún parámetro para "params".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.fr.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.fr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">Ce site d'appel appelle une fonction avec un paramètre 'params'. Cela se traduit par une allocation de tableau même si aucun paramètre n'est passé pour le paramètre params</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">Ce site d'appel appelle une fonction avec un paramètre 'params'. Cela se traduit par une allocation de tableau même si aucun paramètre n'est passé pour le paramètre params</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.it.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.it.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">Questo sito di chiamata chiama una funzione con un parametro 'params'. Viene generata un'allocazione di matrice anche se non viene passato alcun parametro per params</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">Questo sito di chiamata chiama una funzione con un parametro 'params'. Viene generata un'allocazione di matrice anche se non viene passato alcun parametro per params</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.ja.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.ja.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">この呼び出しサイトは 'params' パラメーターを持つ関数を呼び出します。結果として、params パラメーターにパラメーターが何も渡されない場合でも、配列が割り当てられます。</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">この呼び出しサイトは 'params' パラメーターを持つ関数を呼び出します。結果として、params パラメーターにパラメーターが何も渡されない場合でも、配列が割り当てられます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.ko.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.ko.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">이 호출 사이트가 'params' 매개 변수가 있는 함수를 호출하고 있습니다. 이로 인해 params 매개 변수에 대해 매개 변수가 전달되지 않는 경우에도 배열 할당이 발생합니다.</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">이 호출 사이트가 'params' 매개 변수가 있는 함수를 호출하고 있습니다. 이로 인해 params 매개 변수에 대해 매개 변수가 전달되지 않는 경우에도 배열 할당이 발생합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.pl.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.pl.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">Ta lokacja wywołania wywołuje funkcję z parametrem „params”. Powoduje to alokację tablicy nawet wtedy, gdy dla parametru params nie jest przekazywany żaden parametr</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">Ta lokacja wywołania wywołuje funkcję z parametrem „params”. Powoduje to alokację tablicy nawet wtedy, gdy dla parametru params nie jest przekazywany żaden parametr</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.pt-BR.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.pt-BR.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">Este site de chamada está chamando uma função com um parâmetro 'params'. Isso resulta em uma alocação de matriz, mesmo quando não é passado nenhum parâmetro para o parâmetro params</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">Este site de chamada está chamando uma função com um parâmetro 'params'. Isso resulta em uma alocação de matriz, mesmo quando não é passado nenhum parâmetro para o parâmetro params</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.ru.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.ru.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">Это место вызова направляет в функцию вызов с параметром "params". Это приводит к выделению массива, даже если для параметра params не передается никакое значение</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">Это место вызова направляет в функцию вызов с параметром "params". Это приводит к выделению массива, даже если для параметра params не передается никакое значение</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.tr.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.tr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">Bu çağrı sitesi 'params' parametresi ile bir işleve çağrı yapıyor. params parametresiyle geçirilen bir parametre olmasa bile bu durum bir dizi ayırmasına neden olur</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">Bu çağrı sitesi 'params' parametresi ile bir işleve çağrı yapıyor. params parametresiyle geçirilen bir parametre olmasa bile bu durum bir dizi ayırmasına neden olur</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.zh-Hans.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.zh-Hans.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">此调用站点调用带有 "params" 参数的函数。即使没有为 params 参数传入参数，也会导致数组分配</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">此调用站点调用带有 "params" 参数的函数。即使没有为 params 参数传入参数，也会导致数组分配</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.zh-Hant.xlf
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/xlf/AnalyzersResources.zh-Hant.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleMessage">
-        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter</source>
-        <target state="translated">此呼叫站台呼叫函式時設定了 'params' 參數。如此會導致即使沒有為 params 參數傳入任何參數，都會進行陣列配置</target>
+        <source>This call site is calling into a function with a 'params' parameter. This results in an array allocation</source>
+        <target state="needs-review-translation">此呼叫站台呼叫函式時設定了 'params' 參數。如此會導致即使沒有為 params 參數傳入任何參數，都會進行陣列配置</target>
         <note />
       </trans-unit>
       <trans-unit id="ParamsParameterRuleTitle">

--- a/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
+++ b/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
@@ -25,7 +25,7 @@ public class MyClass
     public void Testing()
     {
 
-        Params();
+        Params(); //no allocation, because compiler will implicitly substitute Array<int>.Empty
         Params(1, 2);
         Params(new [] { 1, 2}); // explicit, so no warning
         ParamsWithObjects(new [] { 1, 2}); // explicit, but converted to objects, so stil la warning?!
@@ -44,13 +44,11 @@ public class MyClass
 }";
 
             await VerifyCS.VerifyAnalyzerAsync(sampleProgram,
-                // Test0.cs(10,9): warning HAA0101: This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter
-                VerifyCS.Diagnostic(CallSiteImplicitAllocationAnalyzer.ParamsParameterRule).WithLocation(10, 9),
-                // Test0.cs(11,9): warning HAA0101: This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter
+                // Test0.cs(11,9): warning HAA0101: This call site is calling into a function with a 'params' parameter. This results in an array allocation
                 VerifyCS.Diagnostic(CallSiteImplicitAllocationAnalyzer.ParamsParameterRule).WithLocation(11, 9),
-                // Test0.cs(13,9): warning HAA0101: This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter
+                // Test0.cs(13,9): warning HAA0101: This call site is calling into a function with a 'params' parameter. This results in an array allocation
                 VerifyCS.Diagnostic(CallSiteImplicitAllocationAnalyzer.ParamsParameterRule).WithLocation(13, 9),
-                // Test0.cs(16,20): warning HAA0101: This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter
+                // Test0.cs(16,20): warning HAA0101: This call site is calling into a function with a 'params' parameter. This results in an array allocation
                 VerifyCS.Diagnostic(CallSiteImplicitAllocationAnalyzer.ParamsParameterRule).WithLocation(16, 20));
         }
 

--- a/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
+++ b/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
@@ -25,7 +25,7 @@ public class MyClass
     public void Testing()
     {
 
-        Params(); //no allocation, because compiler will implicitly substitute Array<int>.Empty
+        Params(); //no allocation, because compiler will implicitly substitute Array.Empty<int>()
         Params(1, 2);
         Params(new [] { 1, 2}); // explicit, so no warning
         ParamsWithObjects(new [] { 1, 2}); // explicit, but converted to objects, so stil la warning?!


### PR DESCRIPTION
HAA0101 was incorrectly implemented because the statement This results in an array allocation even if no parameter is passed in for the params parameter is not always true. If no parameter is passed then the compiler will insert Array.Empty<T>() in the method invocation. This PR fixes this issue.

Ported from https://github.com/microsoft/RoslynClrHeapAllocationAnalyzer/pull/78
This is originally committed by @cezarypiatek

FYI @mjsabby 