### PR TITLE
Add additional examples of usage

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
@@ -36,15 +36,33 @@ namespace N
         public void BannedMethod(int i) {}
 
         public void BannedMethod<T>(T t) {}
+
+        public void BannedMethod<T>(Func<T> f) {}
+
+        public string BannedField;
+
+        public string BannedProperty { get; }
+
+        public event EventHandler BannedEvent;
+    }
+
+    class BannedType<T>
+    {
     }
 }
 ```
 
-| Symbol in Source                      | Sample Entry in BannedSymbols.txt  |
-| -----------                           | ----------- |
-| `class BannedType`                    | `T:N.BannedType;Don't use BannedType`       |
-| `BannedType()`                        | `M:N.BannedType.#ctor`       |
-| `int BannedMethod()`                  | `M:N.BannedType.BannedMethod~System.Int32`       |
-| `void BannedMethod(int i)`            | `M:N.BannedType.BannedMethod(System.Int32);Don't use BannedMethod`       |
-| `void BannedMethod<T>(T t)`           | `M:N.BannedType.BannedMethod``1(``0)`       |
+| Symbol in Source                      | Sample Entry in BannedSymbols.txt
+| -----------                           | -----------
+| `class BannedType`                    | `T:N.BannedType;Don't use BannedType`
+| `class BannedType<T>`                 | ``T:N.BannedType`1;Don't use BannedType<T>``
+| `BannedType()`                        | `M:N.BannedType.#ctor`
+| `int BannedMethod()`                  | `M:N.BannedType.BannedMethod`
+| `void BannedMethod(int i)`            | `M:N.BannedType.BannedMethod(System.Int32);Don't use BannedMethod`
+| `void BannedMethod<T>(T t)`           | ```M:N.BannedType.BannedMethod`1(``0)```
+| `void BannedMethod<T>(Func<T> f)`     | ```M:N.BannedType.BannedMethod`1(System.Func{``0})```
+| `string BannedField`                  | `F:N.BannedType.BannedField`
+| `string BannedProperty { get; }`      | `P:N.BannedType.BannedProperty`
+| `event EventHandler BannedEvent;`     | `E:N.BannedType.BannedEvent`
+
 


### PR DESCRIPTION
Add additional examples of usage, and fixed the generic method usage which looked incorrect in markdown.