### PR TITLE
Fix for CA2000 not detected if nameof() is in the scope

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScope.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScope.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
@@ -139,7 +140,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                 return;
                             }
 
-                            if (disposeAnalysisResult.ControlFlowGraph.OriginalOperation.HasAnyOperationDescendant(o => o.Kind == OperationKind.None))
+                            if (disposeAnalysisResult.ControlFlowGraph.OriginalOperation.HasAnyOperationDescendant(o => o.Kind == OperationKind.None && !(o.Parent is INameOfOperation)))
                             {
                                 // Workaround for https://github.com/dotnet/roslyn/issues/32100
                                 // Bail out in presence of OperationKind.None - not implemented IOperation.

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -11920,5 +11920,41 @@ End Class",
                 }
             }.RunAsync();
         }
+
+        [Fact, WorkItem(3297, "https://github.com/dotnet/roslyn-analyzers/issues/3297")]
+        public async Task NameOfInsideTheScope_Diagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+
+class A : IDisposable
+{
+    public void Dispose()
+    {
+
+    }
+}
+
+class Test
+{
+    void M1()
+    {
+        var a = new A();
+    }
+
+    void M2()
+    {
+        var a = new A();
+        var b = nameof(Test);
+    }
+}
+",
+                // Test0.cs(16,17): warning CA2000: Call System.IDisposable.Dispose on object created by 'new A()' before all references to it are out of scope.
+                GetCSharpResultAt(16, 17, "new A()"),
+
+                // Test0.cs(21,17): warning CA2000: Call System.IDisposable.Dispose on object created by 'new A()' before all references to it are out of scope.
+                GetCSharpResultAt(21, 17, "new A()")
+            );
+        }
     }
 }


### PR DESCRIPTION
fixes #3297

Basically any scope that contains a `nameof` operator will be ignored by the CA2000:DisposeObjectsBeforeLosingScope rule. And, in my opinion, `nameof` is used quite often (parameter checks, exception messages, logging, etc.), so it's quite a serious bug.

This bug was introduced by #2704 (workaround for issue #2703), see also: https://github.com/dotnet/roslyn/issues/32100. The contents of the `nameof` expression are an `OperationKind.None`, which is why the hack breaks it. I added additional check for `INameOfOperation` specifically.