### PR TITLE
CA2000 for ref structs, that are not disposed properly

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -2160,6 +2160,37 @@ class Test
         }
 
         [Fact, WorkItem(3305, "https://github.com/dotnet/roslyn-analyzers/issues/3305")]
+        public async Task LocalWithRefStructDisposableAssignment_Internal_NotDisposed_Diagnostic()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithAsyncInterfaces,
+                TestCode = @"
+using System;
+
+ref struct RefStructDisposable
+{
+    internal void Dispose()
+    {
+    }
+}
+
+class Test
+{
+    public static void M1()
+    {
+        var e = new RefStructDisposable();
+    }
+}
+",
+                ExpectedDiagnostics =
+                {
+                    GetCSharpResultAt(15, 17, "new RefStructDisposable()"),
+                }
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(3305, "https://github.com/dotnet/roslyn-analyzers/issues/3305")]
         public async Task LocalWithRefStructDisposableAssignment_Disposed_NoDiagnostic()
         {
             await new VerifyCS.Test

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -2128,6 +2128,64 @@ End Class",
             }.RunAsync();
         }
 
+        [Fact, WorkItem(3305, "https://github.com/dotnet/roslyn-analyzers/issues/3305")]
+        public async Task LocalWithRefStructDisposableAssignment_NotDisposed_Diagnostic()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithAsyncInterfaces,
+                TestCode = @"
+using System;
+
+ref struct RefStructDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+
+class Test
+{
+    public static void M1()
+    {
+        var e = new RefStructDisposable();
+    }
+}
+",
+                ExpectedDiagnostics =
+                {
+                    GetCSharpResultAt(15, 17, "new RefStructDisposable()"),
+                }
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(3305, "https://github.com/dotnet/roslyn-analyzers/issues/3305")]
+        public async Task LocalWithRefStructDisposableAssignment_Disposed_NoDiagnostic()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithAsyncInterfaces,
+                TestCode = @"
+using System;
+
+ref struct RefStructDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+
+class Test
+{
+    public static void M1()
+    {
+        var e = new RefStructDisposable();
+        e.Dispose();
+    }
+}"
+            }.RunAsync();
+        }
+
         [Fact]
         public async Task ArrayElementWithDisposableAssignment_NoDiagnostic()
         {

--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -8,6 +8,9 @@
   <PropertyGroup Label="Configuration">
     <Import_RootNamespace>Analyzer.Utilities</Import_RootNamespace>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(MicrosoftCodeAnalysisVersion)' == '' OR '$(MicrosoftCodeAnalysisVersion)' >= '3.0'">
+    <DefineConstants>$(DefineConstants),CODEANALYSIS_V3_OR_BETTER</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(MicrosoftCodeAnalysisVersion)' != '1.2.1'">
     <DefineConstants>$(DefineConstants);HAS_IOPERATION</DefineConstants>
     <HasIOperation>true</HasIOperation>

--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -283,7 +283,7 @@ namespace Analyzer.Utilities.Extensions
                 if (IsDisposeImplementation(method, iDisposable) ||
                     (Equals(method.ContainingType, iDisposable) &&
                      method.HasDisposeMethodSignature())
-#if NET_ANALYZERS
+#if CODEANALYSIS_V3_OR_BETTER
                     || (method.ContainingType.IsRefLikeType &&
                      method.HasDisposeSignatureByConvention())
 #endif

--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -199,7 +199,7 @@ namespace Analyzer.Utilities.Extensions
         public static bool HasDisposeSignatureByConvention(this IMethodSymbol method)
         {
             return method.HasDisposeMethodSignature()
-                && !method.GetSymbolModifiers().HasFlag(SymbolModifiers.Static)
+                && !method.IsStatic
                 && !method.IsPrivate();
         }
 

--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -194,6 +194,16 @@ namespace Analyzer.Utilities.Extensions
         }
 
         /// <summary>
+        /// Checks if the given method matches Dispose method convention and can be recognized by "using".
+        /// </summary>
+        public static bool HasDisposeSignatureByConvention(this IMethodSymbol method)
+        {
+            return method.HasDisposeMethodSignature()
+                && !method.GetSymbolModifiers().HasFlag(SymbolModifiers.Static)
+                && !method.IsPrivate();
+        }
+
+        /// <summary>
         /// Checks if the given method has the signature "void Dispose(bool)".
         /// </summary>
         public static bool HasDisposeBoolMethodSignature(this IMethodSymbol method)
@@ -272,7 +282,12 @@ namespace Analyzer.Utilities.Extensions
             {
                 if (IsDisposeImplementation(method, iDisposable) ||
                     (Equals(method.ContainingType, iDisposable) &&
-                     method.HasDisposeMethodSignature()))
+                     method.HasDisposeMethodSignature())
+#if NET_ANALYZERS
+                    || (method.ContainingType.IsRefLikeType &&
+                     method.HasDisposeSignatureByConvention())
+#endif
+                )
                 {
                     return DisposeMethodKind.Dispose;
                 }

--- a/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
@@ -126,7 +126,8 @@ namespace Analyzer.Utilities.Extensions
         }
 
         /// <summary>
-        /// Indicates if the given <paramref name="type"/> is a reference type that implements <paramref name="iDisposable"/> or System.IAsyncDisposable or is <see cref="IDisposable"/> or System.IAsyncDisposable type itself.
+        /// Indicates if the given <paramref name="type"/> is disposable,
+        /// and thus can be used in a <code>using</code> or <code>await using</code> statement.
         /// </summary>
         public static bool IsDisposable(this ITypeSymbol type,
             INamedTypeSymbol? iDisposable,
@@ -280,11 +281,7 @@ namespace Analyzer.Utilities.Extensions
         }
 
         public static bool HasValueCopySemantics(this ITypeSymbol typeSymbol)
-            => typeSymbol.IsValueType
-#if NET_ANALYZERS
-                && !typeSymbol.IsRefLikeType
-#endif
-            || typeSymbol.SpecialType == SpecialType.System_String;
+            => typeSymbol.IsValueType || typeSymbol.SpecialType == SpecialType.System_String;
 
         public static bool IsNonNullableValueType([NotNullWhen(returnValue: true)] this ITypeSymbol? typeSymbol)
             => typeSymbol != null && typeSymbol.IsValueType && typeSymbol.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T;

--- a/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
@@ -139,7 +139,7 @@ namespace Analyzer.Utilities.Extensions
                     || IsInterfaceOrImplementsInterface(type, iAsyncDisposable);
             }
 
-#if NET_ANALYZERS
+#if CODEANALYSIS_V3_OR_BETTER
             if (type.IsRefLikeType)
             {
                 return type.GetMembers("Dispose").OfType<IMethodSymbol>()

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
             {
                 if (!location.IsNull &&
                     location.LocationTypeOpt != null &&
-                    !location.LocationTypeOpt.IsValueType &&
+                    !location.LocationTypeOpt.HasValueCopySemantics() &&
                     IsDisposable(location.LocationTypeOpt))
                 {
                     CurrentAnalysisData[location] = value;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
             {
                 if (!location.IsNull &&
                     location.LocationTypeOpt != null &&
-                    !location.LocationTypeOpt.HasValueCopySemantics() &&
+                    (!location.LocationTypeOpt.IsValueType || location.LocationTypeOpt.IsRefLikeType) &&
                     IsDisposable(location.LocationTypeOpt))
                 {
                     CurrentAnalysisData[location] = value;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 {
+    using System.Diagnostics.CodeAnalysis;
     using CopyAnalysisResult = DataFlowAnalysisResult<CopyAnalysis.CopyBlockAnalysisResult, CopyAnalysis.CopyAbstractValue>;
 
     /// <summary>
@@ -78,9 +79,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             return pointsToAnalysis.TryGetOrComputeResultCore(analysisContext, cacheResult: true);
         }
 
-        internal static bool ShouldBeTracked(ITypeSymbol typeSymbol) => typeSymbol.IsReferenceTypeOrNullableValueType() ||
-            typeSymbol?.HasValueCopySemantics() == false ||
-            typeSymbol is ITypeParameterSymbol typeParameter && !typeParameter.HasValueCopySemantics();
+        internal static bool ShouldBeTracked([NotNullWhen(returnValue: true)] ITypeSymbol typeSymbol)
+            => typeSymbol.IsReferenceTypeOrNullableValueType() ||
+               typeSymbol?.IsRefLikeType == true ||
+               typeSymbol is ITypeParameterSymbol typeParameter && !typeParameter.IsValueType;
 
         internal static bool ShouldBeTracked(AnalysisEntity analysisEntity)
             => ShouldBeTracked(analysisEntity.Type) || analysisEntity.IsLValueFlowCaptureEntity || analysisEntity.IsThisOrMeInstance;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -79,7 +79,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         }
 
         internal static bool ShouldBeTracked(ITypeSymbol typeSymbol) => typeSymbol.IsReferenceTypeOrNullableValueType() ||
-            typeSymbol is ITypeParameterSymbol typeParameter && !typeParameter.IsValueType;
+            typeSymbol?.HasValueCopySemantics() == false ||
+            typeSymbol is ITypeParameterSymbol typeParameter && !typeParameter.HasValueCopySemantics();
 
         internal static bool ShouldBeTracked(AnalysisEntity analysisEntity)
             => ShouldBeTracked(analysisEntity.Type) || analysisEntity.IsLValueFlowCaptureEntity || analysisEntity.IsThisOrMeInstance;


### PR DESCRIPTION
fixes https://github.com/dotnet/roslyn-analyzers/issues/3305

In this fix:
- three new tests: `LocalWithRefStructDisposableAssignment_NotDisposed_Diagnostic`, `LocalWithRefStructDisposableAssignment_Internal_NotDisposed_Diagnostic` and `LocalWithRefStructDisposableAssignment_Disposed_NoDiagnostic` (C# only, `protected` is not covered as structs can not declare new `protected` methods)
- `GetDisposeMethodKind` returns `DisposeMethodKind.Dispose` for parameterless `Dispose` instance method on ref-only structs
- `IsDisposable` returns `true` for ref-only structs with non-private parameterless `Dispose` instance method
- `PointsToAnalysis` and `DisposeDataFlowOperationVisitor` track ref-only value types in addition to reference types