### PR TITLE
Ignore XamlGeneratedNamespace.GeneratedInternalTypeHelper

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -339,6 +339,13 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
                 void reportDeclareNewApi(ISymbol symbol, bool isImplicitlyDeclaredConstructor, string publicApiName)
                 {
+                    // TODO: workaround for https://github.com/dotnet/wpf/issues/2690
+                    if (publicApiName == "XamlGeneratedNamespace.GeneratedInternalTypeHelper" ||
+                        publicApiName == "XamlGeneratedNamespace.GeneratedInternalTypeHelper.GeneratedInternalTypeHelper() -> void")
+                    {
+                        return;
+                    }
+
                     // Unshipped public API with no entry in public API file - report diagnostic.
                     string errorMessageName = GetErrorMessageName(symbol, isImplicitlyDeclaredConstructor);
                     // Compute public API names for any stale siblings to remove from unshipped text (e.g. during signature change of unshipped public API).

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -217,6 +217,23 @@ public class C
             await VerifyCSharpAsync(source, shippedText, unshippedText, GetCSharpResultAt(2, 14, DeclarePublicApiAnalyzer.DeclareNewApiRule, "C"));
         }
 
+        [Fact, WorkItem(2690, "https://github.com/dotnet/wpf/issues/2690")]
+        public async Task XamlGeneratedNamespaceWorkaround()
+        {
+            var source = @"
+namespace XamlGeneratedNamespace {
+    public sealed class GeneratedInternalTypeHelper
+    {
+    }
+}
+";
+
+            var shippedText = @"";
+            var unshippedText = @"";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
         [Fact]
         public async Task SimpleMissingMember_CSharp()
         {


### PR DESCRIPTION
Workaround for https://github.com/dotnet/wpf/issues/2690