### PR TITLE
Enforce new IDE code style analyzers as build warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -117,10 +117,10 @@ dotnet_diagnostic.IDE0004.severity = warning
 dotnet_diagnostic.IDE0005.severity = warning
 
 # IDE0051: Remove unused private members (no reads or writes)
-dotnet_diagnostic.IDE0051.severity = suggestion
+dotnet_diagnostic.IDE0051.severity = warning
 
 # IDE0052: Remove unread private members (writes but no reads)
-dotnet_diagnostic.IDE0052.severity = suggestion
+dotnet_diagnostic.IDE0052.severity = warning
 
 # IDE0066: Convert switch statement to expression
 dotnet_diagnostic.IDE0066.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -122,6 +122,9 @@ dotnet_diagnostic.IDE0051.severity = warning
 # IDE0052: Remove unread private members (writes but no reads)
 dotnet_diagnostic.IDE0052.severity = warning
 
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
 # IDE0066: Convert switch statement to expression
 dotnet_diagnostic.IDE0066.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -111,7 +111,7 @@ visual_basic_style_unused_value_assignment_preference = unused_local_variable:wa
 [*.{cs,vb}]
 
 # IDE0004: Remove unnecessary cast
-dotnet_diagnostic.IDE0004.severity = suggestion
+dotnet_diagnostic.IDE0004.severity = warning
 
 # IDE0005: Remove unnecessary usings/imports
 dotnet_diagnostic.IDE0005.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -114,7 +114,7 @@ visual_basic_style_unused_value_assignment_preference = unused_local_variable:wa
 dotnet_diagnostic.IDE0004.severity = warning
 
 # IDE0005: Remove unnecessary usings/imports
-dotnet_diagnostic.IDE0005.severity = suggestion
+dotnet_diagnostic.IDE0005.severity = warning
 
 # IDE0051: Remove unused private members (no reads or writes)
 dotnet_diagnostic.IDE0051.severity = suggestion
@@ -124,6 +124,7 @@ dotnet_diagnostic.IDE0052.severity = suggestion
 
 # IDE0066: Convert switch statement to expression
 dotnet_diagnostic.IDE0066.severity = suggestion
+
 
 ### Configuration for FxCop analyzers executed on this repo ###
 [*.{cs,vb}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -107,6 +107,24 @@ csharp_style_pattern_matching_over_as_with_null_check = true:warning
 visual_basic_style_unused_value_assignment_preference = unused_local_variable:warning
 
 
+### Configuration for IDE code style by diagnostic IDs ###
+[*.{cs,vb}]
+
+# IDE0004: Remove unnecessary cast
+dotnet_diagnostic.IDE0004.severity = suggestion
+
+# IDE0005: Remove unnecessary usings/imports
+dotnet_diagnostic.IDE0005.severity = suggestion
+
+# IDE0051: Remove unused private members (no reads or writes)
+dotnet_diagnostic.IDE0051.severity = suggestion
+
+# IDE0052: Remove unread private members (writes but no reads)
+dotnet_diagnostic.IDE0052.severity = suggestion
+
+# IDE0066: Convert switch statement to expression
+dotnet_diagnostic.IDE0066.severity = suggestion
+
 ### Configuration for FxCop analyzers executed on this repo ###
 [*.{cs,vb}]
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -128,6 +128,10 @@ dotnet_diagnostic.IDE0055.severity = warning
 # IDE0066: Convert switch statement to expression
 dotnet_diagnostic.IDE0066.severity = suggestion
 
+# IDE0073: File header
+dotnet_diagnostic.IDE0073.severity = warning
+file_header_template = Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 
 ### Configuration for FxCop analyzers executed on this repo ###
 [*.{cs,vb}]

--- a/eng/Analyzers_ShippingRules.ruleset
+++ b/eng/Analyzers_ShippingRules.ruleset
@@ -25,13 +25,5 @@
     <!-- Skipped due to https://github.com/dotnet/roslyn-analyzers/issues/1711 -->
     <Rule Id="RS1022" Action="None" />
   </Rules>
-  
-  <!-- TODO: Move the below configurations to .editorconfig once compilers supports .editorconfig -->
-  <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
-    <Rule Id="IDE0005" Action="Warning" /> <!-- Remove unused imports/usings -->
-    <Rule Id="IDE0051" Action="Warning" /> <!-- Remove unused private members -->
-    <Rule Id="IDE0052" Action="Warning" /> <!-- Remove unread private members -->
-    <Rule Id="IDE0055" Action="Warning" /> <!-- Fix Formatting -->
-  </Rules>
 
 </RuleSet>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>2.9.8</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyersVersion>2.9.8</MicrosoftCodeAnalysisFXCopAnalyersVersion>
     <MicrosoftCodeAnalysisAnalyersVersion>3.0.0-beta2.19218.3+e96bad97</MicrosoftCodeAnalysisAnalyersVersion>
-    <CodeStyleAnalyersVersion>3.3.0-beta2-19376-02</CodeStyleAnalyersVersion>
+    <CodeStyleAnalyersVersion>3.6.0-2.20157.5</CodeStyleAnalyersVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
 
     <!-- Roslyn Testing -->

--- a/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
+++ b/src/MetaCompilation.Analyzers/Core/CodeFixProvider.cs
@@ -680,7 +680,7 @@ namespace MetaCompilation.Analyzers
             string name = CodeFixHelper.GetContextParameter(declaration);
             StatementSyntax ifStatement = CodeFixHelper.IfHelper(generator, name) as StatementSyntax;
 
-            var oldBlock = declaration.Body as BlockSyntax;
+            var oldBlock = declaration.Body;
             BlockSyntax newBlock = oldBlock.AddStatements(ifStatement.WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ParseLeadingTrivia("// The SyntaxNode found by the Initialize method should be cast to the expected type. Here, this type is IfStatementSyntax").ElementAt(0), SyntaxFactory.EndOfLine("\r\n"))));
 
             return await ReplaceNode(oldBlock, newBlock, document, cancellationToken).ConfigureAwait(false);
@@ -702,7 +702,7 @@ namespace MetaCompilation.Analyzers
         {
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
 
-            var methodBlock = declaration.Body as BlockSyntax;
+            var methodBlock = declaration.Body;
             var ifKeyword = CodeFixHelper.KeywordHelper(generator, methodBlock) as StatementSyntax;
             BlockSyntax newBlock = methodBlock.AddStatements(ifKeyword.WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.ParseLeadingTrivia("// This statement navigates down the syntax tree one level to extract the 'if' keyword").ElementAt(0), SyntaxFactory.EndOfLine("\r\n"))));
 
@@ -819,7 +819,7 @@ namespace MetaCompilation.Analyzers
             IfStatementSyntax ifStatement;
             if (declaration.Parent.Parent.Parent.Parent.Kind() == SyntaxKind.MethodDeclaration)
             {
-                ifStatement = declaration as IfStatementSyntax;
+                ifStatement = declaration;
             }
             else
             {
@@ -845,7 +845,7 @@ namespace MetaCompilation.Analyzers
             var ifBlockStatements = new SyntaxList<SyntaxNode>();
             if (declaration.Parent.Parent.Parent.Parent.Kind() == SyntaxKind.MethodDeclaration)
             {
-                ifStatement = declaration as IfStatementSyntax;
+                ifStatement = declaration;
             }
             else
             {
@@ -891,7 +891,7 @@ namespace MetaCompilation.Analyzers
 
             if (declaration.Parent.Parent.Parent.Parent.Parent.Parent.Kind() == SyntaxKind.MethodDeclaration)
             {
-                ifStatement = declaration as IfStatementSyntax;
+                ifStatement = declaration;
             }
             else
             {
@@ -939,7 +939,7 @@ namespace MetaCompilation.Analyzers
             }
             else
             {
-                ifStatement = declaration as IfStatementSyntax;
+                ifStatement = declaration;
             }
 
             var returnStatement = generator.ReturnStatement() as ReturnStatementSyntax;
@@ -1335,7 +1335,7 @@ namespace MetaCompilation.Analyzers
         private async Task<Document> InternalStaticAsync(Document document, FieldDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
-            SyntaxNode newFieldDecl = generator.FieldDeclaration(declaration.Declaration.Variables[0].Identifier.Text, generator.IdentifierName("DiagnosticDescriptor"), accessibility: Accessibility.Internal, modifiers: DeclarationModifiers.Static, initializer: declaration.Declaration.Variables[0].Initializer.Value as SyntaxNode).WithLeadingTrivia(declaration.GetLeadingTrivia()).WithTrailingTrivia(declaration.GetTrailingTrivia());
+            SyntaxNode newFieldDecl = generator.FieldDeclaration(declaration.Declaration.Variables[0].Identifier.Text, generator.IdentifierName("DiagnosticDescriptor"), accessibility: Accessibility.Internal, modifiers: DeclarationModifiers.Static, initializer: declaration.Declaration.Variables[0].Initializer.Value).WithLeadingTrivia(declaration.GetLeadingTrivia()).WithTrailingTrivia(declaration.GetTrailingTrivia());
             return await ReplaceNode(declaration, newFieldDecl, document, cancellationToken).ConfigureAwait(false);
         }
 
@@ -1428,7 +1428,7 @@ namespace MetaCompilation.Analyzers
                 {
                     rule = fieldDeclaration;
 
-                    var declaratorSyntax = fieldDeclaration.Declaration.Variables[0] as VariableDeclaratorSyntax;
+                    var declaratorSyntax = fieldDeclaration.Declaration.Variables[0];
                     var objectCreationSyntax = declaratorSyntax.Initializer.Value as ObjectCreationExpressionSyntax;
                     ArgumentListSyntax ruleArgumentList = objectCreationSyntax.ArgumentList;
 
@@ -1470,7 +1470,7 @@ namespace MetaCompilation.Analyzers
 
                 if (isPublic && isConst)
                 {
-                    var ruleIdSyntax = fieldDeclaration.Declaration.Variables[0] as VariableDeclaratorSyntax;
+                    var ruleIdSyntax = fieldDeclaration.Declaration.Variables[0];
                     string newIdIdentifier = ruleIdSyntax.Identifier.Text;
                     newIdName = generator.IdentifierName(newIdIdentifier) as IdentifierNameSyntax;
                 }
@@ -1504,7 +1504,7 @@ namespace MetaCompilation.Analyzers
                 }
             }
 
-            SyntaxNode insertPointNode = insertPoint as SyntaxNode;
+            SyntaxNode insertPointNode = insertPoint;
 
             FieldDeclarationSyntax fieldDeclaration = CodeFixHelper.CreateEmptyRule(generator);
 
@@ -1627,7 +1627,7 @@ namespace MetaCompilation.Analyzers
                 return document;
             }
 
-            var oldBody = firstAccessor.Body as BlockSyntax;
+            var oldBody = firstAccessor.Body;
             SyntaxList<StatementSyntax> oldStatements = oldBody.Statements;
             StatementSyntax oldStatement = null;
             if (oldStatements.Count != 0)
@@ -1725,7 +1725,7 @@ namespace MetaCompilation.Analyzers
                 }
             }
 
-            SyntaxNode insertPointNode = insertPoint as SyntaxNode;
+            SyntaxNode insertPointNode = insertPoint;
 
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
 
@@ -1759,7 +1759,7 @@ namespace MetaCompilation.Analyzers
             {
                 MethodDeclarationSyntax initializeDeclaration = statement.Ancestors().OfType<MethodDeclarationSyntax>().First();
                 MethodDeclarationSyntax newInitializeDeclaration = initializeDeclaration.RemoveNode(statement, 0);
-                return newInitializeDeclaration as SyntaxNode;
+                return newInitializeDeclaration;
             }
 
             // checks if the statement is a correct regsiter statement
@@ -2003,7 +2003,7 @@ namespace MetaCompilation.Analyzers
             internal static SyntaxNode TriviaVarMissingHelper(SyntaxGenerator generator, IfStatementSyntax declaration)
             {
                 MethodDeclarationSyntax methodDecl = declaration.Parent.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
-                var methodBlock = methodDecl.Body as BlockSyntax;
+                var methodBlock = methodDecl.Body;
 
                 string variableName = GetIfKeywordName(methodBlock);
                 SyntaxNode identifierName = generator.IdentifierName(variableName);
@@ -2462,7 +2462,7 @@ namespace MetaCompilation.Analyzers
                 var nodeArgs = new SyntaxList<SyntaxNode>();
                 foreach (ArgumentSyntax arg in args)
                 {
-                    nodeArgs = nodeArgs.Add(arg as SyntaxNode);
+                    nodeArgs = nodeArgs.Add(arg);
                 }
 
                 return nodeArgs;

--- a/src/MetaCompilation.Analyzers/Core/DiagnosticAnalyzer.cs
+++ b/src/MetaCompilation.Analyzers/Core/DiagnosticAnalyzer.cs
@@ -505,8 +505,8 @@ namespace MetaCompilation.Analyzers
             // Checks the AnalyzeIfStatement of the user's analyzer, returns a bool representing whether the check was successful or not
             private bool CheckIfStatementAnalysis(List<string> ruleNames, CompilationAnalysisContext context, IMethodSymbol analysisMethodSymbol)
             {
-                var methodDeclaration = AnalysisGetStatements(analysisMethodSymbol) as MethodDeclarationSyntax;
-                var body = methodDeclaration.Body as BlockSyntax;
+                var methodDeclaration = AnalysisGetStatements(analysisMethodSymbol);
+                var body = methodDeclaration.Body;
                 if (body == null)
                 {
                     return false;
@@ -518,7 +518,7 @@ namespace MetaCompilation.Analyzers
                     return false;
                 }
 
-                var contextParameter = methodDeclaration.ParameterList.Parameters[0] as ParameterSyntax;
+                var contextParameter = methodDeclaration.ParameterList.Parameters[0];
                 if (contextParameter == null)
                 {
                     return false;
@@ -547,7 +547,7 @@ namespace MetaCompilation.Analyzers
                         // HasTrailingTrivia if-statement in user analyzer
                         if (statementCount > 2)
                         {
-                            var triviaBlock = IfStatementAnalysis3(statements, keywordIdentifierToken) as BlockSyntax;
+                            var triviaBlock = IfStatementAnalysis3(statements, keywordIdentifierToken);
                             if (triviaBlock == null)
                             {
                                 IfDiagnostic(context, statements[2], TrailingTriviaCheckIncorrectRule, keywordIdentifierToken.Text);
@@ -964,7 +964,7 @@ namespace MetaCompilation.Analyzers
                 var booleanExpression = statement.Condition as BinaryExpressionSyntax;
                 if (booleanExpression == null)
                 {
-                    var blockResult = WhitespaceKindCheckAlternate(statement, triviaIdentifierToken) as BlockSyntax;
+                    var blockResult = WhitespaceKindCheckAlternate(statement, triviaIdentifierToken);
                     if (blockResult == null)
                     {
                         return emptyResult;
@@ -997,7 +997,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var leftArgumentList = left.ArgumentList as ArgumentListSyntax;
+                var leftArgumentList = left.ArgumentList;
                 if (leftArgumentList == null)
                 {
                     return emptyResult;
@@ -1151,7 +1151,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var leftArgumentList = left.ArgumentList as ArgumentListSyntax;
+                var leftArgumentList = left.ArgumentList;
                 if (leftArgumentList == null)
                 {
                     return emptyResult;
@@ -1631,7 +1631,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var argumentList = invocationExpression.ArgumentList as ArgumentListSyntax;
+                var argumentList = invocationExpression.ArgumentList;
                 if (argumentList == null)
                 {
                     return emptyResult;
@@ -1643,7 +1643,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var startArg = args[0] as ArgumentSyntax;
+                var startArg = args[0];
                 if (startArg == null)
                 {
                     return emptyResult;
@@ -1655,7 +1655,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var endArg = args[1] as ArgumentSyntax;
+                var endArg = args[1];
                 if (endArg == null)
                 {
                     return emptyResult;
@@ -1717,7 +1717,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var argumentList = invocationExpression.ArgumentList as ArgumentListSyntax;
+                var argumentList = invocationExpression.ArgumentList;
                 if (argumentList == null)
                 {
                     return emptyResult;
@@ -1729,7 +1729,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var treeArg = args[0] as ArgumentSyntax;
+                var treeArg = args[0];
                 if (treeArg == null)
                 {
                     return emptyResult;
@@ -1753,7 +1753,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var spanArg = args[1] as ArgumentSyntax;
+                var spanArg = args[1];
                 if (spanArg == null)
                 {
                     return emptyResult;
@@ -1815,7 +1815,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var argumentList = invocationExpression.ArgumentList as ArgumentListSyntax;
+                var argumentList = invocationExpression.ArgumentList;
                 if (argumentList == null)
                 {
                     return emptyResult;
@@ -1827,7 +1827,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var ruleArg = args[0] as ArgumentSyntax;
+                var ruleArg = args[0];
                 if (ruleArg == null)
                 {
                     return emptyResult;
@@ -1839,7 +1839,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var locationArg = args[1] as ArgumentSyntax;
+                var locationArg = args[1];
                 if (locationArg == null)
                 {
                     return emptyResult;
@@ -1887,7 +1887,7 @@ namespace MetaCompilation.Analyzers
                     return false;
                 }
 
-                var argumentList = invocationExpression.ArgumentList as ArgumentListSyntax;
+                var argumentList = invocationExpression.ArgumentList;
                 if (argumentList == null)
                 {
                     return false;
@@ -1899,7 +1899,7 @@ namespace MetaCompilation.Analyzers
                     return false;
                 }
 
-                var diagnosticArg = args[0] as ArgumentSyntax;
+                var diagnosticArg = args[0];
                 if (diagnosticArg == null)
                 {
                     return false;
@@ -1925,7 +1925,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var variableDeclaration = statement.Declaration as VariableDeclarationSyntax;
+                var variableDeclaration = statement.Declaration;
                 if (variableDeclaration == null)
                 {
                     return emptyResult;
@@ -1937,7 +1937,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var variableDeclarator = variables[0] as VariableDeclaratorSyntax;
+                var variableDeclarator = variables[0];
                 if (variableDeclarator == null)
                 {
                     return emptyResult;
@@ -1949,7 +1949,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var equalsValueClause = variableDeclarator.Initializer as EqualsValueClauseSyntax;
+                var equalsValueClause = variableDeclarator.Initializer;
                 if (equalsValueClause == null)
                 {
                     return emptyResult;
@@ -1968,7 +1968,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var variableDeclaration = statement.Declaration as VariableDeclarationSyntax;
+                var variableDeclaration = statement.Declaration;
                 if (variableDeclaration == null)
                 {
                     return emptyResult;
@@ -1980,7 +1980,7 @@ namespace MetaCompilation.Analyzers
                     return emptyResult;
                 }
 
-                var variableDeclarator = variables[0] as VariableDeclaratorSyntax;
+                var variableDeclarator = variables[0];
                 if (variableDeclarator == null)
                 {
                     return emptyResult;
@@ -2038,7 +2038,7 @@ namespace MetaCompilation.Analyzers
 
                 if (statements.Count > 2)
                 {
-                    AccessorListSyntax propertyAccessorList = propertyDeclaration.AccessorList as AccessorListSyntax;
+                    AccessorListSyntax propertyAccessorList = propertyDeclaration.AccessorList;
                     ReportDiagnostic(context, TooManyStatementsRule, propertyAccessorList.Accessors[0].Keyword.GetLocation(), "get accessor", "1 or 2", "create and return an ImmutableArray containing all DiagnosticDescriptors");
                     return false;
                 }
@@ -2074,7 +2074,7 @@ namespace MetaCompilation.Analyzers
                 if (returnExpression is InvocationExpressionSyntax)
                 {
                     var valueClause = returnExpression as InvocationExpressionSyntax;
-                    var returnDeclaration = returnStatement as ReturnStatementSyntax;
+                    var returnDeclaration = returnStatement;
                     bool suppDiagReturnCheck = SuppDiagReturnCheck(context, valueClause, returnDeclaration, ruleNames, propertyDeclaration);
                     if (!suppDiagReturnCheck)
                     {
@@ -2083,7 +2083,7 @@ namespace MetaCompilation.Analyzers
 
                     if (statements.Count > 1)
                     {
-                        AccessorListSyntax propertyAccessorList = propertyDeclaration.AccessorList as AccessorListSyntax;
+                        AccessorListSyntax propertyAccessorList = propertyDeclaration.AccessorList;
                         ReportDiagnostic(context, TooManyStatementsRule, propertyAccessorList.Accessors[0].Keyword.GetLocation(), "get accessor", "1 or 2", "create and return an ImmutableArray containing all DiagnosticDescriptors");
                         return false;
                     }
@@ -2103,8 +2103,8 @@ namespace MetaCompilation.Analyzers
                         return false;
                     }
 
-                    InvocationExpressionSyntax valueClause = symbolResult.ValueClause as InvocationExpressionSyntax;
-                    ReturnStatementSyntax returnDeclaration = symbolResult.ReturnDeclaration as ReturnStatementSyntax;
+                    InvocationExpressionSyntax valueClause = symbolResult.ValueClause;
+                    ReturnStatementSyntax returnDeclaration = symbolResult.ReturnDeclaration;
                     bool suppDiagReturnCheck = SuppDiagReturnCheck(context, valueClause, returnDeclaration, ruleNames, propertyDeclaration);
                     if (!suppDiagReturnCheck)
                     {
@@ -2177,7 +2177,7 @@ namespace MetaCompilation.Analyzers
                     return null;
                 }
 
-                var accessorBody = getAccessor.Body as BlockSyntax;
+                var accessorBody = getAccessor.Body;
                 if (accessorBody == null)
                 {
                     ReportDiagnostic(context, IncorrectAccessorReturnRule, getAccessor.Keyword.GetLocation());
@@ -2218,7 +2218,7 @@ namespace MetaCompilation.Analyzers
                     return false;
                 }
 
-                var valueArguments = valueClause.ArgumentList as ArgumentListSyntax;
+                var valueArguments = valueClause.ArgumentList;
                 if (valueArguments == null)
                 {
                     ReportDiagnostic(context, SupportedRulesRule, valueExpression.GetLocation(), propertyDeclaration.Identifier.Text);
@@ -2289,7 +2289,7 @@ namespace MetaCompilation.Analyzers
                     return result;
                 }
 
-                var equalsValueClause = variableDeclaration.Initializer as EqualsValueClauseSyntax;
+                var equalsValueClause = variableDeclaration.Initializer;
                 if (equalsValueClause == null)
                 {
                     ReportDiagnostic(context, IncorrectAccessorReturnRule, variableDeclaration.GetLocation());
@@ -2356,7 +2356,7 @@ namespace MetaCompilation.Analyzers
                             return emptyRuleNames;
                         }
 
-                        var initializer = declaratorSyntax.Initializer as EqualsValueClauseSyntax;
+                        var initializer = declaratorSyntax.Initializer;
                         if (initializer == null)
                         {
                             return emptyRuleNames;
@@ -2474,7 +2474,7 @@ namespace MetaCompilation.Analyzers
                                         return emptyRuleNames;
                                     }
 
-                                    var ruleName = fieldSymbol.Name as string;
+                                    var ruleName = fieldSymbol.Name;
                                     if (ruleName == null)
                                     {
                                         return emptyRuleNames;
@@ -2711,8 +2711,8 @@ namespace MetaCompilation.Analyzers
                             return new CheckInitializeInfo();
                         }
 
-                        var invocationExpr = bodyResults.InvocationExpr as InvocationExpressionSyntax;
-                        var memberExpr = bodyResults.MemberExpr as MemberAccessExpressionSyntax;
+                        var invocationExpr = bodyResults.InvocationExpr;
+                        var memberExpr = bodyResults.MemberExpr;
                         invocExpr = invocationExpr;
 
                         if (!context.Compilation.GetSemanticModel(invocationExpr.SyntaxTree).GetSymbolInfo(memberExpr).CandidateSymbols.Any())
@@ -2783,7 +2783,7 @@ namespace MetaCompilation.Analyzers
                     return null;
                 }
 
-                var codeBlock = initializeMethod.Body as BlockSyntax;
+                var codeBlock = initializeMethod.Body;
                 if (codeBlock == null)
                 {
                     return null;
@@ -2824,7 +2824,7 @@ namespace MetaCompilation.Analyzers
                 }
 
                 MethodDeclarationSyntax methodDeclaration = statement.Parent.Parent as MethodDeclarationSyntax;
-                ParameterSyntax parameter = methodDeclaration.ParameterList.Parameters[0] as ParameterSyntax;
+                ParameterSyntax parameter = methodDeclaration.ParameterList.Parameters[0];
                 if (memberExprContext.Identifier.Text != parameter.Identifier.ValueText)
                 {
                     ReportDiagnostic(context, InvalidStatementRule, statements[0].GetLocation());

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/AddLanguageSupportToAnalyzerRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/AddLanguageSupportToAnalyzerRuleTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticAnalyzerApiUsageAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticAnalyzerApiUsageAnalyzerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DoNotStorePerCompilationDataOntoFieldsRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DoNotStorePerCompilationDataOntoFieldsRuleTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/InvalidReportDiagnosticRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/InvalidReportDiagnosticRuleTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/InvalidSyntaxKindTypeArgumentRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/InvalidSyntaxKindTypeArgumentRuleTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/MissingKindArgumentToRegisterActionRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/MissingKindArgumentToRegisterActionRuleTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithOnlyEndActionRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithOnlyEndActionRuleTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/UnsupportedSymbolKindArgumentRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/UnsupportedSymbolKindArgumentRuleTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/UpgradeMSBuildWorkspaceAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/UpgradeMSBuildWorkspaceAnalyzerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Analyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/UseReturnValueFromImmutableObjectMethodTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/UseReturnValueFromImmutableObjectMethodTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Analyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers;
 using Test.Utilities;

--- a/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CSharpDoNotHideBaseClassMethods.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CSharpDoNotHideBaseClassMethods.Fixer.cs
@@ -1,4 +1,6 @@
-﻿using System.Composition;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
 using Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Immutable;
 using System.Composition;

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetails.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetails.Fixer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
@@ -160,7 +160,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                         break;
 
                                     case IFieldReferenceOperation fieldReferenceOperation:
-                                        var fieldSymbol = (IFieldSymbol)fieldReferenceOperation.Field;
+                                        var fieldSymbol = fieldReferenceOperation.Field;
                                         possibleDelegateSymbol = fieldSymbol.Type; // Delegate field.
 
                                         if (possibleDelegateSymbol.TypeKind != TypeKind.Delegate)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/Helpers/SecurityHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/Helpers/SecurityHelpers.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseAutoValidateAntiforgeryToken.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseAutoValidateAntiforgeryToken.cs
@@ -140,7 +140,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                     break;
 
                                 case IFieldReferenceOperation fieldReferenceOperation:
-                                    var fieldSymbol = (IFieldSymbol)fieldReferenceOperation.Field;
+                                    var fieldSymbol = fieldReferenceOperation.Field;
 
                                     if (fieldSymbol.Type.TypeKind == TypeKind.Delegate)
                                     {

--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/Helpers/SecurityDiagnosticHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/Helpers/SecurityDiagnosticHelpers.cs
@@ -180,8 +180,7 @@ namespace Microsoft.NetFramework.Analyzers.Helpers
         {
             if (symbol != null && namedType != null)
             {
-                IPropertySymbol property = (IPropertySymbol)symbol;
-                return property.MatchPropertyByName(namedType, propertyName);
+                return symbol.MatchPropertyByName(namedType, propertyName);
             }
 
             return false;
@@ -191,8 +190,7 @@ namespace Microsoft.NetFramework.Analyzers.Helpers
         {
             if (symbol != null && namedType != null)
             {
-                IPropertySymbol property = (IPropertySymbol)symbol;
-                return property.MatchPropertyDerivedByName(namedType, propertyName);
+                return symbol.MatchPropertyDerivedByName(namedType, propertyName);
             }
 
             return false;

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/AvoidEmptyInterfacesTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AvoidEmptyInterfacesAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpAvoidEmptyInterfacesFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.AvoidEmptyInterfacesAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicAvoidEmptyInterfacesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionsShouldImplementGenericInterfaceTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.CollectionsShouldImplementGenericInterfaceAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpCollectionsShouldImplementGenericInterfaceFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.CollectionsShouldImplementGenericInterfaceAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicCollectionsShouldImplementGenericInterfaceFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DeclareTypesInNamespacesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DeclareTypesInNamespacesTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DeclareTypesInNamespacesAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpDeclareTypesInNamespacesFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DeclareTypesInNamespacesAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicDeclareTypesInNamespacesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DefineAccessorsForAttributeArgumentsTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DefineAccessorsForAttributeArgumentsTests.Fixer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpDefineAccessorsForAttributeArgumentsAnalyzer,

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DefineAccessorsForAttributeArgumentsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DefineAccessorsForAttributeArgumentsTests.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines;
-using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpDefineAccessorsForAttributeArgumentsAnalyzer,

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.Fixer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotHideBaseClassMethodsTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotHideBaseClassMethodsAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpDoNotHideBaseClassMethodsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.DoNotHideBaseClassMethodsAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicDoNotHideBaseClassMethodsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumWithFlagsAttributeTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumWithFlagsAttributeTests.Fixer.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumWithFlagsAttributeAnalyzer,

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHavePluralNamesTests.cs
@@ -5,12 +5,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumsShouldHavePluralNamesAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpEnumsShouldHavePluralNamesFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EnumsShouldHavePluralNamesAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicEnumsShouldHavePluralNamesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzerTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzerTests.Fixer.cs
@@ -5,9 +5,6 @@ using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EquatableAnalyzer,
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EquatableFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EquatableAnalyzer,
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.EquatableFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ExceptionsShouldBePublicTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ExceptionsShouldBePublicTests.Fixer.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ExceptionsShouldBePublicAnalyzer,

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldHaveCorrectPrefixTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldHaveCorrectPrefixAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldHaveCorrectPrefixFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldHaveCorrectPrefixAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicIdentifiersShouldHaveCorrectPrefixFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffixTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffixTests.cs
@@ -5,12 +5,6 @@ using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldHaveCorrectSuffixAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldHaveCorrectSuffixFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldHaveCorrectSuffixAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicIdentifiersShouldHaveCorrectSuffixFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
@@ -6,12 +6,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotContainUnderscoresAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldNotContainUnderscoresFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotContainUnderscoresAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicIdentifiersShouldNotContainUnderscoresFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotHaveIncorrectSuffixTests.cs
@@ -3,12 +3,6 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotHaveIncorrectSuffixAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldNotHaveIncorrectSuffixFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotHaveIncorrectSuffixAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicIdentifiersShouldNotHaveIncorrectSuffixFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberParameterRuleTests.cs
@@ -3,12 +3,6 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldNotMatchKeywordsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicIdentifiersShouldNotMatchKeywordsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsMemberRuleTests.cs
@@ -3,12 +3,6 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldNotMatchKeywordsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicIdentifiersShouldNotMatchKeywordsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsNamespaceRuleTests.cs
@@ -3,12 +3,6 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldNotMatchKeywordsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicIdentifiersShouldNotMatchKeywordsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTests.cs
@@ -1,13 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Test.Utilities;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldNotMatchKeywordsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicIdentifiersShouldNotMatchKeywordsFixer>;
-
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
     public class IdentifiersShouldNotMatchKeywordsTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotMatchKeywordsTypeRuleTests.cs
@@ -3,12 +3,6 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpIdentifiersShouldNotMatchKeywordsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.IdentifiersShouldNotMatchKeywordsAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicIdentifiersShouldNotMatchKeywordsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ImplementIDisposableCorrectlyTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ImplementIDisposableCorrectlyAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpImplementIDisposableCorrectlyFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.ImplementIDisposableCorrectlyAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicImplementIDisposableCorrectlyFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithAssemblyVersionTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithAssemblyVersionTests.cs
@@ -1,17 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithAttributesDiagnosticAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpMarkAssembliesWithAssemblyVersionFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithAttributesDiagnosticAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicMarkAssembliesWithAssemblyVersionFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithClsCompliantTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithClsCompliantTests.cs
@@ -1,17 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithAttributesDiagnosticAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpMarkAssembliesWithClsCompliantFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithAttributesDiagnosticAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicMarkAssembliesWithClsCompliantFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithComVisibleTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithComVisibleTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithComVisibleAnalyzer,
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithComVisibleFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithComVisibleAnalyzer,
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MarkAssembliesWithComVisibleFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MovePInvokesToNativeMethodsClassTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MovePInvokesToNativeMethodsClassAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpMovePInvokesToNativeMethodsClassFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.MovePInvokesToNativeMethodsClassAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicMovePInvokesToNativeMethodsClassFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypesTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnlyTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.PropertiesShouldNotBeWriteOnlyAnalyzer,
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.PropertiesShouldNotBeWriteOnlyFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.PropertiesShouldNotBeWriteOnlyAnalyzer,
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.PropertiesShouldNotBeWriteOnlyFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/PropertyNamesShouldNotMatchGetMethodsTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.PropertyNamesShouldNotMatchGetMethodsAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpPropertyNamesShouldNotMatchGetMethodsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.PropertyNamesShouldNotMatchGetMethodsAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicPropertyNamesShouldNotMatchGetMethodsFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/StaticHolderTypeTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/StaticHolderTypeTests.Fixer.cs
@@ -5,9 +5,6 @@ using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.StaticHolderTypesAnalyzer,
     Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpStaticHolderTypesFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.StaticHolderTypesAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespacesTests.cs
@@ -6,12 +6,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.TypeNamesShouldNotMatchNamespacesAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpTypeNamesShouldNotMatchNamespacesFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.TypeNamesShouldNotMatchNamespacesAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicTypeNamesShouldNotMatchNamespacesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseEventsWhereAppropriateTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseEventsWhereAppropriateTests.cs
@@ -3,12 +3,6 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UseEventsWhereAppropriateAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpUseEventsWhereAppropriateFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UseEventsWhereAppropriateAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicUseEventsWhereAppropriateFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseGenericEventHandlerInstancesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseGenericEventHandlerInstancesTests.cs
@@ -5,12 +5,6 @@ using Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpUseGenericEventHandlerInstancesAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpUseGenericEventHandlerInstancesFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicUseGenericEventHandlerInstancesAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicUseGenericEventHandlerInstancesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePreferredTermsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePreferredTermsTests.cs
@@ -1,13 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Test.Utilities;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpUsePreferredTermsAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpUsePreferredTermsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicUsePreferredTermsAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicUsePreferredTermsFixer>;
-
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {
     public class UsePreferredTermsTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UsePropertiesWhereAppropriateAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines.CSharpUsePropertiesWhereAppropriateFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UsePropertiesWhereAppropriateAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines.BasicUsePropertiesWhereAppropriateFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiReview/AvoidCallingProblematicMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiReview/AvoidCallingProblematicMethodsTests.cs
@@ -1,13 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Test.Utilities;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiReview.CSharpAvoidCallingProblematicMethodsAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.ApiReview.CSharpAvoidCallingProblematicMethodsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiReview.BasicAvoidCallingProblematicMethodsAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.ApiReview.BasicAvoidCallingProblematicMethodsFixer>;
-
 namespace Microsoft.CodeQuality.Analyzers.ApiReview.UnitTests
 {
     public class AvoidCallingProblematicMethodsTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Documentation/AvoidUsingCrefTagsWithAPrefixTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Documentation/AvoidUsingCrefTagsWithAPrefixTests.cs
@@ -6,12 +6,6 @@ using Microsoft.CodeQuality.CSharp.Analyzers.Documentation;
 using Microsoft.CodeQuality.VisualBasic.Analyzers.Documentation;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.CSharp.Analyzers.Documentation.CSharpAvoidUsingCrefTagsWithAPrefixAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.Documentation.CSharpAvoidUsingCrefTagsWithAPrefixFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.VisualBasic.Analyzers.Documentation.BasicAvoidUsingCrefTagsWithAPrefixAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.Documentation.BasicAvoidUsingCrefTagsWithAPrefixFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.Documentation.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
 
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.Maintainability.AvoidUninstantiatedInternalClassesAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.Maintainability.CSharpAvoidUninstantiatedInternalClassesFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.Maintainability.AvoidUninstantiatedInternalClassesAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability.BasicAvoidUninstantiatedInternalClassesFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsAnalyzerTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/VariableNamesShouldNotMatchFieldNamesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/VariableNamesShouldNotMatchFieldNamesTests.cs
@@ -1,13 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Test.Utilities;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.CSharp.Analyzers.Maintainability.CSharpVariableNamesShouldNotMatchFieldNamesAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.Maintainability.CSharpVariableNamesShouldNotMatchFieldNamesFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability.BasicVariableNamesShouldNotMatchFieldNamesAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.Maintainability.BasicVariableNamesShouldNotMatchFieldNamesFixer>;
-
 namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
 {
     public class VariableNamesShouldNotMatchFieldNamesTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidDuplicateElementInitializationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidDuplicateElementInitializationTests.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines;
 using Test.Utilities;
 using Xunit;
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/PreferJaggedArraysOverMultidimensionalTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/PreferJaggedArraysOverMultidimensionalTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.QualityGuidelines.PreferJaggedArraysOverMultidimensionalAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines.CSharpPreferJaggedArraysOverMultidimensionalFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.Analyzers.QualityGuidelines.PreferJaggedArraysOverMultidimensionalAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines.BasicPreferJaggedArraysOverMultidimensionalFixer>;
 
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetailsTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetailsTests.Fixer.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ReviewVisibleEventHandlersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ReviewVisibleEventHandlersTests.cs
@@ -1,13 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Test.Utilities;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines.CSharpReviewVisibleEventHandlersAnalyzer,
-    Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines.CSharpReviewVisibleEventHandlersFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines.BasicReviewVisibleEventHandlersAnalyzer,
-    Microsoft.CodeQuality.VisualBasic.Analyzers.QualityGuidelines.BasicReviewVisibleEventHandlersFixer>;
-
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.UnitTests
 {
     public class ReviewVisibleEventHandlersTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Data/ReviewSQLQueriesForSecurityVulnerabilitiesTests.cs
@@ -3,7 +3,6 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
-using Test.Utilities.MinimalImplementations;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Data.ReviewSqlQueriesForSecurityVulnerabilities,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/MarkBooleanPInvokeArgumentsWithMarshalAsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/MarkBooleanPInvokeArgumentsWithMarshalAsTests.cs
@@ -1,13 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Test.Utilities;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.CSharp.Analyzers.InteropServices.CSharpMarkBooleanPInvokeArgumentsWithMarshalAsAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.InteropServices.CSharpMarkBooleanPInvokeArgumentsWithMarshalAsFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.VisualBasic.Analyzers.InteropServices.BasicMarkBooleanPInvokeArgumentsWithMarshalAsAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.InteropServices.BasicMarkBooleanPInvokeArgumentsWithMarshalAsFixer>;
-
 namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
 {
     public class MarkBooleanPInvokeArgumentsWithMarshalAsTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/UseManagedEquivalentsOfWin32ApiTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/UseManagedEquivalentsOfWin32ApiTests.cs
@@ -1,13 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Test.Utilities;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.CSharp.Analyzers.InteropServices.CSharpUseManagedEquivalentsOfWin32ApiAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.InteropServices.CSharpUseManagedEquivalentsOfWin32ApiFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.VisualBasic.Analyzers.InteropServices.BasicUseManagedEquivalentsOfWin32ApiAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.InteropServices.BasicUseManagedEquivalentsOfWin32ApiFixer>;
-
 namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
 {
     public class UseManagedEquivalentsOfWin32ApiTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotUseCountWhenAnyCanBeUsedTests.Base.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotUseCountWhenAnyCanBeUsedTests.Base.cs
@@ -1,17 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using System.Net;
-using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.NetCore.Analyzers.Performance.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotUseCountWhenAnyCanBeUsedTests.Code.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotUseCountWhenAnyCanBeUsedTests.Code.cs
@@ -1,18 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using System.Net;
-using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotUseCountWhenAnyCanBeUsedTests.Data.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotUseCountWhenAnyCanBeUsedTests.Data.cs
@@ -1,18 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Linq;
-using System.Net;
-using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotUseCountWhenAnyCanBeUsedTests.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotUseCountWhenAnyCanBeUsedTests.Tests.cs
@@ -1,15 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Linq;
-using System.Net;
-using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.NetCore.CSharp.Analyzers.Performance;
 using Microsoft.NetCore.VisualBasic.Analyzers.Performance;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/CallGCSuppressFinalizeCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/CallGCSuppressFinalizeCorrectlyTests.cs
@@ -6,12 +6,6 @@ using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.CallGCSuppressFinalizeCorrectlyAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpCallGCSuppressFinalizeCorrectlyFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.CallGCSuppressFinalizeCorrectlyAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicCallGCSuppressFinalizeCorrectlyFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableTypesShouldDeclareFinalizerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableTypesShouldDeclareFinalizerTests.cs
@@ -1,16 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DisposableTypesShouldDeclareFinalizerAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDisposableTypesShouldDeclareFinalizerFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DisposableTypesShouldDeclareFinalizerAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicDisposableTypesShouldDeclareFinalizerFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeMethodsShouldCallBaseClassDisposeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeMethodsShouldCallBaseClassDisposeTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DisposeMethodsShouldCallBaseClassDispose,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDisposeMethodsShouldCallBaseClassDisposeFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DisposeMethodsShouldCallBaseClassDispose,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicDisposeMethodsShouldCallBaseClassDisposeFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseTimersThatPreventPowerStateChangesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseTimersThatPreventPowerStateChangesTests.cs
@@ -1,13 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Test.Utilities;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDoNotUseTimersThatPreventPowerStateChangesAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDoNotUseTimersThatPreventPowerStateChangesFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicDoNotUseTimersThatPreventPowerStateChangesAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicDoNotUseTimersThatPreventPowerStateChangesFixer>;
-
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class DoNotUseTimersThatPreventPowerStateChangesTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ImplementISerializableCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ImplementISerializableCorrectlyTests.cs
@@ -1,14 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpImplementISerializableCorrectlyAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpImplementISerializableCorrectlyFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicImplementISerializableCorrectlyAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicImplementISerializableCorrectlyFixer>;
-using Test.Utilities;
-
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class ImplementISerializableCorrectlyTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ImplementSerializationMethodsCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ImplementSerializationMethodsCorrectlyTests.cs
@@ -1,14 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpImplementSerializationMethodsCorrectlyAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpImplementSerializationMethodsCorrectlyFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicImplementSerializationMethodsCorrectlyAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicImplementSerializationMethodsCorrectlyFixer>;
-using Test.Utilities;
-
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class ImplementSerializationMethodsCorrectlyTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InitializeStaticFieldsInlineTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InitializeStaticFieldsInlineTests.cs
@@ -6,12 +6,6 @@ using Microsoft.NetCore.CSharp.Analyzers.Runtime;
 using Microsoft.NetCore.VisualBasic.Analyzers.Runtime;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpInitializeStaticFieldsInlineAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpInitializeStaticFieldsInlineFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicInitializeStaticFieldsInlineAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicInitializeStaticFieldsInlineFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.InstantiateArgumentExceptionsCorrectlyAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpInstantiateArgumentExceptionsCorrectlyFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.InstantiateArgumentExceptionsCorrectlyAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicInstantiateArgumentExceptionsCorrectlyFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/MarkAllNonSerializableFieldsTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/MarkAllNonSerializableFieldsTests.Fixer.cs
@@ -4,11 +4,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.VisualBasic.Testing;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.NetCore.CSharp.Analyzers.Runtime;
 using Microsoft.NetCore.VisualBasic.Analyzers.Runtime;
-using Test.Utilities;
 using Xunit;
 using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.SerializationRulesDiagnosticAnalyzer,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/NormalizeStringsToUppercaseTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/NormalizeStringsToUppercaseTests.cs
@@ -5,12 +5,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.NormalizeStringsToUppercaseAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpNormalizeStringsToUppercaseFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.NormalizeStringsToUppercaseAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicNormalizeStringsToUppercaseFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideDeserializationMethodsForOptionalFieldsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideDeserializationMethodsForOptionalFieldsTests.cs
@@ -1,16 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.NetCore.CSharp.Analyzers.Runtime;
-using Microsoft.NetCore.VisualBasic.Analyzers.Runtime;
-using Test.Utilities;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpProvideDeserializationMethodsForOptionalFieldsAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpProvideDeserializationMethodsForOptionalFieldsFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicProvideDeserializationMethodsForOptionalFieldsAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicProvideDeserializationMethodsForOptionalFieldsFixer>;
-
 namespace Microsoft.NetFramework.Analyzers.UnitTests
 {
     public class ProvideDeserializationMethodsForOptionalFieldsTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
@@ -3,12 +3,6 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.SpecifyCultureInfoAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpSpecifyCultureInfoFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.SpecifyCultureInfoAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicSpecifyCultureInfoFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProviderTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProviderTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.SpecifyIFormatProviderAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpSpecifyIFormatProviderFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.SpecifyIFormatProviderAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicSpecifyIFormatProviderFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyStringComparisonTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyStringComparisonTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.SpecifyStringComparisonAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpSpecifyStringComparisonFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.SpecifyStringComparisonAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicSpecifyStringComparisonFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotDisableHTTPHeaderCheckingTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotDisableHTTPHeaderCheckingTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/SetViewStateUserKeyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/SetViewStateUserKeyTests.cs
@@ -3,7 +3,6 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
-using Test.Utilities.MinimalImplementations;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Security.SetViewStateUserKey,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTasksWithoutPassingATaskSchedulerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTasksWithoutPassingATaskSchedulerTests.cs
@@ -4,12 +4,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Tasks.DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer,
-    Microsoft.NetCore.CSharp.Analyzers.Tasks.CSharpDoNotCreateTasksWithoutPassingATaskSchedulerFixer>;
-using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Tasks.DoNotCreateTasksWithoutPassingATaskSchedulerAnalyzer,
-    Microsoft.NetCore.VisualBasic.Analyzers.Tasks.BasicDoNotCreateTasksWithoutPassingATaskSchedulerFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/AvoidDuplicateAcceleratorsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/AvoidDuplicateAcceleratorsTests.cs
@@ -1,15 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.NetFramework.CSharp.Analyzers;
-using Microsoft.NetFramework.VisualBasic.Analyzers;
-using Microsoft.CodeAnalysis.Diagnostics;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpAvoidDuplicateAcceleratorsAnalyzer,
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpAvoidDuplicateAcceleratorsFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicAvoidDuplicateAcceleratorsAnalyzer,
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicAvoidDuplicateAcceleratorsFixer>;
-
 namespace Microsoft.NetFramework.Analyzers.UnitTests
 {
     public class AvoidDuplicateAcceleratorsTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/CallBaseClassMethodsOnISerializableTypesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/CallBaseClassMethodsOnISerializableTypesTests.cs
@@ -1,15 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.NetFramework.CSharp.Analyzers;
-using Microsoft.NetFramework.VisualBasic.Analyzers;
-using Microsoft.CodeAnalysis.Diagnostics;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpCallBaseClassMethodsOnISerializableTypesAnalyzer,
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpCallBaseClassMethodsOnISerializableTypesFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicCallBaseClassMethodsOnISerializableTypesAnalyzer,
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicCallBaseClassMethodsOnISerializableTypesFixer>;
-
 namespace Microsoft.NetFramework.Analyzers.UnitTests
 {
     public class CallBaseClassMethodsOnISerializableTypesTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotMarkServicedComponentsWithWebMethodTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotMarkServicedComponentsWithWebMethodTests.cs
@@ -1,15 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.NetFramework.CSharp.Analyzers;
-using Microsoft.NetFramework.VisualBasic.Analyzers;
-using Microsoft.CodeAnalysis.Diagnostics;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpDoNotMarkServicedComponentsWithWebMethodAnalyzer,
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpDoNotMarkServicedComponentsWithWebMethodFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicDoNotMarkServicedComponentsWithWebMethodAnalyzer,
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicDoNotMarkServicedComponentsWithWebMethodFixer>;
-
 namespace Microsoft.NetFramework.Analyzers.UnitTests
 {
     public class DoNotMarkServicedComponentsWithWebMethodTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
     Microsoft.NetFramework.Analyzers.DoNotUseInsecureDtdProcessingAnalyzer,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/MarkWindowsFormsEntryPointsWithStaThreadTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/MarkWindowsFormsEntryPointsWithStaThreadTests.cs
@@ -1,15 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.NetFramework.CSharp.Analyzers;
-using Microsoft.NetFramework.VisualBasic.Analyzers;
-using Microsoft.CodeAnalysis.Diagnostics;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpMarkWindowsFormsEntryPointsWithStaThreadAnalyzer,
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpMarkWindowsFormsEntryPointsWithStaThreadFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicMarkWindowsFormsEntryPointsWithStaThreadAnalyzer,
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicMarkWindowsFormsEntryPointsWithStaThreadFixer>;
-
 namespace Microsoft.NetFramework.Analyzers.UnitTests
 {
     public class MarkWindowsFormsEntryPointsWithStaThreadTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/SetLocaleForDataTypesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/SetLocaleForDataTypesTests.cs
@@ -1,15 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.NetFramework.CSharp.Analyzers;
-using Microsoft.NetFramework.VisualBasic.Analyzers;
-using Microsoft.CodeAnalysis.Diagnostics;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpSetLocaleForDataTypesAnalyzer,
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpSetLocaleForDataTypesFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicSetLocaleForDataTypesAnalyzer,
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicSetLocaleForDataTypesFixer>;
-
 namespace Microsoft.NetFramework.Analyzers.UnitTests
 {
     public class SetLocaleForDataTypesTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/SpecifyMessageBoxOptionsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/SpecifyMessageBoxOptionsTests.cs
@@ -1,15 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.NetFramework.CSharp.Analyzers;
-using Microsoft.NetFramework.VisualBasic.Analyzers;
-using Microsoft.CodeAnalysis.Diagnostics;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpSpecifyMessageBoxOptionsAnalyzer,
-    Microsoft.NetFramework.CSharp.Analyzers.CSharpSpecifyMessageBoxOptionsFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicSpecifyMessageBoxOptionsAnalyzer,
-    Microsoft.NetFramework.VisualBasic.Analyzers.BasicSpecifyMessageBoxOptionsFixer>;
-
 namespace Microsoft.NetFramework.Analyzers.UnitTests
 {
     public class SpecifyMessageBoxOptionsTests

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetFramework.Analyzers/Helpers/SyntaxNodeHelper.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetFramework.Analyzers/Helpers/SyntaxNodeHelper.vb
@@ -248,7 +248,7 @@ Namespace Microsoft.NetFramework.VisualBasic.Analyzers.Helpers
             Dim declaration As MethodBlockSyntax = node.AncestorsAndSelf().OfType(Of MethodBlockSyntax)().FirstOrDefault()
 
             If (declaration IsNot Nothing) Then
-                Return CType(semanticModel.GetDeclaredSymbol(declaration), IMethodSymbol)
+                Return semanticModel.GetDeclaredSymbol(declaration)
             End If
 
             Dim constructor As SubNewStatementSyntax = node.AncestorsAndSelf().OfType(Of SubNewStatementSyntax)().FirstOrDefault()

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DoNotMixAttributesFromDifferentVersionsOfMEFTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DoNotMixAttributesFromDifferentVersionsOfMEFTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DoNotUseGenericCodeActionCreateToCreateCodeActionTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DoNotUseGenericCodeActionCreateToCreateCodeActionTests.cs
@@ -1,15 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Roslyn.Diagnostics.CSharp.Analyzers;
-using Roslyn.Diagnostics.VisualBasic.Analyzers;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Roslyn.Diagnostics.CSharp.Analyzers.CSharpCodeActionCreateAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Roslyn.Diagnostics.VisualBasic.Analyzers.BasicCodeActionCreateAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-
 namespace Roslyn.Diagnostics.Analyzers.UnitTests
 {
     public class DoNotUseGenericCodeActionCreateToCreateCodeActionTests

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTests.cs
@@ -1,12 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Roslyn.Diagnostics.VisualBasic.Analyzers;
-using Test.Utilities;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Roslyn.Diagnostics.VisualBasic.Analyzers.BasicInvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-
 namespace Roslyn.Diagnostics.Analyzers.UnitTests
 {
     public class InvokeTheCorrectPropertyToEnsureCorrectUseSiteDiagnosticsTests

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/PartsExportedWithMEFv2MustBeMarkedAsSharedTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/PartsExportedWithMEFv2MustBeMarkedAsSharedTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/SymbolDeclaredEventMustBeGeneratedForSourceSymbolsTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/SymbolDeclaredEventMustBeGeneratedForSourceSymbolsTests.cs
@@ -1,16 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Roslyn.Diagnostics.CSharp.Analyzers;
-using Roslyn.Diagnostics.VisualBasic.Analyzers;
-using Test.Utilities;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Roslyn.Diagnostics.CSharp.Analyzers.CSharpSymbolDeclaredEventAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Roslyn.Diagnostics.VisualBasic.Analyzers.BasicSymbolDeclaredEventAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-
 namespace Roslyn.Diagnostics.Analyzers.UnitTests
 {
     public class SymbolDeclaredEventMustBeGeneratedForSourceSymbolsTests

--- a/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
+++ b/src/Test.Utilities/DiagnosticAnalyzerTestBase.cs
@@ -10,7 +10,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Test.Utilities/TestValidationMode.cs
+++ b/src/Test.Utilities/TestValidationMode.cs
@@ -1,4 +1,6 @@
-﻿namespace Test.Utilities
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Test.Utilities
 {
     public enum TestValidationMode
     {

--- a/src/Text.Analyzers/UnitTests/IdentifiersShouldBeSpelledCorrectlyTests.cs
+++ b/src/Text.Analyzers/UnitTests/IdentifiersShouldBeSpelledCorrectlyTests.cs
@@ -1,16 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using Test.Utilities;
-using Text.CSharp.Analyzers;
-using Text.VisualBasic.Analyzers;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Text.CSharp.Analyzers.CSharpIdentifiersShouldBeSpelledCorrectlyAnalyzer,
-    Text.CSharp.Analyzers.CSharpIdentifiersShouldBeSpelledCorrectlyFixer>;
-using VerifyVB = Microsoft.CodeAnalysis.VisualBasic.Testing.XUnit.CodeFixVerifier<
-    Text.VisualBasic.Analyzers.BasicIdentifiersShouldBeSpelledCorrectlyAnalyzer,
-    Text.VisualBasic.Analyzers.BasicIdentifiersShouldBeSpelledCorrectlyFixer>;
-
 namespace Text.Analyzers.UnitTests
 {
     public class IdentifiersShouldBeSpelledCorrectlyTests

--- a/src/Tools/GenerateAnalyzerRulesets/CodeFixerExtensions.cs
+++ b/src/Tools/GenerateAnalyzerRulesets/CodeFixerExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;

--- a/src/Tools/GenerateAnalyzerRulesets/JsonWriter.cs
+++ b/src/Tools/GenerateAnalyzerRulesets/JsonWriter.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 // https://github.com/dotnet/roslyn/blob/master/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
 
 using System;

--- a/src/Tools/ReleaseNotesUtil/AnalyzerAssemblyLoader.cs
+++ b/src/Tools/ReleaseNotesUtil/AnalyzerAssemblyLoader.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Reflection;
 using Microsoft.CodeAnalysis;
 
 namespace ReleaseNotesUtil

--- a/src/Tools/ReleaseNotesUtil/CategoryThenIdComparer.cs
+++ b/src/Tools/ReleaseNotesUtil/CategoryThenIdComparer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 
 namespace ReleaseNotesUtil

--- a/src/Tools/ReleaseNotesUtil/DiagnosticIdComparer.cs
+++ b/src/Tools/ReleaseNotesUtil/DiagnosticIdComparer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 

--- a/src/Tools/ReleaseNotesUtil/FixerExtensions.cs
+++ b/src/Tools/ReleaseNotesUtil/FixerExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;

--- a/src/Tools/ReleaseNotesUtil/RuleFileContent.cs
+++ b/src/Tools/ReleaseNotesUtil/RuleFileContent.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace ReleaseNotesUtil

--- a/src/Utilities/Compiler/Extensions/IDictionaryExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IDictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license 
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 

--- a/src/Utilities/Compiler/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;

--- a/src/Utilities/Compiler/Extensions/ImmutableHashSetExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ImmutableHashSetExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license 
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using Analyzer.Utilities.PooledObjects;

--- a/src/Utilities/Compiler/Extensions/PooledHashSetExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/PooledHashSetExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license 
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 

--- a/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license 
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 

--- a/src/Utilities/Compiler/Extensions/SymbolVisibility.cs
+++ b/src/Utilities/Compiler/Extensions/SymbolVisibility.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System;
 
 namespace Analyzer.Utilities.Extensions

--- a/src/Utilities/Compiler/NullableAttributes.cs
+++ b/src/Utilities/Compiler/NullableAttributes.cs
@@ -1,6 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 // This was copied from https://github.com/dotnet/coreclr/blob/60f1e6265bd1039f023a82e0643b524d6aaf7845/src/System.Private.CoreLib/shared/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 // and updated to have the scope of the attributes be internal.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ITaintedDataInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ITaintedDataInfo.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license 
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -475,21 +475,21 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         }
 
         protected override bool IsReachableBlockData(TAnalysisData analysisData)
-            => (analysisData as AnalysisEntityBasedPredicateAnalysisData<TAbstractAnalysisValue>)?.IsReachableBlockData ?? true;
+            => analysisData?.IsReachableBlockData ?? true;
 
         protected sealed override void StartTrackingPredicatedData(AnalysisEntity predicatedEntity, TAnalysisData? truePredicateData, TAnalysisData? falsePredicateData)
-                => (CurrentAnalysisData as AnalysisEntityBasedPredicateAnalysisData<TAbstractAnalysisValue>)?.StartTrackingPredicatedData(
+                => CurrentAnalysisData?.StartTrackingPredicatedData(
                         predicatedEntity,
-                        truePredicateData as AnalysisEntityBasedPredicateAnalysisData<TAbstractAnalysisValue>,
-                        falsePredicateData as AnalysisEntityBasedPredicateAnalysisData<TAbstractAnalysisValue>);
+                        truePredicateData,
+                        falsePredicateData);
         protected sealed override void StopTrackingPredicatedData(AnalysisEntity predicatedEntity)
-            => (CurrentAnalysisData as AnalysisEntityBasedPredicateAnalysisData<TAbstractAnalysisValue>)?.StopTrackingPredicatedData(predicatedEntity);
+            => CurrentAnalysisData?.StopTrackingPredicatedData(predicatedEntity);
         protected sealed override bool HasPredicatedDataForEntity(TAnalysisData analysisData, AnalysisEntity predicatedEntity)
-            => (analysisData as AnalysisEntityBasedPredicateAnalysisData<TAbstractAnalysisValue>)?.HasPredicatedDataForEntity(predicatedEntity) == true;
+            => analysisData?.HasPredicatedDataForEntity(predicatedEntity) == true;
         protected sealed override void TransferPredicatedData(AnalysisEntity fromEntity, AnalysisEntity toEntity)
-            => (CurrentAnalysisData as AnalysisEntityBasedPredicateAnalysisData<TAbstractAnalysisValue>)?.TransferPredicatedData(fromEntity, toEntity);
+            => CurrentAnalysisData?.TransferPredicatedData(fromEntity, toEntity);
         protected sealed override PredicateValueKind ApplyPredicatedDataForEntity(TAnalysisData analysisData, AnalysisEntity predicatedEntity, bool trueData)
-            => (analysisData as AnalysisEntityBasedPredicateAnalysisData<TAbstractAnalysisValue>)?.ApplyPredicatedDataForEntity(predicatedEntity, trueData) ?? PredicateValueKind.Unknown;
+            => analysisData?.ApplyPredicatedDataForEntity(predicatedEntity, trueData) ?? PredicateValueKind.Unknown;
         protected override void SetPredicateValueKind(IOperation operation, TAnalysisData analysisData, PredicateValueKind predicateValueKind)
         {
             base.SetPredicateValueKind(operation, analysisData, predicateValueKind);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/LValueFlowCapturesProvider.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/LValueFlowCapturesProvider.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
+
+#if DEBUG
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+#endif
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {


### PR DESCRIPTION
Strongly recommend to review commit by commit.

Newly enforced analyzers:

```ini
# IDE0004: Remove unnecessary cast
dotnet_diagnostic.IDE0004.severity = warning

# IDE0005: Remove unnecessary usings/imports
dotnet_diagnostic.IDE0005.severity = warning

# IDE0051: Remove unused private members (no reads or writes)
dotnet_diagnostic.IDE0051.severity = warning

# IDE0052: Remove unread private members (writes but no reads)
dotnet_diagnostic.IDE0052.severity = warning

# IDE0066: Convert switch statement to expression
dotnet_diagnostic.IDE0066.severity = warning

# IDE0073: File header
dotnet_diagnostic.IDE0073.severity = warning
file_header_template = Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
```