### PR TITLE
Enhance DiagnosticDescriptorCreationAnalyzer to support analysis of h…

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -207,32 +207,25 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 var idToAnalyzerMap = new ConcurrentDictionary<string, ConcurrentDictionary<string, ConcurrentBag<Location>>>();
                 compilationContext.RegisterOperationAction(operationAnalysisContext =>
                 {
-                    if (!(((IFieldInitializerOperation)operationAnalysisContext.Operation).Value is IObjectCreationOperation objectCreation))
+                    var fieldInitializer = (IFieldInitializerOperation)operationAnalysisContext.Operation;
+                    if (!TryGetDescriptorCreateMethodAndArguments(fieldInitializer, diagnosticDescriptorType, out var creationMethod, out var creationArguments))
                     {
                         return;
                     }
 
-                    var ctor = objectCreation.Constructor;
-                    if (ctor == null ||
-                        !diagnosticDescriptorType.Equals(ctor.ContainingType) ||
-                        !diagnosticDescriptorType.InstanceConstructors.Any(c => c.Equals(ctor)))
-                    {
-                        return;
-                    }
-
-                    AnalyzeTitle(operationAnalysisContext, objectCreation);
-                    AnalyzeHelpLinkUri(operationAnalysisContext, objectCreation);
-                    AnalyzeCustomTags(operationAnalysisContext, objectCreation);
+                    AnalyzeTitle(creationMethod, fieldInitializer, operationAnalysisContext.ReportDiagnostic);
+                    AnalyzeHelpLinkUri(operationAnalysisContext, creationArguments);
+                    AnalyzeCustomTags(operationAnalysisContext, creationArguments);
 
                     string? categoryOpt = null;
                     if (!checkCategoryAndAllowedIds ||
-                        !TryAnalyzeCategory(operationAnalysisContext, objectCreation,
+                        !TryAnalyzeCategory(operationAnalysisContext, creationArguments,
                             additionalTextOpt!, categoryAndAllowedIdsMap!, out categoryOpt, out var allowedIdsInfoList))
                     {
                         allowedIdsInfoList = default;
                     }
 
-                    AnalyzeRuleId(operationAnalysisContext, objectCreation, additionalTextOpt,
+                    AnalyzeRuleId(operationAnalysisContext, creationArguments, additionalTextOpt,
                         categoryOpt, allowedIdsInfoList, idToAnalyzerMap);
 
                 }, OperationKind.FieldInitializer);
@@ -276,28 +269,57 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             });
         }
 
-        private static void AnalyzeTitle(OperationAnalysisContext operationAnalysisContext, IObjectCreationOperation objectCreation)
+        private static bool TryGetDescriptorCreateMethodAndArguments(
+            IFieldInitializerOperation fieldInitializer,
+            INamedTypeSymbol diagnosticDescriptorType,
+            out IMethodSymbol creationMethod,
+            out ImmutableArray<IArgumentOperation> creationArguments)
         {
-            IParameterSymbol title = objectCreation.Constructor.Parameters.FirstOrDefault(p => p.Name == "title");
+            (creationMethod, creationArguments) = fieldInitializer.Value switch
+            {
+                IObjectCreationOperation objectCreation when IsDescriptorConstructor(objectCreation.Constructor)
+                    => (objectCreation.Constructor, objectCreation.Arguments),
+                IInvocationOperation invocation when IsCreateHelper(invocation.TargetMethod)
+                    => (invocation.TargetMethod, invocation.Arguments),
+                _ => default
+            };
+
+            return creationMethod != null;
+
+            bool IsDescriptorConstructor(IMethodSymbol method)
+                => method.ContainingType.Equals(diagnosticDescriptorType);
+
+            // Heuristic to identify helper methods to create DiagnosticDescriptor:
+            //  "A method invocation that returns 'DiagnosticDescriptor' and has a first string parameter named 'id'"
+            bool IsCreateHelper(IMethodSymbol method)
+                => method.ReturnType.Equals(diagnosticDescriptorType) &&
+                    !method.Parameters.IsEmpty &&
+                    method.Parameters[0].Name == DiagnosticIdParameterName &&
+                    method.Parameters[0].Type.SpecialType == SpecialType.System_String;
+        }
+
+        private static void AnalyzeTitle(IMethodSymbol descriptorCreationMethod, IFieldInitializerOperation creation, Action<Diagnostic> reportDiagnostic)
+        {
+            IParameterSymbol title = descriptorCreationMethod.Parameters.FirstOrDefault(p => p.Name == "title");
             if (title != null &&
                 title.Type != null &&
                 title.Type.SpecialType == SpecialType.System_String)
             {
-                Diagnostic diagnostic = Diagnostic.Create(UseLocalizableStringsInDescriptorRule, objectCreation.Syntax.GetLocation(), WellKnownTypeNames.MicrosoftCodeAnalysisLocalizableString);
-                operationAnalysisContext.ReportDiagnostic(diagnostic);
+                Diagnostic diagnostic = creation.Value.CreateDiagnostic(UseLocalizableStringsInDescriptorRule, WellKnownTypeNames.MicrosoftCodeAnalysisLocalizableString);
+                reportDiagnostic(diagnostic);
             }
         }
 
-        private static void AnalyzeHelpLinkUri(OperationAnalysisContext operationAnalysisContext, IObjectCreationOperation objectCreation)
+        private static void AnalyzeHelpLinkUri(OperationAnalysisContext operationAnalysisContext, ImmutableArray<IArgumentOperation> creationArguments)
         {
             // Find the matching argument for helpLinkUri
-            foreach (var argument in objectCreation.Arguments)
+            foreach (var argument in creationArguments)
             {
                 if (argument.Parameter.Name.Equals(HelpLinkUriParameterName, System.StringComparison.OrdinalIgnoreCase))
                 {
                     if (argument.Value.ConstantValue.HasValue && argument.Value.ConstantValue.Value == null)
                     {
-                        Diagnostic diagnostic = Diagnostic.Create(ProvideHelpUriInDescriptorRule, argument.Syntax.GetLocation());
+                        Diagnostic diagnostic = argument.CreateDiagnostic(ProvideHelpUriInDescriptorRule);
                         operationAnalysisContext.ReportDiagnostic(diagnostic);
                     }
 
@@ -306,10 +328,10 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             }
         }
 
-        private static void AnalyzeCustomTags(OperationAnalysisContext operationAnalysisContext, IObjectCreationOperation objectCreation)
+        private static void AnalyzeCustomTags(OperationAnalysisContext operationAnalysisContext, ImmutableArray<IArgumentOperation> creationArguments)
         {
             // Find the matching argument for customTags
-            foreach (var argument in objectCreation.Arguments)
+            foreach (var argument in creationArguments)
             {
                 if (argument.Parameter.Name.Equals(CustomTagsParameterName, StringComparison.OrdinalIgnoreCase))
                 {
@@ -319,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                         arrayCreation.DimensionSizes[0].ConstantValue.Value is int size &&
                         size == 0)
                     {
-                        Diagnostic diagnostic = Diagnostic.Create(ProvideCustomTagsInDescriptorRule, argument.Syntax.GetLocation());
+                        Diagnostic diagnostic = argument.CreateDiagnostic(ProvideCustomTagsInDescriptorRule);
                         operationAnalysisContext.ReportDiagnostic(diagnostic);
                     }
 
@@ -330,7 +352,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
         private static bool TryAnalyzeCategory(
             OperationAnalysisContext operationAnalysisContext,
-            IObjectCreationOperation objectCreation,
+            ImmutableArray<IArgumentOperation> creationArguments,
             AdditionalText additionalText,
             ImmutableDictionary<string, ImmutableArray<(string? prefix, int start, int end)>> categoryAndAllowedIdsInfoMap,
             [NotNullWhen(returnValue: true)] out string? category,
@@ -338,7 +360,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
         {
             category = null;
             allowedIdsInfoList = default;
-            foreach (var argument in objectCreation.Arguments)
+            foreach (var argument in creationArguments)
             {
                 if (argument.Parameter.Name.Equals(CategoryParameterName, StringComparison.Ordinal))
                 {
@@ -377,7 +399,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
         private static void AnalyzeRuleId(
             OperationAnalysisContext operationAnalysisContext,
-            IObjectCreationOperation objectCreation,
+            ImmutableArray<IArgumentOperation> creationArguments,
             AdditionalText? additionalTextOpt,
             string? categoryOpt,
             ImmutableArray<(string? prefix, int start, int end)> allowedIdsInfoListOpt,
@@ -385,7 +407,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
         {
             var analyzer = ((IFieldSymbol)operationAnalysisContext.ContainingSymbol).ContainingType.OriginalDefinition;
             string? ruleId = null;
-            foreach (var argument in objectCreation.Arguments)
+            foreach (var argument in creationArguments)
             {
                 if (argument.Parameter.Name.Equals(DiagnosticIdParameterName, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzerTests.cs
@@ -292,6 +292,65 @@ class MyAnalyzer2 : DiagnosticAnalyzer
         }
 
         [Fact]
+        public async Task RS1017_RS1019_CSharp_VerifyDiagnostic_CreateHelper()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly string NonConstantDiagnosticId = ""NonConstantDiagnosticId"";
+    private static LocalizableResourceString dummyLocalizableTitle = null;
+
+    private static readonly DiagnosticDescriptor descriptor =
+        DiagnosticDescriptorHelper.Create(NonConstantDiagnosticId, dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"");
+
+    private static readonly DiagnosticDescriptor descriptor2 =
+        DiagnosticDescriptorHelper.Create(""DuplicateDiagnosticId"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+    {
+        get
+        {
+            return ImmutableArray.Create(descriptor, descriptor2);
+        }
+    }
+
+    public override void Initialize(AnalysisContext context)
+    {
+    }
+}
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer2 : DiagnosticAnalyzer
+{
+    private static LocalizableString dummyLocalizableTitle = null;
+
+    private static readonly DiagnosticDescriptor descriptor =
+        DiagnosticDescriptorHelper.Create(""DuplicateDiagnosticId"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"");
+
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+    {
+        get
+        {
+            return ImmutableArray.Create(descriptor);
+        }
+    }
+
+    public override void Initialize(AnalysisContext context)
+    {
+    }
+}" + CSharpDiagnosticDescriptorCreationHelper,
+                GetCSharpRS1017ExpectedDiagnostic(14, 43, "descriptor"),
+                GetCSharpRS1019ExpectedDiagnostic(38, 43, "DuplicateDiagnosticId", "MyAnalyzer"));
+        }
+
+        [Fact]
         public async Task RS1017_RS1019_VisualBasic_VerifyDiagnostic()
         {
             await VerifyVB.VerifyAnalyzerAsync(@"
@@ -342,6 +401,53 @@ End Class
         }
 
         [Fact]
+        public async Task RS1017_RS1019_VisualBasic_VerifyDiagnostic_CreateHelper()
+        {
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Imports System
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+
+<DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
+Class MyAnalyzer
+	Inherits DiagnosticAnalyzer
+    Private Shared ReadOnly NonConstantDiagnosticId = ""NonConstantDiagnosticId""
+    Private Shared ReadOnly dummyLocalizableTitle As LocalizableString = Nothing
+    Private Shared ReadOnly descriptor As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(NonConstantDiagnosticId, dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"")
+    Private Shared ReadOnly descriptor2 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""DuplicateDiagnosticId"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"")
+
+	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
+		Get
+			Return ImmutableArray.Create(descriptor, descriptor2)
+		End Get
+	End Property
+
+	Public Overrides Sub Initialize(context As AnalysisContext)
+	End Sub
+End Class
+
+<DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
+Class MyAnalyzer2
+	Inherits DiagnosticAnalyzer
+    Private Shared ReadOnly dummyLocalizableTitle As LocalizableString = Nothing
+    Private Shared ReadOnly descriptor As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""DuplicateDiagnosticId"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"")
+
+	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
+		Get
+			Return ImmutableArray.Create(descriptor)
+		End Get
+	End Property
+
+	Public Overrides Sub Initialize(context As AnalysisContext)
+	End Sub
+End Class
+" + VisualBasicDiagnosticDescriptorCreationHelper,
+                GetBasicRS1017ExpectedDiagnostic(12, 100, "descriptor"),
+                GetBasicRS1019ExpectedDiagnostic(29, 100, "DuplicateDiagnosticId", "MyAnalyzer"));
+        }
+
+        [Fact]
         public async Task RS1017_RS1019_CSharp_NoDiagnosticCases()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
@@ -385,6 +491,46 @@ class MyAnalyzer : DiagnosticAnalyzer
         }
 
         [Fact]
+        public async Task RS1017_RS1019_CSharp_NoDiagnosticCases_CreateHelper()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private const string ConstantDiagnosticId = ""ConstantDiagnosticId"";
+    private static LocalizableString dummyLocalizableTitle = null;
+
+    private static readonly DiagnosticDescriptor descriptor =
+        DiagnosticDescriptorHelper.Create(ConstantDiagnosticId, dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"");
+
+    private static readonly DiagnosticDescriptor descriptor2 =
+        DiagnosticDescriptorHelper.Create(""DuplicateDiagnosticId"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"");
+
+    // Allow multiple descriptors with same rule ID in the same analyzer.
+    private static readonly DiagnosticDescriptor descriptor3 =
+        DiagnosticDescriptorHelper.Create(""DuplicateDiagnosticId"", dummyLocalizableTitle, ""MyDiagnosticMessage2"", ""MyDiagnosticCategory"");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+    {
+        get
+        {
+            return ImmutableArray.Create(descriptor, descriptor2, descriptor3);
+        }
+    }
+
+    public override void Initialize(AnalysisContext context)
+    {
+    }
+}
+" + CSharpDiagnosticDescriptorCreationHelper);
+        }
+
+        [Fact]
         public async Task RS1017_RS1019_VisualBasic_NoDiagnosticCases()
         {
             await VerifyVB.VerifyAnalyzerAsync(@"
@@ -416,6 +562,37 @@ End Class
                 GetBasicRS1028ResultAt(12, 70),
                 GetBasicRS1028ResultAt(13, 71),
                 GetBasicRS1028ResultAt(15, 71));
+        }
+
+        [Fact]
+        public async Task RS1017_RS1019_VisualBasic_NoDiagnosticCases_CreateHelper()
+        {
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Imports System
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+
+<DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
+Class MyAnalyzer
+	Inherits DiagnosticAnalyzer
+    Const ConstantDiagnosticId As String = ""ConstantDiagnosticId""
+    Private Shared ReadOnly dummyLocalizableTitle As LocalizableString = Nothing
+    Private Shared ReadOnly descriptor As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(ConstantDiagnosticId, dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"")
+    Private Shared ReadOnly descriptor2 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""DuplicateDiagnosticId"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""MyDiagnosticCategory"")
+    ' Allow multiple descriptors with same rule ID in the same analyzer.
+    Private Shared ReadOnly descriptor3 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""DuplicateDiagnosticId"", dummyLocalizableTitle, ""MyDiagnosticMessage2"", ""MyDiagnosticCategory"")
+
+	Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
+		Get
+			Return ImmutableArray.Create(descriptor, descriptor2, descriptor3)
+		End Get
+	End Property
+
+	Public Overrides Sub Initialize(context As AnalysisContext)
+	End Sub
+End Class
+" + VisualBasicDiagnosticDescriptorCreationHelper);
         }
 
         #endregion
@@ -504,6 +681,81 @@ CategoryWithPrefixRangeAndId: MyFirstPrefix, MySecondPrefix000-MySecondPrefix099
         }
 
         [Fact]
+        public async Task RS1018_RS1020_CSharp_VerifyDiagnostic_CreateHelper()
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static LocalizableResourceString dummyLocalizableTitle = null;
+
+    private static readonly DiagnosticDescriptor descriptor =
+        DiagnosticDescriptorHelper.Create(""Id1"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""NotAllowedCategory"");
+
+    private static readonly DiagnosticDescriptor descriptor2 =
+        DiagnosticDescriptorHelper.Create(""DifferentPrefixId"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefix"");
+
+    private static readonly DiagnosticDescriptor descriptor3 =
+        DiagnosticDescriptorHelper.Create(""Prefix200"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithRange"");
+
+    private static readonly DiagnosticDescriptor descriptor4 =
+        DiagnosticDescriptorHelper.Create(""Prefix101"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithId"");
+
+    private static readonly DiagnosticDescriptor descriptor5 =
+        DiagnosticDescriptorHelper.Create(""MySecondPrefix400"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"");
+
+    private static readonly DiagnosticDescriptor descriptor6 =
+        DiagnosticDescriptorHelper.Create(""MyThirdPrefix"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+    {
+        get
+        {
+            return ImmutableArray.Create(descriptor, descriptor2, descriptor3, descriptor4, descriptor5, descriptor6);
+        }
+    }
+
+    public override void Initialize(AnalysisContext context)
+    {
+    }
+}" + CSharpDiagnosticDescriptorCreationHelper;
+
+            string additionalText = @"
+# FORMAT:
+# 'Category': Comma separate list of 'StartId-EndId' or 'Id' or 'Prefix'
+
+CategoryWithNoIdRangeOrFormat
+CategoryWithPrefix: Prefix
+CategoryWithRange: Prefix000-Prefix099
+CategoryWithId: Prefix100
+CategoryWithPrefixRangeAndId: MyFirstPrefix, MySecondPrefix000-MySecondPrefix099, MySecondPrefix300
+";
+
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { (AdditionalFileName, additionalText) },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpRS1020ExpectedDiagnostic(13, 96, "NotAllowedCategory", AdditionalFileName),
+                        GetCSharpRS1018ExpectedDiagnostic(16, 43, "DifferentPrefixId", "CategoryWithPrefix", "PrefixXXXX", AdditionalFileName),
+                        GetCSharpRS1018ExpectedDiagnostic(19, 43, "Prefix200", "CategoryWithRange", "Prefix0-Prefix99", AdditionalFileName),
+                        GetCSharpRS1018ExpectedDiagnostic(22, 43, "Prefix101", "CategoryWithId", "Prefix100-Prefix100", AdditionalFileName),
+                        GetCSharpRS1018ExpectedDiagnostic(25, 43, "MySecondPrefix400", "CategoryWithPrefixRangeAndId", "MyFirstPrefixXXXX, MySecondPrefix0-MySecondPrefix99, MySecondPrefix300-MySecondPrefix300", AdditionalFileName),
+                        GetCSharpRS1018ExpectedDiagnostic(28, 43, "MyThirdPrefix", "CategoryWithPrefixRangeAndId", "MyFirstPrefixXXXX, MySecondPrefix0-MySecondPrefix99, MySecondPrefix300-MySecondPrefix300", AdditionalFileName)
+                    }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task RS1018_RS1020_VisualBasic_VerifyDiagnostic()
         {
             var source = @"
@@ -565,6 +817,68 @@ CategoryWithPrefixRangeAndId: MyFirstPrefix, MySecondPrefix000-MySecondPrefix099
                         GetBasicRS1018ExpectedDiagnostic(16, 92, "MySecondPrefix400", "CategoryWithPrefixRangeAndId", "MyFirstPrefixXXXX, MySecondPrefix0-MySecondPrefix99, MySecondPrefix300-MySecondPrefix300", AdditionalFileName),
                         GetBasicRS1028ResultAt(17, 71),
                         GetBasicRS1018ExpectedDiagnostic(17, 92, "MyThirdPrefix", "CategoryWithPrefixRangeAndId", "MyFirstPrefixXXXX, MySecondPrefix0-MySecondPrefix99, MySecondPrefix300-MySecondPrefix300", AdditionalFileName),
+                    }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task RS1018_RS1020_VisualBasic_VerifyDiagnostic_CreateHelper()
+        {
+            var source = @"
+Imports System
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+
+<DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
+Class MyAnalyzer
+    Inherits DiagnosticAnalyzer
+
+    Private Shared dummyLocalizableTitle As LocalizableResourceString = Nothing
+    Private Shared ReadOnly descriptor As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""Id1"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""NotAllowedCategory"")
+    Private Shared ReadOnly descriptor2 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""DifferentPrefixId"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefix"")
+    Private Shared ReadOnly descriptor3 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""Prefix200"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithRange"")
+    Private Shared ReadOnly descriptor4 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""Prefix101"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithId"")
+    Private Shared ReadOnly descriptor5 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""MySecondPrefix400"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"")
+    Private Shared ReadOnly descriptor6 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""MyThirdPrefix"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"")
+
+    Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
+        Get
+            Return ImmutableArray.Create(descriptor, descriptor2, descriptor3, descriptor4, descriptor5, descriptor6)
+        End Get
+    End Property
+
+    Public Overrides Sub Initialize(ByVal context As AnalysisContext)
+    End Sub
+End Class
+" + VisualBasicDiagnosticDescriptorCreationHelper;
+
+            string additionalText = @"
+# FORMAT:
+# 'Category': Comma separate list of 'StartId-EndId' or 'Id' or 'Prefix'
+
+CategoryWithNoIdRangeOrFormat
+CategoryWithPrefix: Prefix
+CategoryWithRange: Prefix000-Prefix099
+CategoryWithId: Prefix100
+CategoryWithPrefixRangeAndId: MyFirstPrefix, MySecondPrefix000-MySecondPrefix099, MySecondPrefix300
+";
+
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { (AdditionalFileName, additionalText) },
+                    ExpectedDiagnostics =
+                    {
+                        GetBasicRS1020ExpectedDiagnostic(12, 153, "NotAllowedCategory", AdditionalFileName),
+                        GetBasicRS1018ExpectedDiagnostic(13, 101, "DifferentPrefixId", "CategoryWithPrefix", "PrefixXXXX", AdditionalFileName),
+                        GetBasicRS1018ExpectedDiagnostic(14, 101, "Prefix200", "CategoryWithRange", "Prefix0-Prefix99", AdditionalFileName),
+                        GetBasicRS1018ExpectedDiagnostic(15, 101, "Prefix101", "CategoryWithId", "Prefix100-Prefix100", AdditionalFileName),
+                        GetBasicRS1018ExpectedDiagnostic(16, 101, "MySecondPrefix400", "CategoryWithPrefixRangeAndId", "MyFirstPrefixXXXX, MySecondPrefix0-MySecondPrefix99, MySecondPrefix300-MySecondPrefix300", AdditionalFileName),
+                        GetBasicRS1018ExpectedDiagnostic(17, 101, "MyThirdPrefix", "CategoryWithPrefixRangeAndId", "MyFirstPrefixXXXX, MySecondPrefix0-MySecondPrefix99, MySecondPrefix300-MySecondPrefix300", AdditionalFileName),
                     }
                 }
             }.RunAsync();
@@ -653,6 +967,77 @@ CategoryWithPrefixRangeAndId: MyFirstPrefix, MySecondPrefix000-MySecondPrefix099
         }
 
         [Fact]
+        public async Task RS1018_RS1020_CSharp_NoDiagnosticCases_CreateHelper()
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static LocalizableResourceString dummyLocalizableTitle = null;
+
+    private static readonly DiagnosticDescriptor descriptor =
+        DiagnosticDescriptorHelper.Create(""Id1"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithNoIdRangeOrFormat"");
+
+    private static readonly DiagnosticDescriptor descriptor2 =
+        DiagnosticDescriptorHelper.Create(""Prefix"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefix"");
+
+    private static readonly DiagnosticDescriptor descriptor2_2 =
+        DiagnosticDescriptorHelper.Create(""Prefix101"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefix"");
+
+    private static readonly DiagnosticDescriptor descriptor3 =
+        DiagnosticDescriptorHelper.Create(""Prefix001"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithRange"");
+
+    private static readonly DiagnosticDescriptor descriptor4 =
+        DiagnosticDescriptorHelper.Create(""Prefix100"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithId"");
+
+    private static readonly DiagnosticDescriptor descriptor5 =
+        DiagnosticDescriptorHelper.Create(""MyFirstPrefix001"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"");
+
+    private static readonly DiagnosticDescriptor descriptor6 =
+        DiagnosticDescriptorHelper.Create(""MySecondPrefix050"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"");
+
+    private static readonly DiagnosticDescriptor descriptor7 =
+        DiagnosticDescriptorHelper.Create(""MySecondPrefix300"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+    {
+        get
+        {
+            return ImmutableArray.Create(descriptor, descriptor2, descriptor2_2, descriptor3, descriptor4, descriptor5, descriptor6, descriptor7);
+        }
+    }
+
+    public override void Initialize(AnalysisContext context)
+    {
+    }
+}" + CSharpDiagnosticDescriptorCreationHelper;
+
+            string additionalText = @"
+# FORMAT:
+# 'Category': Comma separate list of 'StartId-EndId' or 'Id' or 'Prefix'
+
+CategoryWithNoIdRangeOrFormat
+CategoryWithPrefix: Prefix
+CategoryWithRange: Prefix000-Prefix099
+CategoryWithId: Prefix100
+CategoryWithPrefixRangeAndId: MyFirstPrefix, MySecondPrefix000-MySecondPrefix099, MySecondPrefix300
+";
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { (AdditionalFileName, additionalText) }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task RS1018_RS1020_VisualBasic_NoDiagnosticCases()
         {
             var source = @"
@@ -713,6 +1098,61 @@ CategoryWithPrefixRangeAndId: MyFirstPrefix, MySecondPrefix000-MySecondPrefix099
                         GetBasicRS1028ResultAt(18, 71),
                         GetBasicRS1028ResultAt(19, 71),
                     }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task RS1018_RS1020_VisualBasic_NoDiagnosticCases_CreateHelper()
+        {
+            var source = @"
+Imports System
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+
+<DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
+Class MyAnalyzer
+    Inherits DiagnosticAnalyzer
+
+    Private Shared dummyLocalizableTitle As LocalizableResourceString = Nothing
+    Private Shared ReadOnly descriptor As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""Id1"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithNoIdRangeOrFormat"")
+    Private Shared ReadOnly descriptor2 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""Prefix"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefix"")
+    Private Shared ReadOnly descriptor2_2 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""Prefix"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefix"")
+    Private Shared ReadOnly descriptor3 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""Prefix001"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithRange"")
+    Private Shared ReadOnly descriptor4 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""Prefix100"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithId"")
+    Private Shared ReadOnly descriptor5 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""MyFirstPrefix001"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"")
+    Private Shared ReadOnly descriptor6 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""MySecondPrefix050"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"")
+    Private Shared ReadOnly descriptor7 As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(""MySecondPrefix300"", dummyLocalizableTitle, ""MyDiagnosticMessage"", ""CategoryWithPrefixRangeAndId"")
+
+    Public Overrides ReadOnly Property SupportedDiagnostics() As ImmutableArray(Of DiagnosticDescriptor)
+        Get
+            Return ImmutableArray.Create(descriptor, descriptor2, descriptor2_2, descriptor3, descriptor4, descriptor5, descriptor6, descriptor7)
+        End Get
+    End Property
+
+    Public Overrides Sub Initialize(ByVal context As AnalysisContext)
+    End Sub
+End Class
+" + VisualBasicDiagnosticDescriptorCreationHelper;
+
+            string additionalText = @"
+# FORMAT:
+# 'Category': Comma separate list of 'StartId-EndId' or 'Id' or 'Prefix'
+
+CategoryWithNoIdRangeOrFormat
+CategoryWithPrefix: Prefix
+CategoryWithRange: Prefix000-Prefix099
+CategoryWithId: Prefix100
+CategoryWithPrefixRangeAndId: MyFirstPrefix, MySecondPrefix000-MySecondPrefix099, MySecondPrefix300
+";
+
+            await new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { (AdditionalFileName, additionalText) }
                 }
             }.RunAsync();
         }
@@ -1321,6 +1761,25 @@ End Class",
                 .WithArguments(ruleId);
 
         private const string AdditionalFileName = "DiagnosticCategoryAndIdRanges.txt";
+
+        private const string CSharpDiagnosticDescriptorCreationHelper = @"
+internal static class DiagnosticDescriptorHelper
+{
+    // Dummy DiagnosticDescriptor creation helper.
+    public static DiagnosticDescriptor Create(
+        string id,
+        LocalizableString title,
+        LocalizableString messageFormat,
+        string category)
+    => null;
+}";
+        private const string VisualBasicDiagnosticDescriptorCreationHelper = @"
+Friend Partial Module DiagnosticDescriptorHelper
+    ' Dummy DiagnosticDescriptor creation helper.
+    Function Create(id As String, title As LocalizableString, messageFormat As LocalizableString, category As String) As DiagnosticDescriptor
+        Return Nothing
+    End Function
+End Module";
 
         #endregion
     }


### PR DESCRIPTION
…elper methods for creating diagnostic descriptors

This ensures that the analyzers in Microsoft.CodeAnalysis.NetAnalyzers which use a helper method for creating descriptors get all the RS diagnostics for correct descriptor usage: RS1017 (DiagnosticIdMustBeAConstant), RS1019 (UseUniqueDiagnosticId) RS1018 (DiagnosticIdMustBeInSpecifiedFormat) and RS1020 (UseCategoriesFromSpecifiedRange)