### PR TITLE
Implement RS0038 (Prefer null literal)

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Diagnostics.Analyzers;
+
+namespace Roslyn.Diagnostics.CSharp.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class PreferNullLiteral : DiagnosticAnalyzer
+    {
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(RoslynDiagnosticsAnalyzersResources.PreferNullLiteralTitle), RoslynDiagnosticsAnalyzersResources.ResourceManager, typeof(RoslynDiagnosticsAnalyzersResources));
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(RoslynDiagnosticsAnalyzersResources.PreferNullLiteralMessage), RoslynDiagnosticsAnalyzersResources.ResourceManager, typeof(RoslynDiagnosticsAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(RoslynDiagnosticsAnalyzersResources.PreferNullLiteralDescription), RoslynDiagnosticsAnalyzersResources.ResourceManager, typeof(RoslynDiagnosticsAnalyzersResources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            RoslynDiagnosticIds.PreferNullLiteralRuleId,
+            s_localizableTitle,
+            s_localizableMessage,
+            DiagnosticCategory.RoslynDiagnosticsMaintainability,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: s_localizableDescription,
+            helpLinkUri: null,
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterOperationAction(HandleDefaultValueOperation, OperationKind.DefaultValue);
+        }
+
+        private void HandleDefaultValueOperation(OperationAnalysisContext context)
+        {
+            if (!context.Operation.Type.IsReferenceType)
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, context.Operation.Syntax.GetLocation()));
+        }
+    }
+}

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
@@ -38,7 +38,16 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
 
         private void HandleDefaultValueOperation(OperationAnalysisContext context)
         {
-            if (!context.Operation.Type.IsReferenceType)
+            var type = context.Operation.Type;
+            if (type.IsValueType)
+            {
+                if (!(type is INamedTypeSymbol namedType)
+                    || namedType.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T)
+                {
+                    return;
+                }
+            }
+            else if (!type.IsReferenceType)
             {
                 return;
             }

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
@@ -7,8 +7,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Diagnostics.Analyzers;
 
@@ -43,11 +43,11 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var syntax = root.FindNode(location.SourceSpan, getInnermostNodeForTie: true);
 
-            var syntaxGenerator = SyntaxGenerator.GetGenerator(document);
-            var newSyntax = syntaxGenerator.NullLiteralExpression();
+            ExpressionSyntax newSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
             if (syntax is DefaultExpressionSyntax defaultExpression)
             {
-                newSyntax = syntaxGenerator.CastExpression(defaultExpression.Type, newSyntax).WithAdditionalAnnotations(Simplifier.Annotation);
+                newSyntax = SyntaxFactory.ParenthesizedExpression(SyntaxFactory.CastExpression(defaultExpression.Type, newSyntax).WithAdditionalAnnotations(Simplifier.Annotation))
+                    .WithAdditionalAnnotations(Simplifier.Annotation);
             }
 
             return document.WithSyntaxRoot(root.ReplaceNode(syntax, newSyntax));

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editing;
+using Roslyn.Diagnostics.Analyzers;
+
+namespace Roslyn.Diagnostics.CSharp.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PreferNullLiteralCodeFixProvider))]
+    [Shared]
+    public class PreferNullLiteralCodeFixProvider : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(PreferNullLiteral.Rule.Id);
+
+        public override FixAllProvider GetFixAllProvider()
+            => WellKnownFixAllProviders.BatchFixer;
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        RoslynDiagnosticsAnalyzersResources.PreferNullLiteralCodeFix,
+                        cancellationToken => ReplaceWithNullLiteralAsync(context.Document, diagnostic.Location, cancellationToken),
+                        equivalenceKey: nameof(PreferNullLiteralCodeFixProvider)),
+                    diagnostic);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task<Document> ReplaceWithNullLiteralAsync(Document document, Location location, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var syntax = root.FindNode(location.SourceSpan, getInnermostNodeForTie: true);
+
+            var syntaxGenerator = SyntaxGenerator.GetGenerator(document);
+            var newSyntax = syntaxGenerator.NullLiteralExpression();
+
+            return document.WithSyntaxRoot(root.ReplaceNode(syntax, newSyntax));
+        }
+    }
+}

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
@@ -7,7 +7,9 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Diagnostics.Analyzers;
 
 namespace Roslyn.Diagnostics.CSharp.Analyzers
@@ -43,6 +45,10 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
 
             var syntaxGenerator = SyntaxGenerator.GetGenerator(document);
             var newSyntax = syntaxGenerator.NullLiteralExpression();
+            if (syntax is DefaultExpressionSyntax defaultExpression)
+            {
+                newSyntax = syntaxGenerator.CastExpression(defaultExpression.Type, newSyntax).WithAdditionalAnnotations(Simplifier.Annotation);
+            }
 
             return document.WithSyntaxRoot(root.ReplaceNode(syntax, newSyntax));
         }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
@@ -41,5 +41,6 @@ namespace Roslyn.Diagnostics.Analyzers
         public const string RestrictedInternalsVisibleToRuleId = "RS0035";
         public const string AnnotatePublicApiRuleId = "RS0036";
         public const string ShouldAnnotateApiFilesRuleId = "RS0037";
+        public const string PreferNullLiteralRuleId = "RS0038";
     }
 }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.resx
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.resx
@@ -255,4 +255,16 @@
   <data name="FixNumberedComments" xml:space="preserve">
     <value>Fix numbered comments</value>
   </data>
+  <data name="PreferNullLiteralDescription" xml:space="preserve">
+    <value>Use 'null' instead of 'default' for reference types.</value>
+  </data>
+  <data name="PreferNullLiteralMessage" xml:space="preserve">
+    <value>Use 'null' instead of 'default' for reference types</value>
+  </data>
+  <data name="PreferNullLiteralTitle" xml:space="preserve">
+    <value>Prefer null literal</value>
+  </data>
+  <data name="PreferNullLiteralCodeFix" xml:space="preserve">
+    <value>Use 'null' instead of 'default'</value>
+  </data>
 </root>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.cs.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.cs.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Importující konstruktor by měl být [Obsolete]</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">Použijte PartNotDiscoverableAttribute.</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.de.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.de.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Importierender Konstruktor muss "[Obsolete]" lauten</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">"PartNotDiscoverableAttribute" anwenden</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.es.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.es.xlf
@@ -77,6 +77,26 @@
         <target state="translated">El constructor de importación debe ser [Obsolete]</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">Aplicar PartNotDiscoverableAttribute</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.fr.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.fr.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Le constructeur d'importation doit être [Obsolete]</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">Appliquer PartNotDiscoverableAttribute</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.it.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.it.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Il costruttore di importazione deve essere [Obsolete]</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">Applicare PartNotDiscoverableAttribute</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ja.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ja.xlf
@@ -77,6 +77,26 @@
         <target state="translated">インポート コンストラクターは [Obsolete] にする必要があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">PartNotDiscoverableAttribute の適用</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ko.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ko.xlf
@@ -77,6 +77,26 @@
         <target state="translated">가져오기 생성자는 [Obsolete]여야 함</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">PartNotDiscoverableAttribute 적용</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.pl.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.pl.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Konstruktor importujący powinien być oznaczony jako [Obsolete]</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">Zastosuj atrybut PartNotDiscoverableAttribute</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.pt-BR.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.pt-BR.xlf
@@ -77,6 +77,26 @@
         <target state="translated">O construtor de importação deve ser [Obsolete]</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">Aplicar PartNotDiscoverableAttribute</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ru.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ru.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Конструктор импорта должен быть [Obsolete]</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">Применить PartNotDiscoverableAttribute</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.tr.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.tr.xlf
@@ -77,6 +77,26 @@
         <target state="translated">İçeri aktarma oluşturucusunun [Obsolete] olması gerekir</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">PartNotDiscoverableAttribute uygula</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.zh-Hans.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.zh-Hans.xlf
@@ -77,6 +77,26 @@
         <target state="translated">导入构造函数应为 [Obsolete]</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">应用 PartNotDiscoverableAttribute</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.zh-Hant.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.zh-Hant.xlf
@@ -77,6 +77,26 @@
         <target state="translated">匯入建構函式應為 [Obsolete]</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferNullLiteralCodeFix">
+        <source>Use 'null' instead of 'default'</source>
+        <target state="new">Use 'null' instead of 'default'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralDescription">
+        <source>Use 'null' instead of 'default' for reference types.</source>
+        <target state="new">Use 'null' instead of 'default' for reference types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralMessage">
+        <source>Use 'null' instead of 'default' for reference types</source>
+        <target state="new">Use 'null' instead of 'default' for reference types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreferNullLiteralTitle">
+        <source>Prefer null literal</source>
+        <target state="new">Prefer null literal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestExportsShouldNotBeDiscoverableCodeFix">
         <source>Apply PartNotDiscoverableAttribute</source>
         <target state="translated">套用 PartNotDiscoverableAttribute</target>

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
@@ -106,6 +106,49 @@ class Type
         }
 
         [Fact]
+        public async Task PreferNullLiteral_ParenthesizeWhereNecessary()
+        {
+            var source = @"
+using System;
+
+class Type
+{
+    void Method()
+    {
+        Method2([|default(object)|]?.ToString());
+        Method2([|default(string)|]?.ToString());
+        Method2([|default(IComparable)|]?.ToString());
+        Method2(default(int).ToString());
+    }
+
+    void Method2(string value)
+    {
+    }
+}
+";
+            var fixedSource = @"
+using System;
+
+class Type
+{
+    void Method()
+    {
+        Method2(((object)null)?.ToString());
+        Method2(((string)null)?.ToString());
+        Method2(((IComparable)null)?.ToString());
+        Method2(default(int).ToString());
+    }
+
+    void Method2(string value)
+    {
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Fact]
         public async Task PreferNullLiteral_Struct()
         {
             var source = @"

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
@@ -75,6 +75,7 @@ class Type
         Method2([|default(object)|]);
         Method2([|default(string)|]);
         Method2([|default(IComparable)|]);
+        Method2([|default(int?)|]);
         Method2(default(int));
     }
 
@@ -93,6 +94,7 @@ class Type
         Method2((object)null);
         Method2((string)null);
         Method2((IComparable)null);
+        Method2((int?)null);
         Method2(default(int));
     }
 
@@ -118,6 +120,7 @@ class Type
         Method2([|default(object)|]?.ToString());
         Method2([|default(string)|]?.ToString());
         Method2([|default(IComparable)|]?.ToString());
+        Method2([|default(int?)|]?.ToString());
         Method2(default(int).ToString());
     }
 
@@ -136,6 +139,7 @@ class Type
         Method2(((object)null)?.ToString());
         Method2(((string)null)?.ToString());
         Method2(((IComparable)null)?.ToString());
+        Method2(((int?)null)?.ToString());
         Method2(default(int).ToString());
     }
 

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
@@ -63,6 +63,49 @@ class Type
         }
 
         [Fact]
+        public async Task PreferNullLiteral_OverloadResolution()
+        {
+            var source = @"
+using System;
+
+class Type
+{
+    void Method()
+    {
+        Method2([|default(object)|]);
+        Method2([|default(string)|]);
+        Method2([|default(IComparable)|]);
+        Method2(default(int));
+    }
+
+    void Method2<T>(T value)
+    {
+    }
+}
+";
+            var fixedSource = @"
+using System;
+
+class Type
+{
+    void Method()
+    {
+        Method2((object)null);
+        Method2((string)null);
+        Method2((IComparable)null);
+        Method2(default(int));
+    }
+
+    void Method2<T>(T value)
+    {
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Fact]
         public async Task PreferNullLiteral_Struct()
         {
             var source = @"

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Roslyn.Diagnostics.CSharp.Analyzers.PreferNullLiteral,
+    Roslyn.Diagnostics.CSharp.Analyzers.PreferNullLiteralCodeFixProvider>;
+
+namespace Roslyn.Diagnostics.Analyzers.UnitTests
+{
+    public class PreferNullLiteralTests
+    {
+        [Theory]
+        [InlineData("default")]
+        [InlineData("default(object)")]
+        public async Task PreferNullLiteral_Class(string defaultValueExpression)
+        {
+            var source = $@"
+class Type
+{{
+    object Method()
+    {{
+        return [|{defaultValueExpression}|];
+    }}
+}}
+";
+            var fixedSource = @"
+class Type
+{
+    object Method()
+    {
+        return null;
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Theory]
+        [InlineData("default")]
+        [InlineData("default(object)")]
+        public async Task PreferNullLiteral_DefaultParameterValue(string defaultValueExpression)
+        {
+            var source = $@"
+class Type
+{{
+    void Method(object value = [|{defaultValueExpression}|])
+    {{
+    }}
+}}
+";
+            var fixedSource = @"
+class Type
+{
+    void Method(object value = null)
+    {
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task PreferNullLiteral_Struct()
+        {
+            var source = @"
+class Type
+{
+    int Method()
+    {
+        return default;
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task PreferNullLiteral_StructConvertedToReferenceType()
+        {
+            var source = @"
+class Type
+{
+    object Method()
+    {
+        return default(int);
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task PreferNullLiteral_UnconstrainedGeneric()
+        {
+            var source = @"
+class Type
+{
+    T Method<T>()
+    {
+        return default;
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task PreferNullLiteral_GenericConstrainedToReferenceType()
+        {
+            var source = @"
+class Type
+{
+    T Method<T>()
+        where T : class
+    {
+        return [|default|];
+    }
+}
+";
+            var fixedSource = @"
+class Type
+{
+    T Method<T>()
+        where T : class
+    {
+        return null;
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task PreferNullLiteral_GenericConstrainedToInterface()
+        {
+            var source = @"
+class Type
+{
+    T Method<T>()
+        where T : System.IComparable
+    {
+        return default;
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task PreferNullLiteral_GenericConstrainedToValueType()
+        {
+            var source = @"
+class Type
+{
+    T Method<T>()
+        where T : struct
+    {
+        return default;
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+    }
+}


### PR DESCRIPTION
Prefer `null` to `default(T)` (or `default`) when `T` is a reference type.

Additional cases that need to be accounted for:

* [x] Use `(T)null` where necessary to avoid overload resolution errors
* [x] ~~Use `nameof(T.Member)` instead of `nameof(default(T).Member)` in the code fix~~ Not valid C# syntax.