### PR TITLE
Fix default→null bugs

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
@@ -38,6 +38,12 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
 
         private void HandleDefaultValueOperation(OperationAnalysisContext context)
         {
+            if (context.Operation.IsImplicit)
+            {
+                // Ignore implicit operations since they don't appear in source code.
+                return;
+            }
+
             var type = context.Operation.Type;
             if (type.IsValueType)
             {

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
@@ -46,11 +46,16 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
             ExpressionSyntax newSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
             if (syntax is DefaultExpressionSyntax defaultExpression)
             {
-                newSyntax = SyntaxFactory.ParenthesizedExpression(SyntaxFactory.CastExpression(defaultExpression.Type, newSyntax).WithAdditionalAnnotations(Simplifier.Annotation))
+                var castExpression = SyntaxFactory.CastExpression(defaultExpression.Type, newSyntax.WithTrailingTrivia(defaultExpression.Keyword.TrailingTrivia));
+                castExpression = castExpression
+                    .WithOpenParenToken(castExpression.OpenParenToken.WithTriviaFrom(defaultExpression.OpenParenToken))
+                    .WithCloseParenToken(castExpression.CloseParenToken.WithLeadingTrivia(defaultExpression.CloseParenToken.LeadingTrivia));
+
+                newSyntax = SyntaxFactory.ParenthesizedExpression(castExpression.WithAdditionalAnnotations(Simplifier.Annotation))
                     .WithAdditionalAnnotations(Simplifier.Annotation);
             }
 
-            newSyntax = newSyntax.WithLeadingTrivia(syntax.GetLeadingTrivia());
+            newSyntax = newSyntax.WithTriviaFrom(syntax);
             return document.WithSyntaxRoot(root.ReplaceNode(syntax, newSyntax));
         }
     }

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteralCodeFixProvider.cs
@@ -50,6 +50,7 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
                     .WithAdditionalAnnotations(Simplifier.Annotation);
             }
 
+            newSyntax = newSyntax.WithLeadingTrivia(syntax.GetLeadingTrivia());
             return document.WithSyntaxRoot(root.ReplaceNode(syntax, newSyntax));
         }
     }

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
@@ -62,10 +62,8 @@ class Type
             await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
         }
 
-        [Theory]
-        [InlineData("default")]
-        [InlineData("default(object)")]
-        public async Task PreferNullLiteral_ArgumentFormatting(string defaultValueExpression)
+        [Fact]
+        public async Task PreferNullLiteral_ArgumentFormatting()
         {
             var source = $@"
 class Type
@@ -74,8 +72,10 @@ class Type
     {{
         Method2(
             0,
-            [|{defaultValueExpression}|],
-            [|{defaultValueExpression}|],
+            [|default|],
+            /*1*/ [|default|] /*2*/,
+            [|default(object)|],
+            /*1*/ [|default /*2*/ ( /*3*/ object /*4*/ )|] /*5*/,
             """");
     }}
 
@@ -92,7 +92,9 @@ class Type
         Method2(
             0,
             null,
+            /*1*/ null /*2*/,
             null,
+            /*1*/  /*3*/  /*4*/ null /*2*/  /*5*/,
             """");
     }
 

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
@@ -260,5 +260,27 @@ class Type
 
             await VerifyCS.VerifyCodeFixAsync(source, source);
         }
+
+        [Theory]
+        [InlineData("object")]
+        [InlineData("int?")]
+        public async Task IgnoreDefaultParameters(string defaultParameterType)
+        {
+            var source = $@"
+class Type
+{{
+    void Method1()
+    {{
+        Method2(0);
+    }}
+
+    void Method2(int first, {defaultParameterType} value = null)
+    {{
+    }}
+}}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
     }
 }

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/PreferNullLiteralTests.cs
@@ -62,6 +62,49 @@ class Type
             await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
         }
 
+        [Theory]
+        [InlineData("default")]
+        [InlineData("default(object)")]
+        public async Task PreferNullLiteral_ArgumentFormatting(string defaultValueExpression)
+        {
+            var source = $@"
+class Type
+{{
+    void Method()
+    {{
+        Method2(
+            0,
+            [|{defaultValueExpression}|],
+            [|{defaultValueExpression}|],
+            """");
+    }}
+
+    void Method2(params object[] values)
+    {{
+    }}
+}}
+";
+            var fixedSource = @"
+class Type
+{
+    void Method()
+    {
+        Method2(
+            0,
+            null,
+            null,
+            """");
+    }
+
+    void Method2(params object[] values)
+    {
+    }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+        }
+
         [Fact]
         public async Task PreferNullLiteral_OverloadResolution()
         {


### PR DESCRIPTION
* A diagnostic was incorrectly reported when a default value was passed for a nullable value type argument
* The code fix failed to indent parameters replaced with `null`
* The code fix failed to preserve trivia