### PR TITLE
Update Roslyn.Roslyn.Diagnostics.Analyzers to Microsoft.CodeAnalysis 3.3.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ root = true
 indent_style = space
 # (Please don't specify an indent_size here; that has too many unintended consequences.)
 
+# RS1024: Compare symbols correctly
+# https://github.com/dotnet/roslyn-analyzers/issues/3389
+dotnet_diagnostic.RS1024.severity = none
+
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4

--- a/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.csproj
@@ -7,6 +7,7 @@
       Restore would conclude that there is a cyclic dependency between us and the Roslyn.Diagnostics.Analyzers package.
     -->
     <PackageId>*$(MSBuildProjectFullPath)*</PackageId>
+    <MicrosoftCodeAnalysisVersion>3.3.1</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Roslyn.Diagnostics.CSharp.Analyzers" />


### PR DESCRIPTION
RS1024 (Compare symbols correctly) has been disabled to avoid a highly-disruptive bug in the code fix. See dotnet/roslyn-analyzers#3389.