### PR TITLE
Fix UseValueTasksCorrectly handling of null conditionals

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
@@ -142,21 +142,6 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                                 // The "0.9% case" is delegating to and returning another call's returned awaitable. Also good.
                                 return;
 
-                            case OperationKind.Conditional:
-                                // This is a branch of a ternary, so consider the ternary expression instead.
-                                operation = operation.Parent;
-                                continue;
-
-                            case OperationKind.SwitchExpressionArm when operation.Parent.Parent is ISwitchExpressionOperation:
-                                // This is a case of a switch expression arm, so consider the switch expression instead.
-                                operation = operation.Parent.Parent;
-                                continue;
-
-                            case OperationKind.ExpressionStatement:
-                                // Warn! This is a statement. The result should have been used.
-                                operationContext.ReportDiagnostic(invocation.CreateDiagnostic(UnconsumedRule));
-                                return;
-
                             case OperationKind.Argument:
                                 // The "0.09% case" is passing the result of a call directly as an argument to another method.
                                 // This could later result in a problem, as now there's a parameter inside the callee that's
@@ -177,9 +162,27 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                                 }
                                 goto default;
 
+                            // At this point, we're "in the weeds", but there are still some rare-but-used valid patterns to check for.
+
+                            case OperationKind.Coalesce:
+                            case OperationKind.Conditional:
+                            case OperationKind.ConditionalAccess:
+                            case OperationKind.SwitchExpression:
+                            case OperationKind.SwitchExpressionArm:
+                                // This is a ternary, null conditional, or switch expression, so consider the parent expression instead.
+                                operation = operation.Parent;
+                                continue;
+
                             default:
                                 // Handle atypical / difficult cases that require more analysis.
                                 HandleAtypicalValueTaskUsage(operationContext, debugType, operation, invocation);
+                                return;
+
+                            case OperationKind.ExpressionStatement:
+                            case OperationKind.Discard:
+                            case OperationKind.DiscardPattern:
+                                // Warn! This is a statement or discard. The result should have been used.
+                                operationContext.ReportDiagnostic(invocation.CreateDiagnostic(UnconsumedRule));
                                 return;
                         }
                     }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
@@ -1111,6 +1111,14 @@ namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
                         _ = Helpers.ReturnsValueTask();
                         _ = Helpers.ReturnsValueTaskOfT<string>();
                         _ = Helpers.ReturnsValueTaskOfInt();
+
+                        _ = Helpers.ReturnsValueTask().Preserve();
+                        _ = Helpers.ReturnsValueTaskOfT<string>().Preserve();
+                        _ = Helpers.ReturnsValueTaskOfInt().Preserve();
+
+                        _ = Helpers.ReturnsValueTask().AsTask();
+                        _ = Helpers.ReturnsValueTaskOfT<string>().AsTask();
+                        _ = Helpers.ReturnsValueTaskOfInt().AsTask();
                     }
                 }"),
                 GetCSharpResultAt(9, 29, UseValueTasksCorrectlyAnalyzer.GeneralRule),

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
@@ -290,6 +290,29 @@ namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
         }
 
         [Fact]
+        public async Task NoDiagnostics_NullConditional()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(CSBoilerplate(@"
+                using System;
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    public ValueTask NullConditional(C c) => c?.ReturnsValueTask() ?? default;
+                    public async Task NullConditionalWithAwait(C c) => await (c?.ReturnsValueTask() ?? default);
+
+                    public ValueTask<T> NullConditionalOfT<T>(C c) => c?.ReturnsValueTaskOfT<T>() ?? default;
+                    public async Task<T> NullConditionalWithAwaitOfT<T>(C c) => await (c?.ReturnsValueTaskOfT<T>() ?? default);
+
+                    public ValueTask NullConditionalWithSecondaryCall(C c) => c?.ReturnsValueTask() ?? Helpers.ReturnsValueTask();
+                    public ValueTask<T> NullConditionalWithSecondaryCallOfT<T>(C c) => c?.ReturnsValueTaskOfT<T>() ?? Helpers.ReturnsValueTaskOfT<T>();
+
+                    private ValueTask ReturnsValueTask() => default;
+                    private ValueTask<T> ReturnsValueTaskOfT<T>() => default;
+                }"));
+        }
+
+        [Fact]
         public async Task NoDiagnostics_Switch()
         {
             await new VerifyCS.Test
@@ -1071,6 +1094,28 @@ namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
                 GetCSharpResultAt(13, 31, UseValueTasksCorrectlyAnalyzer.GeneralRule),
                 GetCSharpResultAt(14, 39, UseValueTasksCorrectlyAnalyzer.GeneralRule),
                 GetCSharpResultAt(15, 36, UseValueTasksCorrectlyAnalyzer.GeneralRule)
+            );
+        }
+
+        [Fact]
+        public async Task Diagnostics_Discards()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(CSBoilerplate(@"
+                using System;
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    public void Discards()
+                    {
+                        _ = Helpers.ReturnsValueTask();
+                        _ = Helpers.ReturnsValueTaskOfT<string>();
+                        _ = Helpers.ReturnsValueTaskOfInt();
+                    }
+                }"),
+                GetCSharpResultAt(9, 29, UseValueTasksCorrectlyAnalyzer.GeneralRule),
+                GetCSharpResultAt(10, 29, UseValueTasksCorrectlyAnalyzer.GeneralRule),
+                GetCSharpResultAt(11, 29, UseValueTasksCorrectlyAnalyzer.GeneralRule)
             );
         }
 


### PR DESCRIPTION
Just treat it the same as a ternary and walk up to the parent.

Also some minor refactoring just to simplify/clarify things.

And explicitly added in handling of discards.

Fixes https://github.com/dotnet/roslyn-analyzers/issues/3384
cc: @sharwell 